### PR TITLE
ai_core bus foundation (#195 Phase 1 + 2)

### DIFF
--- a/.github/workflows/ai-core-isolation.yml
+++ b/.github/workflows/ai-core-isolation.yml
@@ -1,0 +1,50 @@
+name: ai-core isolation
+
+# Verifies that macrocosmo-ai stays engine-agnostic: no bevy / macrocosmo
+# runtime dependency may creep in. Tests also run here as a fast check.
+
+on:
+  push:
+    branches: [main, release]
+  pull_request:
+    branches: [main]
+
+jobs:
+  isolation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ai-core-isolation-${{ hashFiles('macrocosmo-ai/Cargo.toml', 'Cargo.lock') }}
+          restore-keys: ai-core-isolation-
+
+      - name: Dependency tree must not contain bevy or macrocosmo
+        run: |
+          set -euo pipefail
+          # --edges=normal excludes dev-dependencies (tests may use anything).
+          LEAK=$(cargo tree -p macrocosmo-ai --edges=normal --prefix=none --no-dedupe \
+                  | awk '{print $1}' \
+                  | sort -u \
+                  | grep -E '^(bevy(_[a-z_]+)?|macrocosmo)$' || true)
+          if [ -n "$LEAK" ]; then
+            echo "::error::macrocosmo-ai runtime dependency tree leaks forbidden crate(s):"
+            echo "$LEAK"
+            exit 1
+          fi
+          echo "OK — no bevy / macrocosmo in runtime deps."
+
+      - name: Build macrocosmo-ai (no bevy, no game)
+        run: cargo build -p macrocosmo-ai --verbose
+
+      - name: Test macrocosmo-ai
+        run: cargo test -p macrocosmo-ai --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -3512,8 +3513,11 @@ dependencies = [
 name = "macrocosmo-ai"
 version = "0.2.0"
 dependencies = [
- "bevy",
- "macrocosmo",
+ "ahash",
+ "log",
+ "macrocosmo-ai",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/macrocosmo-ai/Cargo.toml
+++ b/macrocosmo-ai/Cargo.toml
@@ -2,7 +2,19 @@
 name = "macrocosmo-ai"
 version.workspace = true
 edition.workspace = true
+description = "Engine-agnostic AI core for macrocosmo: typed topic bus, feasibility, campaigns."
+
+[features]
+default = []
+mock = []
 
 [dependencies]
-bevy = "0.18.1"
-macrocosmo = { path = "../macrocosmo" }
+ahash = { version = "0.8", features = ["serde"] }
+serde = { version = "1", features = ["derive", "rc"] }
+thiserror = "2"
+log = "0.4"
+
+[dev-dependencies]
+# Self-reference with `mock` feature activates the mock module for
+# integration tests in `tests/` without forcing the feature on consumers.
+macrocosmo-ai = { path = ".", features = ["mock"] }

--- a/macrocosmo-ai/src/bus/command.rs
+++ b/macrocosmo-ai/src/bus/command.rs
@@ -1,0 +1,23 @@
+//! Command topic internal storage.
+//!
+//! Commands are AI → game outputs. The store holds:
+//! - `specs`: declared command kinds. Emitting to an undeclared kind warns + no-ops.
+//! - `pending`: FIFO queue drained by the game consumer.
+
+use ahash::AHashMap;
+
+use crate::command::Command;
+use crate::ids::CommandKindId;
+use crate::spec::CommandSpec;
+
+#[derive(Debug, Default)]
+pub(crate) struct CommandStore {
+    pub(crate) specs: AHashMap<CommandKindId, CommandSpec>,
+    pub(crate) pending: Vec<Command>,
+}
+
+impl CommandStore {
+    pub(crate) fn drain(&mut self) -> Vec<Command> {
+        std::mem::take(&mut self.pending)
+    }
+}

--- a/macrocosmo-ai/src/bus/evidence.rs
+++ b/macrocosmo-ai/src/bus/evidence.rs
@@ -1,0 +1,110 @@
+//! Evidence topic internal storage.
+//!
+//! Evidence is stored per-kind in an append-only `Vec`. On emit, entries older
+//! than the retention window (relative to the newest sample) are evicted.
+//! Query-time filtering by observer/target is O(n) on the per-kind vector;
+//! this is acceptable given realistic evidence volumes in Phase 2.
+
+use crate::evidence::StandingEvidence;
+use crate::spec::EvidenceSpec;
+use crate::time::Tick;
+
+#[derive(Debug)]
+pub(crate) struct EvidenceStore {
+    pub(crate) spec: EvidenceSpec,
+    pub(crate) entries: Vec<StandingEvidence>,
+}
+
+impl EvidenceStore {
+    pub(crate) fn new(spec: EvidenceSpec) -> Self {
+        Self {
+            spec,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Returns `true` if accepted, `false` if dropped due to time-reversed emit.
+    pub(crate) fn push(&mut self, ev: StandingEvidence) -> bool {
+        if let Some(last) = self.entries.last() {
+            if ev.at < last.at {
+                return false;
+            }
+        }
+        let newest = ev.at;
+        self.entries.push(ev);
+        self.evict(newest);
+        true
+    }
+
+    fn evict(&mut self, newest: Tick) {
+        let cutoff = newest.saturating_sub(self.spec.retention.as_ticks());
+        // Entries are append-only in time order; find the first entry >= cutoff.
+        // Using partition_point on at keeps this O(log n).
+        let drop_upto = self.entries.partition_point(|e| e.at < cutoff);
+        if drop_upto > 0 {
+            self.entries.drain(..drop_upto);
+        }
+    }
+
+    /// Iterate entries in the window `[now - duration, now]`.
+    pub(crate) fn window(
+        &self,
+        now: Tick,
+        duration: Tick,
+    ) -> impl Iterator<Item = &StandingEvidence> + '_ {
+        let lower = now.saturating_sub(duration.max(0));
+        self.entries
+            .iter()
+            .filter(move |e| e.at >= lower && e.at <= now)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::{EvidenceKindId, FactionId};
+    use crate::retention::Retention;
+
+    fn spec(retention: Retention) -> EvidenceSpec {
+        EvidenceSpec::new(retention, "test")
+    }
+
+    fn ev(observer: u32, target: u32, at: Tick) -> StandingEvidence {
+        StandingEvidence::new(
+            EvidenceKindId::from("hostile_engagement"),
+            FactionId(observer),
+            FactionId(target),
+            1.0,
+            at,
+        )
+    }
+
+    #[test]
+    fn push_and_window() {
+        let mut s = EvidenceStore::new(spec(Retention::Custom(1000)));
+        s.push(ev(1, 2, 10));
+        s.push(ev(1, 3, 20));
+        s.push(ev(2, 1, 30));
+        let got: Vec<_> = s.window(30, 20).collect();
+        assert_eq!(got.len(), 3);
+    }
+
+    #[test]
+    fn eviction_drops_expired() {
+        let mut s = EvidenceStore::new(spec(Retention::Custom(50)));
+        s.push(ev(1, 2, 10));
+        s.push(ev(1, 2, 20));
+        s.push(ev(1, 2, 80));
+        // newest=80, cutoff=30 -> entries at 10, 20 evicted.
+        assert_eq!(s.entries.len(), 1);
+        assert_eq!(s.entries[0].at, 80);
+    }
+
+    #[test]
+    fn time_reversed_push_dropped() {
+        let mut s = EvidenceStore::new(spec(Retention::Custom(1000)));
+        assert!(s.push(ev(1, 2, 50)));
+        assert!(!s.push(ev(1, 2, 10)));
+        assert_eq!(s.entries.len(), 1);
+    }
+}

--- a/macrocosmo-ai/src/bus/metric.rs
+++ b/macrocosmo-ai/src/bus/metric.rs
@@ -1,0 +1,180 @@
+//! Metric topic internal storage.
+//!
+//! Each declared metric owns a `VecDeque<TimestampedValue>` ordered oldest-front.
+//! Eviction happens on `push` only — we drop samples whose timestamps fall
+//! outside the configured retention window.
+//!
+//! Emit semantics:
+//! - Monotonic in time. If `at < last.at`, the sample is dropped (the bus
+//!   emits a warning at the call site, not here).
+
+use std::collections::VecDeque;
+
+use crate::spec::MetricSpec;
+use crate::time::{Tick, TimestampedValue};
+
+#[derive(Debug)]
+pub(crate) struct MetricStore {
+    pub spec: MetricSpec,
+    pub history: VecDeque<TimestampedValue>,
+}
+
+impl MetricStore {
+    pub(crate) fn new(spec: MetricSpec) -> Self {
+        Self {
+            spec,
+            history: VecDeque::new(),
+        }
+    }
+
+    /// Returns `true` if the sample was accepted, `false` if it was dropped
+    /// as a time-reversed emit. The caller is responsible for warning.
+    pub(crate) fn push(&mut self, at: Tick, value: f64) -> bool {
+        if let Some(last) = self.history.back() {
+            if at < last.at {
+                return false; // time-reversed — drop
+            }
+        }
+        self.history.push_back(TimestampedValue { at, value });
+        self.evict(at);
+        true
+    }
+
+    fn evict(&mut self, newest: Tick) {
+        let cutoff = newest.saturating_sub(self.spec.retention.as_ticks());
+        while let Some(front) = self.history.front() {
+            if front.at < cutoff {
+                self.history.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    pub(crate) fn current(&self) -> Option<f64> {
+        self.history.back().map(|tv| tv.value)
+    }
+
+    /// Iterator over samples within `[now - duration, now]`, oldest-first.
+    /// If the window extends beyond retention, the iterator simply yields
+    /// everything still in history (partial data).
+    pub(crate) fn window(
+        &self,
+        now: Tick,
+        duration: Tick,
+    ) -> impl Iterator<Item = &TimestampedValue> + '_ {
+        let lower = now.saturating_sub(duration.max(0));
+        self.history
+            .iter()
+            .filter(move |tv| tv.at >= lower && tv.at <= now)
+    }
+
+    /// Value at exactly `t`, if a sample with that timestamp exists.
+    pub(crate) fn at(&self, t: Tick) -> Option<f64> {
+        // History is small (retention-bounded) — linear scan is fine.
+        self.history
+            .iter()
+            .rev()
+            .find(|tv| tv.at == t)
+            .map(|tv| tv.value)
+    }
+
+    /// Latest sample at-or-before `t`. Used by DelT to pick the historical
+    /// anchor value when no exact match exists.
+    pub(crate) fn at_or_before(&self, t: Tick) -> Option<f64> {
+        self.history
+            .iter()
+            .rev()
+            .find(|tv| tv.at <= t)
+            .map(|tv| tv.value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::retention::Retention;
+
+    fn store(retention: Retention) -> MetricStore {
+        MetricStore::new(MetricSpec::gauge(retention, "test"))
+    }
+
+    #[test]
+    fn push_in_order_appends() {
+        let mut s = store(Retention::Custom(100));
+        assert!(s.push(0, 1.0));
+        assert!(s.push(10, 2.0));
+        assert!(s.push(20, 3.0));
+        assert_eq!(s.current(), Some(3.0));
+        assert_eq!(s.history.len(), 3);
+    }
+
+    #[test]
+    fn push_time_reversed_drops_and_returns_false() {
+        let mut s = store(Retention::Custom(100));
+        assert!(s.push(10, 1.0));
+        assert!(!s.push(5, 2.0));
+        assert_eq!(s.current(), Some(1.0));
+        assert_eq!(s.history.len(), 1);
+    }
+
+    #[test]
+    fn push_same_timestamp_accepted() {
+        let mut s = store(Retention::Custom(100));
+        assert!(s.push(10, 1.0));
+        assert!(s.push(10, 2.0));
+        assert_eq!(s.current(), Some(2.0));
+        assert_eq!(s.history.len(), 2);
+    }
+
+    #[test]
+    fn eviction_drops_samples_older_than_retention() {
+        let mut s = store(Retention::Custom(100));
+        s.push(0, 1.0);
+        s.push(50, 2.0);
+        s.push(150, 3.0); // cutoff = 50; samples with at < 50 evicted
+        assert_eq!(s.history.len(), 2);
+        assert_eq!(s.history.front().unwrap().at, 50);
+    }
+
+    #[test]
+    fn window_returns_samples_in_range() {
+        let mut s = store(Retention::Custom(1000));
+        for t in 0..10 {
+            s.push(t * 10, t as f64);
+        }
+        let got: Vec<_> = s.window(50, 20).map(|tv| tv.value).collect();
+        assert_eq!(got, vec![3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn window_wider_than_retention_returns_partial() {
+        let mut s = store(Retention::Custom(50));
+        for t in 0..10 {
+            s.push(t * 10, t as f64);
+        }
+        // newest = 90, retention = 50 -> cutoff = 40 -> samples at {40..90} kept.
+        let got: Vec<_> = s.window(90, 1000).map(|tv| tv.value).collect();
+        assert_eq!(got, vec![4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+    }
+
+    #[test]
+    fn at_exact_match() {
+        let mut s = store(Retention::Custom(1000));
+        s.push(10, 1.5);
+        s.push(20, 2.5);
+        assert_eq!(s.at(20), Some(2.5));
+        assert_eq!(s.at(15), None);
+    }
+
+    #[test]
+    fn at_or_before_picks_latest_not_after() {
+        let mut s = store(Retention::Custom(1000));
+        s.push(10, 1.0);
+        s.push(20, 2.0);
+        s.push(30, 3.0);
+        assert_eq!(s.at_or_before(25), Some(2.0));
+        assert_eq!(s.at_or_before(30), Some(3.0));
+        assert_eq!(s.at_or_before(5), None);
+    }
+}

--- a/macrocosmo-ai/src/bus/mod.rs
+++ b/macrocosmo-ai/src/bus/mod.rs
@@ -1,0 +1,436 @@
+//! `AiBus` — the central typed topic bus.
+//!
+//! Topics come in three flavors: metrics (time-series f64), commands (AI→game
+//! output queue), and evidence (per-kind standing observations).
+//!
+//! All topics must be declared via the corresponding `declare_*` before use.
+//! Emitting to an undeclared topic is a no-op + warning.
+
+pub(crate) mod command;
+pub(crate) mod evidence;
+pub(crate) mod metric;
+
+use ahash::AHashMap;
+
+use crate::bus::command::CommandStore;
+use crate::bus::evidence::EvidenceStore;
+use crate::bus::metric::MetricStore;
+use crate::bus_warn;
+use crate::command::Command;
+use crate::evidence::StandingEvidence;
+use crate::ids::{CommandKindId, EvidenceKindId, FactionId, MetricId};
+use crate::spec::{CommandSpec, EvidenceSpec, MetricSpec};
+use crate::time::{Tick, TimestampedValue};
+use crate::warning::WarningMode;
+
+/// Central AI bus — holds all declared topics and their histories.
+#[derive(Debug, Default)]
+pub struct AiBus {
+    metrics: AHashMap<MetricId, MetricStore>,
+    commands: CommandStore,
+    evidence: AHashMap<EvidenceKindId, EvidenceStore>,
+    pub(crate) warning_mode: WarningMode,
+}
+
+impl AiBus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_warning_mode(mode: WarningMode) -> Self {
+        Self {
+            warning_mode: mode,
+            ..Self::default()
+        }
+    }
+
+    pub fn set_warning_mode(&mut self, mode: WarningMode) {
+        self.warning_mode = mode;
+    }
+
+    pub fn warning_mode(&self) -> WarningMode {
+        self.warning_mode
+    }
+
+    // ---- Metric topic ---------------------------------------------------
+
+    /// Declare a metric topic. Re-declaring an existing id overrides the spec
+    /// (preserving history) and emits a warning.
+    pub fn declare_metric(&mut self, id: MetricId, spec: MetricSpec) {
+        if let Some(existing) = self.metrics.get_mut(&id) {
+            bus_warn!(
+                self.warning_mode,
+                "metric '{id}' re-declared; overriding spec {:?} -> {:?}",
+                existing.spec,
+                spec,
+            );
+            existing.spec = spec;
+        } else {
+            self.metrics.insert(id, MetricStore::new(spec));
+        }
+    }
+
+    /// Whether a metric has been declared.
+    pub fn has_metric(&self, id: &MetricId) -> bool {
+        self.metrics.contains_key(id)
+    }
+
+    /// Emit a metric sample. No-op + warning if the id is undeclared or if
+    /// `at` precedes the latest emitted sample for this metric.
+    pub fn emit(&mut self, id: &MetricId, value: f64, at: Tick) {
+        let Some(store) = self.metrics.get_mut(id) else {
+            bus_warn!(
+                self.warning_mode,
+                "emit to undeclared metric '{id}' (value={value}, at={at}); dropping"
+            );
+            return;
+        };
+        if !store.push(at, value) {
+            let last_at = store.history.back().map(|tv| tv.at).unwrap_or(i64::MIN);
+            bus_warn!(
+                self.warning_mode,
+                "time-reversed emit on metric '{id}' (at={at}, last={last_at}); dropping"
+            );
+        }
+    }
+
+    /// Latest value for a metric, or `None` if undeclared / never emitted.
+    pub fn current(&self, id: &MetricId) -> Option<f64> {
+        self.metrics.get(id).and_then(MetricStore::current)
+    }
+
+    /// Iterator over samples in the window `[now - duration, now]`, oldest-first.
+    ///
+    /// If the metric is undeclared, yields an empty iterator. If `duration`
+    /// exceeds retention, yields everything still in history (partial).
+    pub fn window<'a>(
+        &'a self,
+        id: &MetricId,
+        now: Tick,
+        duration: Tick,
+    ) -> Box<dyn Iterator<Item = &'a TimestampedValue> + 'a> {
+        match self.metrics.get(id) {
+            Some(store) => Box::new(store.window(now, duration)),
+            None => Box::new(std::iter::empty()),
+        }
+    }
+
+    /// Exact-timestamp lookup. Returns `None` if undeclared or no sample exists
+    /// at that tick.
+    pub fn at(&self, id: &MetricId, t: Tick) -> Option<f64> {
+        self.metrics.get(id).and_then(|s| s.at(t))
+    }
+
+    /// Latest sample at-or-before `t`. Used by DelT and other lookback
+    /// evaluators where an exact match is not guaranteed.
+    pub fn at_or_before(&self, id: &MetricId, t: Tick) -> Option<f64> {
+        self.metrics.get(id).and_then(|s| s.at_or_before(t))
+    }
+
+    // ---- Command topic --------------------------------------------------
+
+    /// Declare a command kind. Re-declaring overrides the spec and warns.
+    pub fn declare_command(&mut self, kind: CommandKindId, spec: CommandSpec) {
+        if let Some(existing) = self.commands.specs.get_mut(&kind) {
+            bus_warn!(
+                self.warning_mode,
+                "command kind '{kind}' re-declared; overriding spec {:?} -> {:?}",
+                existing,
+                spec,
+            );
+            *existing = spec;
+        } else {
+            self.commands.specs.insert(kind, spec);
+        }
+    }
+
+    /// Whether a command kind has been declared.
+    pub fn has_command_kind(&self, kind: &CommandKindId) -> bool {
+        self.commands.specs.contains_key(kind)
+    }
+
+    /// Emit a command. No-op + warning if the command's kind is undeclared.
+    /// The command's `at` field is supplied by the caller (typically the
+    /// current game tick).
+    pub fn emit_command(&mut self, cmd: Command) {
+        if !self.commands.specs.contains_key(&cmd.kind) {
+            bus_warn!(
+                self.warning_mode,
+                "emit of undeclared command kind '{}'; dropping",
+                cmd.kind
+            );
+            return;
+        }
+        self.commands.pending.push(cmd);
+    }
+
+    /// Drain all pending commands. The game consumer calls this each tick.
+    pub fn drain_commands(&mut self) -> Vec<Command> {
+        self.commands.drain()
+    }
+
+    /// Non-draining peek at the pending command queue.
+    pub fn pending_commands(&self) -> &[Command] {
+        &self.commands.pending
+    }
+
+    // ---- Evidence topic -------------------------------------------------
+
+    /// Declare an evidence kind. Re-declaring overrides the spec and warns.
+    pub fn declare_evidence(&mut self, kind: EvidenceKindId, spec: EvidenceSpec) {
+        if let Some(existing) = self.evidence.get_mut(&kind) {
+            bus_warn!(
+                self.warning_mode,
+                "evidence kind '{kind}' re-declared; overriding spec {:?} -> {:?}",
+                existing.spec,
+                spec,
+            );
+            existing.spec = spec;
+        } else {
+            self.evidence.insert(kind, EvidenceStore::new(spec));
+        }
+    }
+
+    /// Whether an evidence kind has been declared.
+    pub fn has_evidence_kind(&self, kind: &EvidenceKindId) -> bool {
+        self.evidence.contains_key(kind)
+    }
+
+    /// Emit a standing evidence observation. No-op + warning if the kind is
+    /// undeclared or the timestamp precedes the latest sample for this kind.
+    pub fn emit_evidence(&mut self, ev: StandingEvidence) {
+        let kind = ev.kind.clone();
+        let Some(store) = self.evidence.get_mut(&kind) else {
+            bus_warn!(
+                self.warning_mode,
+                "emit of undeclared evidence kind '{kind}' (observer={:?}, target={:?}, at={}); dropping",
+                ev.observer,
+                ev.target,
+                ev.at,
+            );
+            return;
+        };
+        let at = ev.at;
+        if !store.push(ev) {
+            let last_at = store.entries.last().map(|e| e.at).unwrap_or(i64::MIN);
+            bus_warn!(
+                self.warning_mode,
+                "time-reversed evidence emit on kind '{kind}' (at={at}, last={last_at}); dropping"
+            );
+        }
+    }
+
+    /// Evidence for a given observer within `[now - duration, now]`, across
+    /// all declared evidence kinds. Iterator yields references into the
+    /// underlying stores.
+    pub fn evidence_for<'a>(
+        &'a self,
+        observer: FactionId,
+        now: Tick,
+        duration: Tick,
+    ) -> impl Iterator<Item = &'a StandingEvidence> + 'a {
+        self.evidence
+            .values()
+            .flat_map(move |store| store.window(now, duration))
+            .filter(move |e| e.observer == observer)
+    }
+
+    /// Evidence for a given observer and kind within the window. More
+    /// efficient than `evidence_for` when the caller knows the kind.
+    pub fn evidence_of_kind<'a>(
+        &'a self,
+        kind: &EvidenceKindId,
+        observer: FactionId,
+        now: Tick,
+        duration: Tick,
+    ) -> Box<dyn Iterator<Item = &'a StandingEvidence> + 'a> {
+        match self.evidence.get(kind) {
+            Some(store) => Box::new(store.window(now, duration).filter(move |e| e.observer == observer)),
+            None => Box::new(std::iter::empty()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::retention::Retention;
+
+    fn readiness() -> MetricId {
+        MetricId::from("fleet_readiness")
+    }
+
+    fn hostile() -> EvidenceKindId {
+        EvidenceKindId::from("hostile_engagement")
+    }
+
+    #[test]
+    fn declare_emit_current() {
+        let mut bus = AiBus::new();
+        bus.declare_metric(readiness(), MetricSpec::ratio(Retention::Short, "r"));
+        bus.emit(&readiness(), 0.7, 10);
+        bus.emit(&readiness(), 0.8, 20);
+        assert_eq!(bus.current(&readiness()), Some(0.8));
+    }
+
+    #[test]
+    fn emit_to_undeclared_is_noop() {
+        let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+        bus.emit(&MetricId::from("unknown"), 1.0, 0);
+        assert_eq!(bus.current(&MetricId::from("unknown")), None);
+    }
+
+    #[test]
+    fn time_reversed_emit_dropped() {
+        let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+        bus.declare_metric(readiness(), MetricSpec::ratio(Retention::Short, "r"));
+        bus.emit(&readiness(), 0.5, 100);
+        bus.emit(&readiness(), 0.9, 50); // reversed; dropped
+        assert_eq!(bus.current(&readiness()), Some(0.5));
+    }
+
+    #[test]
+    fn redeclare_overrides_spec_preserves_history() {
+        let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+        bus.declare_metric(readiness(), MetricSpec::ratio(Retention::Short, "old"));
+        bus.emit(&readiness(), 0.5, 10);
+        bus.declare_metric(readiness(), MetricSpec::ratio(Retention::Long, "new"));
+        assert_eq!(bus.current(&readiness()), Some(0.5));
+    }
+
+    #[test]
+    fn window_collects_samples() {
+        let mut bus = AiBus::new();
+        bus.declare_metric(readiness(), MetricSpec::ratio(Retention::Long, "r"));
+        for t in 0..10 {
+            bus.emit(&readiness(), t as f64 / 10.0, t * 5);
+        }
+        let collected: Vec<f64> = bus.window(&readiness(), 25, 10).map(|tv| tv.value).collect();
+        assert_eq!(collected, vec![0.3, 0.4, 0.5]);
+    }
+
+    #[test]
+    fn window_on_undeclared_is_empty() {
+        let bus = AiBus::new();
+        let got: Vec<_> = bus.window(&MetricId::from("no"), 100, 50).collect();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn declare_emit_drain_command() {
+        let mut bus = AiBus::new();
+        let kind = CommandKindId::from("attack_target");
+        bus.declare_command(kind.clone(), CommandSpec::new("attack"));
+        bus.emit_command(Command::new(kind.clone(), FactionId(1), 42).with_priority(0.8));
+        bus.emit_command(Command::new(kind.clone(), FactionId(1), 43));
+        let drained = bus.drain_commands();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].at, 42);
+        assert!(bus.drain_commands().is_empty());
+    }
+
+    #[test]
+    fn emit_undeclared_command_kind_is_noop() {
+        let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+        bus.emit_command(Command::new(CommandKindId::from("unknown"), FactionId(1), 0));
+        assert!(bus.drain_commands().is_empty());
+    }
+
+    #[test]
+    fn redeclare_command_overrides_spec() {
+        let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+        let kind = CommandKindId::from("cmd");
+        bus.declare_command(kind.clone(), CommandSpec::new("old"));
+        bus.declare_command(kind.clone(), CommandSpec::new("new"));
+        assert!(bus.has_command_kind(&kind));
+    }
+
+    #[test]
+    fn declare_emit_query_evidence() {
+        let mut bus = AiBus::new();
+        bus.declare_evidence(hostile(), EvidenceSpec::new(Retention::Long, "hostile"));
+        bus.emit_evidence(StandingEvidence::new(
+            hostile(),
+            FactionId(1),
+            FactionId(2),
+            1.0,
+            10,
+        ));
+        bus.emit_evidence(StandingEvidence::new(
+            hostile(),
+            FactionId(1),
+            FactionId(3),
+            0.5,
+            20,
+        ));
+        bus.emit_evidence(StandingEvidence::new(
+            hostile(),
+            FactionId(2),
+            FactionId(1),
+            2.0,
+            25,
+        ));
+
+        // Filter by observer=1
+        let got: Vec<_> = bus.evidence_for(FactionId(1), 30, 50).collect();
+        assert_eq!(got.len(), 2);
+        assert!(got.iter().all(|e| e.observer == FactionId(1)));
+
+        // Filter by observer=2
+        let got2: Vec<_> = bus.evidence_for(FactionId(2), 30, 50).collect();
+        assert_eq!(got2.len(), 1);
+    }
+
+    #[test]
+    fn emit_undeclared_evidence_is_noop() {
+        let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+        bus.emit_evidence(StandingEvidence::new(
+            hostile(),
+            FactionId(1),
+            FactionId(2),
+            1.0,
+            0,
+        ));
+        let got: Vec<_> = bus.evidence_for(FactionId(1), 0, 100).collect();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn evidence_of_kind_filter() {
+        let mut bus = AiBus::new();
+        bus.declare_evidence(hostile(), EvidenceSpec::new(Retention::Long, "h"));
+        let other = EvidenceKindId::from("trade");
+        bus.declare_evidence(other.clone(), EvidenceSpec::new(Retention::Long, "t"));
+        bus.emit_evidence(StandingEvidence::new(
+            hostile(),
+            FactionId(1),
+            FactionId(2),
+            1.0,
+            10,
+        ));
+        bus.emit_evidence(StandingEvidence::new(
+            other.clone(),
+            FactionId(1),
+            FactionId(2),
+            1.0,
+            20,
+        ));
+        let hostile_only: Vec<_> = bus
+            .evidence_of_kind(&hostile(), FactionId(1), 30, 50)
+            .collect();
+        assert_eq!(hostile_only.len(), 1);
+        assert_eq!(hostile_only[0].kind, hostile());
+    }
+
+    #[test]
+    fn at_and_at_or_before() {
+        let mut bus = AiBus::new();
+        bus.declare_metric(readiness(), MetricSpec::ratio(Retention::Long, "r"));
+        bus.emit(&readiness(), 0.1, 10);
+        bus.emit(&readiness(), 0.2, 20);
+        assert_eq!(bus.at(&readiness(), 20), Some(0.2));
+        assert_eq!(bus.at(&readiness(), 15), None);
+        assert_eq!(bus.at_or_before(&readiness(), 15), Some(0.1));
+        assert_eq!(bus.at_or_before(&readiness(), 5), None);
+    }
+}

--- a/macrocosmo-ai/src/campaign.rs
+++ b/macrocosmo-ai/src/campaign.rs
@@ -1,0 +1,113 @@
+//! Campaign state machine.
+//!
+//! A `Campaign` is an in-flight pursuit of an `Objective`. It tracks its
+//! lifecycle state and records when transitions happen. Game-side code
+//! drives transitions based on current feasibility, success criteria, etc.
+//!
+//! Legal transitions:
+//!
+//! ```text
+//!   Proposed ─────┬──→ Active
+//!                 └──→ Abandoned
+//!   Active   ─────┬──→ Suspended
+//!                 ├──→ Succeeded
+//!                 ├──→ Failed
+//!                 └──→ Abandoned
+//!   Suspended ────┬──→ Active
+//!                 ├──→ Failed
+//!                 └──→ Abandoned
+//!   Succeeded ── (terminal)
+//!   Failed    ── (terminal)
+//!   Abandoned ── (terminal)
+//! ```
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::ids::ObjectiveId;
+use crate::time::Tick;
+
+/// Lifecycle state of a campaign.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CampaignState {
+    /// Newly created, not yet active.
+    Proposed,
+    /// Actively being pursued.
+    Active,
+    /// Temporarily paused (e.g., awaiting resources).
+    Suspended,
+    /// Success criteria met.
+    Succeeded,
+    /// Failed irrecoverably.
+    Failed,
+    /// Abandoned by the AI (e.g., feasibility dropped below threshold).
+    Abandoned,
+}
+
+impl CampaignState {
+    /// Whether this state is terminal (no outgoing transitions).
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            CampaignState::Succeeded | CampaignState::Failed | CampaignState::Abandoned
+        )
+    }
+}
+
+/// In-flight pursuit of an `Objective`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Campaign {
+    pub id: ObjectiveId,
+    pub state: CampaignState,
+    pub started_at: Tick,
+    pub last_transition: Tick,
+}
+
+/// Errors arising from illegal state transitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum CampaignError {
+    #[error("illegal transition: {from:?} -> {to:?}")]
+    IllegalTransition {
+        from: CampaignState,
+        to: CampaignState,
+    },
+}
+
+impl Campaign {
+    pub fn new(id: ObjectiveId, at: Tick) -> Self {
+        Self {
+            id,
+            state: CampaignState::Proposed,
+            started_at: at,
+            last_transition: at,
+        }
+    }
+
+    /// Attempt a transition to `to`. Returns `Ok(())` if legal; leaves state
+    /// untouched on `Err`.
+    pub fn transition(&mut self, to: CampaignState, now: Tick) -> Result<(), CampaignError> {
+        if Self::is_legal(self.state, to) {
+            self.state = to;
+            self.last_transition = now;
+            Ok(())
+        } else {
+            Err(CampaignError::IllegalTransition {
+                from: self.state,
+                to,
+            })
+        }
+    }
+
+    fn is_legal(from: CampaignState, to: CampaignState) -> bool {
+        use CampaignState::*;
+        match (from, to) {
+            (Proposed, Active) | (Proposed, Abandoned) => true,
+            (Active, Suspended)
+            | (Active, Succeeded)
+            | (Active, Failed)
+            | (Active, Abandoned) => true,
+            (Suspended, Active) | (Suspended, Failed) | (Suspended, Abandoned) => true,
+            _ => false,
+        }
+    }
+}

--- a/macrocosmo-ai/src/command.rs
+++ b/macrocosmo-ai/src/command.rs
@@ -1,0 +1,131 @@
+//! Command topic value types.
+//!
+//! Commands are AI → game outputs: the AI decides an action and `emit_command`s
+//! it; game code consumes them via `drain_commands`.
+//!
+//! `Command.params` is a small typed map so the AI core stays engine-agnostic
+//! while preserving enough expressiveness for typical parameters
+//! (faction/system/entity refs plus scalars and strings).
+
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use serde::{Deserialize, Serialize};
+
+use crate::ids::{CommandKindId, EntityRef, FactionId, FactionRef, SystemRef};
+use crate::time::Tick;
+
+/// A single parameter value carried by a `Command`.
+///
+/// The enum is intentionally narrow — anything that doesn't fit is the
+/// game's responsibility to encode into an `EntityRef` or a string key.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CommandValue {
+    F64(f64),
+    I64(i64),
+    Str(Arc<str>),
+    Faction(FactionId),
+    FactionRef(FactionRef),
+    System(SystemRef),
+    Entity(EntityRef),
+    Bool(bool),
+}
+
+impl From<f64> for CommandValue {
+    fn from(v: f64) -> Self {
+        CommandValue::F64(v)
+    }
+}
+
+impl From<i64> for CommandValue {
+    fn from(v: i64) -> Self {
+        CommandValue::I64(v)
+    }
+}
+
+impl From<bool> for CommandValue {
+    fn from(v: bool) -> Self {
+        CommandValue::Bool(v)
+    }
+}
+
+impl From<FactionId> for CommandValue {
+    fn from(v: FactionId) -> Self {
+        CommandValue::Faction(v)
+    }
+}
+
+impl From<FactionRef> for CommandValue {
+    fn from(v: FactionRef) -> Self {
+        CommandValue::FactionRef(v)
+    }
+}
+
+impl From<SystemRef> for CommandValue {
+    fn from(v: SystemRef) -> Self {
+        CommandValue::System(v)
+    }
+}
+
+impl From<EntityRef> for CommandValue {
+    fn from(v: EntityRef) -> Self {
+        CommandValue::Entity(v)
+    }
+}
+
+impl From<&str> for CommandValue {
+    fn from(v: &str) -> Self {
+        CommandValue::Str(Arc::from(v))
+    }
+}
+
+impl From<String> for CommandValue {
+    fn from(v: String) -> Self {
+        CommandValue::Str(Arc::from(v.into_boxed_str()))
+    }
+}
+
+/// Parameter map attached to a `Command`. Keys are short `Arc<str>` names.
+pub type CommandParams = AHashMap<Arc<str>, CommandValue>;
+
+/// An AI command destined for the game.
+///
+/// `at` is stamped by the emitter (typically `bus.now()` in the game loop).
+/// `priority` is a numeric score used by downstream queues to order commands.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Command {
+    pub kind: CommandKindId,
+    pub issuer: FactionId,
+    pub target: Option<FactionRef>,
+    pub params: CommandParams,
+    pub at: Tick,
+    pub priority: f64,
+}
+
+impl Command {
+    pub fn new(kind: CommandKindId, issuer: FactionId, at: Tick) -> Self {
+        Self {
+            kind,
+            issuer,
+            target: None,
+            params: AHashMap::new(),
+            at,
+            priority: 0.0,
+        }
+    }
+
+    pub fn with_target(mut self, target: FactionRef) -> Self {
+        self.target = Some(target);
+        self
+    }
+
+    pub fn with_priority(mut self, priority: f64) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    pub fn with_param(mut self, key: impl Into<Arc<str>>, value: impl Into<CommandValue>) -> Self {
+        self.params.insert(key.into(), value.into());
+        self
+    }
+}

--- a/macrocosmo-ai/src/condition.rs
+++ b/macrocosmo-ai/src/condition.rs
@@ -1,0 +1,216 @@
+//! Condition tree and evaluator.
+//!
+//! A `Condition` is a boolean expression over the AI bus. It has no
+//! side effects and is evaluated via `evaluate(&EvalContext)`.
+//!
+//! Phase 1 ships a narrow atom vocabulary sufficient to express
+//! preconditions and simple feasibility gates. The atom set is open — more
+//! atoms can be added without touching the tree combinators.
+
+use serde::{Deserialize, Serialize};
+
+use crate::eval::EvalContext;
+use crate::ids::{EvidenceKindId, MetricId};
+use crate::time::Tick;
+
+/// Tree combinator: logical composition of atomic conditions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Condition {
+    /// Always `true`. Useful as a default precondition.
+    Always,
+    /// Always `false`.
+    Never,
+    /// Conjunction — all children must hold.
+    All(Vec<Condition>),
+    /// Disjunction — at least one child must hold.
+    Any(Vec<Condition>),
+    /// Exclusive — exactly one child must hold.
+    OneOf(Vec<Condition>),
+    /// Negation.
+    Not(Box<Condition>),
+    /// A leaf atom interpreted against the bus.
+    Atom(ConditionAtom),
+}
+
+/// Leaf atoms. Extend freely; the combinators above do not care.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ConditionAtom {
+    /// True iff the metric's current value exceeds `threshold`.
+    MetricAbove { metric: MetricId, threshold: f64 },
+    /// True iff the metric's current value is below `threshold`.
+    MetricBelow { metric: MetricId, threshold: f64 },
+    /// True iff the metric has an emitted value (declared and not stale-empty).
+    MetricPresent { metric: MetricId },
+    /// True iff the observing faction (from `ctx.faction`) has accumulated
+    /// more than `threshold` evidence entries of `kind` in the last
+    /// `window` ticks. Returns `false` if `ctx.faction` is unset.
+    EvidenceCountExceeds {
+        kind: EvidenceKindId,
+        window: Tick,
+        threshold: usize,
+    },
+}
+
+impl Condition {
+    pub fn and(children: impl IntoIterator<Item = Condition>) -> Self {
+        Condition::All(children.into_iter().collect())
+    }
+
+    pub fn or(children: impl IntoIterator<Item = Condition>) -> Self {
+        Condition::Any(children.into_iter().collect())
+    }
+
+    pub fn not(inner: Condition) -> Self {
+        Condition::Not(Box::new(inner))
+    }
+
+    pub fn evaluate(&self, ctx: &EvalContext) -> bool {
+        match self {
+            Condition::Always => true,
+            Condition::Never => false,
+            Condition::All(children) => children.iter().all(|c| c.evaluate(ctx)),
+            Condition::Any(children) => children.iter().any(|c| c.evaluate(ctx)),
+            Condition::OneOf(children) => {
+                children.iter().filter(|c| c.evaluate(ctx)).count() == 1
+            }
+            Condition::Not(inner) => !inner.evaluate(ctx),
+            Condition::Atom(a) => a.evaluate(ctx),
+        }
+    }
+}
+
+impl ConditionAtom {
+    pub fn evaluate(&self, ctx: &EvalContext) -> bool {
+        match self {
+            ConditionAtom::MetricAbove { metric, threshold } => {
+                ctx.bus.current(metric).map_or(false, |v| v > *threshold)
+            }
+            ConditionAtom::MetricBelow { metric, threshold } => {
+                ctx.bus.current(metric).map_or(false, |v| v < *threshold)
+            }
+            ConditionAtom::MetricPresent { metric } => ctx.bus.current(metric).is_some(),
+            ConditionAtom::EvidenceCountExceeds {
+                kind,
+                window,
+                threshold,
+            } => {
+                let Some(observer) = ctx.faction else {
+                    return false;
+                };
+                let count = ctx
+                    .bus
+                    .evidence_of_kind(kind, observer, ctx.now, *window)
+                    .count();
+                count > *threshold
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus::AiBus;
+    use crate::evidence::StandingEvidence;
+    use crate::ids::FactionId;
+    use crate::retention::Retention;
+    use crate::spec::{EvidenceSpec, MetricSpec};
+    use crate::warning::WarningMode;
+
+    fn bus() -> AiBus {
+        AiBus::with_warning_mode(WarningMode::Silent)
+    }
+
+    #[test]
+    fn always_never() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        assert!(Condition::Always.evaluate(&ctx));
+        assert!(!Condition::Never.evaluate(&ctx));
+    }
+
+    #[test]
+    fn all_and_any() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        let t = Condition::Always;
+        let f = Condition::Never;
+        assert!(Condition::All(vec![t.clone(), t.clone()]).evaluate(&ctx));
+        assert!(!Condition::All(vec![t.clone(), f.clone()]).evaluate(&ctx));
+        assert!(Condition::Any(vec![t.clone(), f.clone()]).evaluate(&ctx));
+        assert!(!Condition::Any(vec![f.clone(), f.clone()]).evaluate(&ctx));
+    }
+
+    #[test]
+    fn one_of() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        let t = Condition::Always;
+        let f = Condition::Never;
+        assert!(Condition::OneOf(vec![t.clone(), f.clone()]).evaluate(&ctx));
+        assert!(!Condition::OneOf(vec![t.clone(), t.clone()]).evaluate(&ctx));
+        assert!(!Condition::OneOf(vec![f.clone(), f.clone()]).evaluate(&ctx));
+    }
+
+    #[test]
+    fn not_inverts() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        assert!(Condition::not(Condition::Never).evaluate(&ctx));
+        assert!(!Condition::not(Condition::Always).evaluate(&ctx));
+    }
+
+    #[test]
+    fn metric_above_below_present() {
+        let mut b = bus();
+        let id = MetricId::from("x");
+        b.declare_metric(id.clone(), MetricSpec::gauge(Retention::Short, "x"));
+        b.emit(&id, 0.7, 10);
+        let ctx = EvalContext::new(&b, 10);
+        assert!(ConditionAtom::MetricAbove {
+            metric: id.clone(),
+            threshold: 0.5
+        }
+        .evaluate(&ctx));
+        assert!(ConditionAtom::MetricBelow {
+            metric: id.clone(),
+            threshold: 1.0
+        }
+        .evaluate(&ctx));
+        assert!(ConditionAtom::MetricPresent { metric: id.clone() }.evaluate(&ctx));
+        assert!(!ConditionAtom::MetricPresent {
+            metric: MetricId::from("y"),
+        }
+        .evaluate(&ctx));
+    }
+
+    #[test]
+    fn evidence_count_requires_faction_context() {
+        let mut b = bus();
+        let kind = EvidenceKindId::from("hostile");
+        b.declare_evidence(kind.clone(), EvidenceSpec::new(Retention::Long, "h"));
+        for t in 0..5 {
+            b.emit_evidence(StandingEvidence::new(
+                kind.clone(),
+                FactionId(1),
+                FactionId(2),
+                1.0,
+                t * 10,
+            ));
+        }
+        let atom = ConditionAtom::EvidenceCountExceeds {
+            kind: kind.clone(),
+            window: 100,
+            threshold: 3,
+        };
+        // Without faction set in ctx -> false
+        let ctx_no = EvalContext::new(&b, 50);
+        assert!(!atom.evaluate(&ctx_no));
+        // With faction=1 matching observer -> 5 entries > 3
+        let ctx_yes = EvalContext::new(&b, 50).with_faction(FactionId(1));
+        assert!(atom.evaluate(&ctx_yes));
+        // With faction=2 (no entries) -> false
+        let ctx_other = EvalContext::new(&b, 50).with_faction(FactionId(2));
+        assert!(!atom.evaluate(&ctx_other));
+    }
+}

--- a/macrocosmo-ai/src/eval.rs
+++ b/macrocosmo-ai/src/eval.rs
@@ -1,0 +1,32 @@
+//! Evaluation context passed to pure evaluators (`Condition::evaluate`,
+//! `ValueExpr::evaluate`, `feasibility::evaluate`).
+//!
+//! Holds only references — cheap to copy and thread through recursive
+//! evaluators. Atoms carry their own faction refs; `faction` here is a
+//! "default observer" used when atoms leave it implicit.
+
+use crate::bus::AiBus;
+use crate::ids::FactionId;
+use crate::time::Tick;
+
+#[derive(Clone, Copy)]
+pub struct EvalContext<'a> {
+    pub bus: &'a AiBus,
+    pub now: Tick,
+    pub faction: Option<FactionId>,
+}
+
+impl<'a> EvalContext<'a> {
+    pub fn new(bus: &'a AiBus, now: Tick) -> Self {
+        Self {
+            bus,
+            now,
+            faction: None,
+        }
+    }
+
+    pub fn with_faction(mut self, f: FactionId) -> Self {
+        self.faction = Some(f);
+        self
+    }
+}

--- a/macrocosmo-ai/src/evidence.rs
+++ b/macrocosmo-ai/src/evidence.rs
@@ -1,0 +1,111 @@
+//! Evidence topic value types.
+//!
+//! `StandingEvidence` is a single datum supporting (or weakening) an observer's
+//! opinion of a target faction. Evidence optionally decays exponentially over
+//! time: `effective = magnitude * 0.5^((now - at) / halflife)`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ids::{EvidenceKindId, FactionId};
+use crate::time::Tick;
+
+/// A single piece of evidence influencing perceived standing between factions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StandingEvidence {
+    pub kind: EvidenceKindId,
+    pub observer: FactionId,
+    pub target: FactionId,
+    /// Signed magnitude. Positive = friendly, negative = hostile. Unit is
+    /// defined per-kind; #193 defines the interpretation.
+    pub magnitude: f64,
+    pub at: Tick,
+    /// Optional exponential half-life in ticks. `None` = no decay.
+    pub decay_halflife: Option<Tick>,
+}
+
+impl StandingEvidence {
+    pub fn new(
+        kind: EvidenceKindId,
+        observer: FactionId,
+        target: FactionId,
+        magnitude: f64,
+        at: Tick,
+    ) -> Self {
+        Self {
+            kind,
+            observer,
+            target,
+            magnitude,
+            at,
+            decay_halflife: None,
+        }
+    }
+
+    pub fn with_halflife(mut self, halflife: Tick) -> Self {
+        self.decay_halflife = Some(halflife);
+        self
+    }
+
+    /// Effective magnitude at `now`, applying exponential decay if a half-life
+    /// is set. If `now < at` (evidence from the future), returns the raw
+    /// magnitude — the bus enforces monotonic emits so this only happens
+    /// when querying an observation earlier than its observation time,
+    /// which callers should not do.
+    pub fn current_magnitude(&self, now: Tick) -> f64 {
+        match self.decay_halflife {
+            Some(hl) if hl > 0 => {
+                let elapsed = (now - self.at).max(0) as f64;
+                let factor = 0.5f64.powf(elapsed / hl as f64);
+                self.magnitude * factor
+            }
+            _ => self.magnitude,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(magnitude: f64, at: Tick, halflife: Option<Tick>) -> StandingEvidence {
+        let mut e = StandingEvidence::new(
+            EvidenceKindId::from("test"),
+            FactionId(1),
+            FactionId(2),
+            magnitude,
+            at,
+        );
+        if let Some(hl) = halflife {
+            e = e.with_halflife(hl);
+        }
+        e
+    }
+
+    #[test]
+    fn no_halflife_no_decay() {
+        let e = ev(10.0, 0, None);
+        assert_eq!(e.current_magnitude(0), 10.0);
+        assert_eq!(e.current_magnitude(1000), 10.0);
+    }
+
+    #[test]
+    fn halflife_half_after_one_halflife() {
+        let e = ev(10.0, 0, Some(100));
+        let v = e.current_magnitude(100);
+        assert!((v - 5.0).abs() < 1e-9, "expected 5.0, got {v}");
+    }
+
+    #[test]
+    fn halflife_quarter_after_two_halflives() {
+        let e = ev(10.0, 0, Some(100));
+        let v = e.current_magnitude(200);
+        assert!((v - 2.5).abs() < 1e-9, "expected 2.5, got {v}");
+    }
+
+    #[test]
+    fn no_decay_for_negative_elapsed() {
+        let e = ev(10.0, 100, Some(50));
+        // Querying before observation — should not amplify.
+        assert_eq!(e.current_magnitude(50), 10.0);
+    }
+}

--- a/macrocosmo-ai/src/feasibility.rs
+++ b/macrocosmo-ai/src/feasibility.rs
@@ -1,0 +1,129 @@
+//! Feasibility formula: how an `Objective` is scored against the current
+//! bus state. Pure data + pure evaluator.
+//!
+//! `WeightedSum` is the canonical formula — a linear combination of
+//! `ValueExpr` terms. `Custom(ScriptRef)` is a Phase-later stub.
+//!
+//! `prior` is reserved for future EMA-style smoothing. Phase 2 ignores it.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bus::AiBus;
+use crate::eval::EvalContext;
+use crate::time::Tick;
+use crate::value_expr::{ScriptRef, ValueExpr};
+
+/// A single weighted term in a `WeightedSum` formula.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeasibilityTerm {
+    pub weight: f64,
+    pub expr: ValueExpr,
+}
+
+impl FeasibilityTerm {
+    pub fn new(weight: f64, expr: ValueExpr) -> Self {
+        Self { weight, expr }
+    }
+}
+
+/// Feasibility formula. Evaluated against an `AiBus` + `now`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum FeasibilityFormula {
+    /// Linear combination of weighted `ValueExpr` terms.
+    WeightedSum(Vec<FeasibilityTerm>),
+    /// External script reference. Phase 2 stub returns `0.0`.
+    Custom(ScriptRef),
+}
+
+/// Evaluate a feasibility formula.
+///
+/// `prior` (reserved) is not used in Phase 2; future phases may combine the
+/// fresh score with a stored prior via an EMA or similar smoother.
+pub fn evaluate(
+    formula: &FeasibilityFormula,
+    bus: &AiBus,
+    now: Tick,
+    _prior: Option<f64>,
+) -> f64 {
+    let ctx = EvalContext::new(bus, now);
+    match formula {
+        FeasibilityFormula::WeightedSum(terms) => terms
+            .iter()
+            .map(|t| t.weight * t.expr.evaluate(&ctx))
+            .sum(),
+        FeasibilityFormula::Custom(_) => 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::MetricId;
+    use crate::retention::Retention;
+    use crate::spec::MetricSpec;
+    use crate::value_expr::MetricRef;
+    use crate::warning::WarningMode;
+
+    fn bus() -> AiBus {
+        AiBus::with_warning_mode(WarningMode::Silent)
+    }
+
+    #[test]
+    fn empty_weighted_sum_is_zero() {
+        let b = bus();
+        let f = FeasibilityFormula::WeightedSum(vec![]);
+        assert_eq!(evaluate(&f, &b, 0, None), 0.0);
+    }
+
+    #[test]
+    fn weighted_sum_of_literals() {
+        let b = bus();
+        let f = FeasibilityFormula::WeightedSum(vec![
+            FeasibilityTerm::new(0.5, ValueExpr::Literal(2.0)),
+            FeasibilityTerm::new(0.25, ValueExpr::Literal(4.0)),
+        ]);
+        // 0.5*2 + 0.25*4 = 1.0 + 1.0 = 2.0
+        assert_eq!(evaluate(&f, &b, 0, None), 2.0);
+    }
+
+    #[test]
+    fn weighted_sum_over_metrics() {
+        let mut b = bus();
+        let readiness = MetricId::from("readiness");
+        let force = MetricId::from("force");
+        b.declare_metric(
+            readiness.clone(),
+            MetricSpec::ratio(Retention::Short, "r"),
+        );
+        b.declare_metric(force.clone(), MetricSpec::gauge(Retention::Short, "f"));
+        b.emit(&readiness, 0.8, 10);
+        b.emit(&force, 100.0, 10);
+        let f = FeasibilityFormula::WeightedSum(vec![
+            FeasibilityTerm::new(1.0, ValueExpr::Metric(MetricRef::new(readiness))),
+            FeasibilityTerm::new(
+                0.01,
+                ValueExpr::Metric(MetricRef::new(force)),
+            ),
+        ]);
+        // 1.0*0.8 + 0.01*100 = 0.8 + 1.0 = 1.8
+        assert!((evaluate(&f, &b, 10, None) - 1.8).abs() < 1e-9);
+    }
+
+    #[test]
+    fn custom_formula_is_stub_zero() {
+        let b = bus();
+        let f = FeasibilityFormula::Custom(ScriptRef::from("myscript"));
+        assert_eq!(evaluate(&f, &b, 0, None), 0.0);
+    }
+
+    #[test]
+    fn prior_is_ignored_in_phase2() {
+        let b = bus();
+        let f = FeasibilityFormula::WeightedSum(vec![FeasibilityTerm::new(
+            1.0,
+            ValueExpr::Literal(0.5),
+        )]);
+        assert_eq!(evaluate(&f, &b, 0, None), 0.5);
+        assert_eq!(evaluate(&f, &b, 0, Some(0.9)), 0.5);
+    }
+}

--- a/macrocosmo-ai/src/ids.rs
+++ b/macrocosmo-ai/src/ids.rs
@@ -1,0 +1,143 @@
+//! Strongly-typed ID newtypes for the AI bus.
+//!
+//! String-based IDs use `Arc<str>` for cheap clones and stable hashing.
+//! Numeric IDs are opaque newtypes — the integration layer in `macrocosmo/src/ai/`
+//! (#203) is responsible for translating these to/from engine types
+//! (`macrocosmo::faction::FactionId`, Bevy `Entity`, etc.).
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+/// Opaque faction identifier. The integration layer maps this to the engine's
+/// canonical faction identifier (e.g., a `u32` derived from a `FactionTypeDefinition`
+/// or an `Entity` index).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FactionId(pub u32);
+
+impl From<u32> for FactionId {
+    fn from(v: u32) -> Self {
+        Self(v)
+    }
+}
+
+/// Reference to a faction: either the observing faction itself, or a specific
+/// other faction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum FactionRef {
+    /// "self" in the observing context.
+    Me,
+    Other(FactionId),
+}
+
+impl From<FactionId> for FactionRef {
+    fn from(id: FactionId) -> Self {
+        FactionRef::Other(id)
+    }
+}
+
+/// Opaque handle to a star system. Integration layer maps this to Bevy `Entity`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SystemRef(pub u64);
+
+/// Opaque handle to an arbitrary game entity (ship, colony, structure, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EntityRef(pub u64);
+
+/// Helper: declare an `Arc<str>`-backed string newtype used for topic IDs and
+/// similar identifiers. Derives the common traits and provides `From<&str>`,
+/// `From<String>`, `Deref<Target = str>`.
+macro_rules! arc_str_id {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        pub struct $name(Arc<str>);
+
+        impl $name {
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                Self(Arc::from(s))
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(Arc::from(s.into_boxed_str()))
+            }
+        }
+
+        impl From<Arc<str>> for $name {
+            fn from(s: Arc<str>) -> Self {
+                Self(s)
+            }
+        }
+
+        impl std::ops::Deref for $name {
+            type Target = str;
+            fn deref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+arc_str_id! {
+    /// Identifier for a metric topic (e.g. `"fleet_readiness"`).
+    MetricId
+}
+
+arc_str_id! {
+    /// Identifier for a command kind (e.g. `"attack_target"`).
+    CommandKindId
+}
+
+arc_str_id! {
+    /// Identifier for an evidence kind (e.g. `"hostile_engagement"`).
+    EvidenceKindId
+}
+
+arc_str_id! {
+    /// Identifier for an objective (e.g. `"defensive_posture"`).
+    ObjectiveId
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arc_str_id_equality_across_constructors() {
+        let a = MetricId::from("fleet_readiness");
+        let b = MetricId::from(String::from("fleet_readiness"));
+        assert_eq!(a, b);
+        assert_eq!(a.as_str(), "fleet_readiness");
+        assert_eq!(&*a, "fleet_readiness");
+    }
+
+    #[test]
+    fn faction_ref_from_faction_id() {
+        let fid = FactionId(7);
+        let r: FactionRef = fid.into();
+        assert_eq!(r, FactionRef::Other(FactionId(7)));
+    }
+
+    #[test]
+    fn ids_are_hashable_in_maps() {
+        use std::collections::HashMap;
+        let mut m: HashMap<MetricId, i32> = HashMap::new();
+        m.insert(MetricId::from("a"), 1);
+        m.insert(MetricId::from("b"), 2);
+        assert_eq!(m.get(&MetricId::from("a")), Some(&1));
+    }
+}

--- a/macrocosmo-ai/src/lib.rs
+++ b/macrocosmo-ai/src/lib.rs
@@ -1,36 +1,50 @@
-//! macrocosmo-ai — 疎結合 AI クレート。
+//! macrocosmo-ai — engine-agnostic AI core for macrocosmo.
 //!
-//! macrocosmo engine が提供する FactionRelations / KnowledgeStore / Ship 等を
-//! 読み取り専用で参照し、CommandQueue / PendingDiplomaticAction / ScopedFlags
-//! への書き込みのみを行う。
+//! 設計方針:
+//! - **Typed topic bus** アーキテクチャ。`AiBus` に metric / command / evidence の
+//!   3 種類のトピックを型付きで保持する。
+//! - **Callback は ai_core に流れ込まない**。game 側は bus に emit し、
+//!   純粋関数 (feasibility::evaluate, nash::solve_*, Condition::evaluate 等) を
+//!   呼ぶ。ai_core から game への呼び戻しは存在しない。
+//! - **依存方向**: `macrocosmo → macrocosmo-ai` (逆は禁止)。本 crate は
+//!   bevy / macrocosmo / mlua に依存しない。型変換レイヤは macrocosmo 側の
+//!   `src/ai/` モジュール (#203) で実装される。
 //!
-//! 境界ルール:
-//! - 他 faction の真値にはアクセスしない (KnowledgeStore 経由のみ)
-//! - Lua Engine には間接アクセス (engine の提供する Command 型経由)
-//!
-//! 初期段階では空の Plugin のみ提供。個別 AI 機能 (#189-#194) は段階的に
-//! ここに実装される。
-
-use bevy::prelude::*;
-
-/// AI 基盤 Plugin。
-///
-/// 登録方法: 現状の macrocosmo クレートは lib + bin の単一クレートのため、
-/// macrocosmo → macrocosmo-ai の循環依存を避けて **本プラグインは bin から
-/// 登録されない**。AI 実装時 (#189 以降) に以下のどちらかで統合予定:
-///
-/// 1. `macrocosmo-bin` を別 crate として切り出し、両者を依存する
-///    (案 B、0.3.0 完成後)
-/// 2. macrocosmo engine に AiPlugin 用の hook trait を定義し、macrocosmo-ai
-///    がそれを実装する形 (案 C)
-///
-/// いずれも #189 AI umbrella 実装時に決定。現段階では空プラグインとして用意。
-pub struct AiPlugin;
-
-impl Plugin for AiPlugin {
-    fn build(&self, _app: &mut App) {
-        // #189 以降の AI system がここに登録される。
-    }
-}
+//! Phase 1 + 2 の範囲については issue #195 を参照。
 
 pub mod ai_params;
+pub mod bus;
+pub mod campaign;
+pub mod command;
+pub mod condition;
+pub mod eval;
+pub mod evidence;
+pub mod feasibility;
+pub mod ids;
+pub mod nash;
+pub mod objective;
+pub mod projection;
+pub mod retention;
+pub mod spec;
+pub mod time;
+pub mod value_expr;
+pub mod warning;
+
+#[cfg(any(test, feature = "mock"))]
+pub mod mock;
+
+pub use bus::AiBus;
+pub use condition::{Condition, ConditionAtom};
+pub use eval::EvalContext;
+pub use value_expr::{MetricRef, ScriptRef, ValueExpr};
+
+pub use command::{Command, CommandParams, CommandValue};
+pub use evidence::StandingEvidence;
+pub use ids::{
+    CommandKindId, EntityRef, EvidenceKindId, FactionId, FactionRef, MetricId, ObjectiveId,
+    SystemRef,
+};
+pub use retention::Retention;
+pub use spec::{CommandSpec, EvidenceSpec, MetricSpec, MetricType};
+pub use time::{Tick, TimestampedValue};
+pub use warning::WarningMode;

--- a/macrocosmo-ai/src/mock.rs
+++ b/macrocosmo-ai/src/mock.rs
@@ -1,0 +1,206 @@
+//! Mock helpers for tests and downstream verification harnesses.
+//!
+//! Gated behind `feature = "mock"` so downstream crates (e.g. a future
+//! `ai_test_harness` or #196 Headless Verification) can depend on this
+//! module explicitly via:
+//!
+//! ```toml
+//! macrocosmo-ai = { path = "...", features = ["mock"] }
+//! ```
+//!
+//! Tests inside this crate enable the feature transitively via the
+//! `dev-dependencies` self-reference in `Cargo.toml`.
+
+use crate::bus::AiBus;
+use crate::command::Command;
+use crate::evidence::StandingEvidence;
+use crate::ids::{CommandKindId, EvidenceKindId, FactionId, MetricId};
+use crate::retention::Retention;
+use crate::spec::{CommandSpec, EvidenceSpec, MetricSpec};
+use crate::time::Tick;
+use crate::warning::WarningMode;
+
+/// Common metric ids used by fixtures. Not exhaustive — add freely.
+pub mod metric_ids {
+    use crate::ids::MetricId;
+    pub fn fleet_readiness() -> MetricId {
+        MetricId::from("fleet_readiness")
+    }
+    pub fn economic_capacity() -> MetricId {
+        MetricId::from("economic_capacity")
+    }
+    pub fn local_force_ratio() -> MetricId {
+        MetricId::from("local_force_ratio")
+    }
+}
+
+/// Common command kinds used by fixtures.
+pub mod command_kinds {
+    use crate::ids::CommandKindId;
+    pub fn attack_target() -> CommandKindId {
+        CommandKindId::from("attack_target")
+    }
+    pub fn reposition() -> CommandKindId {
+        CommandKindId::from("reposition")
+    }
+    pub fn retreat() -> CommandKindId {
+        CommandKindId::from("retreat")
+    }
+}
+
+/// Common evidence kinds used by fixtures.
+pub mod evidence_kinds {
+    use crate::ids::EvidenceKindId;
+    pub fn hostile_engagement() -> EvidenceKindId {
+        EvidenceKindId::from("hostile_engagement")
+    }
+    pub fn fleet_loss() -> EvidenceKindId {
+        EvidenceKindId::from("fleet_loss")
+    }
+}
+
+/// Build a silent-mode bus with the canonical fixture schemas pre-declared.
+/// No data is emitted — callers populate as needed.
+pub fn preconfigured_bus() -> AiBus {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+
+    bus.declare_metric(
+        metric_ids::fleet_readiness(),
+        MetricSpec::ratio(Retention::Medium, "fleet readiness (0..1)"),
+    );
+    bus.declare_metric(
+        metric_ids::economic_capacity(),
+        MetricSpec::ratio(Retention::Medium, "economic capacity (0..1)"),
+    );
+    bus.declare_metric(
+        metric_ids::local_force_ratio(),
+        MetricSpec::gauge(Retention::Short, "own/enemy force ratio"),
+    );
+
+    bus.declare_command(
+        command_kinds::attack_target(),
+        CommandSpec::new("issue an attack against a target"),
+    );
+    bus.declare_command(
+        command_kinds::reposition(),
+        CommandSpec::new("move fleet to a tactical position"),
+    );
+    bus.declare_command(
+        command_kinds::retreat(),
+        CommandSpec::new("fall back from engagement"),
+    );
+
+    bus.declare_evidence(
+        evidence_kinds::hostile_engagement(),
+        EvidenceSpec::new(Retention::Long, "hostile engaged our assets"),
+    );
+    bus.declare_evidence(
+        evidence_kinds::fleet_loss(),
+        EvidenceSpec::new(Retention::Long, "we lost a fleet asset"),
+    );
+
+    bus
+}
+
+/// Emit a linearly interpolated series of metric samples over
+/// `[start_at, start_at + steps * step]`.
+pub fn emit_linear(
+    bus: &mut AiBus,
+    metric: &MetricId,
+    from: f64,
+    to: f64,
+    start_at: Tick,
+    step: Tick,
+    steps: usize,
+) {
+    if steps == 0 {
+        return;
+    }
+    let denom = if steps > 1 { (steps - 1) as f64 } else { 1.0 };
+    for i in 0..steps {
+        let t = start_at + (i as Tick) * step;
+        let frac = i as f64 / denom;
+        let v = from + (to - from) * frac;
+        bus.emit(metric, v, t);
+    }
+}
+
+/// Emit a single evidence point conveniently.
+pub fn emit_evidence(
+    bus: &mut AiBus,
+    kind: EvidenceKindId,
+    observer: FactionId,
+    target: FactionId,
+    magnitude: f64,
+    at: Tick,
+) {
+    bus.emit_evidence(StandingEvidence::new(kind, observer, target, magnitude, at));
+}
+
+/// Emit a simple command with a priority.
+pub fn emit_command(
+    bus: &mut AiBus,
+    kind: CommandKindId,
+    issuer: FactionId,
+    at: Tick,
+    priority: f64,
+) {
+    bus.emit_command(Command::new(kind, issuer, at).with_priority(priority));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preconfigured_bus_has_canonical_metrics() {
+        let bus = preconfigured_bus();
+        assert!(bus.has_metric(&metric_ids::fleet_readiness()));
+        assert!(bus.has_metric(&metric_ids::economic_capacity()));
+        assert!(bus.has_metric(&metric_ids::local_force_ratio()));
+        assert!(bus.has_command_kind(&command_kinds::attack_target()));
+        assert!(bus.has_evidence_kind(&evidence_kinds::hostile_engagement()));
+    }
+
+    #[test]
+    fn emit_linear_produces_expected_samples() {
+        let mut bus = preconfigured_bus();
+        let id = metric_ids::fleet_readiness();
+        emit_linear(&mut bus, &id, 0.0, 1.0, 0, 10, 5);
+        let got: Vec<f64> = bus.window(&id, 40, 50).map(|tv| tv.value).collect();
+        assert_eq!(got.len(), 5);
+        assert!((got[0] - 0.0).abs() < 1e-9);
+        assert!((got[4] - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn emit_linear_single_step() {
+        let mut bus = preconfigured_bus();
+        let id = metric_ids::fleet_readiness();
+        emit_linear(&mut bus, &id, 0.5, 0.5, 0, 10, 1);
+        assert_eq!(bus.current(&id), Some(0.5));
+    }
+
+    #[test]
+    fn emit_linear_zero_steps_is_noop() {
+        let mut bus = preconfigured_bus();
+        let id = metric_ids::fleet_readiness();
+        emit_linear(&mut bus, &id, 0.0, 1.0, 0, 10, 0);
+        assert_eq!(bus.current(&id), None);
+    }
+
+    #[test]
+    fn helper_emit_command_enqueues() {
+        let mut bus = preconfigured_bus();
+        emit_command(
+            &mut bus,
+            command_kinds::attack_target(),
+            FactionId(1),
+            10,
+            0.9,
+        );
+        let drained = bus.drain_commands();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].priority, 0.9);
+    }
+}

--- a/macrocosmo-ai/src/nash.rs
+++ b/macrocosmo-ai/src/nash.rs
@@ -1,0 +1,45 @@
+//! Nash equilibrium solver — **Phase 2 stub**.
+//!
+//! The real 2-player zero-sum solver (#190) will live here. For now we provide
+//! the type shapes so downstream code can compile and test against the
+//! interface, returning zero-payoff placeholders.
+
+use serde::{Deserialize, Serialize};
+
+/// A payoff pair: `row` is the row player's utility, `col` is the column
+/// player's utility. In a zero-sum game `col = -row`.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+pub struct NashPayoff {
+    pub row: f64,
+    pub col: f64,
+}
+
+/// Solve a 2x2 2-player zero-sum game.
+///
+/// **TODO Phase 3**: implement a minimax / LP-based solver. For now this
+/// returns `NashPayoff { row: 0.0, col: 0.0 }` regardless of input.
+#[allow(unused_variables)]
+pub fn solve_2p_zero_sum(payoff_matrix: &[[f64; 2]; 2]) -> NashPayoff {
+    NashPayoff {
+        row: 0.0,
+        col: 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stub_returns_zero() {
+        let m = [[1.0, -1.0], [-1.0, 1.0]];
+        assert_eq!(solve_2p_zero_sum(&m), NashPayoff::default());
+    }
+
+    #[test]
+    fn payoff_is_default_zero() {
+        let p = NashPayoff::default();
+        assert_eq!(p.row, 0.0);
+        assert_eq!(p.col, 0.0);
+    }
+}

--- a/macrocosmo-ai/src/objective.rs
+++ b/macrocosmo-ai/src/objective.rs
@@ -1,0 +1,147 @@
+//! Objective data types.
+//!
+//! An `Objective` describes what the AI is trying to achieve and how its
+//! progress is measured. It is pure data — no evaluation logic beyond
+//! constructors. Evaluation is split across:
+//!
+//! - `condition::Condition::evaluate` for preconditions / success criteria
+//! - `feasibility::evaluate` for the feasibility score
+//! - Game-side code for decomposition and delegation
+
+use ahash::AHashMap;
+use serde::{Deserialize, Serialize};
+
+use crate::condition::Condition;
+use crate::feasibility::FeasibilityFormula;
+use crate::ids::ObjectiveId;
+use crate::value_expr::ValueExpr;
+
+/// Free-form parameter bag attached to an `Objective` (e.g., target faction,
+/// target metric threshold). Game code interprets keys.
+pub type ObjectiveParams = AHashMap<std::sync::Arc<str>, ValueExpr>;
+
+/// The set of preconditions that must hold for an objective to be considered
+/// feasible to pursue. A single `Condition` suffices — use `Condition::All`
+/// (or the `Condition::and(...)` helper) for conjunction.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PreconditionSet {
+    pub condition: Condition,
+}
+
+impl PreconditionSet {
+    pub fn new(condition: Condition) -> Self {
+        Self { condition }
+    }
+
+    pub fn always() -> Self {
+        Self {
+            condition: Condition::Always,
+        }
+    }
+}
+
+impl Default for PreconditionSet {
+    fn default() -> Self {
+        Self::always()
+    }
+}
+
+/// The condition under which an objective is considered complete.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SuccessCriteria {
+    pub condition: Condition,
+}
+
+impl SuccessCriteria {
+    pub fn new(condition: Condition) -> Self {
+        Self { condition }
+    }
+}
+
+/// A rule for decomposing a parent objective into sub-objectives when a
+/// trigger condition holds. Game-side orchestration applies these rules.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DecompositionRule {
+    pub parent: ObjectiveId,
+    pub children: Vec<ObjectiveId>,
+    pub trigger: Condition,
+}
+
+/// A full objective definition.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Objective {
+    pub id: ObjectiveId,
+    pub params: ObjectiveParams,
+    pub precondition: PreconditionSet,
+    pub success: SuccessCriteria,
+    pub feasibility: FeasibilityFormula,
+}
+
+impl Objective {
+    pub fn new(
+        id: ObjectiveId,
+        precondition: PreconditionSet,
+        success: SuccessCriteria,
+        feasibility: FeasibilityFormula,
+    ) -> Self {
+        Self {
+            id,
+            params: AHashMap::new(),
+            precondition,
+            success,
+            feasibility,
+        }
+    }
+
+    pub fn with_param(
+        mut self,
+        key: impl Into<std::sync::Arc<str>>,
+        value: ValueExpr,
+    ) -> Self {
+        self.params.insert(key.into(), value);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feasibility::{FeasibilityFormula, FeasibilityTerm};
+
+    #[test]
+    fn precondition_default_is_always() {
+        let p = PreconditionSet::default();
+        assert_eq!(p.condition, Condition::Always);
+    }
+
+    #[test]
+    fn objective_ctor_builds_sane_struct() {
+        let id = ObjectiveId::from("defensive_posture");
+        let obj = Objective::new(
+            id.clone(),
+            PreconditionSet::always(),
+            SuccessCriteria::new(Condition::Always),
+            FeasibilityFormula::WeightedSum(vec![FeasibilityTerm::new(
+                1.0,
+                ValueExpr::Literal(0.5),
+            )]),
+        )
+        .with_param("intensity", ValueExpr::Literal(0.8));
+        assert_eq!(obj.id, id);
+        assert!(obj.params.contains_key("intensity"));
+    }
+
+    #[test]
+    fn decomposition_rule_roundtrips() {
+        let parent = ObjectiveId::from("eliminate_threat");
+        let child_a = ObjectiveId::from("attack_target");
+        let child_b = ObjectiveId::from("fortify_border");
+        let rule = DecompositionRule {
+            parent: parent.clone(),
+            children: vec![child_a.clone(), child_b.clone()],
+            trigger: Condition::Always,
+        };
+        assert_eq!(rule.parent, parent);
+        assert_eq!(rule.children.len(), 2);
+    }
+}

--- a/macrocosmo-ai/src/projection.rs
+++ b/macrocosmo-ai/src/projection.rs
@@ -1,0 +1,52 @@
+//! Trajectory projection — **Phase 2 stub**.
+//!
+//! The real projection (economic / combat dynamics, #190 / #191) will land
+//! here. Phase 2 provides the API shape only so callers can compile and
+//! tests can assert the default empty trajectory.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bus::AiBus;
+use crate::ids::MetricId;
+use crate::time::{Tick, TimestampedValue};
+
+/// A projected time-series trajectory of a single metric.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Trajectory {
+    /// Projected samples, oldest-first.
+    pub points: Vec<TimestampedValue>,
+}
+
+impl Trajectory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Project `metric` forward by `horizon` ticks.
+///
+/// **TODO Phase 3**: fit a dynamics model from bus history and extrapolate.
+/// For now this returns an empty trajectory regardless of inputs.
+#[allow(unused_variables)]
+pub fn project_trajectory(bus: &AiBus, metric: &MetricId, horizon: Tick) -> Trajectory {
+    Trajectory::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::warning::WarningMode;
+
+    #[test]
+    fn stub_returns_empty_trajectory() {
+        let bus = AiBus::with_warning_mode(WarningMode::Silent);
+        let t = project_trajectory(&bus, &MetricId::from("power"), 100);
+        assert!(t.points.is_empty());
+    }
+
+    #[test]
+    fn default_trajectory_is_empty() {
+        let t = Trajectory::default();
+        assert!(t.points.is_empty());
+    }
+}

