### PR TITLE
#226: Unify prerequisites across Building/Hull/Module + derived ShipDesign

### DIFF
--- a/macrocosmo/scripts/ships/modules.lua
+++ b/macrocosmo/scripts/ships/modules.lua
@@ -38,7 +38,7 @@ local weapon_laser = define_module {
     id = "weapon_laser",
     name = "Laser Battery",
     slot_type = slot_types.weapon,
-    prerequisite_tech = tech.military.kinetic_weapons,
+    prerequisites = has_tech(tech.military.kinetic_weapons),
     weapon = {
         track = 5.0, precision = 0.85, cooldown = 1, range = 10.0,
         shield_damage = 4.0, shield_damage_div = 1.0, shield_piercing = 0.0,
@@ -52,7 +52,7 @@ local weapon_railgun = define_module {
     id = "weapon_railgun",
     name = "Railgun",
     slot_type = slot_types.weapon,
-    prerequisite_tech = tech.military.kinetic_weapons,
+    prerequisites = has_tech(tech.military.kinetic_weapons),
     weapon = {
         track = 2.0, precision = 0.90, cooldown = 3, range = 20.0,
         shield_damage = 1.0, shield_damage_div = 0.5, shield_piercing = 0.5,
@@ -66,7 +66,7 @@ local weapon_missile = define_module {
     id = "weapon_missile",
     name = "Missile Launcher",
     slot_type = slot_types.weapon,
-    prerequisite_tech = tech.military.kinetic_weapons,
+    prerequisites = has_tech(tech.military.kinetic_weapons),
     weapon = {
         track = 8.0, precision = 0.70, cooldown = 2, range = 15.0,
         shield_damage = 1.0, shield_damage_div = 0.5, shield_piercing = 0.8,
@@ -92,7 +92,7 @@ local shield_generator = define_module {
     id = "shield_generator",
     name = "Shield Generator",
     slot_type = slot_types.defense,
-    prerequisite_tech = tech.military.deflector_shields,
+    prerequisites = has_tech(tech.military.deflector_shields),
     modifiers = {
         { target = "ship.shield_max", base_add = 40.0 },
         { target = "ship.shield_regen", base_add = 2.0 },

--- a/macrocosmo/src/colony/system_buildings.rs
+++ b/macrocosmo/src/colony/system_buildings.rs
@@ -400,6 +400,7 @@ mod tests {
             capabilities: shipyard_caps,
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
+            prerequisites: None,
         });
 
         let mut port_caps = HashMap::new();
@@ -427,6 +428,7 @@ mod tests {
             capabilities: port_caps,
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
+            prerequisites: None,
         });
         registry
     }

--- a/macrocosmo/src/scripting/building_api.rs
+++ b/macrocosmo/src/scripting/building_api.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use bevy::prelude::*;
 
 use crate::amount::Amt;
+use crate::condition::Condition;
+use crate::scripting::condition_parser::parse_prerequisites_field;
 
 /// An upgrade path from one building to another.
 #[derive(Clone, Debug)]
@@ -41,6 +43,9 @@ pub struct BuildingDefinition {
     /// Whether this building can be built directly (true) or only obtained via upgrade (false).
     /// Buildings with cost = nil in Lua are upgrade-only.
     pub is_direct_buildable: bool,
+    /// Optional Condition tree gating construction / upgrade of this building.
+    /// Populated from the Lua `prerequisites = has_tech(...)` / `all(...)` / ... field.
+    pub prerequisites: Option<Condition>,
 }
 
 /// Parameters for a named building capability.
@@ -184,6 +189,7 @@ pub fn parse_building_definitions(lua: &mlua::Lua) -> Result<Vec<BuildingDefinit
         let is_system_building: bool = table.get::<Option<bool>>("is_system_building")?.unwrap_or(false);
         let capabilities = parse_capabilities_table(&table)?;
         let upgrade_to = parse_upgrade_to_table(&table)?;
+        let prerequisites = parse_prerequisites_field(&table)?;
 
         result.push(BuildingDefinition {
             id,
@@ -201,6 +207,7 @@ pub fn parse_building_definitions(lua: &mlua::Lua) -> Result<Vec<BuildingDefinit
             capabilities,
             upgrade_to,
             is_direct_buildable,
+            prerequisites,
         });
     }
 
@@ -452,6 +459,7 @@ mod tests {
             capabilities: HashMap::new(),
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
+            prerequisites: None,
         });
 
         let mine = registry.get("mine").unwrap();
@@ -476,6 +484,7 @@ mod tests {
             capabilities: HashMap::new(),
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
+            prerequisites: None,
         });
 
         assert_eq!(registry.buildings.len(), 2);
@@ -568,6 +577,7 @@ mod tests {
             capabilities: HashMap::new(),
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
+            prerequisites: None,
         });
 
         // Replace with updated values
@@ -587,6 +597,7 @@ mod tests {
             capabilities: HashMap::new(),
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
+            prerequisites: None,
         });
 
         assert_eq!(registry.buildings.len(), 1);
@@ -670,6 +681,7 @@ mod tests {
             capabilities: HashMap::new(),
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
+            prerequisites: None,
         });
 
         // Upgrade-only planet building
@@ -689,6 +701,7 @@ mod tests {
             capabilities: HashMap::new(),
             upgrade_to: Vec::new(),
             is_direct_buildable: false,
+            prerequisites: None,
         });
 
         // planet_buildings() should only return direct-buildable ones
@@ -698,5 +711,84 @@ mod tests {
 
         // But the registry still has both
         assert!(registry.get("advanced_mine").is_some());
+    }
+
+    #[test]
+    fn test_building_api_parses_prerequisites_field() {
+        use crate::condition::{Condition, ConditionAtom};
+
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_building {
+                id = "plain",
+                name = "Plain",
+            }
+            define_building {
+                id = "tech_gated",
+                name = "Tech Gated",
+                prerequisites = has_tech("industrial_automated_mining"),
+            }
+            define_building {
+                id = "complex_gated",
+                name = "Complex Gated",
+                prerequisites = all(
+                    has_tech("tech_a"),
+                    any(has_tech("tech_b"), has_flag("enabled"))
+                ),
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_building_definitions(lua).unwrap();
+        assert_eq!(defs.len(), 3);
+
+        assert!(defs[0].prerequisites.is_none());
+
+        assert_eq!(
+            defs[1].prerequisites,
+            Some(Condition::Atom(ConditionAtom::has_tech(
+                "industrial_automated_mining"
+            )))
+        );
+
+        assert!(matches!(&defs[2].prerequisites, Some(Condition::All(_))));
+    }
+
+    #[test]
+    fn test_building_api_prerequisites_from_lua_file_wires_advanced_mine() {
+        // Ensures scripts/buildings/basic.lua now populates prerequisites for
+        // advanced_mine / advanced_power_plant (previously silently dropped).
+        use crate::condition::{AtomKind, Condition};
+
+        let engine = ScriptEngine::new().unwrap();
+        let building_script =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/buildings/basic.lua");
+        if !building_script.exists() {
+            return;
+        }
+        engine.load_file(&building_script).unwrap();
+        let defs = parse_building_definitions(engine.lua()).unwrap();
+        let by_id: std::collections::HashMap<_, _> =
+            defs.iter().map(|d| (d.id.as_str(), d)).collect();
+
+        let adv_mine = by_id.get("advanced_mine").unwrap();
+        match &adv_mine.prerequisites {
+            Some(Condition::Atom(atom)) => match &atom.kind {
+                AtomKind::HasTech(id) => assert_eq!(id, "industrial_automated_mining"),
+                other => panic!("expected HasTech atom, got {:?}", other),
+            },
+            other => panic!(
+                "expected advanced_mine prerequisites to be a HasTech atom, got {:?}",
+                other
+            ),
+        }
+
+        let adv_pp = by_id.get("advanced_power_plant").unwrap();
+        assert!(adv_pp.prerequisites.is_some());
     }
 }

