### PR TITLE
#203: AI integration layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,6 +3505,7 @@ version = "0.2.0"
 dependencies = [
  "bevy",
  "bevy_egui",
+ "macrocosmo-ai",
  "mlua",
  "rand",
 ]

--- a/macrocosmo/Cargo.toml
+++ b/macrocosmo/Cargo.toml
@@ -8,3 +8,4 @@ bevy = "0.18.1"
 bevy_egui = "0.39.1"
 mlua = { version = "0.11", features = ["luajit", "vendored", "send"] }
 rand = "0.9"
+macrocosmo-ai = { path = "../macrocosmo-ai" }

--- a/macrocosmo/src/ai/convert.rs
+++ b/macrocosmo/src/ai/convert.rs
@@ -1,0 +1,120 @@
+//! Type conversion helpers between macrocosmo (Bevy) and macrocosmo-ai.
+//!
+//! The AI core uses opaque numeric newtypes (`FactionId(u32)`,
+//! `SystemRef(u64)`, `EntityRef(u64)`) to avoid depending on Bevy. The
+//! helpers here translate Bevy `Entity` and engine-owned types into those
+//! opaque ids and back again.
+//!
+//! ## Round-trip properties
+//!
+//! - `Entity ↔ SystemRef/EntityRef` is lossless: we use
+//!   `Entity::to_bits()` / `Entity::from_bits()` which preserves both the
+//!   index and the generation.
+//! - `Entity → FactionId` is **lossy**: we take only `Entity::index()`.
+//!   Faction entities are long-lived (they live for the entire session
+//!   and are not despawned/respawned), so the generation bits are
+//!   unnecessary and dropping them yields a stable `u32` suitable for
+//!   `FactionId`. There is no `from_ai_faction` because the reverse
+//!   mapping is not well-defined in general.
+
+use bevy::prelude::Entity;
+use macrocosmo_ai::{EntityRef, FactionId, FactionRef, SystemRef, Tick};
+
+use crate::time_system::GameClock;
+
+/// Derive an AI-side [`FactionId`] from a Bevy [`Entity`].
+///
+/// Uses `Entity::index()` (the `u32` part). Faction entities are
+/// session-stable — no despawn/respawn — so the dropped generation bits
+/// do not cause collisions within a run.
+pub fn to_ai_faction(entity: Entity) -> FactionId {
+    // Bevy 0.18's `Entity::index()` returns an `EntityIndex` newtype; call
+    // its own `.index()` to retrieve the underlying `u32`.
+    FactionId(entity.index().index())
+}
+
+/// `FactionRef::Me` — the observing faction in the current context.
+pub fn to_ai_faction_ref_me() -> FactionRef {
+    FactionRef::Me
+}
+
+/// `FactionRef::Other(id)` derived from a Bevy [`Entity`].
+pub fn to_ai_faction_ref_other(entity: Entity) -> FactionRef {
+    FactionRef::Other(to_ai_faction(entity))
+}
+
+/// Convert a star-system [`Entity`] to an AI-side [`SystemRef`]. Lossless.
+pub fn to_ai_system(entity: Entity) -> SystemRef {
+    SystemRef(entity.to_bits())
+}
+
+/// Reverse of [`to_ai_system`]. Lossless as long as the `SystemRef` was
+/// produced by [`to_ai_system`].
+pub fn from_ai_system(r: SystemRef) -> Entity {
+    Entity::from_bits(r.0)
+}
+
+/// Convert any game [`Entity`] (ship, colony, structure, …) to an
+/// AI-side [`EntityRef`]. Lossless.
+pub fn to_ai_entity(entity: Entity) -> EntityRef {
+    EntityRef(entity.to_bits())
+}
+
+/// Reverse of [`to_ai_entity`]. Lossless as long as the `EntityRef` was
+/// produced by [`to_ai_entity`].
+pub fn from_ai_entity(r: EntityRef) -> Entity {
+    Entity::from_bits(r.0)
+}
+
+/// Read the current tick (hexadies) from the [`GameClock`]. The AI crate
+/// treats [`Tick`] as an opaque monotonic `i64`; macrocosmo's unit is
+/// hexadies.
+pub fn tick_from_clock(clock: &GameClock) -> Tick {
+    clock.elapsed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::world::World;
+
+    #[test]
+    fn entity_roundtrips_via_system_ref() {
+        let mut w = World::new();
+        let e = w.spawn_empty().id();
+        let r = to_ai_system(e);
+        assert_eq!(from_ai_system(r), e);
+    }
+
+    #[test]
+    fn entity_roundtrips_via_entity_ref() {
+        let mut w = World::new();
+        let e = w.spawn_empty().id();
+        let r = to_ai_entity(e);
+        assert_eq!(from_ai_entity(r), e);
+    }
+
+    #[test]
+    fn faction_id_is_entity_index() {
+        let mut w = World::new();
+        let e = w.spawn_empty().id();
+        assert_eq!(to_ai_faction(e), FactionId(e.index().index()));
+    }
+
+    #[test]
+    fn faction_ref_me_and_other() {
+        let mut w = World::new();
+        let e = w.spawn_empty().id();
+        assert_eq!(to_ai_faction_ref_me(), FactionRef::Me);
+        assert_eq!(
+            to_ai_faction_ref_other(e),
+            FactionRef::Other(FactionId(e.index().index()))
+        );
+    }
+
+    #[test]
+    fn tick_from_clock_matches_elapsed() {
+        let clock = GameClock::new(42);
+        assert_eq!(tick_from_clock(&clock), 42);
+    }
+}