--- a/macrocosmo-ai/src/retention.rs
+++ b/macrocosmo-ai/src/retention.rs
@@ -1,0 +1,51 @@
+//! Retention policies for time-series topic history.
+//!
+//! Named variants match the four canonical windows from #192 `DelT` design.
+//! `Custom(Tick)` allows arbitrary overrides without forcing a named bucket.
+
+use serde::{Deserialize, Serialize};
+
+use crate::time::Tick;
+
+/// Retention window for a time-series topic. Old samples are evicted when
+/// they fall outside this window relative to the newest emitted sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Retention {
+    /// 30 hexadies (~short-term situational awareness).
+    Short,
+    /// 120 hexadies.
+    Medium,
+    /// 500 hexadies.
+    Long,
+    /// 1200 hexadies (maximum DelT window).
+    VeryLong,
+    /// Arbitrary retention in hexadies.
+    Custom(Tick),
+}
+
+impl Retention {
+    /// Length of the retention window in ticks (hexadies).
+    pub fn as_ticks(self) -> Tick {
+        match self {
+            Retention::Short => 30,
+            Retention::Medium => 120,
+            Retention::Long => 500,
+            Retention::VeryLong => 1200,
+            Retention::Custom(t) => t,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn named_retentions_map_to_expected_ticks() {
+        assert_eq!(Retention::Short.as_ticks(), 30);
+        assert_eq!(Retention::Medium.as_ticks(), 120);
+        assert_eq!(Retention::Long.as_ticks(), 500);
+        assert_eq!(Retention::VeryLong.as_ticks(), 1200);
+        assert_eq!(Retention::Custom(77).as_ticks(), 77);
+    }
+}

--- a/macrocosmo-ai/src/spec.rs
+++ b/macrocosmo-ai/src/spec.rs
@@ -1,0 +1,80 @@
+//! Topic specs — schemas declared up-front via `AiBus::declare_*`.
+//!
+//! Specs describe *what* a topic holds and *how long* history is kept,
+//! without touching the values themselves. They are plain data.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::retention::Retention;
+
+/// Semantic kind of a metric value. Does not affect storage (all values are `f64`),
+/// but documents intent and enables UI / validation downstream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MetricType {
+    /// Point-in-time scalar (e.g., "current fleet strength").
+    Gauge,
+    /// Monotonically increasing counter (e.g., "ships lost").
+    Counter,
+    /// Bounded 0..=1 ratio (e.g., "fleet readiness").
+    Ratio,
+    /// Untyped raw value; no interpretation.
+    Raw,
+}
+
+/// Declaration schema for a metric topic.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetricSpec {
+    pub kind: MetricType,
+    pub retention: Retention,
+    pub description: Arc<str>,
+}
+
+impl MetricSpec {
+    pub fn gauge(retention: Retention, description: impl Into<Arc<str>>) -> Self {
+        Self {
+            kind: MetricType::Gauge,
+            retention,
+            description: description.into(),
+        }
+    }
+
+    pub fn ratio(retention: Retention, description: impl Into<Arc<str>>) -> Self {
+        Self {
+            kind: MetricType::Ratio,
+            retention,
+            description: description.into(),
+        }
+    }
+}
+
+/// Declaration schema for a command kind.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommandSpec {
+    pub description: Arc<str>,
+}
+
+impl CommandSpec {
+    pub fn new(description: impl Into<Arc<str>>) -> Self {
+        Self {
+            description: description.into(),
+        }
+    }
+}
+
+/// Declaration schema for an evidence kind.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvidenceSpec {
+    pub retention: Retention,
+    pub description: Arc<str>,
+}
+
+impl EvidenceSpec {
+    pub fn new(retention: Retention, description: impl Into<Arc<str>>) -> Self {
+        Self {
+            retention,
+            description: description.into(),
+        }
+    }
+}