--- a/macrocosmo/src/scripting/condition_parser.rs
+++ b/macrocosmo/src/scripting/condition_parser.rs
@@ -1,5 +1,33 @@
 use crate::condition::{AtomKind, Condition, ConditionAtom, ConditionScope};
 
+/// Parse an optional `prerequisites` field from a definition table.
+///
+/// Accepts three shapes (all shared across `define_structure`, `define_building`,
+/// `define_hull`, `define_module`):
+///
+/// * `nil` — no prerequisites.
+/// * a condition table produced by the condition helper functions
+///   (`has_tech`, `all`, `any`, `one_of`, `not_cond`, `has_flag`, ...).
+/// * a function `function(ctx) return <condition table> end` — the function is
+///   called with a `ConditionCtx` to allow scoped atoms like `ctx.empire:has_tech(...)`.
+pub fn parse_prerequisites_field(
+    table: &mlua::Table,
+) -> Result<Option<Condition>, mlua::Error> {
+    let prereq_value: mlua::Value = table.get("prerequisites")?;
+    match prereq_value {
+        mlua::Value::Table(prereq_table) => Ok(Some(parse_condition(&prereq_table)?)),
+        mlua::Value::Function(func) => {
+            let ctx = crate::scripting::condition_ctx::ConditionCtx;
+            let result: mlua::Table = func.call(ctx)?;
+            Ok(Some(parse_condition(&result)?))
+        }
+        mlua::Value::Nil => Ok(None),
+        _ => Err(mlua::Error::RuntimeError(
+            "Expected table, function, or nil for 'prerequisites' field".to_string(),
+        )),
+    }
+}
+
 /// Parse an optional `scope` field from a Lua table and convert to ConditionScope.
 fn parse_scope(table: &mlua::Table) -> Result<ConditionScope, mlua::Error> {
     let scope_str: Option<String> = table.get("scope")?;

--- a/macrocosmo/src/scripting/ship_design_api.rs
+++ b/macrocosmo/src/scripting/ship_design_api.rs
@@ -1,4 +1,5 @@
 use crate::amount::Amt;
+use crate::scripting::condition_parser::parse_prerequisites_field;
 use crate::ship_design::{
     DesignSlotAssignment, HullDefinition, HullSlot, ModuleDefinition, ModuleModifier,
     ModuleUpgradePath, ShipDesignDefinition, SlotTypeDefinition, WeaponStats,
@@ -46,6 +47,9 @@ pub fn parse_hulls(lua: &mlua::Lua) -> Result<Vec<HullDefinition>, mlua::Error> 
         // Parse hull modifiers (optional, same format as module modifiers)
         let modifiers = parse_module_modifiers(&table)?;
 
+        // Parse optional prerequisites (shared helper).
+        let prerequisites = parse_prerequisites_field(&table)?;
+
         result.push(HullDefinition {
             id,
             name,
@@ -59,6 +63,7 @@ pub fn parse_hulls(lua: &mlua::Lua) -> Result<Vec<HullDefinition>, mlua::Error> 
             build_time,
             maintenance,
             modifiers,
+            prerequisites,
         });
     }
 
@@ -411,6 +416,44 @@ mod tests {
         assert_eq!(corvette.build_cost_energy, Amt::units(100));
         assert_eq!(corvette.build_time, 60);
         assert_eq!(corvette.maintenance, Amt::new(0, 500));
+    }
+
+    #[test]
+    fn test_hull_parses_prerequisites() {
+        use crate::condition::{Condition, ConditionAtom};
+
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_hull {
+                id = "plain_hull",
+                name = "Plain",
+                base_hp = 30,
+            }
+            define_hull {
+                id = "cruiser",
+                name = "Cruiser",
+                base_hp = 200,
+                prerequisites = has_tech("hull_cruiser"),
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_hulls(lua).unwrap();
+        assert_eq!(defs.len(), 2);
+
+        let plain = defs.iter().find(|h| h.id == "plain_hull").unwrap();
+        assert!(plain.prerequisites.is_none());
+
+        let cruiser = defs.iter().find(|h| h.id == "cruiser").unwrap();
+        assert_eq!(
+            cruiser.prerequisites,
+            Some(Condition::Atom(ConditionAtom::has_tech("hull_cruiser")))
+        );
     }
 
     #[test]

--- a/macrocosmo/src/scripting/ship_design_api.rs
+++ b/macrocosmo/src/scripting/ship_design_api.rs
@@ -83,11 +83,6 @@ pub fn parse_modules(lua: &mlua::Lua) -> Result<Vec<ModuleDefinition>, mlua::Err
         let description: String = table.get::<Option<String>>("description")?.unwrap_or_default();
         let slot_type_value: mlua::Value = table.get("slot_type")?;
         let slot_type = crate::scripting::extract_ref_id(&slot_type_value)?;
-        let prereq_value: mlua::Value = table.get("prerequisite_tech")?;
-        let prerequisite_tech = match prereq_value {
-            mlua::Value::Nil => None,
-            v => Some(crate::scripting::extract_ref_id(&v)?),
-        };
 
         // Parse modifiers array
         let modifiers = parse_module_modifiers(&table)?;
@@ -101,6 +96,11 @@ pub fn parse_modules(lua: &mlua::Lua) -> Result<Vec<ModuleDefinition>, mlua::Err
         // Parse upgrade_to array (optional)
         let upgrade_to = parse_module_upgrade_to(&table)?;
 
+        // #226: prerequisites (Condition tree). Hard migration — the legacy
+        // `prerequisite_tech = "foo"` field is no longer read; any Lua that
+        // still sets it will have its value silently dropped.
+        let prerequisites = parse_prerequisites_field(&table)?;
+
         result.push(ModuleDefinition {
             id,
             name,
@@ -110,7 +110,7 @@ pub fn parse_modules(lua: &mlua::Lua) -> Result<Vec<ModuleDefinition>, mlua::Err
             weapon,
             cost_minerals,
             cost_energy,
-            prerequisite_tech,
+            prerequisites,
             upgrade_to,
         });
     }
@@ -511,6 +511,78 @@ mod tests {
         assert_eq!(armor.modifiers[1].multiplier, -0.05);
         assert_eq!(armor.cost_minerals, Amt::units(80));
         assert_eq!(armor.cost_energy, Amt::ZERO);
+    }
+
+    #[test]
+    fn test_module_parses_prerequisites() {
+        use crate::condition::{Condition, ConditionAtom};
+
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_module {
+                id = "plain",
+                name = "Plain",
+                slot_type = "utility",
+                cost = { minerals = 10 },
+            }
+            define_module {
+                id = "advanced",
+                name = "Advanced",
+                slot_type = "utility",
+                prerequisites = all(has_tech("laser_weapons"), has_flag("militarized")),
+                cost = { minerals = 10 },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_modules(lua).unwrap();
+        assert_eq!(defs.len(), 2);
+
+        let plain = defs.iter().find(|m| m.id == "plain").unwrap();
+        assert!(plain.prerequisites.is_none());
+
+        let advanced = defs.iter().find(|m| m.id == "advanced").unwrap();
+        assert_eq!(
+            advanced.prerequisites,
+            Some(Condition::All(vec![
+                Condition::Atom(ConditionAtom::has_tech("laser_weapons")),
+                Condition::Atom(ConditionAtom::has_flag("militarized")),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_module_ignores_legacy_prerequisite_tech_field() {
+        // #226 hard migration: `prerequisite_tech = "..."` is no longer read.
+        // A module that only sets the legacy field ends up with no prerequisites.
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_module {
+                id = "legacy",
+                name = "Legacy",
+                slot_type = "utility",
+                prerequisite_tech = "old_tech_string",
+                cost = { minerals = 10 },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_modules(lua).unwrap();
+        assert_eq!(defs.len(), 1);
+        assert!(
+            defs[0].prerequisites.is_none(),
+            "legacy prerequisite_tech must be dropped silently"
+        );
     }
 
     #[test]

--- a/macrocosmo/src/scripting/structure_api.rs
+++ b/macrocosmo/src/scripting/structure_api.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::amount::Amt;
 use crate::deep_space::{CapabilityParams, ResourceCost, StructureDefinition};
-use crate::scripting::condition_parser::parse_condition;
+use crate::scripting::condition_parser::parse_prerequisites_field;
 
 /// Parse structure definitions from the Lua `_structure_definitions` global table.
 /// Each entry should have at minimum `id` and `name` fields.
@@ -27,8 +27,8 @@ pub fn parse_structure_definitions(lua: &mlua::Lua) -> Result<Vec<StructureDefin
         // energy_drain is specified in millis in Lua (e.g. 100 = 0.1 units)
         let energy_drain = Amt::milli(energy_drain_raw as u64);
 
-        // Parse prerequisites as an optional Condition table
-        let prerequisites = parse_prerequisites(&table)?;
+        // Parse prerequisites as an optional Condition table (shared helper).
+        let prerequisites = parse_prerequisites_field(&table)?;
 
         // Parse capabilities as a table of tables: { cap_name = { range = N }, ... }
         let capabilities = parse_capabilities_map(&table)?;
@@ -64,29 +64,6 @@ fn parse_cost_table(table: &mlua::Table) -> Result<ResourceCost, mlua::Error> {
         mlua::Value::Nil => Ok(ResourceCost::default()),
         _ => Err(mlua::Error::RuntimeError(
             "Expected table or nil for 'cost' field".to_string(),
-        )),
-    }
-}
-
-/// Parse optional `prerequisites` field as a Condition tree.
-/// Accepts either a condition table (from has_tech/all/any/etc.) or a function
-/// that receives a ConditionCtx and returns a condition table.
-fn parse_prerequisites(table: &mlua::Table) -> Result<Option<crate::condition::Condition>, mlua::Error> {
-    let prereq_value: mlua::Value = table.get("prerequisites")?;
-    match prereq_value {
-        mlua::Value::Table(prereq_table) => {
-            let cond = parse_condition(&prereq_table)?;
-            Ok(Some(cond))
-        }
-        mlua::Value::Function(func) => {
-            let ctx = crate::scripting::condition_ctx::ConditionCtx;
-            let result: mlua::Table = func.call(ctx)?;
-            let cond = parse_condition(&result)?;
-            Ok(Some(cond))
-        }
-        mlua::Value::Nil => Ok(None),
-        _ => Err(mlua::Error::RuntimeError(
-            "Expected table, function, or nil for 'prerequisites' field".to_string(),
         )),
     }
 }

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -640,7 +640,7 @@ mod tests {
             cost_energy: Amt::units(50),
             modifiers: vec![],
             weapon: None,
-            prerequisite_tech: None,
+            prerequisites: None,
             upgrade_to: Vec::new(),
         });
         let modules = vec![

--- a/macrocosmo/src/ship_design.rs
+++ b/macrocosmo/src/ship_design.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use bevy::prelude::*;
 
 use crate::amount::Amt;
+use crate::condition::Condition;
 
 /// Defines a module slot type (weapon, utility, engine, special).
 #[derive(Clone, Debug)]
@@ -48,6 +49,9 @@ pub struct HullDefinition {
     pub build_time: i64,
     pub maintenance: Amt,
     pub modifiers: Vec<ModuleModifier>,
+    /// Optional Condition tree gating access to this hull.
+    /// Populated from the Lua `prerequisites = has_tech(...)` / ... field.
+    pub prerequisites: Option<Condition>,
 }
 
 #[derive(Resource, Default)]
@@ -644,6 +648,7 @@ mod tests {
             build_time: 60,
             maintenance: Amt::new(0, 500),
             modifiers: vec![],
+            prerequisites: None,
         });
 
         let corvette = registry.get("corvette").unwrap();
@@ -747,6 +752,7 @@ mod tests {
             build_time: 60,
             maintenance: Amt::new(0, 500),
             modifiers: vec![],
+            prerequisites: None,
         });
 
         let mut modules = ModuleRegistry::default();

--- a/macrocosmo/src/ship_design.rs
+++ b/macrocosmo/src/ship_design.rs
@@ -117,7 +117,13 @@ pub struct ModuleDefinition {
     pub weapon: Option<WeaponStats>,
     pub cost_minerals: Amt,
     pub cost_energy: Amt,
-    pub prerequisite_tech: Option<String>,
+    /// Optional Condition tree gating access to this module.
+    /// Populated from the Lua `prerequisites = has_tech(...)` / ... field.
+    ///
+    /// Previously named `prerequisite_tech: Option<String>`; hard-migrated
+    /// in #226 to a full Condition tree so modules can be gated by arbitrary
+    /// combinations of tech / flags / buildings / modifiers.
+    pub prerequisites: Option<Condition>,
     /// Available upgrade paths from this module.
     pub upgrade_to: Vec<ModuleUpgradePath>,
 }
@@ -677,7 +683,7 @@ mod tests {
             weapon: None,
             cost_minerals: Amt::units(100),
             cost_energy: Amt::units(50),
-            prerequisite_tech: None,
+            prerequisites: None,
             upgrade_to: Vec::new(),
         });
 
@@ -765,7 +771,7 @@ mod tests {
             weapon: None,
             cost_minerals: Amt::ZERO,
             cost_energy: Amt::ZERO,
-            prerequisite_tech: None,
+            prerequisites: None,
             upgrade_to: Vec::new(),
         };
         modules.insert(make("ftl_drive", "ftl"));

--- a/macrocosmo/src/ship_design.rs
+++ b/macrocosmo/src/ship_design.rs
@@ -524,6 +524,38 @@ pub fn load_ship_designs(
     }
 }
 
+/// #226: derive a ship design's effective prerequisites from its hull and
+/// modules. A design has no first-class `prerequisites` field — instead the
+/// conditions gating the underlying hull + modules are composed here.
+///
+/// * 0 sub-conditions → `None`
+/// * 1 sub-condition   → the sub-condition unwrapped (avoids a noisy `All([X])`)
+/// * N sub-conditions  → `Condition::All(...)`
+pub fn ship_design_effective_prerequisites(
+    design: &ShipDesignDefinition,
+    hulls: &HullRegistry,
+    modules: &ModuleRegistry,
+) -> Option<Condition> {
+    let mut parts: Vec<Condition> = Vec::new();
+    if let Some(hull) = hulls.get(&design.hull_id) {
+        if let Some(c) = &hull.prerequisites {
+            parts.push(c.clone());
+        }
+    }
+    for assign in &design.modules {
+        if let Some(m) = modules.get(&assign.module_id) {
+            if let Some(c) = &m.prerequisites {
+                parts.push(c.clone());
+            }
+        }
+    }
+    match parts.len() {
+        0 => None,
+        1 => Some(parts.into_iter().next().unwrap()),
+        _ => Some(Condition::All(parts)),
+    }
+}
+
 /// Compute total cost for a ship design: hull cost + sum of module costs.
 /// Returns (minerals, energy, build_time, maintenance).
 pub fn design_cost(
@@ -964,6 +996,65 @@ mod tests {
         // Both module costs are zero in the fixture, so refit cost is zero.
         assert_eq!(m, Amt::ZERO);
         assert_eq!(e, Amt::ZERO);
+    }
+
+    #[test]
+    fn ship_design_effective_prereqs_empty_when_none() {
+        let (hulls, modules) = validation_fixture();
+        let design = make_design(
+            "noop",
+            vec![DesignSlotAssignment { slot_type: "ftl".into(), module_id: "ftl_drive".into() }],
+        );
+        assert!(ship_design_effective_prerequisites(&design, &hulls, &modules).is_none());
+    }
+
+    #[test]
+    fn ship_design_effective_prereqs_single_unwrapped_not_wrapped_in_all() {
+        use crate::condition::ConditionAtom;
+        let (mut hulls, modules) = validation_fixture();
+        // Attach a prerequisite to the corvette hull.
+        let mut corvette = hulls.get("corvette").unwrap().clone();
+        corvette.prerequisites = Some(Condition::Atom(ConditionAtom::has_tech("hull_corvette")));
+        hulls.insert(corvette);
+
+        let design = make_design(
+            "ok",
+            vec![DesignSlotAssignment { slot_type: "ftl".into(), module_id: "ftl_drive".into() }],
+        );
+        let eff = ship_design_effective_prerequisites(&design, &hulls, &modules);
+        // Exactly one contributing condition (hull's). Must not be wrapped in All.
+        assert_eq!(
+            eff,
+            Some(Condition::Atom(ConditionAtom::has_tech("hull_corvette")))
+        );
+    }
+
+    #[test]
+    fn ship_design_effective_prereqs_derived_from_hull_and_modules() {
+        use crate::condition::ConditionAtom;
+        let (mut hulls, mut modules) = validation_fixture();
+        // Hull requires tech T1.
+        let mut corvette = hulls.get("corvette").unwrap().clone();
+        corvette.prerequisites = Some(Condition::Atom(ConditionAtom::has_tech("T1")));
+        hulls.insert(corvette);
+        // FTL drive module requires tech T2.
+        let mut ftl = modules.get("ftl_drive").unwrap().clone();
+        ftl.prerequisites = Some(Condition::Atom(ConditionAtom::has_tech("T2")));
+        modules.insert(ftl);
+
+        let design = make_design(
+            "ok",
+            vec![DesignSlotAssignment { slot_type: "ftl".into(), module_id: "ftl_drive".into() }],
+        );
+        let eff = ship_design_effective_prerequisites(&design, &hulls, &modules);
+        match eff {
+            Some(Condition::All(parts)) => {
+                assert_eq!(parts.len(), 2);
+                assert_eq!(parts[0], Condition::Atom(ConditionAtom::has_tech("T1")));
+                assert_eq!(parts[1], Condition::Atom(ConditionAtom::has_tech("T2")));
+            }
+            other => panic!("expected Condition::All, got {:?}", other),
+        }
     }
 
     #[test]

--- a/macrocosmo/src/technology/unlocks.rs
+++ b/macrocosmo/src/technology/unlocks.rs
@@ -24,6 +24,10 @@ pub enum UnlockKind {
     Tech,
 }
 
+// NOTE: `UnlockKind::Building` was already declared but was not populated before
+// BuildingDefinition grew its `prerequisites` field. It is now wired up in
+// `build_tech_unlock_index` below.
+
 /// A single thing unlocked by a technology.
 #[derive(Clone, Debug)]
 pub struct UnlockEntry {
@@ -123,11 +127,20 @@ pub fn build_tech_unlock_index(
         }
     }
 
-    // Buildings: BuildingDefinition has no Condition prerequisites field today,
-    // but iterate so a future field gets picked up here. (No-op for now.)
-    for (_id, _def) in &buildings.buildings {
-        // Placeholder: when buildings gain a `prerequisites: Option<Condition>`
-        // field, walk it via `extract_tech_ids` and push entries.
+    // Buildings: walk the optional Condition tree for HasTech atoms.
+    for (id, def) in &buildings.buildings {
+        if let Some(cond) = &def.prerequisites {
+            for tech_id in extract_tech_ids(cond) {
+                index.push(
+                    tech_id,
+                    UnlockEntry {
+                        kind: UnlockKind::Building,
+                        id: id.clone(),
+                        name: def.name.clone(),
+                    },
+                );
+            }
+        }
     }
 
     // Structures: walk the optional Condition tree for HasTech atoms.
@@ -234,7 +247,7 @@ mod tests {
         }
     }
 
-    fn make_building(id: &str, name: &str) -> BuildingDefinition {
+    fn make_building(id: &str, name: &str, prereq: Option<Condition>) -> BuildingDefinition {
         BuildingDefinition {
             id: id.to_string(),
             name: name.to_string(),
@@ -251,6 +264,7 @@ mod tests {
             capabilities: HashMap::<String, BCapabilityParams>::new(),
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
+            prerequisites: prereq,
         }
     }
 
@@ -384,11 +398,9 @@ mod tests {
     }
 
     #[test]
-    fn building_registry_iteration_is_safe_no_op() {
-        // BuildingDefinition has no prerequisites field today; iterating it
-        // must simply not contribute any entries.
+    fn building_without_prerequisites_produces_no_entries() {
         let mut buildings = BuildingRegistry::default();
-        buildings.insert(make_building("mine", "Mine"));
+        buildings.insert(make_building("mine", "Mine", None));
         let index = run_index(
             ModuleRegistry::default(),
             buildings,
@@ -396,6 +408,50 @@ mod tests {
             TechTree::default(),
         );
         assert_eq!(index.total_entries(), 0);
+    }
+
+    #[test]
+    fn building_unlocked_by_has_tech() {
+        let mut buildings = BuildingRegistry::default();
+        let cond = Condition::Atom(ConditionAtom::has_tech("industrial_automated_mining"));
+        buildings.insert(make_building("advanced_mine", "Advanced Mine", Some(cond)));
+
+        let index = run_index(
+            ModuleRegistry::default(),
+            buildings,
+            StructureRegistry::default(),
+            TechTree::default(),
+        );
+
+        let entries = index.for_tech("industrial_automated_mining");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, UnlockKind::Building);
+        assert_eq!(entries[0].id, "advanced_mine");
+        assert_eq!(entries[0].name, "Advanced Mine");
+    }
+
+    #[test]
+    fn building_unlocked_by_complex_condition() {
+        let mut buildings = BuildingRegistry::default();
+        let cond = Condition::All(vec![
+            Condition::Atom(ConditionAtom::has_tech("tech_a")),
+            Condition::Any(vec![
+                Condition::Atom(ConditionAtom::has_tech("tech_b")),
+                Condition::Atom(ConditionAtom::has_flag("some_flag")),
+            ]),
+        ]);
+        buildings.insert(make_building("mega_mine", "Mega Mine", Some(cond)));
+        let index = run_index(
+            ModuleRegistry::default(),
+            buildings,
+            StructureRegistry::default(),
+            TechTree::default(),
+        );
+        // Both tech_a and tech_b should index the building; the has_flag atom is ignored.
+        assert_eq!(index.for_tech("tech_a").len(), 1);
+        assert_eq!(index.for_tech("tech_b").len(), 1);
+        assert_eq!(index.for_tech("tech_a")[0].kind, UnlockKind::Building);
+        assert_eq!(index.for_tech("tech_a")[0].id, "mega_mine");
     }
 
     #[test]

--- a/macrocosmo/src/technology/unlocks.rs
+++ b/macrocosmo/src/technology/unlocks.rs
@@ -11,7 +11,9 @@ use bevy::prelude::*;
 use crate::condition::{AtomKind, Condition};
 use crate::deep_space::StructureRegistry;
 use crate::scripting::building_api::BuildingRegistry;
-use crate::ship_design::{HullRegistry, ModuleRegistry};
+use crate::ship_design::{
+    ship_design_effective_prerequisites, HullRegistry, ModuleRegistry, ShipDesignRegistry,
+};
 
 use super::tree::{TechId, TechTree};
 
@@ -25,6 +27,8 @@ pub enum UnlockKind {
     /// A hull unlocked by tech. Populated once HullDefinition gains a
     /// `prerequisites: Option<Condition>` field (#226).
     Hull,
+    /// A ship design unlocked by tech (derived from hull + modules, #226).
+    ShipDesign,
 }
 
 /// A single thing unlocked by a technology.
@@ -107,6 +111,7 @@ pub fn build_tech_unlock_index(
     buildings: Res<BuildingRegistry>,
     structures: Res<StructureRegistry>,
     hulls: Res<HullRegistry>,
+    designs: Res<ShipDesignRegistry>,
     tech_trees: Query<&TechTree>,
     tech_tree_res: Option<Res<TechTree>>,
 ) {
@@ -155,6 +160,23 @@ pub fn build_tech_unlock_index(
                         kind: UnlockKind::Hull,
                         id: id.clone(),
                         name: def.name.clone(),
+                    },
+                );
+            }
+        }
+    }
+
+    // Ship designs: derive effective prerequisites from hull + modules, then
+    // walk them for HasTech atoms.
+    for (id, design) in &designs.designs {
+        if let Some(cond) = ship_design_effective_prerequisites(design, &hulls, &modules) {
+            for tech_id in extract_tech_ids(&cond) {
+                index.push(
+                    tech_id,
+                    UnlockEntry {
+                        kind: UnlockKind::ShipDesign,
+                        id: id.clone(),
+                        name: design.name.clone(),
                     },
                 );
             }
@@ -220,7 +242,10 @@ mod tests {
     use crate::condition::ConditionAtom;
     use crate::deep_space::{ResourceCost, StructureDefinition};
     use crate::scripting::building_api::{BuildingDefinition, CapabilityParams as BCapabilityParams};
-    use crate::ship_design::{HullDefinition, HullRegistry, ModuleDefinition, ModuleRegistry};
+    use crate::ship_design::{
+        DesignSlotAssignment, HullDefinition, HullRegistry, ModuleDefinition, ModuleRegistry,
+        ShipDesignDefinition, ShipDesignRegistry,
+    };
     use crate::technology::tree::{TechCost, Technology};
     use std::collections::HashMap;
 
@@ -294,7 +319,14 @@ mod tests {
         structures: StructureRegistry,
         tree: TechTree,
     ) -> TechUnlockIndex {
-        run_index_with_hulls(modules, buildings, structures, HullRegistry::default(), tree)
+        run_index_full(
+            modules,
+            buildings,
+            structures,
+            HullRegistry::default(),
+            ShipDesignRegistry::default(),
+            tree,
+        )
     }
 
     fn run_index_with_hulls(
@@ -304,12 +336,31 @@ mod tests {
         hulls: HullRegistry,
         tree: TechTree,
     ) -> TechUnlockIndex {
+        run_index_full(
+            modules,
+            buildings,
+            structures,
+            hulls,
+            ShipDesignRegistry::default(),
+            tree,
+        )
+    }
+
+    fn run_index_full(
+        modules: ModuleRegistry,
+        buildings: BuildingRegistry,
+        structures: StructureRegistry,
+        hulls: HullRegistry,
+        designs: ShipDesignRegistry,
+        tree: TechTree,
+    ) -> TechUnlockIndex {
         let mut app = App::new();
         app.init_resource::<TechUnlockIndex>();
         app.insert_resource(modules);
         app.insert_resource(buildings);
         app.insert_resource(structures);
         app.insert_resource(hulls);
+        app.insert_resource(designs);
         // Use the resource fallback path -- simpler than spawning an empire.
         app.insert_resource(tree);
         app.add_systems(Update, build_tech_unlock_index);
@@ -541,6 +592,78 @@ mod tests {
         );
         assert_eq!(index.total_entries(), 0);
         assert!(index.for_tech("anything").is_empty());
+    }
+
+    #[test]
+    fn ship_design_unlocked_from_derived_prereqs() {
+        // A design whose hull requires T1 and whose module requires T2 should
+        // appear as a UnlockKind::ShipDesign entry under BOTH techs.
+        let mut hulls = HullRegistry::default();
+        let mut corvette = make_hull(
+            "corvette",
+            "Corvette",
+            Some(Condition::Atom(ConditionAtom::has_tech("T1"))),
+        );
+        // Give the hull at least one slot so the design can reference it.
+        corvette.slots = vec![crate::ship_design::HullSlot {
+            slot_type: "ftl".into(),
+            count: 1,
+        }];
+        hulls.insert(corvette);
+
+        let mut modules = ModuleRegistry::default();
+        modules.insert(ModuleDefinition {
+            id: "ftl_drive".into(),
+            name: "FTL Drive".into(),
+            description: String::new(),
+            slot_type: "ftl".into(),
+            modifiers: Vec::new(),
+            weapon: None,
+            cost_minerals: Amt::ZERO,
+            cost_energy: Amt::ZERO,
+            prerequisites: Some(Condition::Atom(ConditionAtom::has_tech("T2"))),
+            upgrade_to: Vec::new(),
+        });
+
+        let mut designs = ShipDesignRegistry::default();
+        designs.insert(ShipDesignDefinition {
+            id: "explorer".into(),
+            name: "Explorer".into(),
+            description: String::new(),
+            hull_id: "corvette".into(),
+            modules: vec![DesignSlotAssignment {
+                slot_type: "ftl".into(),
+                module_id: "ftl_drive".into(),
+            }],
+            can_survey: false,
+            can_colonize: false,
+            maintenance: Amt::ZERO,
+            build_cost_minerals: Amt::ZERO,
+            build_cost_energy: Amt::ZERO,
+            build_time: 1,
+            hp: 50.0,
+            sublight_speed: 0.5,
+            ftl_range: 10.0,
+            revision: 0,
+        });
+
+        let index = run_index_full(
+            modules,
+            BuildingRegistry::default(),
+            StructureRegistry::default(),
+            hulls,
+            designs,
+            TechTree::default(),
+        );
+
+        // Both T1 and T2 should list the design + the hull / module themselves.
+        let t1 = index.for_tech("T1");
+        assert!(t1.iter().any(|e| e.kind == UnlockKind::ShipDesign && e.id == "explorer"));
+        assert!(t1.iter().any(|e| e.kind == UnlockKind::Hull && e.id == "corvette"));
+
+        let t2 = index.for_tech("T2");
+        assert!(t2.iter().any(|e| e.kind == UnlockKind::ShipDesign && e.id == "explorer"));
+        assert!(t2.iter().any(|e| e.kind == UnlockKind::Module && e.id == "ftl_drive"));
     }
 
     #[test]

--- a/macrocosmo/src/technology/unlocks.rs
+++ b/macrocosmo/src/technology/unlocks.rs
@@ -96,9 +96,9 @@ fn collect_tech_ids(cond: &Condition, out: &mut Vec<String>) {
 /// Runs once at startup, after every registry has finished its own Lua-load
 /// system. Iterates:
 ///
-/// * `ModuleRegistry` — `prerequisite_tech: Option<String>`
-/// * `BuildingRegistry` — currently no prerequisites (placeholder iteration
-///   so future Condition-based prerequisites are picked up automatically)
+/// * `ModuleRegistry` — `prerequisites: Option<Condition>`
+/// * `BuildingRegistry` — `prerequisites: Option<Condition>`
+/// * `HullRegistry` — `prerequisites: Option<Condition>`
 /// * `StructureRegistry` — `prerequisites: Option<Condition>`
 /// * `TechTree` — each tech's `prerequisites: Vec<TechId>` (reversed)
 pub fn build_tech_unlock_index(
@@ -113,17 +113,19 @@ pub fn build_tech_unlock_index(
     // Reset in case the system somehow runs again.
     index.unlocks.clear();
 
-    // Modules: direct `prerequisite_tech` field.
+    // Modules: walk the optional Condition tree for HasTech atoms.
     for (id, def) in &modules.modules {
-        if let Some(tech_id) = &def.prerequisite_tech {
-            index.push(
-                tech_id.clone(),
-                UnlockEntry {
-                    kind: UnlockKind::Module,
-                    id: id.clone(),
-                    name: def.name.clone(),
-                },
-            );
+        if let Some(cond) = &def.prerequisites {
+            for tech_id in extract_tech_ids(cond) {
+                index.push(
+                    tech_id,
+                    UnlockEntry {
+                        kind: UnlockKind::Module,
+                        id: id.clone(),
+                        name: def.name.clone(),
+                    },
+                );
+            }
         }
     }
 
@@ -222,7 +224,7 @@ mod tests {
     use crate::technology::tree::{TechCost, Technology};
     use std::collections::HashMap;
 
-    fn make_module(id: &str, name: &str, prereq: Option<&str>) -> ModuleDefinition {
+    fn make_module(id: &str, name: &str, prereq: Option<Condition>) -> ModuleDefinition {
         ModuleDefinition {
             id: id.to_string(),
             name: name.to_string(),
@@ -232,7 +234,7 @@ mod tests {
             weapon: None,
             cost_minerals: Amt::ZERO,
             cost_energy: Amt::ZERO,
-            prerequisite_tech: prereq.map(|s| s.to_string()),
+            prerequisites: prereq,
             upgrade_to: Vec::new(),
         }
     }
@@ -336,9 +338,13 @@ mod tests {
     }
 
     #[test]
-    fn module_unlocked_by_prerequisite_tech() {
+    fn module_unlocked_by_has_tech() {
         let mut modules = ModuleRegistry::default();
-        modules.insert(make_module("laser_mk2", "Laser Mk.II", Some("laser_weapons")));
+        modules.insert(make_module(
+            "laser_mk2",
+            "Laser Mk.II",
+            Some(Condition::Atom(ConditionAtom::has_tech("laser_weapons"))),
+        ));
         modules.insert(make_module("plain", "Plain Module", None));
 
         let index = run_index(
@@ -355,6 +361,32 @@ mod tests {
         assert_eq!(entries[0].name, "Laser Mk.II");
         // The module without a prereq should not appear under any tech.
         assert!(!index.unlocks.values().flatten().any(|e| e.id == "plain"));
+    }
+
+    #[test]
+    fn module_unlocked_by_complex_condition() {
+        let mut modules = ModuleRegistry::default();
+        let cond = Condition::All(vec![
+            Condition::Atom(ConditionAtom::has_tech("advanced_weapons")),
+            Condition::Any(vec![
+                Condition::Atom(ConditionAtom::has_tech("fusion_power")),
+                Condition::Atom(ConditionAtom::has_flag("superpowered")),
+            ]),
+        ]);
+        modules.insert(make_module("super_weapon", "Super Weapon", Some(cond)));
+
+        let index = run_index(
+            modules,
+            BuildingRegistry::default(),
+            StructureRegistry::default(),
+            TechTree::default(),
+        );
+
+        // advanced_weapons and fusion_power each index the module once.
+        assert_eq!(index.for_tech("advanced_weapons").len(), 1);
+        assert_eq!(index.for_tech("fusion_power").len(), 1);
+        assert_eq!(index.for_tech("advanced_weapons")[0].id, "super_weapon");
+        assert_eq!(index.for_tech("advanced_weapons")[0].kind, UnlockKind::Module);
     }
 
     #[test]

--- a/macrocosmo/src/technology/unlocks.rs
+++ b/macrocosmo/src/technology/unlocks.rs
@@ -11,7 +11,7 @@ use bevy::prelude::*;
 use crate::condition::{AtomKind, Condition};
 use crate::deep_space::StructureRegistry;
 use crate::scripting::building_api::BuildingRegistry;
-use crate::ship_design::ModuleRegistry;
+use crate::ship_design::{HullRegistry, ModuleRegistry};
 
 use super::tree::{TechId, TechTree};
 
@@ -22,11 +22,10 @@ pub enum UnlockKind {
     Building,
     Structure,
     Tech,
+    /// A hull unlocked by tech. Populated once HullDefinition gains a
+    /// `prerequisites: Option<Condition>` field (#226).
+    Hull,
 }
-
-// NOTE: `UnlockKind::Building` was already declared but was not populated before
-// BuildingDefinition grew its `prerequisites` field. It is now wired up in
-// `build_tech_unlock_index` below.
 
 /// A single thing unlocked by a technology.
 #[derive(Clone, Debug)]
@@ -107,6 +106,7 @@ pub fn build_tech_unlock_index(
     modules: Res<ModuleRegistry>,
     buildings: Res<BuildingRegistry>,
     structures: Res<StructureRegistry>,
+    hulls: Res<HullRegistry>,
     tech_trees: Query<&TechTree>,
     tech_tree_res: Option<Res<TechTree>>,
 ) {
@@ -135,6 +135,22 @@ pub fn build_tech_unlock_index(
                     tech_id,
                     UnlockEntry {
                         kind: UnlockKind::Building,
+                        id: id.clone(),
+                        name: def.name.clone(),
+                    },
+                );
+            }
+        }
+    }
+
+    // Hulls: walk the optional Condition tree for HasTech atoms.
+    for (id, def) in &hulls.hulls {
+        if let Some(cond) = &def.prerequisites {
+            for tech_id in extract_tech_ids(cond) {
+                index.push(
+                    tech_id,
+                    UnlockEntry {
+                        kind: UnlockKind::Hull,
                         id: id.clone(),
                         name: def.name.clone(),
                     },
@@ -202,7 +218,7 @@ mod tests {
     use crate::condition::ConditionAtom;
     use crate::deep_space::{ResourceCost, StructureDefinition};
     use crate::scripting::building_api::{BuildingDefinition, CapabilityParams as BCapabilityParams};
-    use crate::ship_design::{ModuleDefinition, ModuleRegistry};
+    use crate::ship_design::{HullDefinition, HullRegistry, ModuleDefinition, ModuleRegistry};
     use crate::technology::tree::{TechCost, Technology};
     use std::collections::HashMap;
 
@@ -276,11 +292,22 @@ mod tests {
         structures: StructureRegistry,
         tree: TechTree,
     ) -> TechUnlockIndex {
+        run_index_with_hulls(modules, buildings, structures, HullRegistry::default(), tree)
+    }
+
+    fn run_index_with_hulls(
+        modules: ModuleRegistry,
+        buildings: BuildingRegistry,
+        structures: StructureRegistry,
+        hulls: HullRegistry,
+        tree: TechTree,
+    ) -> TechUnlockIndex {
         let mut app = App::new();
         app.init_resource::<TechUnlockIndex>();
         app.insert_resource(modules);
         app.insert_resource(buildings);
         app.insert_resource(structures);
+        app.insert_resource(hulls);
         // Use the resource fallback path -- simpler than spawning an empire.
         app.insert_resource(tree);
         app.add_systems(Update, build_tech_unlock_index);
@@ -288,6 +315,24 @@ mod tests {
         app.world_mut()
             .remove_resource::<TechUnlockIndex>()
             .expect("TechUnlockIndex should exist after update")
+    }
+
+    fn make_hull(id: &str, name: &str, prereq: Option<Condition>) -> HullDefinition {
+        HullDefinition {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: String::new(),
+            base_hp: 50.0,
+            base_speed: 0.5,
+            base_evasion: 0.0,
+            slots: Vec::new(),
+            build_cost_minerals: Amt::ZERO,
+            build_cost_energy: Amt::ZERO,
+            build_time: 10,
+            maintenance: Amt::ZERO,
+            modifiers: Vec::new(),
+            prerequisites: prereq,
+        }
     }
 
     #[test]
@@ -464,5 +509,26 @@ mod tests {
         );
         assert_eq!(index.total_entries(), 0);
         assert!(index.for_tech("anything").is_empty());
+    }
+
+    #[test]
+    fn hull_unlocked_by_has_tech() {
+        let mut hulls = HullRegistry::default();
+        let cond = Condition::Atom(ConditionAtom::has_tech("hull_cruiser"));
+        hulls.insert(make_hull("cruiser", "Cruiser", Some(cond)));
+
+        let index = run_index_with_hulls(
+            ModuleRegistry::default(),
+            BuildingRegistry::default(),
+            StructureRegistry::default(),
+            hulls,
+            TechTree::default(),
+        );
+
+        let entries = index.for_tech("hull_cruiser");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, UnlockKind::Hull);
+        assert_eq!(entries[0].id, "cruiser");
+        assert_eq!(entries[0].name, "Cruiser");
     }
 }

--- a/macrocosmo/src/ui/overlays.rs
+++ b/macrocosmo/src/ui/overlays.rs
@@ -737,6 +737,7 @@ pub fn draw_overlays(
                                                     UnlockKind::Building => "Building",
                                                     UnlockKind::Structure => "Structure",
                                                     UnlockKind::Hull => "Hull",
+                                                    UnlockKind::ShipDesign => "Ship Design",
                                                     // `Tech` entries handled in the "Leads to" list above.
                                                     UnlockKind::Tech => continue,
                                                 };

--- a/macrocosmo/src/ui/overlays.rs
+++ b/macrocosmo/src/ui/overlays.rs
@@ -736,6 +736,7 @@ pub fn draw_overlays(
                                                     UnlockKind::Module => "Module",
                                                     UnlockKind::Building => "Building",
                                                     UnlockKind::Structure => "Structure",
+                                                    UnlockKind::Hull => "Hull",
                                                     // `Tech` entries handled in the "Leads to" list above.
                                                     UnlockKind::Tech => continue,
                                                 };

--- a/macrocosmo/tests/combat.rs
+++ b/macrocosmo/tests/combat.rs
@@ -55,7 +55,7 @@ fn test_hostile_destroyed_when_hp_zero() {
             }),
             cost_minerals: Amt::ZERO,
             cost_energy: Amt::ZERO,
-            prerequisite_tech: None,
+            prerequisites: None,
             upgrade_to: Vec::new(),
         },
     );
@@ -234,7 +234,7 @@ fn test_combat_takes_multiple_ticks() {
             }),
             cost_minerals: Amt::ZERO,
             cost_energy: Amt::ZERO,
-            prerequisite_tech: None,
+            prerequisites: None,
             upgrade_to: Vec::new(),
         },
     );
@@ -310,7 +310,7 @@ fn test_shield_regenerates() {
                 },
             ],
             weapon: None,
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         });
     }
@@ -381,7 +381,7 @@ fn test_shield_regen_caps_at_max() {
                 },
             ],
             weapon: None,
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         });
     }
@@ -454,7 +454,7 @@ fn test_combat_damages_3_layers() {
                 base_add: 50.0, multiplier: 0.0, add: 0.0,
             }],
             weapon: None,
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         });
         module_reg.insert(macrocosmo::ship_design::ModuleDefinition {
@@ -467,7 +467,7 @@ fn test_combat_damages_3_layers() {
                 base_add: 30.0, multiplier: 0.0, add: 0.0,
             }],
             weapon: None,
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         });
     }