--- a/macrocosmo/src/ai/emit.rs
+++ b/macrocosmo/src/ai/emit.rs
@@ -1,0 +1,153 @@
+//! `SystemParam` ergonomic wrappers around [`AiBusResource`].
+//!
+//! Game systems interact with the AI bus through three flavours of param:
+//!
+//! - [`AiBusWriter`] — mutable access to the bus + `GameClock`, used by
+//!   systems under [`AiTickSet::MetricProduce`](super::AiTickSet::MetricProduce)
+//!   or any system that needs to emit metrics / commands / evidence with
+//!   automatic tick stamping.
+//! - [`AiBusReader`] — read-only access, used by reasoning systems under
+//!   [`AiTickSet::Reason`](super::AiTickSet::Reason).
+//! - [`AiBusDrainer`] — mutable access that only drains the pending
+//!   command queue, used by systems under
+//!   [`AiTickSet::CommandDrain`](super::AiTickSet::CommandDrain) that
+//!   convert AI commands back into ECS actions.
+//!
+//! Each helper stamps `at = clock.elapsed` when the caller does not
+//! specify an explicit tick; this keeps emit sites concise.
+
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use macrocosmo_ai::{
+    AiBus, Command, FactionId, MetricId, StandingEvidence, Tick, TimestampedValue,
+};
+
+use crate::ai::plugin::AiBusResource;
+use crate::time_system::GameClock;
+
+/// Mutable bus access with automatic tick stamping.
+#[derive(SystemParam)]
+pub struct AiBusWriter<'w> {
+    bus: ResMut<'w, AiBusResource>,
+    clock: Res<'w, GameClock>,
+}
+
+impl<'w> AiBusWriter<'w> {
+    /// Current tick (hexadies) as seen by the bus emitter.
+    pub fn now(&self) -> Tick {
+        self.clock.elapsed
+    }
+
+    /// Emit a metric sample stamped at [`Self::now`].
+    pub fn emit(&mut self, id: &MetricId, value: f64) {
+        let at = self.now();
+        self.bus.0.emit(id, value, at);
+    }
+
+    /// Emit a metric sample at an explicit tick. Prefer [`Self::emit`]
+    /// unless stamping historical data (e.g. during loading).
+    pub fn emit_at(&mut self, id: &MetricId, value: f64, at: Tick) {
+        self.bus.0.emit(id, value, at);
+    }
+
+    /// Enqueue a command on the bus. The caller controls the command's
+    /// `at` field; callers that want automatic stamping should set
+    /// `cmd.at = writer.now()` before calling.
+    pub fn emit_command(&mut self, cmd: Command) {
+        self.bus.0.emit_command(cmd);
+    }
+
+    /// Emit standing evidence. If `ev.at == 0`, the writer overwrites it
+    /// with [`Self::now`] so opt-in auto-stamping works by leaving the
+    /// default `at`.
+    pub fn emit_evidence(&mut self, mut ev: StandingEvidence) {
+        if ev.at == 0 {
+            ev.at = self.now();
+        }
+        self.bus.0.emit_evidence(ev);
+    }
+
+    /// Direct mutable access to the underlying `AiBus` for operations
+    /// not covered by the helpers above (e.g. schema declarations from
+    /// late-loaded content).
+    pub fn bus(&mut self) -> &mut AiBus {
+        &mut self.bus.0
+    }
+}
+
+/// Read-only bus access.
+#[derive(SystemParam)]
+pub struct AiBusReader<'w> {
+    bus: Res<'w, AiBusResource>,
+    clock: Res<'w, GameClock>,
+}
+
+impl<'w> AiBusReader<'w> {
+    /// Current tick (hexadies).
+    pub fn now(&self) -> Tick {
+        self.clock.elapsed
+    }
+
+    /// Latest value for a metric, or `None` if undeclared / never emitted.
+    pub fn current(&self, id: &MetricId) -> Option<f64> {
+        self.bus.0.current(id)
+    }
+
+    /// Exact-timestamp metric lookup.
+    pub fn at(&self, id: &MetricId, t: Tick) -> Option<f64> {
+        self.bus.0.at(id, t)
+    }
+
+    /// Latest-at-or-before-`t` metric lookup.
+    pub fn at_or_before(&self, id: &MetricId, t: Tick) -> Option<f64> {
+        self.bus.0.at_or_before(id, t)
+    }
+
+    /// Metric window `[now - duration, now]`, collected into a `Vec` for
+    /// convenience. Callers that iterate repeatedly should prefer
+    /// [`Self::bus`] for zero-allocation access.
+    pub fn window(&self, id: &MetricId, duration: Tick) -> Vec<TimestampedValue> {
+        self.bus.0.window(id, self.now(), duration).copied().collect()
+    }
+
+    /// Evidence for a given observer over `[now - duration, now]`.
+    pub fn evidence_for(
+        &self,
+        observer: FactionId,
+        duration: Tick,
+    ) -> Vec<StandingEvidence> {
+        self.bus
+            .0
+            .evidence_for(observer, self.now(), duration)
+            .cloned()
+            .collect()
+    }
+
+    /// Non-draining peek at the pending command queue.
+    pub fn pending_commands(&self) -> &[Command] {
+        self.bus.0.pending_commands()
+    }
+
+    /// Direct read access to the underlying bus.
+    pub fn bus(&self) -> &AiBus {
+        &self.bus.0
+    }
+}
+
+/// Mutable bus access specialised to draining the pending command queue.
+///
+/// Used by systems under
+/// [`AiTickSet::CommandDrain`](super::AiTickSet::CommandDrain) that
+/// convert AI-produced commands into ECS mutations. Does **not** carry a
+/// `GameClock` because draining does not need to stamp.
+#[derive(SystemParam)]
+pub struct AiBusDrainer<'w> {
+    bus: ResMut<'w, AiBusResource>,
+}
+
+impl<'w> AiBusDrainer<'w> {
+    /// Drain and return every pending command.
+    pub fn drain_commands(&mut self) -> Vec<Command> {
+        self.bus.0.drain_commands()
+    }
+}