--- a/macrocosmo-ai/src/time.rs
+++ b/macrocosmo-ai/src/time.rs
@@ -1,0 +1,22 @@
+//! Time primitives for the AI bus.
+//!
+//! AI core is agnostic to the unit of time — the engine uses hexadies (integer days),
+//! but this crate only cares that time is a monotonic `i64`.
+
+use serde::{Deserialize, Serialize};
+
+/// Monotonic integer timestamp. In macrocosmo this is a hexadies count.
+pub type Tick = i64;
+
+/// A value sampled at a specific tick.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TimestampedValue {
+    pub at: Tick,
+    pub value: f64,
+}
+
+impl TimestampedValue {
+    pub fn new(at: Tick, value: f64) -> Self {
+        Self { at, value }
+    }
+}

--- a/macrocosmo-ai/src/value_expr.rs
+++ b/macrocosmo-ai/src/value_expr.rs
@@ -1,0 +1,232 @@
+//! Value expressions — `f64`-valued computations over the AI bus.
+//!
+//! `ValueExpr` is the building block for feasibility formulas and other
+//! numeric reasoning. It is a pure evaluator: `evaluate(&EvalContext)` reads
+//! the bus and returns a scalar. Phase 2 supports literals, metric lookups,
+//! arithmetic composition, clamping, and the DelT lookback operator.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::eval::EvalContext;
+use crate::ids::MetricId;
+use crate::time::Tick;
+
+/// Reference to a metric by id. Wraps `MetricId` so that future variants
+/// (e.g. faction-scoped or kind-qualified lookups) can be added without
+/// breaking call sites.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MetricRef {
+    pub id: MetricId,
+}
+
+impl MetricRef {
+    pub fn new(id: MetricId) -> Self {
+        Self { id }
+    }
+}
+
+impl From<MetricId> for MetricRef {
+    fn from(id: MetricId) -> Self {
+        Self { id }
+    }
+}
+
+/// Opaque reference to a script function evaluated outside of ai_core.
+/// Phase 2 stub — `Custom` variants return `0.0`; future phases resolve
+/// these via a scripting bridge (#192 / #198).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ScriptRef(pub Arc<str>);
+
+impl From<&str> for ScriptRef {
+    fn from(s: &str) -> Self {
+        Self(Arc::from(s))
+    }
+}
+
+/// An expression producing an `f64` when evaluated against the bus.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ValueExpr {
+    /// Constant literal.
+    Literal(f64),
+    /// Current value of a metric. `0.0` if undeclared or no samples.
+    Metric(MetricRef),
+    /// `current(metric) - value_at_or_before(now - window)` — the change
+    /// over the given lookback window. `0.0` if either side is missing.
+    ///
+    /// Implementation uses `bus.current` for the right-hand side and
+    /// `bus.at_or_before(metric, now - window)` for the left. This matches
+    /// the #192 DelT semantics at Short/Medium/Long/VeryLong windows.
+    DelT { metric: MetricRef, window: Tick },
+    /// Sum of children (empty sum = 0.0).
+    Add(Vec<ValueExpr>),
+    /// Product of children (empty product = 1.0).
+    Mul(Vec<ValueExpr>),
+    /// Clamp `expr` into `[lo, hi]`.
+    Clamp {
+        expr: Box<ValueExpr>,
+        lo: f64,
+        hi: f64,
+    },
+    /// External script reference. Phase 2 stub returns `0.0`.
+    Custom(ScriptRef),
+}
+
+impl ValueExpr {
+    pub fn evaluate(&self, ctx: &EvalContext) -> f64 {
+        match self {
+            ValueExpr::Literal(v) => *v,
+            ValueExpr::Metric(m) => ctx.bus.current(&m.id).unwrap_or(0.0),
+            ValueExpr::DelT { metric, window } => {
+                let current = ctx.bus.current(&metric.id).unwrap_or(0.0);
+                let lookback_at = ctx.now.saturating_sub(*window);
+                let prev = ctx.bus.at_or_before(&metric.id, lookback_at).unwrap_or(0.0);
+                current - prev
+            }
+            ValueExpr::Add(children) => children.iter().map(|c| c.evaluate(ctx)).sum(),
+            ValueExpr::Mul(children) => {
+                if children.is_empty() {
+                    1.0
+                } else {
+                    children.iter().map(|c| c.evaluate(ctx)).product()
+                }
+            }
+            ValueExpr::Clamp { expr, lo, hi } => {
+                let v = expr.evaluate(ctx);
+                v.max(*lo).min(*hi)
+            }
+            ValueExpr::Custom(_) => 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus::AiBus;
+    use crate::retention::Retention;
+    use crate::spec::MetricSpec;
+    use crate::warning::WarningMode;
+
+    fn bus() -> AiBus {
+        AiBus::with_warning_mode(WarningMode::Silent)
+    }
+
+    #[test]
+    fn literal() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        assert_eq!(ValueExpr::Literal(3.5).evaluate(&ctx), 3.5);
+    }
+
+    #[test]
+    fn metric_lookup_default_zero_if_missing() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        let m = MetricRef::new(MetricId::from("missing"));
+        assert_eq!(ValueExpr::Metric(m).evaluate(&ctx), 0.0);
+    }
+
+    #[test]
+    fn metric_lookup_returns_current() {
+        let mut b = bus();
+        let id = MetricId::from("x");
+        b.declare_metric(id.clone(), MetricSpec::gauge(Retention::Long, "x"));
+        b.emit(&id, 4.2, 10);
+        let ctx = EvalContext::new(&b, 10);
+        assert_eq!(
+            ValueExpr::Metric(MetricRef::new(id)).evaluate(&ctx),
+            4.2
+        );
+    }
+
+    #[test]
+    fn add_and_mul() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        let add = ValueExpr::Add(vec![
+            ValueExpr::Literal(1.0),
+            ValueExpr::Literal(2.5),
+            ValueExpr::Literal(0.5),
+        ]);
+        assert_eq!(add.evaluate(&ctx), 4.0);
+        let mul = ValueExpr::Mul(vec![ValueExpr::Literal(2.0), ValueExpr::Literal(3.0)]);
+        assert_eq!(mul.evaluate(&ctx), 6.0);
+        assert_eq!(ValueExpr::Add(vec![]).evaluate(&ctx), 0.0);
+        assert_eq!(ValueExpr::Mul(vec![]).evaluate(&ctx), 1.0);
+    }
+
+    #[test]
+    fn clamp_bounds_value() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        let e = ValueExpr::Clamp {
+            expr: Box::new(ValueExpr::Literal(5.0)),
+            lo: 0.0,
+            hi: 1.0,
+        };
+        assert_eq!(e.evaluate(&ctx), 1.0);
+        let e2 = ValueExpr::Clamp {
+            expr: Box::new(ValueExpr::Literal(-5.0)),
+            lo: 0.0,
+            hi: 1.0,
+        };
+        assert_eq!(e2.evaluate(&ctx), 0.0);
+    }
+
+    #[test]
+    fn custom_is_stub_zero() {
+        let b = bus();
+        let ctx = EvalContext::new(&b, 0);
+        assert_eq!(ValueExpr::Custom(ScriptRef::from("x")).evaluate(&ctx), 0.0);
+    }
+
+    #[test]
+    fn delt_basic_delta_across_window() {
+        let mut b = bus();
+        let id = MetricId::from("x");
+        b.declare_metric(id.clone(), MetricSpec::gauge(Retention::Long, "x"));
+        b.emit(&id, 10.0, 0);
+        b.emit(&id, 15.0, 50);
+        b.emit(&id, 30.0, 100);
+        let ctx = EvalContext::new(&b, 100);
+        let delt = ValueExpr::DelT {
+            metric: MetricRef::new(id.clone()),
+            window: 100,
+        };
+        // current=30, at_or_before(now-100)=at_or_before(0)=10 -> 20
+        assert_eq!(delt.evaluate(&ctx), 20.0);
+    }
+
+    #[test]
+    fn delt_uses_at_or_before_for_gap() {
+        let mut b = bus();
+        let id = MetricId::from("x");
+        b.declare_metric(id.clone(), MetricSpec::gauge(Retention::Long, "x"));
+        b.emit(&id, 5.0, 10);
+        b.emit(&id, 25.0, 100);
+        let ctx = EvalContext::new(&b, 100);
+        let delt = ValueExpr::DelT {
+            metric: MetricRef::new(id.clone()),
+            window: 50,
+        };
+        // current=25, now-window=50, at_or_before(50)=5 -> 20
+        assert_eq!(delt.evaluate(&ctx), 20.0);
+    }
+
+    #[test]
+    fn delt_zero_when_no_prior() {
+        let mut b = bus();
+        let id = MetricId::from("x");
+        b.declare_metric(id.clone(), MetricSpec::gauge(Retention::Long, "x"));
+        b.emit(&id, 10.0, 100);
+        let ctx = EvalContext::new(&b, 100);
+        let delt = ValueExpr::DelT {
+            metric: MetricRef::new(id.clone()),
+            window: 50,
+        };
+        // at_or_before(50) -> None -> 0.0, current=10 -> 10
+        assert_eq!(delt.evaluate(&ctx), 10.0);
+    }
+}