@@ -598,7 +598,7 @@ fn test_weapon_cooldown() {
             armor_damage: 0.0, armor_damage_div: 0.0, armor_piercing: 0.0,
             hull_damage: 1.0, hull_damage_div: 0.0,
         }),
-        cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+        cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
         upgrade_to: Vec::new(),
     });
     module_reg.insert(macrocosmo::ship_design::ModuleDefinition {
@@ -613,7 +613,7 @@ fn test_weapon_cooldown() {
             armor_damage: 0.0, armor_damage_div: 0.0, armor_piercing: 0.0,
             hull_damage: 1.0, hull_damage_div: 0.0,
         }),
-        cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+        cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
         upgrade_to: Vec::new(),
     });
 
@@ -702,7 +702,7 @@ fn test_shield_piercing() {
                 armor_damage: 5.0, armor_damage_div: 0.0, armor_piercing: 1.0,     // always pierce armor
                 hull_damage: 5.0, hull_damage_div: 0.0,
             }),
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         },
     );
@@ -791,7 +791,7 @@ fn test_retreat_ships_skip_combat_no_damage_dealt() {
                 armor_damage: 5.0, armor_damage_div: 0.0, armor_piercing: 0.0,
                 hull_damage: 5.0, hull_damage_div: 0.0,
             }),
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         },
     );