--- a/macrocosmo/src/ai/mod.rs
+++ b/macrocosmo/src/ai/mod.rs
@@ -1,0 +1,42 @@
+//! AI integration layer — bridges the pure `macrocosmo-ai` core into the
+//! Bevy-based game engine (`macrocosmo`).
+//!
+//! This module is the **only** place where `macrocosmo` (Bevy / ECS / Lua)
+//! and `macrocosmo-ai` (engine-agnostic pure Rust) meet. The dependency
+//! direction is strictly `macrocosmo → macrocosmo-ai`; the AI crate has no
+//! knowledge of Bevy, `Entity`, `GameClock`, etc., and CI
+//! (`ai-core-isolation.yml`) enforces this invariant.
+//!
+//! The public surface consists of:
+//!
+//! - [`AiPlugin`] — the Bevy plugin that registers the [`AiBusResource`]
+//!   (wrapping `macrocosmo_ai::AiBus`), runs a one-time schema declaration
+//!   at `Startup`, and configures ordered system sets under `Update`.
+//! - [`AiBusResource`] — thin `Resource` newtype around `AiBus` with
+//!   `Deref`/`DerefMut` to the underlying bus for ergonomic access.
+//! - [`AiTickSet`] — the three ordered system sets each AI-related system
+//!   hangs under: `MetricProduce → Reason → CommandDrain`, all scheduled
+//!   `.after(crate::time_system::advance_game_time)`.
+//! - [`emit::AiBusWriter`] / [`emit::AiBusReader`] / [`emit::AiBusDrainer`]
+//!   — `SystemParam` helpers wrapping write / read / drain access to the
+//!   bus with automatic tick stamping from `GameClock`.
+//! - [`convert`] — `Entity`/`GameClock` ↔ `macrocosmo-ai` type helpers.
+//!
+//! Content (metrics/commands/evidence) is declared by downstream issues via
+//! [`schema::declare_all`]; this integration issue (#203) establishes the
+//! infrastructure only.
+//!
+//! For convenience, the entire `macrocosmo-ai` crate is re-exported as
+//! [`core`] so callers can refer to AI types via `crate::ai::core::…`.
+
+pub mod convert;
+pub mod emit;
+pub mod plugin;
+pub mod schema;
+
+pub use plugin::{AiBusResource, AiPlugin, AiTickSet};
+
+/// Re-export of the `macrocosmo-ai` crate. Callers should prefer
+/// `crate::ai::core::…` over `macrocosmo_ai::…` so that swapping the AI
+/// core (e.g. for a mock) is a single edit in this module.
+pub use macrocosmo_ai as core;

