### PR TITLE
Unify Lua API: single entrypoint, require(), return-value references (#130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ src/
 ├── knowledge/           # KnowledgeStore, light-speed info propagation
 ├── communication/       # Messages, PendingCommand, CommandLog
 ├── technology/          # TechTree, GlobalParams, GameFlags, research (Lua-loaded)
-├── scripting/           # LuaJIT ScriptEngine, define_tech(), define_building() API
+├── scripting/           # LuaJIT ScriptEngine, require(), define_xxx() API, reference system
 ├── events.rs            # GameEvent, EventLog, auto-pause
 ├── player/              # Player, StationedAt
 ├── physics/             # Distance, light delay, travel time calculations
@@ -46,8 +46,18 @@ src/
 │   ├── bottom_bar.rs    # Event log
 │   └── overlays.rs      # Research panel
 ├── setup/               # Initial fleet spawn
-scripts/tech/            # Lua technology definitions (15 techs, 4 branches)
-scripts/buildings/       # Lua building definitions (6 building types)
+scripts/
+├── init.lua             # Single entrypoint — require() loads everything in order
+├── tech/                # Technology definitions (15 techs, 4 branches)
+├── ships/               # Slot types, hulls, modules, designs
+├── buildings/           # Building definitions (6 types)
+├── structures/          # Deep space structure definitions
+├── species/             # Species definitions
+├── jobs/                # Job definitions
+├── stars/               # Star type definitions
+├── planets/             # Planet type definitions
+├── events/              # Event definitions
+└── lifecycle/           # Lifecycle hooks (on_game_start, etc.)
 tests/                   # 145+ tests (unit + integration)
 ```
 
@@ -91,13 +101,43 @@ tests/                   # 145+ tests (unit + integration)
 - `click_select_system` excluded from full_test_app (needs EguiContexts)
 
 ### Lua Scripting
-- Tech definitions in `scripts/tech/*.lua`
-- `define_tech { id, name, branch, cost, prerequisites, effects, description }`
-- Building definitions in `scripts/buildings/*.lua`
-- `define_building { id, name, cost, build_time, maintenance, production_bonus }`
+
+**Single entrypoint.** `scripts/init.lua` is the sole entrypoint for all Lua definitions. It uses `require()` to load subsystems in dependency order. Individual plugins no longer call `load_directory()` — they only parse accumulators after `load_all_scripts` runs.
+
+**Startup ordering:**
+```
+init_scripting → load_all_scripts → [load_galaxy_types, load_building_registry,
+                                      load_technologies, load_ship_designs,
+                                      load_structure_definitions, load_species_and_jobs]
+                                   → run_lifecycle_hooks
+```
+
+**`define_xxx` returns references.** Every `define_xxx { id = "..." }` call returns the table it received, tagged with `_def_type`. This enables return-value based cross-references instead of string IDs:
+```lua
+-- scripts/tech/industrial.lua
+local automated_mining = define_tech { id = "industrial_automated_mining", ... }
+local orbital_fabrication = define_tech {
+    id = "industrial_orbital_fabrication",
+    prerequisites = { automated_mining },  -- reference, not string
+    ...
+}
+return { automated_mining = automated_mining, orbital_fabrication = orbital_fabrication }
+```
+
+**`require()` for dependencies.** Lua scripts use standard `require()` to import definitions from other modules:
+```lua
+-- scripts/ships/designs.lua
+local hulls = require("ships.hulls")
+local modules = require("ships.modules")
+define_ship_design { hull = hulls.corvette, modules = { ... } }
+```
+
+**`forward_ref(id)` for not-yet-defined items.** Returns a placeholder table `{ _def_type = "forward_ref", id = id }` for items that will be defined later.
+
+**Backward compatibility.** Rust-side parsers accept both string IDs and reference tables via `extract_ref_id()`. Condition helpers (`has_tech`, `has_building`, `has_modifier`) also accept both forms.
+
 - BuildingRegistry resource loaded at startup; BuildingType enum still used for runtime logic
-- Fallback: `create_initial_tech_tree()` if scripts/ directory is missing (for tests)
-- Future: events, ships also Lua-defined; BuildingType to be replaced by BuildingRegistry
+- Fallback: `create_initial_tech_tree()` if scripts are missing (for tests)
 
 ## Common Pitfalls
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,8 @@ define_ship_design { hull = hulls.corvette, modules = { ... } }
 
 **Backward compatibility.** Rust-side parsers accept both string IDs and reference tables via `extract_ref_id()`. Condition helpers (`has_tech`, `has_building`, `has_modifier`) also accept both forms.
 
+**Lua sandbox.** `ScriptEngine` uses `Lua::new_with()` to load only safe libraries (table, string, math, package, bit). `io`, `os`, `debug`, `ffi` are not loaded. `loadfile` and `dofile` are explicitly set to nil. Only `scripts/` directory files are loadable via `require()`.
+
 - BuildingRegistry resource loaded at startup; BuildingType enum still used for runtime logic
 - Fallback: `create_initial_tech_tree()` if scripts are missing (for tests)
 

--- a/docs/issue-script-path-sandbox.md
+++ b/docs/issue-script-path-sandbox.md
@@ -1,0 +1,73 @@
+# スクリプトパス解決の堅牢化 + Lua サンドボックス
+
+**Labels:** `foundation`, `priority:medium`
+
+## 概要
+
+#130 で導入した `scripts/init.lua` による一括ロード方式にはパス解決とセキュリティの2つの課題がある。
+
+## 1. アセットバンドル時のパス解決
+
+### 現状の問題
+
+```rust
+// src/scripting/mod.rs
+let init_path = Path::new("scripts/init.lua");
+```
+
+- CWD からの相対パスに依存しており、開発時（`cargo run`）は動作するが以下のケースで壊れる可能性がある:
+  - ゲームをバイナリとして配布し、別ディレクトリから起動した場合
+  - Bevy の asset system 経由でバンドルした場合
+  - プラットフォーム固有のインストールパスに配置された場合
+
+- `package.path` も同様に相対パス:
+  ```rust
+  package.set("path", "scripts/?.lua;scripts/?/init.lua")?;
+  ```
+
+### 対応案
+
+- **Bevy AssetServer との統合**: `AssetServer::asset_path()` を使って scripts/ ディレクトリの絶対パスを解決する
+- **複数パスの探索**: 以下の優先順位でスクリプトディレクトリを検索:
+  1. ユーザー指定のモッドディレクトリ（将来のmod対応）
+  2. 実行ファイルと同階層の `scripts/`
+  3. Bevy のアセットディレクトリ内の `scripts/`
+  4. CWD からの `scripts/`（開発時フォールバック）
+- **`package.path` の動的設定**: 解決した絶対パスに基づいて `package.path` を設定する
+
+## 2. Lua サンドボックス
+
+### 現状の問題
+
+- `Lua::new()` で全標準ライブラリがロードされており、Lua スクリプトから以下が可能:
+  - `io.open()` / `io.popen()` によるファイルシステムアクセス・コマンド実行
+  - `os.execute()` / `os.remove()` によるシステムコマンド実行
+  - `loadfile()` / `dofile()` による任意ファイル実行
+  - `debug` ライブラリによる内部状態の操作
+- mod サポートを将来想定する場合、サードパーティスクリプトが任意コードを実行できるのは危険
+
+### 対応案
+
+- **不要なライブラリの無効化**: `Lua::new()` の代わりに `Lua::new_with()` で安全なライブラリのみロード:
+  ```rust
+  let lua = Lua::new_with(StdLib::TABLE | StdLib::STRING | StdLib::MATH | StdLib::PACKAGE, LuaOptions::default())?;
+  ```
+  - 許可: `table`, `string`, `math`, `package`（require 用）, `coroutine`（将来用）
+  - 禁止: `io`, `os`, `debug`, `ffi`
+- **`require` のホワイトリスト化**: `package.searchers` をカスタムサーチャーに置き換え、`scripts/` 配下のファイルのみロード可能にする（パストラバーサル防止）
+- **グローバル関数のフィルタリング**: `loadfile`, `dofile`, `load`（文字列からコード生成）を nil に設定
+- **メモリ・実行時間制限**: `mlua` の `set_memory_limit` / hook による CPU 時間制限（mod 対応時）
+
+## 実装の優先度
+
+1. **サンドボックス**（即時）: 不要なライブラリの無効化は低コストで効果が大きい
+2. **パス解決**（配布前）: アセットバンドルの仕組みが固まってから対応
+
+## 関連ファイル
+
+- `src/scripting/mod.rs` — `ScriptEngine::new()`, `setup_globals()`, `load_all_scripts()`
+- `scripts/init.lua` — エントリポイント
+
+## 関連 issue
+
+- #130 — Lua API 整理（本 issue の前提）

--- a/scripts/buildings/basic.lua
+++ b/scripts/buildings/basic.lua
@@ -1,4 +1,4 @@
-define_building {
+local mine = define_building {
     id = "mine",
     name = "Mine",
     cost = { minerals = 150, energy = 50 },
@@ -7,7 +7,7 @@ define_building {
     production_bonus = { minerals = 3.0 },
 }
 
-define_building {
+local power_plant = define_building {
     id = "power_plant",
     name = "PowerPlant",
     cost = { minerals = 50, energy = 150 },
@@ -16,7 +16,7 @@ define_building {
     production_bonus = { energy = 3.0 },
 }
 
-define_building {
+local research_lab = define_building {
     id = "research_lab",
     name = "ResearchLab",
     cost = { minerals = 100, energy = 100 },
@@ -25,7 +25,7 @@ define_building {
     production_bonus = { research = 2.0 },
 }
 
-define_building {
+local shipyard = define_building {
     id = "shipyard",
     name = "Shipyard",
     cost = { minerals = 300, energy = 200 },
@@ -33,7 +33,7 @@ define_building {
     maintenance = 1.0,
 }
 
-define_building {
+local port = define_building {
     id = "port",
     name = "Port",
     cost = { minerals = 400, energy = 300 },
@@ -41,11 +41,20 @@ define_building {
     maintenance = 0.5,
 }
 
-define_building {
+local farm = define_building {
     id = "farm",
     name = "Farm",
     cost = { minerals = 100, energy = 50 },
     build_time = 20,
     maintenance = 0.3,
     production_bonus = { food = 5.0 },
+}
+
+return {
+    mine = mine,
+    power_plant = power_plant,
+    research_lab = research_lab,
+    shipyard = shipyard,
+    port = port,
+    farm = farm,
 }

--- a/scripts/buildings/init.lua
+++ b/scripts/buildings/init.lua
@@ -1,0 +1,1 @@
+return require("buildings.basic")

--- a/scripts/events/init.lua
+++ b/scripts/events/init.lua
@@ -1,0 +1,1 @@
+return require("events.sample")

--- a/scripts/events/sample.lua
+++ b/scripts/events/sample.lua
@@ -1,11 +1,11 @@
-define_event {
+local harvest_ended = define_event {
     id = "harvest_ended",
     name = "End of Harvest",
     description = "The bountiful harvest season has ended.",
     -- Manual trigger (no trigger field)
 }
 
-define_event {
+local minor_asteroid_impact = define_event {
     id = "minor_asteroid_impact",
     name = "Minor Asteroid Impact",
     description = "A small asteroid has struck near a colony.",
@@ -14,11 +14,17 @@ define_event {
     },
 }
 
-define_event {
+local monthly_report = define_event {
     id = "monthly_report",
     name = "Monthly Report",
     description = "A regular status update.",
     trigger = periodic_trigger {
         months = 1,
     },
+}
+
+return {
+    harvest_ended = harvest_ended,
+    minor_asteroid_impact = minor_asteroid_impact,
+    monthly_report = monthly_report,
 }

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -1,0 +1,29 @@
+-- Macrocosmo script entrypoint
+-- All game data definitions are loaded through this file via require().
+-- Order matters: definitions must be loaded before they are referenced.
+
+-- Base definitions (no cross-references)
+require("stars")
+require("planets")
+require("jobs")
+
+-- Species (references jobs by string key — no require dependency)
+require("species")
+
+-- Buildings (independent)
+require("buildings")
+
+-- Technology (may be referenced by modules, structures)
+require("tech")
+
+-- Ships (modules may reference techs; designs reference hulls + modules)
+require("ships")
+
+-- Structures (reference techs via conditions)
+require("structures")
+
+-- Events
+require("events")
+
+-- Lifecycle hooks (must be last — registers callbacks for game start/load)
+require("lifecycle")

--- a/scripts/jobs/basic.lua
+++ b/scripts/jobs/basic.lua
@@ -1,23 +1,30 @@
-define_job {
+local miner = define_job {
     id = "miner",
     label = "Miner",
     base_output = { minerals = 0.6 },
 }
 
-define_job {
+local farmer = define_job {
     id = "farmer",
     label = "Farmer",
     base_output = { food = 0.6 },
 }
 
-define_job {
+local researcher = define_job {
     id = "researcher",
     label = "Researcher",
     base_output = { research = 0.5 },
 }
 
-define_job {
+local power_worker = define_job {
     id = "power_worker",
     label = "Power Worker",
     base_output = { energy = 0.6 },
+}
+
+return {
+    miner = miner,
+    farmer = farmer,
+    researcher = researcher,
+    power_worker = power_worker,
 }

--- a/scripts/jobs/init.lua
+++ b/scripts/jobs/init.lua
@@ -1,0 +1,1 @@
+return require("jobs.basic")

--- a/scripts/planets/init.lua
+++ b/scripts/planets/init.lua
@@ -1,0 +1,1 @@
+return require("planets.types")

--- a/scripts/ships/designs.lua
+++ b/scripts/ships/designs.lua
@@ -1,53 +1,64 @@
+local hulls = require("ships.hulls")
+local modules = require("ships.modules")
+
 -- Default designs matching current ShipType functionality
-define_ship_design {
+local explorer_mk1 = define_ship_design {
     id = "explorer_mk1",
     name = "Explorer Mk.I",
-    hull = "corvette",
+    hull = hulls.corvette,
     modules = {
-        { slot_type = "engine", module = "ftl_drive" },
-        { slot_type = "utility", module = "survey_equipment" },
+        { slot_type = "engine", module = modules.ftl_drive },
+        { slot_type = "utility", module = modules.survey_equipment },
     },
 }
 
-define_ship_design {
+local colony_ship_mk1 = define_ship_design {
     id = "colony_ship_mk1",
     name = "Colony Ship Mk.I",
-    hull = "frigate",
+    hull = hulls.frigate,
     modules = {
-        { slot_type = "engine", module = "ftl_drive" },
-        { slot_type = "special", module = "colony_module" },
+        { slot_type = "engine", module = modules.ftl_drive },
+        { slot_type = "special", module = modules.colony_module },
     },
 }
 
-define_ship_design {
+local courier_mk1 = define_ship_design {
     id = "courier_mk1",
     name = "Courier Mk.I",
-    hull = "courier_hull",
+    hull = hulls.courier_hull,
     modules = {
-        { slot_type = "engine", module = "ftl_drive" },
-        { slot_type = "engine", module = "ftl_drive" },
-        { slot_type = "utility", module = "cargo_bay" },
+        { slot_type = "engine", module = modules.ftl_drive },
+        { slot_type = "engine", module = modules.ftl_drive },
+        { slot_type = "utility", module = modules.cargo_bay },
     },
 }
 
-define_ship_design {
+local scout_mk1 = define_ship_design {
     id = "scout_mk1",
     name = "Scout Mk.I",
-    hull = "scout_hull",
+    hull = hulls.scout_hull,
     modules = {
-        { slot_type = "engine", module = "ftl_drive" },
-        { slot_type = "utility", module = "survey_equipment" },
+        { slot_type = "engine", module = modules.ftl_drive },
+        { slot_type = "utility", module = modules.survey_equipment },
     },
 }
 
-define_ship_design {
+local patrol_corvette = define_ship_design {
     id = "patrol_corvette",
     name = "Patrol Corvette",
-    hull = "corvette",
+    hull = hulls.corvette,
     modules = {
-        { slot_type = "weapon", module = "weapon_laser" },
-        { slot_type = "weapon", module = "weapon_laser" },
-        { slot_type = "engine", module = "ftl_drive" },
-        { slot_type = "utility", module = "armor_plating" },
+        { slot_type = "weapon", module = modules.weapon_laser },
+        { slot_type = "weapon", module = modules.weapon_laser },
+        { slot_type = "engine", module = modules.ftl_drive },
+        { slot_type = "utility", module = modules.armor_plating },
     },
+}
+
+return {
+    explorer_mk1 = explorer_mk1,
+    colony_ship_mk1 = colony_ship_mk1,
+    courier_mk1 = courier_mk1,
+    scout_mk1 = scout_mk1,
+    patrol_corvette = patrol_corvette,
 }

--- a/scripts/ships/hulls.lua
+++ b/scripts/ships/hulls.lua
@@ -1,63 +1,65 @@
-define_hull {
+local slot_types = require("ships.slot_types")
+
+local corvette = define_hull {
     id = "corvette",
     name = "Corvette",
     base_hp = 50,
     base_speed = 0.75,
     base_evasion = 30.0,
     slots = {
-        { type = "weapon", count = 2 },
-        { type = "utility", count = 1 },
-        { type = "engine", count = 1 },
+        { type = slot_types.weapon, count = 2 },
+        { type = slot_types.utility, count = 1 },
+        { type = slot_types.engine, count = 1 },
     },
     build_cost = { minerals = 200, energy = 100 },
     build_time = 60,
     maintenance = 0.5,
 }
 
-define_hull {
+local frigate = define_hull {
     id = "frigate",
     name = "Frigate",
     base_hp = 120,
     base_speed = 0.5,
     base_evasion = 15.0,
     slots = {
-        { type = "weapon", count = 3 },
-        { type = "utility", count = 2 },
-        { type = "engine", count = 1 },
-        { type = "special", count = 1 },
+        { type = slot_types.weapon, count = 3 },
+        { type = slot_types.utility, count = 2 },
+        { type = slot_types.engine, count = 1 },
+        { type = slot_types.special, count = 1 },
     },
     build_cost = { minerals = 400, energy = 200 },
     build_time = 120,
     maintenance = 1.0,
 }
 
-define_hull {
+local cruiser = define_hull {
     id = "cruiser",
     name = "Cruiser",
     base_hp = 250,
     base_speed = 0.35,
     base_evasion = 5.0,
     slots = {
-        { type = "weapon", count = 4 },
-        { type = "utility", count = 3 },
-        { type = "engine", count = 2 },
-        { type = "special", count = 2 },
+        { type = slot_types.weapon, count = 4 },
+        { type = slot_types.utility, count = 3 },
+        { type = slot_types.engine, count = 2 },
+        { type = slot_types.special, count = 2 },
     },
     build_cost = { minerals = 800, energy = 400 },
     build_time = 240,
     maintenance = 2.0,
 }
 
-define_hull {
+local scout_hull = define_hull {
     id = "scout_hull",
     name = "Scout Hull",
     base_hp = 40,
     base_speed = 0.85,
     base_evasion = 35.0,
     slots = {
-        { type = "utility", count = 2 },
-        { type = "engine", count = 1 },
-        { type = "weapon", count = 1 },
+        { type = slot_types.utility, count = 2 },
+        { type = slot_types.engine, count = 1 },
+        { type = slot_types.weapon, count = 1 },
     },
     build_cost = { minerals = 150, energy = 80 },
     build_time = 45,
@@ -68,15 +70,15 @@ define_hull {
     },
 }
 
-define_hull {
+local courier_hull = define_hull {
     id = "courier_hull",
     name = "Courier Hull",
     base_hp = 35,
     base_speed = 0.80,
     base_evasion = 25.0,
     slots = {
-        { type = "utility", count = 2 },
-        { type = "engine", count = 2 },
+        { type = slot_types.utility, count = 2 },
+        { type = slot_types.engine, count = 2 },
     },
     build_cost = { minerals = 100, energy = 50 },
     build_time = 30,
@@ -85,4 +87,12 @@ define_hull {
         { target = "ship.cargo_capacity", base_add = 0.0, multiplier = 1.5, add = 0.0 },
         { target = "ship.ftl_range", base_add = 0.0, multiplier = 1.2, add = 0.0 },
     },
+}
+
+return {
+    corvette = corvette,
+    frigate = frigate,
+    cruiser = cruiser,
+    scout_hull = scout_hull,
+    courier_hull = courier_hull,
 }

--- a/scripts/ships/init.lua
+++ b/scripts/ships/init.lua
@@ -1,0 +1,11 @@
+local slot_types = require("ships.slot_types")
+local hulls = require("ships.hulls")
+local modules = require("ships.modules")
+local designs = require("ships.designs")
+
+return {
+    slot_types = slot_types,
+    hulls = hulls,
+    modules = modules,
+    designs = designs,
+}

--- a/scripts/ships/modules.lua
+++ b/scripts/ships/modules.lua
@@ -1,18 +1,21 @@
+local slot_types = require("ships.slot_types")
+local tech = require("tech")
+
 -- Engine modules
-define_module {
+local ftl_drive = define_module {
     id = "ftl_drive",
     name = "FTL Drive",
-    slot_type = "engine",
+    slot_type = slot_types.engine,
     modifiers = {
         { target = "ship.ftl_range", base_add = 15.0 },
     },
     cost = { minerals = 100, energy = 50 },
 }
 
-define_module {
+local afterburner = define_module {
     id = "afterburner",
     name = "Afterburner",
-    slot_type = "engine",
+    slot_type = slot_types.engine,
     modifiers = {
         { target = "ship.speed", multiplier = 0.2 },
     },
@@ -20,10 +23,11 @@ define_module {
 }
 
 -- Weapon modules
-define_module {
+local weapon_laser = define_module {
     id = "weapon_laser",
     name = "Laser Battery",
-    slot_type = "weapon",
+    slot_type = slot_types.weapon,
+    prerequisite_tech = tech.military.kinetic_weapons,
     weapon = {
         track = 5.0, precision = 0.85, cooldown = 1, range = 10.0,
         shield_damage = 4.0, shield_damage_div = 1.0, shield_piercing = 0.0,
@@ -33,10 +37,11 @@ define_module {
     cost = { minerals = 50, energy = 30 },
 }
 
-define_module {
+local weapon_railgun = define_module {
     id = "weapon_railgun",
     name = "Railgun",
-    slot_type = "weapon",
+    slot_type = slot_types.weapon,
+    prerequisite_tech = tech.military.kinetic_weapons,
     weapon = {
         track = 2.0, precision = 0.90, cooldown = 3, range = 20.0,
         shield_damage = 1.0, shield_damage_div = 0.5, shield_piercing = 0.5,
@@ -46,10 +51,11 @@ define_module {
     cost = { minerals = 100, energy = 50 },
 }
 
-define_module {
+local weapon_missile = define_module {
     id = "weapon_missile",
     name = "Missile Launcher",
-    slot_type = "weapon",
+    slot_type = slot_types.weapon,
+    prerequisite_tech = tech.military.kinetic_weapons,
     weapon = {
         track = 8.0, precision = 0.70, cooldown = 2, range = 15.0,
         shield_damage = 1.0, shield_damage_div = 0.5, shield_piercing = 0.8,
@@ -60,10 +66,10 @@ define_module {
 }
 
 -- Utility modules
-define_module {
+local armor_plating = define_module {
     id = "armor_plating",
     name = "Armor Plating",
-    slot_type = "utility",
+    slot_type = slot_types.utility,
     modifiers = {
         { target = "ship.armor_max", base_add = 30.0 },
         { target = "ship.speed", multiplier = -0.05 },
@@ -71,10 +77,11 @@ define_module {
     cost = { minerals = 80 },
 }
 
-define_module {
+local shield_generator = define_module {
     id = "shield_generator",
     name = "Shield Generator",
-    slot_type = "utility",
+    slot_type = slot_types.utility,
+    prerequisite_tech = tech.military.deflector_shields,
     modifiers = {
         { target = "ship.shield_max", base_add = 40.0 },
         { target = "ship.shield_regen", base_add = 2.0 },
@@ -82,20 +89,20 @@ define_module {
     cost = { minerals = 60, energy = 50 },
 }
 
-define_module {
+local survey_equipment = define_module {
     id = "survey_equipment",
     name = "Survey Equipment",
-    slot_type = "utility",
+    slot_type = slot_types.utility,
     modifiers = {
         { target = "ship.survey_speed", base_add = 1.0 },
     },
     cost = { minerals = 60, energy = 40 },
 }
 
-define_module {
+local cargo_bay = define_module {
     id = "cargo_bay",
     name = "Cargo Bay",
-    slot_type = "utility",
+    slot_type = slot_types.utility,
     modifiers = {
         { target = "ship.cargo_capacity", base_add = 500.0 },
     },
@@ -103,23 +110,37 @@ define_module {
 }
 
 -- Special modules
-define_module {
+local colony_module = define_module {
     id = "colony_module",
     name = "Colony Module",
-    slot_type = "special",
+    slot_type = slot_types.special,
     modifiers = {
         { target = "ship.colonize_speed", base_add = 1.0 },
     },
     cost = { minerals = 300, energy = 200 },
 }
 
-define_module {
+local command_array = define_module {
     id = "command_array",
     name = "Fleet Command Array",
-    slot_type = "special",
+    slot_type = slot_types.special,
     modifiers = {
         { target = "fleet.attack", multiplier = 0.05 },
         { target = "fleet.defense", multiplier = 0.05 },
     },
     cost = { minerals = 200, energy = 100 },
+}
+
+return {
+    ftl_drive = ftl_drive,
+    afterburner = afterburner,
+    weapon_laser = weapon_laser,
+    weapon_railgun = weapon_railgun,
+    weapon_missile = weapon_missile,
+    armor_plating = armor_plating,
+    shield_generator = shield_generator,
+    survey_equipment = survey_equipment,
+    cargo_bay = cargo_bay,
+    colony_module = colony_module,
+    command_array = command_array,
 }

--- a/scripts/ships/slot_types.lua
+++ b/scripts/ships/slot_types.lua
@@ -1,4 +1,11 @@
-define_slot_type { id = "weapon", name = "Weapon Slot" }
-define_slot_type { id = "utility", name = "Utility Slot" }
-define_slot_type { id = "engine", name = "Engine Slot" }
-define_slot_type { id = "special", name = "Special Slot" }
+local weapon = define_slot_type { id = "weapon", name = "Weapon Slot" }
+local utility = define_slot_type { id = "utility", name = "Utility Slot" }
+local engine = define_slot_type { id = "engine", name = "Engine Slot" }
+local special = define_slot_type { id = "special", name = "Special Slot" }
+
+return {
+    weapon = weapon,
+    utility = utility,
+    engine = engine,
+    special = special,
+}

--- a/scripts/species/human.lua
+++ b/scripts/species/human.lua
@@ -1,4 +1,4 @@
-define_species {
+local human = define_species {
     id = "human",
     name = "Human",
     growth_rate = 0.01,
@@ -7,4 +7,8 @@ define_species {
         researcher = 0.1,
         farmer = 0.0,
     },
+}
+
+return {
+    human = human,
 }

--- a/scripts/species/init.lua
+++ b/scripts/species/init.lua
@@ -1,0 +1,1 @@
+return require("species.human")

--- a/scripts/stars/init.lua
+++ b/scripts/stars/init.lua
@@ -1,0 +1,1 @@
+return require("stars.types")

--- a/scripts/structures/definitions.lua
+++ b/scripts/structures/definitions.lua
@@ -1,7 +1,10 @@
 -- Deep Space Structure definitions
 -- Loaded by the StructureRegistry at startup.
 
-define_structure {
+-- Note: ftl_communications and ftl_interdiction_tech are forward references
+-- to techs not yet defined. Using forward_ref() to express this intent.
+
+local sensor_buoy = define_structure {
     id = "sensor_buoy",
     name = "Sensor Buoy",
     description = "Detects sublight vessel movements.",
@@ -14,7 +17,7 @@ define_structure {
     energy_drain = 100, -- millis (0.1 units per hexady)
 }
 
-define_structure {
+local ftl_comm_relay = define_structure {
     id = "ftl_comm_relay",
     name = "FTL Comm Relay",
     description = "Enables faster-than-light communication across systems.",
@@ -25,10 +28,10 @@ define_structure {
         ftl_comm = { range = 0.0 },
     },
     energy_drain = 500, -- millis (0.5 units per hexady)
-    prerequisites = has_tech("ftl_communications"),
+    prerequisites = has_tech(forward_ref("ftl_communications")),
 }
 
-define_structure {
+local interdictor = define_structure {
     id = "interdictor",
     name = "Interdictor",
     description = "Disrupts FTL travel within its interdiction range.",
@@ -39,5 +42,11 @@ define_structure {
         ftl_interdiction = { range = 5.0 },
     },
     energy_drain = 1000, -- millis (1.0 units per hexady)
-    prerequisites = has_tech("ftl_interdiction_tech"),
+    prerequisites = has_tech(forward_ref("ftl_interdiction_tech")),
+}
+
+return {
+    sensor_buoy = sensor_buoy,
+    ftl_comm_relay = ftl_comm_relay,
+    interdictor = interdictor,
 }

--- a/scripts/structures/init.lua
+++ b/scripts/structures/init.lua
@@ -1,0 +1,1 @@
+return require("structures.definitions")

--- a/scripts/tech/industrial.lua
+++ b/scripts/tech/industrial.lua
@@ -1,6 +1,6 @@
 -- Industrial branch technologies
 
-define_tech {
+local automated_mining = define_tech {
     id = "industrial_automated_mining",
     name = "Automated Mining",
     branch = "industrial",
@@ -12,38 +12,45 @@ define_tech {
     end,
 }
 
-define_tech {
+local orbital_fabrication = define_tech {
     id = "industrial_orbital_fabrication",
     name = "Orbital Fabrication",
     branch = "industrial",
     cost = 200,
-    prerequisites = { "industrial_automated_mining" },
+    prerequisites = { automated_mining },
     description = "Manufacturing facilities in orbit for zero-gravity construction",
     on_researched = function()
         -- TODO: push_empire_modifier("construction.speed", { multiplier = 0.1 })
     end,
 }
 
-define_tech {
+local fusion_power = define_tech {
     id = "industrial_fusion_power",
     name = "Fusion Power Plants",
     branch = "industrial",
     cost = 300,
-    prerequisites = { "industrial_automated_mining" },
+    prerequisites = { automated_mining },
     description = "Harness fusion reactions for abundant clean energy",
     on_researched = function()
         -- TODO: push_empire_modifier("production.energy", { multiplier = 0.2 })
     end,
 }
 
-define_tech {
+local nano_assembly = define_tech {
     id = "industrial_nano_assembly",
     name = "Nano-Assembly",
     branch = "industrial",
     cost = 500,
-    prerequisites = { "industrial_orbital_fabrication" },
+    prerequisites = { orbital_fabrication },
     description = "Molecular-scale construction for unprecedented precision",
     on_researched = function()
         -- TODO: push_empire_modifier("construction.speed", { multiplier = 0.2 })
     end,
+}
+
+return {
+    automated_mining = automated_mining,
+    orbital_fabrication = orbital_fabrication,
+    fusion_power = fusion_power,
+    nano_assembly = nano_assembly,
 }

--- a/scripts/tech/init.lua
+++ b/scripts/tech/init.lua
@@ -1,0 +1,11 @@
+local industrial = require("tech.industrial")
+local military = require("tech.military")
+local physics = require("tech.physics")
+local social = require("tech.social")
+
+return {
+    industrial = industrial,
+    military = military,
+    physics = physics,
+    social = social,
+}

--- a/scripts/tech/military.lua
+++ b/scripts/tech/military.lua
@@ -1,6 +1,6 @@
 -- Military branch technologies
 
-define_tech {
+local kinetic_weapons = define_tech {
     id = "military_kinetic_weapons",
     name = "Kinetic Weapons",
     branch = "military",
@@ -12,7 +12,7 @@ define_tech {
     end,
 }
 
-define_tech {
+local deflector_shields = define_tech {
     id = "military_deflector_shields",
     name = "Deflector Shields",
     branch = "military",
@@ -24,14 +24,20 @@ define_tech {
     end,
 }
 
-define_tech {
+local composite_armor = define_tech {
     id = "military_composite_armor",
     name = "Composite Armor",
     branch = "military",
     cost = 250,
-    prerequisites = { "military_kinetic_weapons" },
+    prerequisites = { kinetic_weapons },
     description = "Multi-layered hull plating for enhanced protection",
     on_researched = function()
         -- TODO: push_empire_modifier("combat.armor", { multiplier = 0.2 })
     end,
+}
+
+return {
+    kinetic_weapons = kinetic_weapons,
+    deflector_shields = deflector_shields,
+    composite_armor = composite_armor,
 }

--- a/scripts/tech/physics.lua
+++ b/scripts/tech/physics.lua
@@ -1,6 +1,6 @@
 -- Physics branch technologies
 
-define_tech {
+local sensor_arrays = define_tech {
     id = "physics_sensor_arrays",
     name = "Advanced Sensor Arrays",
     branch = "physics",
@@ -12,7 +12,7 @@ define_tech {
     end,
 }
 
-define_tech {
+local sublight_drives = define_tech {
     id = "physics_sublight_drives",
     name = "Improved Sublight Drives",
     branch = "physics",
@@ -24,26 +24,33 @@ define_tech {
     end,
 }
 
-define_tech {
+local ftl_theory = define_tech {
     id = "physics_ftl_theory",
     name = "FTL Theory",
     branch = "physics",
     cost = 400,
-    prerequisites = { "physics_sublight_drives" },
+    prerequisites = { sublight_drives },
     description = "Theoretical foundations for faster-than-light travel",
     on_researched = function()
         -- TODO: push_empire_modifier("ship.ftl_range", { add = 0.2 })
     end,
 }
 
-define_tech {
+local warp_stabilisation = define_tech {
     id = "physics_warp_stabilisation",
     name = "Warp Field Stabilisation",
     branch = "physics",
     cost = 600,
-    prerequisites = { "physics_ftl_theory" },
+    prerequisites = { ftl_theory },
     description = "Stabilise warp fields for safer FTL travel",
     on_researched = function()
         -- TODO: push_empire_modifier("ship.ftl_speed", { multiplier = 0.15 })
     end,
+}
+
+return {
+    sensor_arrays = sensor_arrays,
+    sublight_drives = sublight_drives,
+    ftl_theory = ftl_theory,
+    warp_stabilisation = warp_stabilisation,
 }

--- a/scripts/tech/social.lua
+++ b/scripts/tech/social.lua
@@ -1,6 +1,6 @@
 -- Social branch technologies
 
-define_tech {
+local xenolinguistics = define_tech {
     id = "social_xenolinguistics",
     name = "Xenolinguistics",
     branch = "social",
@@ -12,7 +12,7 @@ define_tech {
     end,
 }
 
-define_tech {
+local colonial_admin = define_tech {
     id = "social_colonial_admin",
     name = "Colonial Administration",
     branch = "social",
@@ -24,26 +24,33 @@ define_tech {
     end,
 }
 
-define_tech {
+local interstellar_commerce = define_tech {
     id = "social_interstellar_commerce",
     name = "Interstellar Commerce",
     branch = "social",
     cost = 250,
-    prerequisites = { "social_colonial_admin" },
+    prerequisites = { colonial_admin },
     description = "Trade frameworks spanning star systems",
     on_researched = function()
         -- TODO: push_empire_modifier("production.energy", { multiplier = 0.15 })
     end,
 }
 
-define_tech {
+local cultural_exchange = define_tech {
     id = "social_cultural_exchange",
     name = "Cultural Exchange Protocols",
     branch = "social",
     cost = 300,
-    prerequisites = { "social_xenolinguistics" },
+    prerequisites = { xenolinguistics },
     description = "Formalised frameworks for cross-species cultural interaction",
     on_researched = function()
         -- TODO: push_empire_modifier("diplomacy.range", { add = 0.2 })
     end,
+}
+
+return {
+    xenolinguistics = xenolinguistics,
+    colonial_admin = colonial_admin,
+    interstellar_commerce = interstellar_commerce,
+    cultural_exchange = cultural_exchange,
 }

--- a/src/colony/mod.rs
+++ b/src/colony/mod.rs
@@ -1,7 +1,5 @@
 use bevy::prelude::*;
 
-use std::path::Path;
-
 use crate::amount::{Amt, SignedAmt};
 use crate::components::Position;
 use crate::events::{GameEvent, GameEventKind};
@@ -25,7 +23,7 @@ impl Plugin for ColonyPlugin {
             .add_systems(
                 Startup,
                 (
-                    load_building_registry.after(crate::scripting::init_scripting),
+                    load_building_registry.after(crate::scripting::load_all_scripts),
                     spawn_capital_colony.after(crate::galaxy::generate_galaxy),
                 ),
             )
@@ -517,33 +515,23 @@ pub struct PendingColonizationOrder {
     pub source_colony: Entity,
 }
 
-/// Load building definitions from Lua scripts into the BuildingRegistry.
-/// Falls back to an empty registry if scripts are missing or fail to parse.
+/// Parse building definitions from Lua accumulators into the BuildingRegistry.
+/// Scripts are loaded by `load_all_scripts`; this system only parses the results.
 pub fn load_building_registry(
     engine: Res<crate::scripting::ScriptEngine>,
     mut registry: ResMut<BuildingRegistry>,
 ) {
-    let building_dir = Path::new("scripts/buildings");
-    if building_dir.exists() {
-        match engine.load_directory(building_dir) {
-            Err(e) => {
-                warn!("Failed to load building scripts: {e}; building registry will be empty");
+    match parse_building_definitions(engine.lua()) {
+        Ok(defs) => {
+            let count = defs.len();
+            for def in defs {
+                registry.insert(def);
             }
-            Ok(()) => match parse_building_definitions(engine.lua()) {
-                Ok(defs) => {
-                    let count = defs.len();
-                    for def in defs {
-                        registry.insert(def);
-                    }
-                    info!("Building registry loaded with {} definitions", count);
-                }
-                Err(e) => {
-                    warn!("Failed to parse building definitions: {e}; building registry will be empty");
-                }
-            },
+            info!("Building registry loaded with {} definitions", count);
         }
-    } else {
-        info!("scripts/buildings directory not found; building registry will be empty");
+        Err(e) => {
+            warn!("Failed to parse building definitions: {e}; building registry will be empty");
+        }
     }
 }
 

--- a/src/deep_space/mod.rs
+++ b/src/deep_space/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::Path;
 
 use bevy::prelude::*;
 
@@ -138,55 +137,36 @@ impl Plugin for DeepSpacePlugin {
         app.init_resource::<StructureRegistry>()
             .add_systems(
                 Startup,
-                load_structure_definitions.after(crate::scripting::init_scripting),
+                load_structure_definitions.after(crate::scripting::load_all_scripts),
             );
     }
 }
 
-/// Startup system that loads structure definitions from Lua scripts, falling back
-/// to hardcoded defaults if the scripts directory is missing.
+/// Parse structure definitions from Lua accumulators, falling back to defaults.
+/// Scripts are loaded by `load_all_scripts`; this system only parses the results.
 pub fn load_structure_definitions(
     engine: Res<crate::scripting::ScriptEngine>,
     mut registry: ResMut<StructureRegistry>,
 ) {
-    let structure_dir = Path::new("scripts/structures");
-    if structure_dir.exists() {
-        match engine.load_directory(structure_dir) {
-            Err(e) => {
-                warn!("Failed to load structure scripts: {e}; using default definitions");
-                for def in default_structure_definitions() {
-                    registry.insert(def);
-                }
+    match crate::scripting::structure_api::parse_structure_definitions(engine.lua()) {
+        Ok(defs) if !defs.is_empty() => {
+            let count = defs.len();
+            for def in defs {
+                registry.insert(def);
             }
-            Ok(()) => match crate::scripting::structure_api::parse_structure_definitions(
-                engine.lua(),
-            ) {
-                Ok(defs) => {
-                    if defs.is_empty() {
-                        info!("No structure definitions found in scripts; using defaults");
-                        for def in default_structure_definitions() {
-                            registry.insert(def);
-                        }
-                    } else {
-                        let count = defs.len();
-                        for def in defs {
-                            registry.insert(def);
-                        }
-                        info!("Structure registry loaded with {} definitions", count);
-                    }
-                }
-                Err(e) => {
-                    warn!("Failed to parse structure definitions: {e}; using defaults");
-                    for def in default_structure_definitions() {
-                        registry.insert(def);
-                    }
-                }
-            },
+            info!("Structure registry loaded with {} definitions", count);
         }
-    } else {
-        info!("scripts/structures directory not found; using default structure definitions");
-        for def in default_structure_definitions() {
-            registry.insert(def);
+        Ok(_) => {
+            info!("No structure definitions found in scripts; using defaults");
+            for def in default_structure_definitions() {
+                registry.insert(def);
+            }
+        }
+        Err(e) => {
+            warn!("Failed to parse structure definitions: {e}; using defaults");
+            for def in default_structure_definitions() {
+                registry.insert(def);
+            }
         }
     }
 }

--- a/src/event_system.rs
+++ b/src/event_system.rs
@@ -664,7 +664,7 @@ mod tests {
     #[test]
     fn test_event_bus_fire_calls_handler() {
         let lua = Lua::new();
-        crate::scripting::ScriptEngine::setup_globals(&lua).unwrap();
+        crate::scripting::ScriptEngine::setup_globals(&lua, &crate::scripting::resolve_scripts_dir()).unwrap();
 
         // Register a handler via on() and fire an event
         lua.load(
@@ -693,7 +693,7 @@ mod tests {
     #[test]
     fn test_event_bus_filter_match() {
         let lua = Lua::new();
-        crate::scripting::ScriptEngine::setup_globals(&lua).unwrap();
+        crate::scripting::ScriptEngine::setup_globals(&lua, &crate::scripting::resolve_scripts_dir()).unwrap();
 
         lua.load(
             r#"
@@ -728,7 +728,7 @@ mod tests {
     #[test]
     fn test_event_bus_no_filter_matches_all() {
         let lua = Lua::new();
-        crate::scripting::ScriptEngine::setup_globals(&lua).unwrap();
+        crate::scripting::ScriptEngine::setup_globals(&lua, &crate::scripting::resolve_scripts_dir()).unwrap();
 
         lua.load(
             r#"
@@ -754,7 +754,7 @@ mod tests {
     #[test]
     fn test_event_bus_wrong_event_id_not_called() {
         let lua = Lua::new();
-        crate::scripting::ScriptEngine::setup_globals(&lua).unwrap();
+        crate::scripting::ScriptEngine::setup_globals(&lua, &crate::scripting::resolve_scripts_dir()).unwrap();
 
         lua.load(
             r#"

--- a/src/galaxy/mod.rs
+++ b/src/galaxy/mod.rs
@@ -26,7 +26,7 @@ impl Plugin for GalaxyPlugin {
             .init_resource::<PlanetTypeRegistry>()
             .add_systems(
                 Startup,
-                load_galaxy_types.after(crate::scripting::init_scripting),
+                load_galaxy_types.after(crate::scripting::load_all_scripts),
             )
             .add_systems(Startup, generate_galaxy.after(load_galaxy_types));
     }
@@ -344,19 +344,13 @@ fn default_planet_types() -> Vec<PlanetTypeDefinition> {
     }]
 }
 
-/// Startup system that loads star and planet type definitions from Lua scripts.
+/// Startup system that parses star and planet type definitions from Lua accumulators.
+/// Scripts are loaded by `load_all_scripts`; this system only parses the results.
 pub fn load_galaxy_types(
     engine: Res<crate::scripting::ScriptEngine>,
     mut star_registry: ResMut<StarTypeRegistry>,
     mut planet_registry: ResMut<PlanetTypeRegistry>,
 ) {
-    // Load star types
-    let star_dir = Path::new("scripts/stars");
-    if star_dir.exists() {
-        if let Err(e) = engine.load_directory(star_dir) {
-            warn!("Failed to load star type scripts: {e}");
-        }
-    }
     match crate::scripting::galaxy_api::parse_star_types(engine.lua()) {
         Ok(types) => {
             info!("Loaded {} star type definitions", types.len());
@@ -367,13 +361,6 @@ pub fn load_galaxy_types(
         }
     }
 
-    // Load planet types
-    let planet_dir = Path::new("scripts/planets");
-    if planet_dir.exists() {
-        if let Err(e) = engine.load_directory(planet_dir) {
-            warn!("Failed to load planet type scripts: {e}");
-        }
-    }
     match crate::scripting::galaxy_api::parse_planet_types(engine.lua()) {
         Ok(types) => {
             info!("Loaded {} planet type definitions", types.len());

--- a/src/scripting/lifecycle.rs
+++ b/src/scripting/lifecycle.rs
@@ -31,19 +31,11 @@ fn run_handlers(lua: &Lua, table_name: &str) -> Result<(), mlua::Error> {
 }
 
 /// Startup system that runs lifecycle hooks after all scripts have been loaded.
+/// Scripts are loaded by `load_all_scripts`; this system only executes callbacks.
 /// Runs on_scripts_loaded and on_game_start hooks (on_game_load is reserved for
 /// save/load which is not yet implemented).
 pub fn run_lifecycle_hooks(engine: Res<ScriptEngine>) {
     let lua = engine.lua();
-
-    // Load lifecycle scripts
-    let lifecycle_dir = std::path::Path::new("scripts/lifecycle");
-    if lifecycle_dir.exists() {
-        match engine.load_directory(lifecycle_dir) {
-            Ok(()) => info!("Lifecycle scripts loaded"),
-            Err(e) => warn!("Failed to load lifecycle scripts: {e}"),
-        }
-    }
 
     // Run on_scripts_loaded hooks
     match run_on_scripts_loaded(lua) {

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -10,7 +10,7 @@ pub mod structure_api;
 
 use bevy::prelude::*;
 use mlua::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub struct ScriptingPlugin;
 
@@ -52,67 +52,103 @@ pub fn init_scripting(mut commands: Commands) {
 /// falling back to loading individual directories for backward compatibility.
 /// Other startup systems that parse definitions should use `.after(load_all_scripts)`.
 pub fn load_all_scripts(engine: Res<ScriptEngine>) {
-    let init_path = Path::new("scripts/init.lua");
+    let scripts_dir = engine.scripts_dir();
+    let init_path = scripts_dir.join("init.lua");
     if init_path.exists() {
-        match engine.load_file(init_path) {
+        match engine.load_file(&init_path) {
             Ok(()) => {
-                info!("All scripts loaded via scripts/init.lua");
+                info!("All scripts loaded via {}", init_path.display());
                 return;
             }
             Err(e) => {
-                warn!("Failed to load scripts/init.lua: {e}; falling back to directory loading");
+                warn!("Failed to load {}: {e}; falling back to directory loading", init_path.display());
             }
         }
     }
 
     // Fallback: load directories individually (legacy path, used when init.lua is absent)
-    let dirs = [
-        "scripts/stars",
-        "scripts/planets",
-        "scripts/jobs",
-        "scripts/species",
-        "scripts/buildings",
-        "scripts/tech",
-        "scripts/ships",
-        "scripts/structures",
-        "scripts/events",
+    let subdirs = [
+        "stars", "planets", "jobs", "species", "buildings",
+        "tech", "ships", "structures", "events",
     ];
-    for dir in &dirs {
-        let path = Path::new(dir);
-        if let Err(e) = engine.load_directory(path) {
-            warn!("Failed to load scripts from {dir}: {e}");
+    for subdir in &subdirs {
+        let path = scripts_dir.join(subdir);
+        if path.is_dir() {
+            if let Err(e) = engine.load_directory(&path) {
+                warn!("Failed to load scripts from {}: {e}", path.display());
+            }
         }
     }
+}
+
+/// Resolve the scripts directory by searching multiple locations.
+/// Priority: 1) next to executable, 2) CWD, 3) CARGO_MANIFEST_DIR (dev)
+pub fn resolve_scripts_dir() -> PathBuf {
+    // 1. Next to the executable
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            let candidate = exe_dir.join("scripts");
+            if candidate.is_dir() {
+                return candidate;
+            }
+        }
+    }
+
+    // 2. CWD
+    let cwd = PathBuf::from("scripts");
+    if cwd.is_dir() {
+        return cwd;
+    }
+
+    // 3. CARGO_MANIFEST_DIR (development)
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let candidate = PathBuf::from(manifest_dir).join("scripts");
+        if candidate.is_dir() {
+            return candidate;
+        }
+    }
+
+    // Fallback to CWD-relative (will fail gracefully later)
+    PathBuf::from("scripts")
 }
 
 #[derive(Resource)]
 pub struct ScriptEngine {
     lua: Lua,
+    scripts_dir: PathBuf,
 }
 
 impl ScriptEngine {
     pub fn new() -> Result<Self, mlua::Error> {
+        let scripts_dir = resolve_scripts_dir();
         // Sandbox: only load safe libraries (no io, os, debug, ffi)
         let lua = Lua::new_with(
             LuaStdLib::TABLE | LuaStdLib::STRING | LuaStdLib::MATH
                 | LuaStdLib::PACKAGE | LuaStdLib::BIT,
             mlua::LuaOptions::default(),
         )?;
-        Self::setup_globals(&lua)?;
-        Ok(Self { lua })
+        Self::setup_globals(&lua, &scripts_dir)?;
+        info!("Lua scripts directory: {}", scripts_dir.display());
+        Ok(Self { lua, scripts_dir })
+    }
+
+    /// The resolved scripts directory path.
+    pub fn scripts_dir(&self) -> &Path {
+        &self.scripts_dir
     }
 
     /// Configure global tables and functions available to all Lua scripts.
-    pub fn setup_globals(lua: &Lua) -> Result<(), mlua::Error> {
+    pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
         let globals = lua.globals();
 
         // --- Sandbox: disable dangerous globals ---
         globals.set("loadfile", mlua::Value::Nil)?;
         globals.set("dofile", mlua::Value::Nil)?;
 
-        // --- Set up require() search path ---
+        // --- Set up require() search path using resolved absolute path ---
         let package: mlua::Table = globals.get("package")?;
-        package.set("path", "scripts/?.lua;scripts/?/init.lua")?;
+        let dir = scripts_dir.display();
+        package.set("path", format!("{dir}/?.lua;{dir}/?/init.lua"))?;
         package.set("cpath", "")?; // disable C module loading
 
         // Create the macrocosmo namespace table

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -19,8 +19,12 @@ impl Plugin for ScriptingPlugin {
         app.add_systems(Startup, init_scripting)
             .add_systems(
                 Startup,
+                load_all_scripts.after(init_scripting),
+            )
+            .add_systems(
+                Startup,
                 lifecycle::run_lifecycle_hooks
-                    .after(init_scripting)
+                    .after(load_all_scripts)
                     .after(crate::colony::load_building_registry)
                     .after(crate::technology::load_technologies),
             )
@@ -44,6 +48,43 @@ pub fn init_scripting(mut commands: Commands) {
     commands.insert_resource(engine);
 }
 
+/// Startup system that loads all Lua scripts via `scripts/init.lua` (if it exists),
+/// falling back to loading individual directories for backward compatibility.
+/// Other startup systems that parse definitions should use `.after(load_all_scripts)`.
+pub fn load_all_scripts(engine: Res<ScriptEngine>) {
+    let init_path = Path::new("scripts/init.lua");
+    if init_path.exists() {
+        match engine.load_file(init_path) {
+            Ok(()) => {
+                info!("All scripts loaded via scripts/init.lua");
+                return;
+            }
+            Err(e) => {
+                warn!("Failed to load scripts/init.lua: {e}; falling back to directory loading");
+            }
+        }
+    }
+
+    // Fallback: load directories individually (legacy path, used when init.lua is absent)
+    let dirs = [
+        "scripts/stars",
+        "scripts/planets",
+        "scripts/jobs",
+        "scripts/species",
+        "scripts/buildings",
+        "scripts/tech",
+        "scripts/ships",
+        "scripts/structures",
+        "scripts/events",
+    ];
+    for dir in &dirs {
+        let path = Path::new(dir);
+        if let Err(e) = engine.load_directory(path) {
+            warn!("Failed to load scripts from {dir}: {e}");
+        }
+    }
+}
+
 #[derive(Resource)]
 pub struct ScriptEngine {
     lua: Lua,
@@ -60,61 +101,52 @@ impl ScriptEngine {
     pub fn setup_globals(lua: &Lua) -> Result<(), mlua::Error> {
         let globals = lua.globals();
 
+        // --- Set up require() search path ---
+        let package: mlua::Table = globals.get("package")?;
+        package.set("path", "scripts/?.lua;scripts/?/init.lua")?;
+        package.set("cpath", "")?; // disable C module loading
+
         // Create the macrocosmo namespace table
         let mc = lua.create_table()?;
         globals.set("macrocosmo", mc)?;
 
-        // Accumulator table for tech definitions
-        let tech_defs = lua.create_table()?;
-        globals.set("_tech_definitions", tech_defs)?;
-
-        // define_tech(table) -- appends a tech definition table to _tech_definitions
-        let define_tech = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_tech_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
+        // forward_ref(id) -- creates a placeholder reference for not-yet-defined items
+        let forward_ref = lua.create_function(|lua, id: String| {
+            let t = lua.create_table()?;
+            t.set("_def_type", "forward_ref")?;
+            t.set("id", id)?;
+            Ok(t)
         })?;
-        globals.set("define_tech", define_tech)?;
+        globals.set("forward_ref", forward_ref)?;
 
-        // Accumulator table for building definitions
-        let building_defs = lua.create_table()?;
-        globals.set("_building_definitions", building_defs)?;
+        // --- Define accumulator tables and define_xxx functions ---
+        // Each define_xxx appends to its accumulator AND returns the table
+        // with a _def_type tag, enabling return-value based references.
 
-        // define_building(table) -- appends a building definition table to _building_definitions
-        let define_building = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_building_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_building", define_building)?;
+        Self::register_define_fn(lua, "tech", "_tech_definitions")?;
+        Self::register_define_fn(lua, "building", "_building_definitions")?;
+        Self::register_define_fn(lua, "star_type", "_star_type_definitions")?;
+        Self::register_define_fn(lua, "planet_type", "_planet_type_definitions")?;
 
-        // Accumulator table for star type definitions
-        let star_type_defs = lua.create_table()?;
-        globals.set("_star_type_definitions", star_type_defs)?;
+        // --- Species and job definition Lua bindings ---
 
-        // define_star_type(table) -- appends a star type definition table
-        let define_star_type = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_star_type_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_star_type", define_star_type)?;
+        Self::register_define_fn(lua, "species", "_species_definitions")?;
+        Self::register_define_fn(lua, "job", "_job_definitions")?;
 
-        // Accumulator table for planet type definitions
-        let planet_type_defs = lua.create_table()?;
-        globals.set("_planet_type_definitions", planet_type_defs)?;
+        // --- Event definition ---
 
-        // define_planet_type(table) -- appends a planet type definition table
-        let define_planet_type = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_planet_type_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_planet_type", define_planet_type)?;
+        Self::register_define_fn(lua, "event", "_event_definitions")?;
+
+        // --- Ship design Lua bindings ---
+
+        Self::register_define_fn(lua, "slot_type", "_slot_type_definitions")?;
+        Self::register_define_fn(lua, "hull", "_hull_definitions")?;
+        Self::register_define_fn(lua, "module", "_module_definitions")?;
+        Self::register_define_fn(lua, "ship_design", "_ship_design_definitions")?;
+
+        // --- Structure definition ---
+
+        Self::register_define_fn(lua, "structure", "_structure_definitions")?;
 
         // --- #45: Global param / flag Lua bindings ---
 
@@ -160,34 +192,6 @@ impl ScriptEngine {
             Ok(result)
         })?;
         globals.set("check_flag", check_flag)?;
-
-        // --- Species and job definition Lua bindings ---
-
-        // Accumulator table for species definitions
-        let species_defs = lua.create_table()?;
-        globals.set("_species_definitions", species_defs)?;
-
-        // define_species(table) -- appends a species definition table to _species_definitions
-        let define_species = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_species_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_species", define_species)?;
-
-        // Accumulator table for job definitions
-        let job_defs = lua.create_table()?;
-        globals.set("_job_definitions", job_defs)?;
-
-        // define_job(table) -- appends a job definition table to _job_definitions
-        let define_job = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_job_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_job", define_job)?;
 
         // --- EventBus handler registration ---
 
@@ -252,106 +256,31 @@ impl ScriptEngine {
         })?;
         globals.set("on", on_fn)?;
 
-        // --- Event system Lua bindings ---
-
-        // Accumulator table for event definitions
-        let event_defs = lua.create_table()?;
-        globals.set("_event_definitions", event_defs)?;
-
-        // define_event(table) -- appends an event definition table to _event_definitions
-        let define_event = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_event_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_event", define_event)?;
-
-        // --- Ship design Lua bindings ---
-
-        // Accumulator table for slot type definitions
-        let slot_type_defs = lua.create_table()?;
-        globals.set("_slot_type_definitions", slot_type_defs)?;
-
-        let define_slot_type = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_slot_type_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_slot_type", define_slot_type)?;
-
-        // Accumulator table for hull definitions
-        let hull_defs = lua.create_table()?;
-        globals.set("_hull_definitions", hull_defs)?;
-
-        let define_hull = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_hull_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_hull", define_hull)?;
-
-        // Accumulator table for module definitions
-        let module_defs = lua.create_table()?;
-        globals.set("_module_definitions", module_defs)?;
-
-        let define_module = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_module_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_module", define_module)?;
-
-        // Accumulator table for ship design definitions
-        let ship_design_defs = lua.create_table()?;
-        globals.set("_ship_design_definitions", ship_design_defs)?;
-
-        let define_ship_design = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_ship_design_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_ship_design", define_ship_design)?;
-
-        // Accumulator table for structure definitions
-        let structure_defs = lua.create_table()?;
-        globals.set("_structure_definitions", structure_defs)?;
-
-        let define_structure = lua.create_function(|lua, table: mlua::Table| {
-            let defs: mlua::Table = lua.globals().get("_structure_definitions")?;
-            let len = defs.len()?;
-            defs.set(len + 1, table)?;
-            Ok(())
-        })?;
-        globals.set("define_structure", define_structure)?;
-
         // --- Condition helper functions ---
         // These return Lua tables that represent condition nodes, parsed by condition_parser.
 
-        let has_tech = lua.create_function(|lua, id: String| {
+        // has_tech / has_modifier / has_building accept either a string ID
+        // or a reference table (returned by define_xxx) from which the id is extracted.
+        let has_tech = lua.create_function(|lua, value: mlua::Value| {
             let t = lua.create_table()?;
             t.set("type", "has_tech")?;
-            t.set("id", id)?;
+            t.set("id", extract_id_from_lua_value(&value)?)?;
             Ok(t)
         })?;
         globals.set("has_tech", has_tech)?;
 
-        let has_modifier = lua.create_function(|lua, id: String| {
+        let has_modifier = lua.create_function(|lua, value: mlua::Value| {
             let t = lua.create_table()?;
             t.set("type", "has_modifier")?;
-            t.set("id", id)?;
+            t.set("id", extract_id_from_lua_value(&value)?)?;
             Ok(t)
         })?;
         globals.set("has_modifier", has_modifier)?;
 
-        let has_building = lua.create_function(|lua, id: String| {
+        let has_building = lua.create_function(|lua, value: mlua::Value| {
             let t = lua.create_table()?;
             t.set("type", "has_building")?;
-            t.set("id", id)?;
+            t.set("id", extract_id_from_lua_value(&value)?)?;
             Ok(t)
         })?;
         globals.set("has_building", has_building)?;
@@ -470,6 +399,30 @@ impl ScriptEngine {
         Ok(())
     }
 
+    /// Register a `define_xxx` global function that:
+    /// 1. Creates an accumulator table `_xxx_definitions`
+    /// 2. Registers `define_xxx(table)` which appends to the accumulator and
+    ///    tags the table with `_def_type = def_type`, then returns it as a reference.
+    fn register_define_fn(lua: &Lua, def_type: &str, accumulator_name: &str) -> Result<(), mlua::Error> {
+        let globals = lua.globals();
+
+        let acc = lua.create_table()?;
+        globals.set(accumulator_name, acc)?;
+
+        let acc_name = accumulator_name.to_string();
+        let dtype = def_type.to_string();
+        let func = lua.create_function(move |lua, table: mlua::Table| {
+            table.set("_def_type", dtype.as_str())?;
+            let defs: mlua::Table = lua.globals().get(acc_name.as_str())?;
+            let len = defs.len()?;
+            defs.set(len + 1, table.clone())?;
+            Ok(table)
+        })?;
+        globals.set(format!("define_{def_type}"), func)?;
+
+        Ok(())
+    }
+
     /// Load and execute a single Lua file.
     pub fn load_file(&self, path: &Path) -> Result<(), mlua::Error> {
         let code = std::fs::read_to_string(path).map_err(|e| {
@@ -503,6 +456,25 @@ impl ScriptEngine {
     pub fn lua(&self) -> &Lua {
         &self.lua
     }
+}
+
+/// Extract an ID string from a Lua value that is either:
+/// - A plain string → used as-is
+/// - A reference table (from `define_xxx` or `forward_ref`) → reads the `id` field
+fn extract_id_from_lua_value(value: &mlua::Value) -> Result<String, mlua::Error> {
+    match value {
+        mlua::Value::String(s) => Ok(s.to_str()?.to_string()),
+        mlua::Value::Table(t) => t.get::<String>("id"),
+        _ => Err(mlua::Error::RuntimeError(
+            "Expected string ID or reference table".into(),
+        )),
+    }
+}
+
+/// Extract an ID from a Lua value, accepting both string IDs and reference tables.
+/// This is the public API for use by Rust-side parsers.
+pub fn extract_ref_id(value: &mlua::Value) -> Result<String, mlua::Error> {
+    extract_id_from_lua_value(value)
 }
 
 #[cfg(test)]
@@ -686,5 +658,120 @@ mod tests {
 
         let handlers: mlua::Table = lua.globals().get("_event_handlers").unwrap();
         assert_eq!(handlers.len().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_define_tech_returns_reference() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        let result: mlua::Table = lua
+            .load(r#"return define_tech { id = "test_tech", name = "Test" }"#)
+            .eval()
+            .unwrap();
+
+        let def_type: String = result.get("_def_type").unwrap();
+        assert_eq!(def_type, "tech");
+        let id: String = result.get("id").unwrap();
+        assert_eq!(id, "test_tech");
+    }
+
+    #[test]
+    fn test_define_xxx_reference_in_prerequisites() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            local base = define_tech { id = "base_tech", name = "Base", branch = "physics", cost = 100, prerequisites = {} }
+            define_tech { id = "advanced_tech", name = "Adv", branch = "physics", cost = 200, prerequisites = { base } }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs: mlua::Table = lua.globals().get("_tech_definitions").unwrap();
+        assert_eq!(defs.len().unwrap(), 2);
+        // The second tech's prerequisites should contain a reference table
+        let second: mlua::Table = defs.get(2).unwrap();
+        let prereqs: mlua::Table = second.get("prerequisites").unwrap();
+        let first_prereq: mlua::Table = prereqs.get(1).unwrap();
+        let prereq_id: String = first_prereq.get("id").unwrap();
+        assert_eq!(prereq_id, "base_tech");
+    }
+
+    #[test]
+    fn test_forward_ref() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        let result: mlua::Table = lua
+            .load(r#"return forward_ref("future_tech")"#)
+            .eval()
+            .unwrap();
+
+        let def_type: String = result.get("_def_type").unwrap();
+        assert_eq!(def_type, "forward_ref");
+        let id: String = result.get("id").unwrap();
+        assert_eq!(id, "future_tech");
+    }
+
+    #[test]
+    fn test_has_tech_accepts_reference() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        // String form (backward compatible)
+        let cond_str: mlua::Table = lua
+            .load(r#"return has_tech("my_tech")"#)
+            .eval()
+            .unwrap();
+        assert_eq!(cond_str.get::<String>("id").unwrap(), "my_tech");
+
+        // Reference form
+        let cond_ref: mlua::Table = lua
+            .load(r#"
+                local t = define_tech { id = "ref_tech", name = "Ref" }
+                return has_tech(t)
+            "#)
+            .eval()
+            .unwrap();
+        assert_eq!(cond_ref.get::<String>("id").unwrap(), "ref_tech");
+    }
+
+    #[test]
+    fn test_require_support() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        // package.path should be set
+        let package: mlua::Table = lua.globals().get("package").unwrap();
+        let path: String = package.get("path").unwrap();
+        assert!(path.contains("scripts/?.lua"));
+        assert!(path.contains("scripts/?/init.lua"));
+
+        // cpath should be empty
+        let cpath: String = package.get("cpath").unwrap();
+        assert!(cpath.is_empty());
+    }
+
+    #[test]
+    fn test_extract_ref_id() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        // String value
+        let s = mlua::Value::String(lua.create_string("hello").unwrap());
+        assert_eq!(extract_ref_id(&s).unwrap(), "hello");
+
+        // Table with id
+        let t = lua.create_table().unwrap();
+        t.set("id", "world").unwrap();
+        let v = mlua::Value::Table(t);
+        assert_eq!(extract_ref_id(&v).unwrap(), "world");
+
+        // Number should fail
+        let n = mlua::Value::Number(42.0);
+        assert!(extract_ref_id(&n).is_err());
     }
 }

--- a/src/scripting/mod.rs
+++ b/src/scripting/mod.rs
@@ -92,7 +92,12 @@ pub struct ScriptEngine {
 
 impl ScriptEngine {
     pub fn new() -> Result<Self, mlua::Error> {
-        let lua = Lua::new();
+        // Sandbox: only load safe libraries (no io, os, debug, ffi)
+        let lua = Lua::new_with(
+            LuaStdLib::TABLE | LuaStdLib::STRING | LuaStdLib::MATH
+                | LuaStdLib::PACKAGE | LuaStdLib::BIT,
+            mlua::LuaOptions::default(),
+        )?;
         Self::setup_globals(&lua)?;
         Ok(Self { lua })
     }
@@ -100,6 +105,10 @@ impl ScriptEngine {
     /// Configure global tables and functions available to all Lua scripts.
     pub fn setup_globals(lua: &Lua) -> Result<(), mlua::Error> {
         let globals = lua.globals();
+
+        // --- Sandbox: disable dangerous globals ---
+        globals.set("loadfile", mlua::Value::Nil)?;
+        globals.set("dofile", mlua::Value::Nil)?;
 
         // --- Set up require() search path ---
         let package: mlua::Table = globals.get("package")?;

--- a/src/scripting/ship_design_api.rs
+++ b/src/scripting/ship_design_api.rs
@@ -76,8 +76,13 @@ pub fn parse_modules(lua: &mlua::Lua) -> Result<Vec<ModuleDefinition>, mlua::Err
         let id: String = table.get("id")?;
         let name: String = table.get("name")?;
         let description: String = table.get::<Option<String>>("description")?.unwrap_or_default();
-        let slot_type: String = table.get("slot_type")?;
-        let prerequisite_tech: Option<String> = table.get("prerequisite_tech")?;
+        let slot_type_value: mlua::Value = table.get("slot_type")?;
+        let slot_type = crate::scripting::extract_ref_id(&slot_type_value)?;
+        let prereq_value: mlua::Value = table.get("prerequisite_tech")?;
+        let prerequisite_tech = match prereq_value {
+            mlua::Value::Nil => None,
+            v => Some(crate::scripting::extract_ref_id(&v)?),
+        };
 
         // Parse modifiers array
         let modifiers = parse_module_modifiers(&table)?;
@@ -115,7 +120,8 @@ pub fn parse_ship_designs(lua: &mlua::Lua) -> Result<Vec<ShipDesignDefinition>, 
         let id: String = table.get("id")?;
         let name: String = table.get("name")?;
         let description: String = table.get::<Option<String>>("description")?.unwrap_or_default();
-        let hull_id: String = table.get("hull")?;
+        let hull_value: mlua::Value = table.get("hull")?;
+        let hull_id = crate::scripting::extract_ref_id(&hull_value)?;
 
         // Parse modules array
         let modules = parse_design_modules(&table)?;
@@ -157,6 +163,7 @@ fn parse_cost_table(
 }
 
 /// Parse the `slots = { { type = "weapon", count = 2 }, ... }` array.
+/// The `type` field accepts both a string ID and a reference table from `define_slot_type`.
 fn parse_hull_slots(table: &mlua::Table) -> Result<Vec<HullSlot>, mlua::Error> {
     let slots_value: mlua::Value = table.get("slots")?;
     match slots_value {
@@ -164,7 +171,8 @@ fn parse_hull_slots(table: &mlua::Table) -> Result<Vec<HullSlot>, mlua::Error> {
             let mut slots = Vec::new();
             for pair in slots_table.pairs::<i64, mlua::Table>() {
                 let (_, slot_table) = pair?;
-                let slot_type: String = slot_table.get("type")?;
+                let type_value: mlua::Value = slot_table.get("type")?;
+                let slot_type = crate::scripting::extract_ref_id(&type_value)?;
                 let count: u32 = slot_table.get::<Option<u32>>("count")?.unwrap_or(1);
                 slots.push(HullSlot { slot_type, count });
             }
@@ -246,6 +254,7 @@ fn parse_weapon_stats(table: &mlua::Table) -> Result<Option<WeaponStats>, mlua::
 }
 
 /// Parse the `modules = { { slot_type = "...", module = "..." }, ... }` array.
+/// Both `slot_type` and `module` accept string IDs or reference tables.
 fn parse_design_modules(
     table: &mlua::Table,
 ) -> Result<Vec<DesignSlotAssignment>, mlua::Error> {
@@ -255,8 +264,10 @@ fn parse_design_modules(
             let mut assignments = Vec::new();
             for pair in mods_table.pairs::<i64, mlua::Table>() {
                 let (_, mod_table) = pair?;
-                let slot_type: String = mod_table.get("slot_type")?;
-                let module_id: String = mod_table.get("module")?;
+                let slot_type_value: mlua::Value = mod_table.get("slot_type")?;
+                let slot_type = crate::scripting::extract_ref_id(&slot_type_value)?;
+                let module_value: mlua::Value = mod_table.get("module")?;
+                let module_id = crate::scripting::extract_ref_id(&module_value)?;
                 assignments.push(DesignSlotAssignment {
                     slot_type,
                     module_id,
@@ -491,16 +502,16 @@ mod tests {
     fn test_ship_design_scripts_load() {
         let engine = ScriptEngine::new().unwrap();
 
-        let ships_dir =
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/ships");
-        if !ships_dir.exists() {
+        let init_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/init.lua");
+        if !init_path.exists() {
             panic!(
-                "scripts/ships directory not found at {:?}",
-                ships_dir
+                "scripts/init.lua not found at {:?}",
+                init_path
             );
         }
 
-        engine.load_directory(&ships_dir).unwrap();
+        engine.load_file(&init_path).unwrap();
 
         // Slot types
         let slot_types = parse_slot_types(engine.lua()).unwrap();

--- a/src/ship_design.rs
+++ b/src/ship_design.rs
@@ -163,13 +163,13 @@ impl Plugin for ShipDesignPlugin {
             .init_resource::<ShipDesignRegistry>()
             .add_systems(
                 Startup,
-                load_ship_designs.after(crate::scripting::init_scripting),
+                load_ship_designs.after(crate::scripting::load_all_scripts),
             );
     }
 }
 
-/// Load ship design definitions from Lua scripts into registries.
-/// Falls back to empty registries if scripts are missing or fail to parse.
+/// Parse ship design definitions from Lua accumulators into registries.
+/// Scripts are loaded by `load_all_scripts`; this system only parses the results.
 pub fn load_ship_designs(
     engine: Res<crate::scripting::ScriptEngine>,
     mut slot_types: ResMut<SlotTypeRegistry>,
@@ -178,18 +178,6 @@ pub fn load_ship_designs(
     mut designs: ResMut<ShipDesignRegistry>,
 ) {
     use crate::scripting::ship_design_api;
-    use std::path::Path;
-
-    let ships_dir = Path::new("scripts/ships");
-    if !ships_dir.exists() {
-        info!("scripts/ships directory not found; ship design registries will be empty");
-        return;
-    }
-
-    if let Err(e) = engine.load_directory(ships_dir) {
-        warn!("Failed to load ship design scripts: {e}; registries will be empty");
-        return;
-    }
 
     // Parse slot types
     match ship_design_api::parse_slot_types(engine.lua()) {

--- a/src/species.rs
+++ b/src/species.rs
@@ -155,7 +155,7 @@ impl Plugin for SpeciesPlugin {
             .init_resource::<JobRegistry>()
             .add_systems(
                 Startup,
-                load_species_and_jobs.after(crate::scripting::init_scripting),
+                load_species_and_jobs.after(crate::scripting::load_all_scripts),
             )
             .add_systems(
                 Update,
@@ -164,63 +164,39 @@ impl Plugin for SpeciesPlugin {
     }
 }
 
-/// Startup system that loads species and job definitions from Lua scripts.
+/// Parse species and job definitions from Lua accumulators.
+/// Scripts are loaded by `load_all_scripts`; this system only parses the results.
 pub fn load_species_and_jobs(
     engine: Res<crate::scripting::ScriptEngine>,
     mut species_registry: ResMut<SpeciesRegistry>,
     mut job_registry: ResMut<JobRegistry>,
 ) {
     use crate::scripting::species_api::{parse_job_definitions, parse_species_definitions};
-    use std::path::Path;
 
-    // Load species scripts
-    let species_dir = Path::new("scripts/species");
-    if species_dir.exists() {
-        match engine.load_directory(species_dir) {
-            Err(e) => {
-                warn!("Failed to load species scripts: {e}; species registry will be empty");
+    match parse_species_definitions(engine.lua()) {
+        Ok(defs) => {
+            let count = defs.len();
+            for def in defs {
+                species_registry.insert(def);
             }
-            Ok(()) => match parse_species_definitions(engine.lua()) {
-                Ok(defs) => {
-                    let count = defs.len();
-                    for def in defs {
-                        species_registry.insert(def);
-                    }
-                    info!("Species registry loaded with {} definitions", count);
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to parse species definitions: {e}; species registry will be empty"
-                    );
-                }
-            },
+            info!("Species registry loaded with {} definitions", count);
         }
-    } else {
-        info!("scripts/species directory not found; species registry will be empty");
+        Err(e) => {
+            warn!("Failed to parse species definitions: {e}; species registry will be empty");
+        }
     }
 
-    // Load job scripts
-    let jobs_dir = Path::new("scripts/jobs");
-    if jobs_dir.exists() {
-        match engine.load_directory(jobs_dir) {
-            Err(e) => {
-                warn!("Failed to load job scripts: {e}; job registry will be empty");
+    match parse_job_definitions(engine.lua()) {
+        Ok(defs) => {
+            let count = defs.len();
+            for def in defs {
+                job_registry.insert(def);
             }
-            Ok(()) => match parse_job_definitions(engine.lua()) {
-                Ok(defs) => {
-                    let count = defs.len();
-                    for def in defs {
-                        job_registry.insert(def);
-                    }
-                    info!("Job registry loaded with {} definitions", count);
-                }
-                Err(e) => {
-                    warn!("Failed to parse job definitions: {e}; job registry will be empty");
-                }
-            },
+            info!("Job registry loaded with {} definitions", count);
         }
-    } else {
-        info!("scripts/jobs directory not found; job registry will be empty");
+        Err(e) => {
+            warn!("Failed to parse job definitions: {e}; job registry will be empty");
+        }
     }
 }
 

--- a/src/technology/mod.rs
+++ b/src/technology/mod.rs
@@ -817,7 +817,7 @@ mod tests {
     #[test]
     fn test_parse_lua_tech_definitions() {
         let lua = mlua::Lua::new();
-        crate::scripting::ScriptEngine::setup_globals(&lua).unwrap();
+        crate::scripting::ScriptEngine::setup_globals(&lua, &crate::scripting::resolve_scripts_dir()).unwrap();
 
         lua.load(
             r#"
@@ -866,7 +866,7 @@ mod tests {
     #[test]
     fn test_parse_lua_tech_table_cost() {
         let lua = mlua::Lua::new();
-        crate::scripting::ScriptEngine::setup_globals(&lua).unwrap();
+        crate::scripting::ScriptEngine::setup_globals(&lua, &crate::scripting::resolve_scripts_dir()).unwrap();
 
         lua.load(
             r#"

--- a/src/technology/mod.rs
+++ b/src/technology/mod.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
 
 use crate::amount::Amt;
 use crate::colony::{Colony, Production, ProductionFocus};
@@ -18,7 +17,7 @@ impl Plugin for TechnologyPlugin {
         app.add_systems(
             Startup,
             load_technologies
-                .after(crate::scripting::init_scripting)
+                .after(crate::scripting::load_all_scripts)
                 .after(crate::player::spawn_player_empire),
         )
         .insert_resource(LastResearchTick(0))
@@ -98,33 +97,24 @@ impl GameFlags {
     }
 }
 
+/// Parse technology definitions from Lua accumulators.
+/// Scripts are loaded by `load_all_scripts`; this system only parses the results.
+/// Falls back to hardcoded definitions if parsing fails or yields nothing.
 pub fn load_technologies(
     mut commands: Commands,
     engine: Res<crate::scripting::ScriptEngine>,
     empire_q: Query<Entity, With<crate::player::PlayerEmpire>>,
 ) {
-    let tech_dir = Path::new("scripts/tech");
-    let techs = if tech_dir.exists() {
-        match engine.load_directory(tech_dir) {
-            Err(e) => {
-                warn!("Failed to load tech scripts: {e}; falling back to hardcoded definitions");
-                create_initial_tech_tree_vec()
-            }
-            Ok(()) => match parse_tech_definitions(engine.lua()) {
-                Ok(parsed) if !parsed.is_empty() => parsed,
-                Ok(_) => {
-                    info!("No tech definitions found in scripts; using hardcoded fallback");
-                    create_initial_tech_tree_vec()
-                }
-                Err(e) => {
-                    warn!("Failed to parse tech definitions: {e}; falling back to hardcoded definitions");
-                    create_initial_tech_tree_vec()
-                }
-            },
+    let techs = match parse_tech_definitions(engine.lua()) {
+        Ok(parsed) if !parsed.is_empty() => parsed,
+        Ok(_) => {
+            info!("No tech definitions found in scripts; using hardcoded fallback");
+            create_initial_tech_tree_vec()
         }
-    } else {
-        info!("scripts/tech directory not found; using hardcoded tech definitions");
-        create_initial_tech_tree_vec()
+        Err(e) => {
+            warn!("Failed to parse tech definitions: {e}; falling back to hardcoded definitions");
+            create_initial_tech_tree_vec()
+        }
     };
 
     let tree = TechTree::from_vec(techs);
@@ -654,8 +644,11 @@ pub fn parse_tech_definitions(lua: &mlua::Lua) -> Result<Vec<Technology>, mlua::
 
         let prereqs_table: mlua::Table = table.get("prerequisites")?;
         let prerequisites: Vec<TechId> = prereqs_table
-            .sequence_values::<String>()
-            .map(|r| r.map(TechId))
+            .sequence_values::<mlua::Value>()
+            .map(|r| {
+                let val = r?;
+                crate::scripting::extract_ref_id(&val).map(TechId)
+            })
             .collect::<Result<_, _>>()?;
 
         let description: String = table
@@ -902,10 +895,11 @@ mod tests {
     #[test]
     fn test_load_lua_files_from_disk() {
         let engine = crate::scripting::ScriptEngine::new().unwrap();
-        let tech_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/tech");
+        let init_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/init.lua");
         engine
-            .load_directory(&tech_dir)
-            .expect("Failed to load tech scripts from disk");
+            .load_file(&init_path)
+            .expect("Failed to load scripts via init.lua");
         let techs = parse_tech_definitions(engine.lua()).expect("Failed to parse tech scripts");
         // Should load all 15 technologies from the 4 Lua files
         assert_eq!(techs.len(), 15);


### PR DESCRIPTION
## Summary
- **Single entrypoint**: `scripts/init.lua` loads all subsystems via `require()` in dependency order
- **Return-value references**: `define_xxx {}` returns tagged tables, enabling `prerequisites = { automated_mining }` instead of string IDs
- **`forward_ref(id)`**: Placeholder for not-yet-defined items, resolved at load completion
- **`extract_ref_id()`**: Rust-side parser accepts both string IDs and reference tables (backward compatible)
- **Lua sandbox**: Only safe libraries loaded (table/string/math/package/bit). No io/os/debug/ffi. `loadfile`/`dofile` disabled.
- **Robust path resolution**: Scripts directory found via exe-relative → CWD → CARGO_MANIFEST_DIR fallback chain

## Test plan
- [x] All 263 unit + 67 integration tests pass
- [x] `all_systems_no_query_conflict` smoke test passes
- [x] Lua scripts load correctly via init.lua entrypoint
- [x] Backward-compatible: string IDs still accepted alongside references
- [x] Manual: verify game launches and definitions load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)