@@ -932,7 +932,7 @@ fn test_aggressive_ships_engage_combat() {
                 armor_damage: 5.0, armor_damage_div: 0.0, armor_piercing: 0.0,
                 hull_damage: 5.0, hull_damage_div: 0.0,
             }),
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         },
     );
@@ -1010,7 +1010,7 @@ fn test_defensive_ships_engage_combat_same_as_before() {
                 armor_damage: 5.0, armor_damage_div: 0.0, armor_piercing: 0.0,
                 hull_damage: 5.0, hull_damage_div: 0.0,
             }),
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         },
     );
@@ -1088,7 +1088,7 @@ fn test_mixed_roe_only_non_retreat_fight() {
                 armor_damage: 5.0, armor_damage_div: 0.0, armor_piercing: 0.0,
                 hull_damage: 5.0, hull_damage_div: 0.0,
             }),
-            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisite_tech: None,
+            cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
         },
     );
@@ -1510,7 +1510,7 @@ fn install_test_weapon_module(app: &mut App) {
             }),
             cost_minerals: Amt::ZERO,
             cost_energy: Amt::ZERO,
-            prerequisite_tech: None,
+            prerequisites: None,
             upgrade_to: Vec::new(),
         });
 }

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -31,6 +31,7 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
         is_system_building: false, capabilities: HashMap::new(),
         upgrade_to: Vec::new(), is_direct_buildable: true,