--- a/macrocosmo/src/ai/plugin.rs
+++ b/macrocosmo/src/ai/plugin.rs
@@ -1,0 +1,119 @@
+//! `AiPlugin`: Bevy plugin that wires `macrocosmo-ai` into the game app.
+//!
+//! Responsibilities (Phase 1 / #203 — infrastructure only):
+//!
+//! - Registers [`AiBusResource`] (a thin newtype wrapper around
+//!   `macrocosmo_ai::AiBus`).
+//! - Runs [`schema::declare_all`] once at `Startup` so downstream systems
+//!   can assume every content-level topic they depend on is declared.
+//! - Declares the [`AiTickSet`] ordering
+//!   (`MetricProduce → Reason → CommandDrain`) under `Update`, all chained
+//!   `.after(crate::time_system::advance_game_time)` so the bus observes
+//!   a monotonically advancing `GameClock`.
+//!
+//! No concrete AI systems are registered here — future issues (#204 et al.)
+//! add systems under the appropriate `AiTickSet` set.
+
+use std::ops::{Deref, DerefMut};
+
+use bevy::prelude::*;
+use macrocosmo_ai::{AiBus, WarningMode};
+
+use crate::ai::schema;
+
+/// Resource wrapper around [`AiBus`].
+///
+/// The wrapper exists because `AiBus` is defined in a dependency crate and
+/// cannot have `#[derive(Resource)]` applied directly. `Deref` /
+/// `DerefMut` forward all bus operations transparently.
+///
+/// Default `WarningMode` is [`WarningMode::Enabled`] (the `AiBus::default()`
+/// behaviour), which logs through the `log` crate when the bus sees a
+/// misuse (emitting to an undeclared topic, time-reversed emits, etc.).
+#[derive(Resource, Debug, Default)]
+pub struct AiBusResource(pub AiBus);
+
+impl AiBusResource {
+    /// Construct with an explicit [`WarningMode`].
+    pub fn with_warning_mode(mode: WarningMode) -> Self {
+        Self(AiBus::with_warning_mode(mode))
+    }
+}
+
+impl Deref for AiBusResource {
+    type Target = AiBus;
+    fn deref(&self) -> &AiBus {
+        &self.0
+    }
+}
+
+impl DerefMut for AiBusResource {
+    fn deref_mut(&mut self) -> &mut AiBus {
+        &mut self.0
+    }
+}
+
+/// Ordered system sets for AI-related work under `Update`.
+///
+/// All three run `.after(crate::time_system::advance_game_time)` and are
+/// chained: `MetricProduce → Reason → CommandDrain`.
+///
+/// Phase 1 (#203) adds no systems to these sets; they exist so downstream
+/// issues can register systems with the correct ordering from the start
+/// without a later schema-change.
+#[derive(SystemSet, Debug, Clone, Hash, PartialEq, Eq)]
+pub enum AiTickSet {
+    /// Systems that **read** game state and **write** metric / evidence
+    /// topics into the bus.
+    MetricProduce,
+    /// Systems that **read** bus metrics / evidence and decide what
+    /// commands to emit.
+    Reason,
+    /// Systems that **drain** pending commands from the bus and apply
+    /// them to ECS game state.
+    CommandDrain,
+}
+
+/// AI integration plugin. See module docs.
+pub struct AiPlugin;
+
+impl Plugin for AiPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<AiBusResource>()
+            .add_systems(Startup, schema::declare_all)
+            .configure_sets(
+                Update,
+                (
+                    AiTickSet::MetricProduce,
+                    AiTickSet::Reason,
+                    AiTickSet::CommandDrain,
+                )
+                    .chain()
+                    .after(crate::time_system::advance_game_time),
+            );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_registers_bus_resource() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(crate::time_system::GameClock::new(0));
+        app.insert_resource(crate::time_system::GameSpeed::default());
+        app.add_plugins(AiPlugin);
+        app.update();
+        assert!(app.world().get_resource::<AiBusResource>().is_some());
+    }
+
+    #[test]
+    fn bus_resource_deref_exposes_ai_bus() {
+        let r = AiBusResource::default();
+        // default() through Deref should match a fresh AiBus behaviourally:
+        // no metrics declared.
+        assert!(!r.has_metric(&macrocosmo_ai::MetricId::from("nope")));
+    }
+}