--- a/macrocosmo-ai/src/warning.rs
+++ b/macrocosmo-ai/src/warning.rs
@@ -1,0 +1,33 @@
+//! Warning policy for the AI bus.
+//!
+//! The bus emits warnings via the `log` crate on recoverable misuses:
+//! - re-declaring an already-declared topic (spec override)
+//! - emitting to an undeclared topic (no-op)
+//! - emitting a time-reversed sample (no-op, sample dropped)
+//!
+//! `WarningMode::Silent` suppresses these warnings — useful for tests or
+//! performance-sensitive production configurations where the caller has
+//! audited the emit sites.
+
+use serde::{Deserialize, Serialize};
+
+/// Warning emission policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum WarningMode {
+    /// Emit warnings via `log::warn` (default).
+    #[default]
+    Enabled,
+    /// Suppress warnings.
+    Silent,
+}
+
+/// Emit a warning if `mode` is `Enabled`. Internal helper.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! bus_warn {
+    ($mode:expr, $($arg:tt)+) => {
+        if matches!($mode, $crate::warning::WarningMode::Enabled) {
+            log::warn!($($arg)+);
+        }
+    };
+}

--- a/macrocosmo-ai/tests/ai_core_isolation.rs
+++ b/macrocosmo-ai/tests/ai_core_isolation.rs
@@ -1,0 +1,72 @@
+//! CI isolation test: proves `macrocosmo-ai` is engine-agnostic by exercising
+//! the public API using only items from this crate.
+//!
+//! If a bevy or macrocosmo type leaks into a public signature, this file will
+//! fail to compile.
+
+use macrocosmo_ai::{
+    AiBus, Command, CommandKindId, CommandSpec, EvidenceKindId, EvidenceSpec, FactionId, MetricId,
+    MetricSpec, Retention, StandingEvidence, WarningMode,
+};
+
+#[test]
+fn metric_round_trip() {
+    let mut bus = AiBus::new();
+    let id = MetricId::from("faction.power");
+    bus.declare_metric(id.clone(), MetricSpec::gauge(Retention::Medium, "power"));
+    bus.emit(&id, 10.0, 100);
+    bus.emit(&id, 12.0, 110);
+    assert_eq!(bus.current(&id), Some(12.0));
+    let window: Vec<f64> = bus.window(&id, 110, 50).map(|tv| tv.value).collect();
+    assert_eq!(window, vec![10.0, 12.0]);
+}
+
+#[test]
+fn command_round_trip() {
+    let mut bus = AiBus::new();
+    let kind = CommandKindId::from("attack_target");
+    bus.declare_command(kind.clone(), CommandSpec::new("attack"));
+    bus.emit_command(
+        Command::new(kind.clone(), FactionId(1), 10)
+            .with_priority(0.9)
+            .with_param("target_system", 42i64),
+    );
+    let drained = bus.drain_commands();
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].kind, kind);
+    assert!(bus.drain_commands().is_empty());
+}
+
+#[test]
+fn evidence_round_trip() {
+    let mut bus = AiBus::new();
+    let kind = EvidenceKindId::from("hostile_engagement");
+    bus.declare_evidence(kind.clone(), EvidenceSpec::new(Retention::Long, "hostile"));
+    bus.emit_evidence(StandingEvidence::new(
+        kind.clone(),
+        FactionId(1),
+        FactionId(2),
+        1.5,
+        10,
+    ));
+    let got: Vec<_> = bus.evidence_for(FactionId(1), 20, 50).collect();
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].target, FactionId(2));
+}
+
+#[test]
+fn silent_warning_mode_suppresses_warnings() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    // Emit to undeclared — should no-op without logging.
+    bus.emit(&MetricId::from("nope"), 1.0, 0);
+    bus.emit_command(Command::new(CommandKindId::from("nope"), FactionId(1), 0));
+    bus.emit_evidence(StandingEvidence::new(
+        EvidenceKindId::from("nope"),
+        FactionId(1),
+        FactionId(2),
+        1.0,
+        0,
+    ));
+    // No side effects observable.
+    assert_eq!(bus.current(&MetricId::from("nope")), None);
+}