+        prerequisites: None,
     });
     registry.insert(BuildingDefinition {
         id: "power_plant".into(), name: "PowerPlant".into(), description: String::new(),
@@ -40,6 +41,7 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
         is_system_building: false, capabilities: HashMap::new(),
         upgrade_to: Vec::new(), is_direct_buildable: true,
+        prerequisites: None,
     });
     registry.insert(BuildingDefinition {
         id: "research_lab".into(), name: "ResearchLab".into(), description: String::new(),
@@ -49,6 +51,7 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         production_bonus_research: Amt::units(2), production_bonus_food: Amt::ZERO,
         is_system_building: true, capabilities: HashMap::new(),
         upgrade_to: Vec::new(), is_direct_buildable: true,
+        prerequisites: None,
     });
     let mut shipyard_caps = HashMap::new();
     shipyard_caps.insert("shipyard".to_string(), CapabilityParams {
@@ -62,6 +65,7 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
         is_system_building: true, capabilities: shipyard_caps,
         upgrade_to: Vec::new(), is_direct_buildable: true,
+        prerequisites: None,
     });
     let mut port_caps = HashMap::new();
     port_caps.insert("port".to_string(), CapabilityParams {
@@ -80,6 +84,7 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
         is_system_building: true, capabilities: port_caps,
         upgrade_to: Vec::new(), is_direct_buildable: true,
+        prerequisites: None,
     });
     registry.insert(BuildingDefinition {
         id: "farm".into(), name: "Farm".into(), description: String::new(),
@@ -89,6 +94,7 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         production_bonus_research: Amt::ZERO, production_bonus_food: Amt::units(5),
         is_system_building: false, capabilities: HashMap::new(),
         upgrade_to: Vec::new(), is_direct_buildable: true,
+        prerequisites: None,
     });
     registry
 }

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -1425,6 +1425,7 @@ fn test_hull_modifiers_applied_to_ship() {
                     add: 0.0,
                 },
             ],
+            prerequisites: None,
         });
     }
 
@@ -1826,6 +1827,7 @@ fn install_refit_fixture(app: &mut App) {
         build_time: 60,
         maintenance: Amt::new(0, 500),
         modifiers: vec![],
+        prerequisites: None,
     });
 
     let mut modules = ModuleRegistry::default();

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -1840,7 +1840,7 @@ fn install_refit_fixture(app: &mut App) {
         weapon: None,
         cost_minerals: Amt::units(mineral),
         cost_energy: Amt::units(energy),
-        prerequisite_tech: None,
+        prerequisites: None,
         upgrade_to: Vec::new(),
     };
     modules.insert(mk("laser_mk1", 50, 20));


### PR DESCRIPTION
Closes #226. Adds prerequisites: Option<Condition> to BuildingDefinition / HullDefinition / ModuleDefinition. Removes deprecated prerequisite_tech from ModuleDefinition (hard migration). ShipDesign effective prereqs derived from hull + modules via helper. New UnlockKind::Hull / UnlockKind::ShipDesign. Research panel now displays Building / Hull / ShipDesign unlocks (previously silently dropped for buildings). Scripts migrated.