--- a/macrocosmo/src/ai/schema.rs
+++ b/macrocosmo/src/ai/schema.rs
@@ -1,0 +1,35 @@
+//! Startup-time schema declarations for the AI bus.
+//!
+//! The bus requires every metric / command / evidence kind to be declared
+//! before values can be emitted. This module centralises those
+//! declarations so downstream systems can assume the schema is available
+//! by the time `Update` runs.
+//!
+//! Phase 1 (#203) keeps the schema **empty** — content is added by later
+//! issues (first concrete capability: #204 FleetCombatCapability). The
+//! `declare_all` system is still wired into `Startup` in `AiPlugin` so
+//! future issues only need to add entries to `declare_metrics`,
+//! `declare_commands`, or `declare_evidence`.
+
+use bevy::prelude::*;
+use macrocosmo_ai::AiBus;
+
+use crate::ai::plugin::AiBusResource;
+
+/// Declare every metric / command / evidence topic used by the engine.
+///
+/// Runs once in `Startup` via [`AiPlugin`](crate::ai::AiPlugin).
+pub fn declare_all(mut bus: ResMut<AiBusResource>) {
+    declare_metrics(&mut bus.0);
+    declare_commands(&mut bus.0);
+    declare_evidence(&mut bus.0);
+}
+
+/// Metric topics. Empty in #203; populated by downstream capability issues.
+fn declare_metrics(_bus: &mut AiBus) {}
+
+/// Command kinds. Empty in #203; populated by downstream capability issues.
+fn declare_commands(_bus: &mut AiBus) {}
+
+/// Evidence kinds. Empty in #203; populated by downstream capability issues.
+fn declare_evidence(_bus: &mut AiBus) {}

--- a/macrocosmo/src/lib.rs
+++ b/macrocosmo/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ai;
 pub mod amount;
 pub mod choice;
 pub mod colony;

--- a/macrocosmo/src/main.rs
+++ b/macrocosmo/src/main.rs
@@ -1,3 +1,4 @@
+mod ai;
 mod amount;
 mod choice;
 mod colony;