--- a/macrocosmo-ai/tests/bus_behavior.rs
+++ b/macrocosmo-ai/tests/bus_behavior.rs
@@ -1,0 +1,97 @@
+//! Behavioral tests for `AiBus`: redeclaration, silent mode, partial windows.
+
+use macrocosmo_ai::{
+    AiBus, CommandKindId, CommandSpec, EvidenceKindId, EvidenceSpec, FactionId, MetricId,
+    MetricSpec, Retention, StandingEvidence, WarningMode,
+};
+
+#[test]
+fn redeclare_metric_preserves_history() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    let id = MetricId::from("x");
+    bus.declare_metric(id.clone(), MetricSpec::gauge(Retention::Short, "old"));
+    bus.emit(&id, 1.0, 10);
+    bus.emit(&id, 2.0, 20);
+    bus.declare_metric(id.clone(), MetricSpec::gauge(Retention::Long, "new"));
+    assert_eq!(bus.current(&id), Some(2.0));
+}
+
+#[test]
+fn redeclare_command_preserves_pending() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    let kind = CommandKindId::from("c");
+    bus.declare_command(kind.clone(), CommandSpec::new("v1"));
+    bus.emit_command(macrocosmo_ai::Command::new(kind.clone(), FactionId(1), 10));
+    bus.declare_command(kind.clone(), CommandSpec::new("v2"));
+    let drained = bus.drain_commands();
+    assert_eq!(drained.len(), 1);
+}
+
+#[test]
+fn redeclare_evidence_preserves_history() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    let kind = EvidenceKindId::from("e");
+    bus.declare_evidence(kind.clone(), EvidenceSpec::new(Retention::Short, "old"));
+    bus.emit_evidence(StandingEvidence::new(
+        kind.clone(),
+        FactionId(1),
+        FactionId(2),
+        1.0,
+        10,
+    ));
+    bus.declare_evidence(kind.clone(), EvidenceSpec::new(Retention::Long, "new"));
+    let got: Vec<_> = bus.evidence_for(FactionId(1), 20, 100).collect();
+    assert_eq!(got.len(), 1);
+}
+
+#[test]
+fn emit_to_undeclared_metric_is_noop() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    let id = MetricId::from("undeclared");
+    bus.emit(&id, 42.0, 10);
+    assert_eq!(bus.current(&id), None);
+}
+
+#[test]
+fn time_reversed_metric_emit_drops_sample() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    let id = MetricId::from("x");
+    bus.declare_metric(id.clone(), MetricSpec::gauge(Retention::Long, "x"));
+    bus.emit(&id, 1.0, 100);
+    bus.emit(&id, 2.0, 50); // reversed
+    assert_eq!(bus.current(&id), Some(1.0));
+}
+
+#[test]
+fn window_wider_than_retention_returns_partial() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    let id = MetricId::from("x");
+    bus.declare_metric(id.clone(), MetricSpec::gauge(Retention::Custom(50), "x"));
+    for t in 0..10 {
+        bus.emit(&id, t as f64, t * 10);
+    }
+    // newest=90, retention=50 -> kept samples at t in {40..=90}
+    let all: Vec<f64> = bus.window(&id, 90, 10_000).map(|tv| tv.value).collect();
+    assert_eq!(all, vec![4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+}
+
+#[test]
+fn window_on_undeclared_is_empty() {
+    let bus = AiBus::new();
+    let got: Vec<_> = bus.window(&MetricId::from("nope"), 100, 50).collect();
+    assert!(got.is_empty());
+}
+
+#[test]
+fn default_warning_mode_is_enabled() {
+    let bus = AiBus::new();
+    assert_eq!(bus.warning_mode(), WarningMode::Enabled);
+}
+
+#[test]
+fn set_warning_mode_toggles() {
+    let mut bus = AiBus::new();
+    assert_eq!(bus.warning_mode(), WarningMode::Enabled);
+    bus.set_warning_mode(WarningMode::Silent);
+    assert_eq!(bus.warning_mode(), WarningMode::Silent);
+}

--- a/macrocosmo-ai/tests/campaign_sm.rs
+++ b/macrocosmo-ai/tests/campaign_sm.rs
@@ -1,0 +1,93 @@
+//! Campaign state machine transitions.
+
+use macrocosmo_ai::campaign::{Campaign, CampaignError, CampaignState};
+use macrocosmo_ai::ObjectiveId;
+
+fn oid() -> ObjectiveId {
+    ObjectiveId::from("test_objective")
+}
+
+#[test]
+fn new_campaign_starts_proposed() {
+    let c = Campaign::new(oid(), 10);
+    assert_eq!(c.state, CampaignState::Proposed);
+    assert_eq!(c.started_at, 10);
+    assert_eq!(c.last_transition, 10);
+}
+
+#[test]
+fn proposed_to_active_legal() {
+    let mut c = Campaign::new(oid(), 0);
+    assert!(c.transition(CampaignState::Active, 1).is_ok());
+    assert_eq!(c.state, CampaignState::Active);
+    assert_eq!(c.last_transition, 1);
+}
+
+#[test]
+fn proposed_to_abandoned_legal() {
+    let mut c = Campaign::new(oid(), 0);
+    assert!(c.transition(CampaignState::Abandoned, 1).is_ok());
+    assert_eq!(c.state, CampaignState::Abandoned);
+}
+
+#[test]
+fn proposed_to_suspended_illegal() {
+    let mut c = Campaign::new(oid(), 0);
+    let err = c.transition(CampaignState::Suspended, 1).unwrap_err();
+    assert_eq!(
+        err,
+        CampaignError::IllegalTransition {
+            from: CampaignState::Proposed,
+            to: CampaignState::Suspended
+        }
+    );
+    assert_eq!(c.state, CampaignState::Proposed);
+}
+
+#[test]
+fn active_to_all_valid_exits() {
+    for to in [
+        CampaignState::Suspended,
+        CampaignState::Succeeded,
+        CampaignState::Failed,
+        CampaignState::Abandoned,
+    ] {
+        let mut c = Campaign::new(oid(), 0);
+        c.transition(CampaignState::Active, 1).unwrap();
+        assert!(c.transition(to, 2).is_ok(), "failed transition to {to:?}");
+    }
+}
+
+#[test]
+fn suspended_to_active_allowed() {
+    let mut c = Campaign::new(oid(), 0);
+    c.transition(CampaignState::Active, 1).unwrap();
+    c.transition(CampaignState::Suspended, 2).unwrap();
+    c.transition(CampaignState::Active, 3).unwrap();
+    assert_eq!(c.state, CampaignState::Active);
+}
+
+#[test]
+fn terminal_states_reject_any_transition() {
+    for terminal in [
+        CampaignState::Succeeded,
+        CampaignState::Failed,
+        CampaignState::Abandoned,
+    ] {
+        let mut c = Campaign::new(oid(), 0);
+        c.transition(CampaignState::Active, 1).unwrap();
+        c.transition(terminal, 2).unwrap();
+        assert!(terminal.is_terminal());
+        let err = c.transition(CampaignState::Active, 3);
+        assert!(err.is_err());
+    }
+}
+
+#[test]
+fn failed_transition_preserves_state_and_timestamp() {
+    let mut c = Campaign::new(oid(), 0);
+    c.transition(CampaignState::Active, 1).unwrap();
+    let _ = c.transition(CampaignState::Proposed, 99); // illegal
+    assert_eq!(c.state, CampaignState::Active);
+    assert_eq!(c.last_transition, 1);
+}

--- a/macrocosmo-ai/tests/feasibility_eval.rs
+++ b/macrocosmo-ai/tests/feasibility_eval.rs
@@ -1,0 +1,51 @@
+//! Integration test: feasibility evaluation end-to-end against a bus.
+
+use macrocosmo_ai::{
+    feasibility::{self, FeasibilityFormula, FeasibilityTerm},
+    AiBus, MetricId, MetricRef, MetricSpec, Retention, ValueExpr, WarningMode,
+};
+
+#[test]
+fn weighted_sum_end_to_end() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    let readiness = MetricId::from("fleet_readiness");
+    let capacity = MetricId::from("economic_capacity");
+    bus.declare_metric(
+        readiness.clone(),
+        MetricSpec::ratio(Retention::Medium, "r"),
+    );
+    bus.declare_metric(
+        capacity.clone(),
+        MetricSpec::ratio(Retention::Medium, "c"),
+    );
+    bus.emit(&readiness, 0.6, 50);
+    bus.emit(&capacity, 0.4, 50);
+
+    let formula = FeasibilityFormula::WeightedSum(vec![
+        FeasibilityTerm::new(0.7, ValueExpr::Metric(MetricRef::new(readiness))),
+        FeasibilityTerm::new(0.3, ValueExpr::Metric(MetricRef::new(capacity))),
+    ]);
+    let score = feasibility::evaluate(&formula, &bus, 50, None);
+    // 0.7*0.6 + 0.3*0.4 = 0.42 + 0.12 = 0.54
+    assert!((score - 0.54).abs() < 1e-9, "score={score}");
+}
+
+#[test]
+fn delt_in_formula() {
+    let mut bus = AiBus::with_warning_mode(WarningMode::Silent);
+    let power = MetricId::from("power");
+    bus.declare_metric(power.clone(), MetricSpec::gauge(Retention::Long, "p"));
+    bus.emit(&power, 10.0, 0);
+    bus.emit(&power, 30.0, 100);
+
+    let formula = FeasibilityFormula::WeightedSum(vec![FeasibilityTerm::new(
+        1.0,
+        ValueExpr::DelT {
+            metric: MetricRef::new(power),
+            window: 100,
+        },
+    )]);
+    let score = feasibility::evaluate(&formula, &bus, 100, None);
+    // delta = 30 - 10 = 20
+    assert_eq!(score, 20.0);
+}