@@ -59,6 +60,7 @@ fn main() {
             notifications::NotificationsPlugin,
             faction::FactionRelationsPlugin,
             choice::ChoicesPlugin,
+            ai::AiPlugin,
         ))
         .add_plugins(ui::UiPlugin)
         .run();

--- a/macrocosmo/tests/ai_integration.rs
+++ b/macrocosmo/tests/ai_integration.rs
@@ -1,0 +1,110 @@
+//! Integration tests for `macrocosmo::ai` — the AI integration layer (#203).
+//!
+//! These tests validate the infrastructure wiring only; no content
+//! (metrics/commands/evidence) is declared in #203, so the tests stick to
+//! plugin boot behaviour, `AiBusWriter` stamping, and Bevy Query conflict
+//! detection via `full_test_app()`.
+
+mod common;
+
+use bevy::prelude::*;
+use macrocosmo::ai::emit::AiBusWriter;
+use macrocosmo::ai::{AiBusResource, AiPlugin};
+use macrocosmo::time_system::{GameClock, GameSpeed};
+use macrocosmo_ai::{MetricId, MetricSpec, Retention, WarningMode};
+
+use common::{full_test_app, test_app};
+
+/// Build a minimal app carrying just the bits AiPlugin needs to boot.
+fn minimal_ai_app() -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(GameClock::new(0));
+    app.insert_resource(GameSpeed::default());
+    app.add_plugins(AiPlugin);
+    app
+}
+
+#[test]
+fn ai_plugin_boots_and_ticks_empty_bus() {
+    let mut app = minimal_ai_app();
+
+    // Run Startup + a handful of Update ticks. With nothing registered
+    // under `AiTickSet::*` this must be a no-op that doesn't panic.
+    for _ in 0..5 {
+        app.update();
+    }
+
+    // AiBusResource must exist and have no declared content.
+    let bus = app
+        .world()
+        .get_resource::<AiBusResource>()
+        .expect("AiBusResource missing after AiPlugin::build");
+    assert!(!bus.has_metric(&MetricId::from("unused")));
+}
+
+/// Confirm `AiBusWriter::emit` stamps with the current `GameClock` tick,
+/// and that `emit_at` respects caller-supplied ticks.
+#[test]
+fn ai_bus_writer_stamps_current_tick() {
+    let mut app = minimal_ai_app();
+
+    // Declare a test metric directly on the bus resource. Use Silent mode
+    // to keep test output clean; re-declaration in later ticks is a
+    // no-op for this test.
+    {
+        let mut bus = app.world_mut().resource_mut::<AiBusResource>();
+        bus.0.set_warning_mode(WarningMode::Silent);
+        bus.0.declare_metric(
+            MetricId::from("ai_integration_test"),
+            MetricSpec::ratio(Retention::Long, "test"),
+        );
+    }
+
+    // System that emits 0.25 at the current tick.
+    fn emit_at_now(mut writer: AiBusWriter) {
+        writer.emit(&MetricId::from("ai_integration_test"), 0.25);
+    }
+    app.add_systems(Update, emit_at_now);
+
+    // Tick 1: clock=10, emit -> stamp at=10.
+    app.world_mut().resource_mut::<GameClock>().elapsed = 10;
+    app.update();
+    {
+        let bus = app.world().resource::<AiBusResource>();
+        assert_eq!(bus.at(&MetricId::from("ai_integration_test"), 10), Some(0.25));
+    }
+
+    // Tick 2: clock=25, emit -> stamp at=25. Previous sample still there.
+    app.world_mut().resource_mut::<GameClock>().elapsed = 25;
+    app.update();
+    {
+        let bus = app.world().resource::<AiBusResource>();
+        assert_eq!(bus.at(&MetricId::from("ai_integration_test"), 25), Some(0.25));
+        assert_eq!(bus.at(&MetricId::from("ai_integration_test"), 10), Some(0.25));
+        assert_eq!(bus.current(&MetricId::from("ai_integration_test")), Some(0.25));
+    }
+}
+
+/// `full_test_app()` includes visualization + every game system registered
+/// side-by-side. If AiPlugin introduces a Query conflict (B0001) with any
+/// of them, Bevy will panic at schedule build / tick time.
+#[test]
+fn ai_plugin_no_query_conflict_with_full_test_app() {
+    let mut app = full_test_app();
+    for _ in 0..3 {
+        app.update();
+    }
+    assert!(app.world().get_resource::<AiBusResource>().is_some());
+}
+
+/// `test_app()` also embeds `AiPlugin`; make sure the headless logic app
+/// still boots cleanly so pre-existing tests keep working.
+#[test]
+fn ai_plugin_coexists_with_test_app() {
+    let mut app = test_app();
+    for _ in 0..3 {
+        app.update();
+    }
+    assert!(app.world().get_resource::<AiBusResource>().is_some());
+}

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -214,6 +214,10 @@ pub fn test_app() -> App {
     app.add_plugins(MinimalPlugins);
     app.insert_resource(GameClock::new(0));
     app.insert_resource(GameSpeed::default());
+    // GameClock is inserted above so AiPlugin's Startup schema::declare_all
+    // (which does not yet use GameClock, but AiBusWriter SystemParams rely
+    // on it at runtime) always observes the test clock.
+    app.add_plugins(macrocosmo::ai::AiPlugin);
     app.insert_resource(LastProductionTick(0));
     app.insert_resource(EventLog::default());
     app.insert_resource(EventSystem::default());
@@ -370,6 +374,11 @@ pub fn full_test_app() -> App {
     // --- Core resources ---
     app.insert_resource(GameClock::new(0));
     app.insert_resource(GameSpeed::default());
+    // AI integration plugin (#203) — AiBusResource + ordered AiTickSet sets.
+    // Added here after GameClock is inserted so AiBusWriter SystemParams can
+    // read it, and so `full_test_app` can detect Query conflicts (B0001)
+    // introduced by AI systems at CI time.
+    app.add_plugins(macrocosmo::ai::AiPlugin);
     app.insert_resource(LastProductionTick(0));
     app.insert_resource(EventLog::default());
     app.insert_resource(EventSystem::default());


### PR DESCRIPTION
Closes #203.

## Summary
- Add `macrocosmo-ai = { path = "../macrocosmo-ai" }` to `macrocosmo/Cargo.toml` (dependency direction: macrocosmo → macrocosmo-ai, enforced by the existing `ai-core-isolation` workflow).
- New `macrocosmo/src/ai/` module:
  - `plugin.rs` — `AiPlugin`, `AiBusResource` (newtype `Resource` wrapping `AiBus` with `Deref`/`DerefMut`), three ordered system sets (`AiTickSet::MetricProduce → Reason → CommandDrain`) chained `.after(advance_game_time)`.
  - `schema.rs` — `declare_all` runs on `Startup`; content placeholders are empty (future issues populate).
  - `convert.rs` — `Entity ↔ SystemRef/EntityRef` lossless; `Entity → FactionId` via session-stable `Entity::index().index()`.
  - `emit.rs` — `AiBusWriter`/`AiBusReader`/`AiBusDrainer` `SystemParam` helpers with auto-stamping from `GameClock`.
  - `mod.rs` — re-exports + `pub use macrocosmo_ai as core`.
- `AiPlugin` registered in `main.rs`; module registered in `lib.rs`.
- `tests/common/mod.rs` — `test_app()` and `full_test_app()` now include `AiPlugin` so the latter catches B0001 query conflicts introduced by AI wiring.
- `tests/ai_integration.rs` — 4 smoke tests (plugin boot, `AiBusWriter` tick stamping, no-B0001 under `full_test_app`, coexistence with `test_app`).

Phase 1 infrastructure only — no metrics/commands/evidence are declared yet; downstream issues (starting with #204) populate the schema and add systems under the `AiTickSet` sets.

## Test plan
- [x] `cargo test --workspace` green locally (macrocosmo 545 unit + integration incl. new ai_integration; macrocosmo-ai 23 tests).
- [x] `cargo tree -p macrocosmo-ai --edges=normal` shows no bevy/macrocosmo runtime deps (matches CI grep).
- [ ] CI `ai-core-isolation` passes on this PR.
- [ ] CI build/test pipelines pass on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)