### PR DESCRIPTION
Closes #195.

## Summary

`macrocosmo-ai` を純粋 Rust の **typed topic bus** として実装。AI コアが game に対して一切 callback を持たない疎結合設計の基盤を確立する。Phase 3 以降 (#203 integration, #204 初 capability) の前提となる。

- `AiBus`: metric / command / evidence の 3 トピックを宣言+型付きで保持
- pure 評価関数: `Condition::evaluate`, `ValueExpr::evaluate`, `feasibility::evaluate`
- data types: `Objective`, `Campaign` (SM)
- stubs: `nash::solve_2p_zero_sum`, `projection::project_trajectory`
- CI: `.github/workflows/ai-core-isolation.yml` で `cargo tree` が bevy/macrocosmo を含まないことを verify

依存: `ahash`, `serde`, `thiserror`, `log` のみ。bevy / macrocosmo / mlua 非依存。

依存方向の反転 (`macrocosmo → macrocosmo-ai`)、`AiPlugin` の再配置、`WorldQuery` 相当の Bevy ECS アダプタは #203 (integration) で扱う。

## Test plan

- [x] `cargo test -p macrocosmo-ai` 全通過 (64 unit + 23 integration = 87 tests)
- [x] `cargo build --workspace` 成功
- [x] `cargo tree -p macrocosmo-ai --edges=normal` に bevy / macrocosmo が出ないことをローカル verify
- [ ] CI workflow `ai-core-isolation` が通ることを GitHub Actions で確認

## Architecture decisions (see `memory/project_ai_core_bus_architecture.md`)

- **型完全分離**: ai_core は独自 newtype、macrocosmo の型は参照しない
- **callback なし**: subscribe は「topic を bus が保持する宣言 (`declare_*`)」
- **data-first**: Objective / IntentKind は最初から data として設計 (Phase 4 enum→data 移行は不要)
- **Value = f64 統一**: DelT 差分で f32 の精度低下を避けるため
- **警告ポリシー**: override / 未宣言 emit / 時間逆順 emit は `log::warn` + no-op、`WarningMode::Silent` で抑制可能

## Out of scope (別 issue)

- #203 AI integration レイヤ (macrocosmo 側、依存反転、AiPlugin、WorldQuery 実装)
- #204 初 AiCapability (FleetCombatCapability)
- #190-#194 各 AI sub-issue
- #192 DelT の evaluator は bus.window ベースで実装済、完全な ValueExpr 言語拡張は #192 で追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)