### PR TITLE
#223: Deep-space deliverable placement pipeline

### DIFF
--- a/macrocosmo/scripts/structures/definitions.lua
+++ b/macrocosmo/scripts/structures/definitions.lua
@@ -1,29 +1,37 @@
 -- Deep Space Structure definitions
 -- Loaded by the StructureRegistry at startup.
+--
+-- #223: Shipyard-buildable, Cargo-transportable structures are declared via
+-- `define_deliverable`. `define_structure` is reserved for world-only entities
+-- (e.g. debris wrecks) or upgrade-only outputs that cannot be built directly.
 
 -- Note: ftl_communications and ftl_interdiction_tech are forward references
 -- to techs not yet defined. Using forward_ref() to express this intent.
 
-local sensor_buoy = define_structure {
+local sensor_buoy = define_deliverable {
     id = "sensor_buoy",
     name = "Sensor Buoy",
     description = "Detects sublight vessel movements.",
     max_hp = 20,
     cost = { minerals = 50, energy = 30 },
     build_time = 15,
+    cargo_size = 1,
+    scrap_refund = 0.5,
     capabilities = {
         detect_sublight = { range = 3.0 },
     },
     energy_drain = 100, -- millis (0.1 units per hexady)
 }
 
-local ftl_comm_relay = define_structure {
+local ftl_comm_relay = define_deliverable {
     id = "ftl_comm_relay",
     name = "FTL Comm Relay",
     description = "Enables faster-than-light communication across systems.",
     max_hp = 50,
     cost = { minerals = 200, energy = 150 },
     build_time = 30,
+    cargo_size = 2,
+    scrap_refund = 0.4,
     capabilities = {
         -- range_ly: source relay observes ships within this range; receiver
         -- relay requires the player be within its own range_ly. A value of 0
@@ -34,13 +42,15 @@ local ftl_comm_relay = define_structure {
     prerequisites = has_tech(forward_ref("ftl_communications")),
 }
 
-local interdictor = define_structure {
+local interdictor = define_deliverable {
     id = "interdictor",
     name = "Interdictor",
     description = "Disrupts FTL travel within its interdiction range.",
     max_hp = 80,
     cost = { minerals = 300, energy = 200 },
     build_time = 45,
+    cargo_size = 3,
+    scrap_refund = 0.3,
     capabilities = {
         ftl_interdiction = { range = 5.0 },
     },

--- a/macrocosmo/src/colony/building_queue.rs
+++ b/macrocosmo/src/colony/building_queue.rs
@@ -5,11 +5,11 @@ use crate::events::{GameEvent, GameEventKind};
 use crate::galaxy::{Planet, StarSystem};
 use crate::components::Position;
 use crate::scripting::building_api::BuildingId;
-use crate::ship::{spawn_ship, Owner, Ship};
+use crate::ship::{spawn_ship, CargoItem, Owner, Ship};
 use crate::time_system::GameClock;
 
 use super::{
-    Colony, LastProductionTick, ResourceStockpile, SystemBuildings,
+    Colony, DeliverableStockpile, LastProductionTick, ResourceStockpile, SystemBuildings,
 };
 
 #[derive(Component)]
@@ -17,7 +17,25 @@ pub struct BuildQueue {
     pub queue: Vec<BuildOrder>,
 }
 
+/// #223: What kind of thing a `BuildOrder` builds.
+///
+/// Keeping `Ship` as the default preserves existing call sites (the previous
+/// queue only built ships). `Deliverable` adds the new path used by #223:
+/// completed deliverables are pushed into the system's `DeliverableStockpile`
+/// instead of spawning a `Ship` entity.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub enum BuildKind {
+    #[default]
+    Ship,
+    Deliverable {
+        cargo_size: u32,
+    },
+}
+
 pub struct BuildOrder {
+    /// #223: What this order builds (Ship or Deliverable). Defaults to Ship
+    /// for back-compat with existing construction sites.
+    pub kind: BuildKind,
     pub design_id: String,
     pub display_name: String,
     pub minerals_cost: Amt,
@@ -136,6 +154,8 @@ impl BuildingQueue {
 }
 
 /// #32: build_time_remaining countdown, #35: shipyard check
+/// #223: Deliverable orders land in the system's DeliverableStockpile rather
+/// than spawning Ship entities.
 pub fn tick_build_queue(
     mut commands: Commands,
     clock: Res<GameClock>,
@@ -144,6 +164,7 @@ pub fn tick_build_queue(
     building_registry: Res<crate::scripting::building_api::BuildingRegistry>,
     mut colonies: Query<(&Colony, &mut BuildQueue)>,
     mut stockpiles: Query<&mut ResourceStockpile, With<StarSystem>>,
+    mut deliverable_stockpiles: Query<&mut DeliverableStockpile, With<StarSystem>>,
     positions: Query<&Position>,
     stars: Query<&StarSystem>,
     planets: Query<&Planet>,
@@ -160,12 +181,18 @@ pub fn tick_build_queue(
         return;
     }
 
+    // Per-order completion info (#223).
+    enum Completion {
+        Ship { design_id: String, display_name: String },
+        Deliverable { definition_id: String, display_name: String },
+    }
+
     // Collect build queue processing results
     struct BuildResult {
         system: Entity,
         minerals_consumed: Amt,
         energy_consumed: Amt,
-        completed_ships: Vec<(String, String)>, // (design_id, display_name)
+        completed: Vec<Completion>,
     }
 
     let mut results: Vec<BuildResult> = Vec::new();
@@ -173,10 +200,11 @@ pub fn tick_build_queue(
     for (colony, mut build_queue) in &mut colonies {
         let Some(sys) = colony.system(&planets) else { continue };
 
-        // #35: Skip ship construction if system has no shipyard capability
+        // #35: Skip ship construction if system has no shipyard capability.
+        // Deliverables also require a shipyard.
         let has_shipyard = system_buildings.get(sys).is_ok_and(|sb| sb.has_shipyard(&building_registry));
         if !build_queue.queue.is_empty() && !has_shipyard {
-            warn!("System lacks a Shipyard; skipping ship construction");
+            warn!("System lacks a Shipyard; skipping construction");
             continue;
         }
 
@@ -186,7 +214,7 @@ pub fn tick_build_queue(
         let mut available_energy = stockpile.energy;
         let mut total_minerals_consumed = Amt::ZERO;
         let mut total_energy_consumed = Amt::ZERO;
-        let mut completed_ships = Vec::new();
+        let mut completed: Vec<Completion> = Vec::new();
 
         for _ in 0..delta {
             if build_queue.queue.is_empty() {
@@ -210,8 +238,19 @@ pub fn tick_build_queue(
             order.build_time_remaining -= 1;
 
             if build_queue.queue[0].is_complete() {
-                let completed = build_queue.queue.remove(0);
-                completed_ships.push((completed.design_id, completed.display_name));
+                let completed_order = build_queue.queue.remove(0);
+                match completed_order.kind {
+                    BuildKind::Ship => completed.push(Completion::Ship {
+                        design_id: completed_order.design_id,
+                        display_name: completed_order.display_name,
+                    }),
+                    BuildKind::Deliverable { .. } => {
+                        completed.push(Completion::Deliverable {
+                            definition_id: completed_order.design_id,
+                            display_name: completed_order.display_name,
+                        });
+                    }
+                }
             }
         }
 
@@ -219,35 +258,60 @@ pub fn tick_build_queue(
             system: sys,
             minerals_consumed: total_minerals_consumed,
             energy_consumed: total_energy_consumed,
-            completed_ships,
+            completed,
         });
     }
 
-    // Apply stockpile changes and spawn ships
+    // Apply stockpile changes and spawn ships / enqueue deliverables
     for result in results {
         if let Ok(mut stockpile) = stockpiles.get_mut(result.system) {
             stockpile.minerals = stockpile.minerals.sub(result.minerals_consumed);
             stockpile.energy = stockpile.energy.sub(result.energy_consumed);
         }
-        for (design_id, display_name) in result.completed_ships {
-            if let Ok(pos) = positions.get(result.system) {
-                spawn_ship(
-                    &mut commands,
-                    &design_id,
-                    display_name.clone(),
-                    result.system,
-                    *pos,
-                    ship_owner,
-                    &design_registry,
-                );
-                let sys_name = stars.get(result.system).map(|s| s.name.clone()).unwrap_or_default();
-                events.write(GameEvent {
-                    timestamp: clock.elapsed,
-                    kind: GameEventKind::ShipBuilt,
-                    description: format!("{} built at {}", display_name, sys_name),
-                    related_system: Some(result.system),
-                });
-                info!("Ship built and launched: {}", display_name);
+        for c in result.completed {
+            let sys_name = stars.get(result.system).map(|s| s.name.clone()).unwrap_or_default();
+            match c {
+                Completion::Ship { design_id, display_name } => {
+                    if let Ok(pos) = positions.get(result.system) {
+                        spawn_ship(
+                            &mut commands,
+                            &design_id,
+                            display_name.clone(),
+                            result.system,
+                            *pos,
+                            ship_owner,
+                            &design_registry,
+                        );
+                        events.write(GameEvent {
+                            timestamp: clock.elapsed,
+                            kind: GameEventKind::ShipBuilt,
+                            description: format!("{} built at {}", display_name, sys_name),
+                            related_system: Some(result.system),
+                        });
+                        info!("Ship built and launched: {}", display_name);
+                    }
+                }
+                Completion::Deliverable { definition_id, display_name } => {
+                    // #223: Push the new CargoItem into the system's DeliverableStockpile.
+                    // If the component doesn't yet exist, add one via commands.
+                    let item = CargoItem::Deliverable { definition_id: definition_id.clone() };
+                    if let Ok(mut dstock) = deliverable_stockpiles.get_mut(result.system) {
+                        dstock.push(item);
+                    } else {
+                        commands.entity(result.system).insert(DeliverableStockpile {
+                            items: vec![item],
+                        });
+                    }
+                    events.write(GameEvent {
+                        timestamp: clock.elapsed,
+                        kind: GameEventKind::ShipBuilt,
+                        description: format!(
+                            "Deliverable '{}' produced at {}", display_name, sys_name
+                        ),
+                        related_system: Some(result.system),
+                    });
+                    info!("Deliverable produced: {} @ {}", display_name, sys_name);
+                }
             }
         }
     }
@@ -509,6 +573,7 @@ mod tests {
     fn make_order(minerals_cost: Amt, minerals_invested: Amt, energy_cost: Amt, energy_invested: Amt) -> BuildOrder {
         let build_time = 60;
         BuildOrder {
+            kind: BuildKind::default(),
             design_id: "explorer_mk1".to_string(),
             display_name: "Explorer".to_string(),
             minerals_cost,

--- a/macrocosmo/src/colony/mod.rs
+++ b/macrocosmo/src/colony/mod.rs
@@ -92,6 +92,32 @@ pub struct ResourceStockpile {
     pub authority: Amt,
 }
 
+/// #223: Per-star-system cargo-item stockpile. Shipyard-built deliverables
+/// land here when construction completes, ready to be loaded onto a ship's
+/// Cargo via `QueuedCommand::LoadDeliverable`.
+#[derive(Component, Default, Debug, Clone)]
+pub struct DeliverableStockpile {
+    pub items: Vec<crate::ship::CargoItem>,
+}
+
+impl DeliverableStockpile {
+    pub fn push(&mut self, item: crate::ship::CargoItem) {
+        self.items.push(item);
+    }
+
+    pub fn remove(&mut self, index: usize) -> Option<crate::ship::CargoItem> {
+        if index < self.items.len() {
+            Some(self.items.remove(index))
+        } else {
+            None
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
 #[derive(Component)]
 pub struct ResourceCapacity {
     pub minerals: Amt,

--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -1,3 +1,32 @@
+//! # Deep-space structures + deliverable placement (#223)
+//!
+//! This module hosts the data model and systems for entities that live at
+//! arbitrary galactic coordinates outside star systems:
+//!
+//! * `DeepSpaceStructure` — the minimal marker component for any such entity.
+//! * `DeliverableDefinition` (aliased as `StructureDefinition`) — Lua-loaded
+//!   schema describing capabilities, HP, prerequisites, optional upgrade
+//!   graph (`upgrade_to` / `upgrade_from`), and the optional
+//!   `DeliverableMetadata` that marks a definition as shipyard-buildable.
+//! * `DeliverableRegistry` — one-per-App resource holding every definition,
+//!   plus a cached `effective_edges` map combining explicit `upgrade_to`
+//!   edges with self-declared `upgrade_from` edges for forward-ref isolation.
+//! * `ConstructionPlatform` / `Scrapyard` / `LifetimeCost` — runtime
+//!   components that track transitional states:
+//!     - `ConstructionPlatform` gates capabilities while the structure is
+//!       still assembling; `TransferToStructure` from a ship fills
+//!       `accumulated`, and `tick_platform_upgrade` swaps
+//!       `definition_id → target_id` once a target's cost is covered.
+//!     - `Scrapyard` is installed by `dismantle_structure` and holds a
+//!       `remaining = lifetime_cost × scrap_refund` pool. A ship's
+//!       `LoadFromScrapyard` command drains it; when empty,
+//!       `tick_scrapyard_despawn` removes the entity.
+//!     - `LifetimeCost` accumulates every cost invested so far (initial
+//!       deploy cost + every upgrade cost), used for scrap refund scaling.
+//!
+//! The shipyard → cargo → deploy path lives in `src/colony/building_queue.rs`
+//! (`tick_build_queue` dispatching on `BuildKind::Deliverable`) and
+//! `src/ship/deliverable_ops.rs` (command processors).
 use std::collections::HashMap;
 
 use bevy::prelude::*;

--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -120,39 +120,175 @@ pub struct CapabilityParams {
     // Extensible: add more fields as needed.
 }
 
-/// Data-driven definition of a structure type, loaded from Lua or hardcoded fallback.
+/// #223: An edge in the deliverable upgrade graph — a platform kit can be
+/// upgraded to `target_id` by spending `cost` over `build_time` hexadies.
 #[derive(Clone, Debug)]
-pub struct StructureDefinition {
+pub struct UpgradeEdge {
+    pub target_id: String,
+    pub cost: ResourceCost,
+    pub build_time: i64,
+}
+
+/// #223: Shipyard-specific metadata. Present only when the deliverable was
+/// declared via `define_deliverable` (i.e. can be built directly at a shipyard
+/// and transported in a ship's Cargo). World-only structures declared via
+/// `define_structure` leave this as `None`.
+#[derive(Clone, Debug)]
+pub struct DeliverableMetadata {
+    pub cost: ResourceCost,
+    pub build_time: i64,
+    pub cargo_size: u32,
+    /// 0.0..=1.0 — fraction of lifetime_cost returned as Scrapyard resources on dismantle.
+    pub scrap_refund: f32,
+}
+
+/// #223: Unified definition covering both world-side structures and
+/// shipyard-buildable deliverables. The `deliverable` field distinguishes them:
+///   - `Some(_)` — shipyard-buildable (via `define_deliverable`)
+///   - `None`    — world-spawn only / upgrade output (via `define_structure`)
+#[derive(Clone, Debug)]
+pub struct DeliverableDefinition {
     pub id: String,
     pub name: String,
     pub description: String,
     pub max_hp: f64,
-    pub cost: ResourceCost,
-    pub build_time: i64, // hexadies
-    pub energy_drain: Amt, // per hexady maintenance
-    pub prerequisites: Option<Condition>,
+    pub energy_drain: Amt,
     pub capabilities: HashMap<String, CapabilityParams>,
+    pub prerequisites: Option<Condition>,
+
+    /// `Some(_)` when the deliverable is shipyard-buildable.
+    pub deliverable: Option<DeliverableMetadata>,
+
+    /// Outgoing upgrade edges: starting from this deliverable, it can become
+    /// one of these targets by paying the edge cost.
+    pub upgrade_to: Vec<UpgradeEdge>,
+
+    /// Optional self-declared inbound edge: "this deliverable can be reached
+    /// from `source` by paying `cost`." Preserves referential churn isolation
+    /// (a new target may self-declare without touching the platform def).
+    ///
+    /// When set, `target_id` holds the upstream source id and the edge cost/
+    /// build_time describe the upstream→this transition. Cf. `upgrade_to`
+    /// which describes this→downstream transitions.
+    pub upgrade_from: Option<UpgradeEdge>,
 }
 
-/// Registry of all structure definitions.
+impl DeliverableDefinition {
+    /// Convenience: the direct shipyard build cost if this deliverable can be
+    /// built at a shipyard; otherwise `None` (upgrade-only output).
+    pub fn shipyard_cost(&self) -> Option<&ResourceCost> {
+        self.deliverable.as_ref().map(|m| &m.cost)
+    }
+
+    /// Convenience: shipyard build time in hexadies (`None` if not buildable).
+    pub fn shipyard_build_time(&self) -> Option<i64> {
+        self.deliverable.as_ref().map(|m| m.build_time)
+    }
+
+    /// Returns `true` if this deliverable carries the `construction_platform`
+    /// capability marker, meaning on-deploy it enters a waiting state until
+    /// an upgrade target is selected and resources are delivered.
+    pub fn is_construction_platform(&self) -> bool {
+        self.capabilities.contains_key("construction_platform")
+    }
+}
+
+/// Back-compat alias: existing code continues to use `StructureDefinition`.
+pub type StructureDefinition = DeliverableDefinition;
+
+/// Registry of all deliverable/structure definitions.
+///
+/// `effective_edges[source_id]` holds the merged outbound upgrade edges for
+/// `source_id`, built once during `load_structure_definitions` by combining
+/// each definition's `upgrade_to[*]` with any other definition's self-declared
+/// `upgrade_from` that names `source_id`. `upgrade_to` wins on conflict.
 #[derive(Resource, Default)]
-pub struct StructureRegistry {
-    pub definitions: HashMap<String, StructureDefinition>,
+pub struct DeliverableRegistry {
+    pub definitions: HashMap<String, DeliverableDefinition>,
+    pub effective_edges: HashMap<String, Vec<UpgradeEdge>>,
 }
 
-impl StructureRegistry {
-    /// Look up a structure definition by id.
-    pub fn get(&self, id: &str) -> Option<&StructureDefinition> {
+/// Back-compat alias.
+pub type StructureRegistry = DeliverableRegistry;
+
+impl DeliverableRegistry {
+    /// Look up a structure/deliverable definition by id.
+    pub fn get(&self, id: &str) -> Option<&DeliverableDefinition> {
         self.definitions.get(id)
     }
 
-    /// Insert a structure definition, replacing any existing one with the same id.
-    pub fn insert(&mut self, def: StructureDefinition) {
+    /// Insert a definition, replacing any existing one with the same id.
+    /// NOTE: This does NOT automatically rebuild `effective_edges`; call
+    /// `rebuild_effective_edges` after batch-inserts.
+    pub fn insert(&mut self, def: DeliverableDefinition) {
         self.definitions.insert(def.id.clone(), def);
+    }
+
+    /// Outbound upgrade edges effective at runtime for `source_id`. Uses the
+    /// cached `effective_edges` table if populated, otherwise falls back to
+    /// the definition's own `upgrade_to` list (which excludes inverse
+    /// `upgrade_from` self-declarations).
+    pub fn outgoing_edges(&self, source_id: &str) -> &[UpgradeEdge] {
+        if let Some(v) = self.effective_edges.get(source_id) {
+            return v.as_slice();
+        }
+        self.definitions
+            .get(source_id)
+            .map(|d| d.upgrade_to.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Rebuild `effective_edges` by merging `upgrade_to[*]` with inverse
+    /// `upgrade_from` self-declarations from every other definition. On
+    /// conflict (same source→target declared twice), the `upgrade_to`
+    /// declaration wins; a warning is logged at the caller level.
+    ///
+    /// Returns a list of non-fatal validation warnings as `(source, target)`
+    /// tuples describing conflicts, so the caller can `log::warn!` them.
+    pub fn rebuild_effective_edges(&mut self) -> Vec<(String, String)> {
+        let mut merged: HashMap<String, Vec<UpgradeEdge>> = HashMap::new();
+        let mut conflicts: Vec<(String, String)> = Vec::new();
+
+        // First pass: collect all `upgrade_to` edges.
+        for (source_id, def) in &self.definitions {
+            for edge in &def.upgrade_to {
+                merged
+                    .entry(source_id.clone())
+                    .or_default()
+                    .push(edge.clone());
+            }
+        }
+
+        // Second pass: inverse `upgrade_from` (self-declared inbound edge on target).
+        for (target_id, def) in &self.definitions {
+            if let Some(uf) = &def.upgrade_from {
+                let source_id = uf.target_id.clone(); // for upgrade_from, target_id holds the SOURCE.
+                let inverse_edge = UpgradeEdge {
+                    target_id: target_id.clone(),
+                    cost: uf.cost.clone(),
+                    build_time: uf.build_time,
+                };
+                let entry = merged.entry(source_id.clone()).or_default();
+                // Does an `upgrade_to` edge for the same target already exist?
+                if entry.iter().any(|e| e.target_id == *target_id) {
+                    // Conflict — `upgrade_to` wins, we skip the inverse edge.
+                    conflicts.push((source_id, target_id.clone()));
+                } else {
+                    entry.push(inverse_edge);
+                }
+            }
+        }
+
+        self.effective_edges = merged;
+        conflicts
     }
 }
 
 /// Default structure definitions used when Lua scripts are not available (e.g. in tests).
+///
+/// All three defaults are shipyard-buildable deliverables (they carry
+/// `DeliverableMetadata`) so existing tests and fallback startup continue to
+/// see the same practical behaviour as before #223.
 pub fn default_structure_definitions() -> Vec<StructureDefinition> {
     use crate::condition::ConditionAtom;
 
@@ -162,28 +298,29 @@ pub fn default_structure_definitions() -> Vec<StructureDefinition> {
             name: "Sensor Buoy".to_string(),
             description: "Detects sublight vessel movements.".to_string(),
             max_hp: 20.0,
-            cost: ResourceCost {
-                minerals: Amt::units(50),
-                energy: Amt::units(30),
-            },
-            build_time: 15,
             capabilities: HashMap::from([(
                 "detect_sublight".to_string(),
                 CapabilityParams { range: 3.0 },
             )]),
             energy_drain: Amt::milli(100),
             prerequisites: None,
+            deliverable: Some(DeliverableMetadata {
+                cost: ResourceCost {
+                    minerals: Amt::units(50),
+                    energy: Amt::units(30),
+                },
+                build_time: 15,
+                cargo_size: 1,
+                scrap_refund: 0.5,
+            }),
+            upgrade_to: Vec::new(),
+            upgrade_from: None,
         },
         StructureDefinition {
             id: "ftl_comm_relay".to_string(),
             name: "FTL Comm Relay".to_string(),
             description: "Enables faster-than-light communication across systems.".to_string(),
             max_hp: 50.0,
-            cost: ResourceCost {
-                minerals: Amt::units(200),
-                energy: Amt::units(150),
-            },
-            build_time: 30,
             capabilities: HashMap::from([(
                 "ftl_comm_relay".to_string(),
                 CapabilityParams { range: 5.0 },
@@ -192,17 +329,23 @@ pub fn default_structure_definitions() -> Vec<StructureDefinition> {
             prerequisites: Some(Condition::Atom(ConditionAtom::has_tech(
                 "ftl_communications",
             ))),
+            deliverable: Some(DeliverableMetadata {
+                cost: ResourceCost {
+                    minerals: Amt::units(200),
+                    energy: Amt::units(150),
+                },
+                build_time: 30,
+                cargo_size: 2,
+                scrap_refund: 0.4,
+            }),
+            upgrade_to: Vec::new(),
+            upgrade_from: None,
         },
         StructureDefinition {
             id: "interdictor".to_string(),
             name: "Interdictor".to_string(),
             description: "Disrupts FTL travel within its interdiction range.".to_string(),
             max_hp: 80.0,
-            cost: ResourceCost {
-                minerals: Amt::units(300),
-                energy: Amt::units(200),
-            },
-            build_time: 45,
             capabilities: HashMap::from([(
                 "ftl_interdiction".to_string(),
                 CapabilityParams { range: 5.0 },
@@ -211,6 +354,17 @@ pub fn default_structure_definitions() -> Vec<StructureDefinition> {
             prerequisites: Some(Condition::Atom(ConditionAtom::has_tech(
                 "ftl_interdiction_tech",
             ))),
+            deliverable: Some(DeliverableMetadata {
+                cost: ResourceCost {
+                    minerals: Amt::units(300),
+                    energy: Amt::units(200),
+                },
+                build_time: 45,
+                cargo_size: 3,
+                scrap_refund: 0.3,
+            }),
+            upgrade_to: Vec::new(),
+            upgrade_from: None,
         },
     ]
 }
@@ -629,11 +783,6 @@ mod tests {
             name: "Advanced Sensor Buoy".to_string(),
             description: "Enhanced sensor buoy.".to_string(),
             max_hp: 40.0,
-            cost: ResourceCost {
-                minerals: Amt::units(100),
-                energy: Amt::units(60),
-            },
-            build_time: 20,
             capabilities: HashMap::from([
                 ("detect_sublight".to_string(), CapabilityParams { range: 5.0 }),
                 ("detect_ftl".to_string(), CapabilityParams { range: 3.0 }),
@@ -642,6 +791,17 @@ mod tests {
             prerequisites: Some(Condition::Atom(ConditionAtom::has_tech(
                 "advanced_sensors",
             ))),
+            deliverable: Some(DeliverableMetadata {
+                cost: ResourceCost {
+                    minerals: Amt::units(100),
+                    energy: Amt::units(60),
+                },
+                build_time: 20,
+                cargo_size: 1,
+                scrap_refund: 0.5,
+            }),
+            upgrade_to: Vec::new(),
+            upgrade_from: None,
         });
 
         assert_eq!(registry.definitions.len(), 3);

--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -369,6 +369,197 @@ pub fn default_structure_definitions() -> Vec<StructureDefinition> {
     ]
 }
 
+/// #223: Tracks the total resource cost ever invested into a `DeepSpaceStructure`
+/// entity. Starts at the deliverable's `cost` when deployed; is incremented by
+/// `UpgradeEdge.cost` every time the structure is upgraded via a
+/// `ConstructionPlatform`. When the structure is dismantled, the resulting
+/// `Scrapyard.remaining = lifetime_cost * scrap_refund`.
+#[derive(Component, Clone, Debug, Default)]
+pub struct LifetimeCost(pub ResourceCost);
+
+/// #223: Marker component on a freshly-deployed construction platform that is
+/// awaiting upgrade resources. While this is present, the structure's
+/// capabilities are gated OFF (it's still "under construction"). Once enough
+/// resources accumulate, the structure upgrades to `target_id` and this
+/// component is removed.
+///
+/// `target_id.is_none()` means the player hasn't yet chosen which upgrade edge
+/// to pursue; transfers are refused until a target is selected. UI can default
+/// `target_id` to the sole edge when `upgrade_to` has exactly one element.
+#[derive(Component, Clone, Debug, Default)]
+pub struct ConstructionPlatform {
+    pub target_id: Option<String>,
+    pub accumulated: ResourceCost,
+}
+
+/// #223: Marker component on a dismantled structure. While present, the
+/// structure's capabilities are gated OFF. A co-located ship can drain the
+/// `remaining` pool into its own Cargo via `QueuedCommand::LoadFromScrapyard`.
+/// When `remaining.is_zero()`, the entity is despawned next tick by
+/// `tick_scrapyard_despawn`.
+#[derive(Component, Clone, Debug)]
+pub struct Scrapyard {
+    pub remaining: ResourceCost,
+    pub original_definition_id: String,
+}
+
+impl ResourceCost {
+    pub fn is_zero(&self) -> bool {
+        self.minerals == Amt::ZERO && self.energy == Amt::ZERO
+    }
+
+    /// Saturating add of `other` into self (consumes `other`).
+    pub fn add_assign_saturating(&mut self, other: &ResourceCost) {
+        self.minerals = self.minerals.add(other.minerals);
+        self.energy = self.energy.add(other.energy);
+    }
+
+    /// Returns true iff `self` covers (≥) every component of `other`.
+    pub fn covers(&self, other: &ResourceCost) -> bool {
+        self.minerals >= other.minerals && self.energy >= other.energy
+    }
+
+    /// Multiply by a scalar in 0..=1 (used for scrap refund).
+    pub fn scale(&self, factor: f32) -> ResourceCost {
+        let f = factor.clamp(0.0, 1.0) as f64;
+        ResourceCost {
+            minerals: Amt::from_f64(self.minerals.to_f64() * f),
+            energy: Amt::from_f64(self.energy.to_f64() * f),
+        }
+    }
+}
+
+/// #223: Spawn a new `DeepSpaceStructure` entity at the given position with the
+/// given owner, according to the definition identified by `definition_id`.
+///
+/// Behaviour:
+///   - The entity always gets: `DeepSpaceStructure`, `Position`,
+///     `StructureHitpoints` (at max_hp), `LifetimeCost` (initial = def's
+///     shipyard cost if present, else zero).
+///   - If the definition has the `construction_platform` capability marker,
+///     a `ConstructionPlatform` component is added. The `target_id` defaults
+///     to the single `upgrade_to` edge's target when there is exactly one;
+///     otherwise it is `None` (awaiting player selection).
+///   - Otherwise the entity is fully active: its capabilities fire on the
+///     next tick.
+pub fn spawn_deliverable_entity(
+    commands: &mut Commands,
+    definition_id: &str,
+    position: [f64; 3],
+    owner: Owner,
+    registry: &StructureRegistry,
+) -> Option<Entity> {
+    let def = registry.get(definition_id)?;
+
+    let initial_cost = def
+        .deliverable
+        .as_ref()
+        .map(|m| m.cost.clone())
+        .unwrap_or_default();
+
+    let mut ent = commands.spawn((
+        DeepSpaceStructure {
+            definition_id: definition_id.to_string(),
+            name: def.name.clone(),
+            owner,
+        },
+        crate::components::Position::from(position),
+        StructureHitpoints {
+            current: def.max_hp,
+            max: def.max_hp,
+        },
+        LifetimeCost(initial_cost),
+    ));
+
+    if def.is_construction_platform() {
+        let target_id = if def.upgrade_to.len() == 1 {
+            Some(def.upgrade_to[0].target_id.clone())
+        } else {
+            None
+        };
+        ent.insert(ConstructionPlatform {
+            target_id,
+            accumulated: ResourceCost::default(),
+        });
+    }
+
+    Some(ent.id())
+}
+
+/// #223: Apply player-scheduled upgrades: for each `ConstructionPlatform` that
+/// has `accumulated >= target.cost`, swap the definition_id to the target,
+/// bump the `LifetimeCost`, and remove the `ConstructionPlatform`.
+pub fn tick_platform_upgrade(
+    mut commands: Commands,
+    registry: Res<StructureRegistry>,
+    clock: Res<crate::time_system::GameClock>,
+    mut events: MessageWriter<crate::events::GameEvent>,
+    mut platforms: Query<(
+        Entity,
+        &mut DeepSpaceStructure,
+        &mut LifetimeCost,
+        &mut ConstructionPlatform,
+    )>,
+) {
+    for (entity, mut structure, mut lifetime, mut platform) in platforms.iter_mut() {
+        let Some(target_id) = platform.target_id.clone() else {
+            continue;
+        };
+        // Find the edge: from structure.definition_id → target_id.
+        let edges = registry.outgoing_edges(&structure.definition_id);
+        let Some(edge) = edges.iter().find(|e| e.target_id == target_id) else {
+            continue;
+        };
+
+        if !platform.accumulated.covers(&edge.cost) {
+            continue;
+        }
+
+        // Upgrade! Consume edge.cost from accumulated; the remainder stays so
+        // a subsequent upgrade (rare today, but possible) is not penalised.
+        platform.accumulated.minerals = platform.accumulated.minerals.sub(edge.cost.minerals);
+        platform.accumulated.energy = platform.accumulated.energy.sub(edge.cost.energy);
+
+        // Update the structure identity.
+        if let Some(new_def) = registry.get(&target_id) {
+            let old_name = structure.name.clone();
+            structure.definition_id = target_id.clone();
+            structure.name = new_def.name.clone();
+            // Bump lifetime cost by the edge cost.
+            lifetime.0.add_assign_saturating(&edge.cost);
+            events.write(crate::events::GameEvent {
+                timestamp: clock.elapsed,
+                kind: crate::events::GameEventKind::ShipBuilt,
+                description: format!(
+                    "Platform upgraded: {} → {}",
+                    old_name,
+                    new_def.name,
+                ),
+                related_system: None,
+            });
+            info!(
+                "Deep-space structure {:?} upgraded → {}",
+                entity, new_def.name,
+            );
+        }
+
+        // Remove the construction marker so capabilities fire next tick.
+        commands.entity(entity).remove::<ConstructionPlatform>();
+    }
+}
+
+/// #223: Despawn any `Scrapyard` whose resources have been drained by a ship.
+pub fn tick_scrapyard_despawn(
+    mut commands: Commands,
+    scrapyards: Query<(Entity, &Scrapyard)>,
+) {
+    for (entity, scrap) in &scrapyards {
+        if scrap.remaining.is_zero() {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
 pub struct DeepSpacePlugin;
 
 impl Plugin for DeepSpacePlugin {
@@ -384,6 +575,8 @@ impl Plugin for DeepSpacePlugin {
                     sensor_buoy_detect_system,
                     verify_relay_pairings_system,
                     relay_knowledge_propagate_system,
+                    tick_platform_upgrade,
+                    tick_scrapyard_despawn,
                 )
                     .after(crate::time_system::advance_game_time)
                     .after(crate::ship::sublight_movement_system)
@@ -410,7 +603,10 @@ impl Plugin for DeepSpacePlugin {
 pub fn sensor_buoy_detect_system(
     clock: Res<crate::time_system::GameClock>,
     registry: Res<StructureRegistry>,
-    structures: Query<(&DeepSpaceStructure, &crate::components::Position)>,
+    structures: Query<
+        (&DeepSpaceStructure, &crate::components::Position),
+        (Without<ConstructionPlatform>, Without<Scrapyard>),
+    >,
     ships: Query<(
         Entity,
         &crate::ship::Ship,
@@ -558,7 +754,12 @@ pub fn relay_knowledge_propagate_system(
     clock: Res<crate::time_system::GameClock>,
     registry: Res<StructureRegistry>,
     // All relays, paired with their position + structure data.
-    relays: Query<(Entity, &DeepSpaceStructure, &crate::components::Position, &FTLCommRelay)>,
+    // #223: Relays gated behind a ConstructionPlatform or a Scrapyard do not
+    // propagate knowledge — they're in a non-operational transitional state.
+    relays: Query<
+        (Entity, &DeepSpaceStructure, &crate::components::Position, &FTLCommRelay),
+        (Without<ConstructionPlatform>, Without<Scrapyard>),
+    >,
     // Any relay (incl. un-sending side) — used to look up partner position.
     relay_positions: Query<&crate::components::Position, With<DeepSpaceStructure>>,
     // Partner's structure definition for its range.

--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -701,12 +701,168 @@ pub fn relay_knowledge_propagate_system(
     }
 }
 
+/// #223: Validation outcome for a loaded deliverable registry.
+#[derive(Debug, Default, Clone)]
+pub struct DeliverableValidationReport {
+    /// Warnings: conflicts or style issues; do NOT fail loading.
+    pub warnings: Vec<String>,
+    /// Errors: fatal — the offending definition should be rejected.
+    pub errors: Vec<String>,
+}
+
+impl DeliverableValidationReport {
+    pub fn is_ok(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+/// #223: Run registry-wide validation on the deliverable graph per the 5 rules
+/// from issue #223:
+///
+/// 1. Both-sides conflict warning: target T declares `upgrade_from` AND some X
+///    references T in `upgrade_to[*]` — `upgrade_to` wins, emit a warning.
+/// 2. Cost mismatch warning: the two declarations of the same edge disagree on
+///    `cost` or `build_time` — warn; `upgrade_to` wins.
+/// 3. Dangling reference (target or source id not in registry) — ERROR.
+/// 4. Unreachable node (no shipyard cost AND no inbound edge) — ERROR.
+/// 5. `construction_platform` capability without any outgoing edge (from its
+///    own `upgrade_to` or any other definition's `upgrade_from`) — ERROR.
+///
+/// Also (re)builds `effective_edges` on the registry as a side effect so that
+/// runtime callers can read merged outbound edges from a single table.
+pub fn validate_and_build_edges(
+    registry: &mut DeliverableRegistry,
+) -> DeliverableValidationReport {
+    let mut report = DeliverableValidationReport::default();
+
+    let ids: std::collections::HashSet<String> = registry.definitions.keys().cloned().collect();
+
+    // Rule 3: dangling refs (collected first so rule 2 can skip edges with
+    // missing endpoints without misreporting them as "conflict").
+    for (src_id, def) in &registry.definitions {
+        for edge in &def.upgrade_to {
+            if !ids.contains(&edge.target_id) {
+                report.errors.push(format!(
+                    "deliverable '{src_id}' upgrade_to references unknown target '{}'",
+                    edge.target_id
+                ));
+            }
+        }
+        if let Some(uf) = &def.upgrade_from {
+            if !ids.contains(&uf.target_id) {
+                report.errors.push(format!(
+                    "deliverable '{src_id}' upgrade_from references unknown source '{}'",
+                    uf.target_id
+                ));
+            }
+        }
+    }
+
+    // Rule 1 + 2: conflict detection between upgrade_to and inverse upgrade_from.
+    // For every target T with `upgrade_from` set, look up the claimed source X.
+    // If X also has an `upgrade_to` pointing to T, it's a style conflict; if
+    // the cost or build_time disagree, append a cost-mismatch warning.
+    for (target_id, t_def) in &registry.definitions {
+        let Some(uf) = &t_def.upgrade_from else {
+            continue;
+        };
+        let source_id = &uf.target_id;
+        let Some(s_def) = registry.definitions.get(source_id) else {
+            continue; // rule 3 already reported the dangling source
+        };
+        if let Some(to_edge) = s_def
+            .upgrade_to
+            .iter()
+            .find(|e| e.target_id == *target_id)
+        {
+            report.warnings.push(format!(
+                "upgrade edge '{source_id}' -> '{target_id}' declared on BOTH sides \
+                 (upgrade_to and upgrade_from); using upgrade_to values"
+            ));
+            if to_edge.cost.minerals != uf.cost.minerals
+                || to_edge.cost.energy != uf.cost.energy
+                || to_edge.build_time != uf.build_time
+            {
+                report.warnings.push(format!(
+                    "upgrade edge '{source_id}' -> '{target_id}' has mismatched cost/build_time \
+                     between upgrade_to and upgrade_from; upgrade_to wins"
+                ));
+            }
+        }
+    }
+
+    // Rule 4: unreachable nodes.
+    // A deliverable is "reachable" if it has shipyard cost OR any inbound edge
+    // (via someone's upgrade_to, or via its own upgrade_from).
+    let mut inbound: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for def in registry.definitions.values() {
+        for e in &def.upgrade_to {
+            inbound.insert(e.target_id.clone());
+        }
+    }
+    for (id, def) in &registry.definitions {
+        let shipyard_buildable = def.deliverable.is_some();
+        let has_upgrade_from = def.upgrade_from.is_some();
+        let has_upstream = inbound.contains(id);
+        if !shipyard_buildable && !has_upgrade_from && !has_upstream {
+            report.errors.push(format!(
+                "deliverable '{id}' is unreachable: has no shipyard cost and no inbound upgrade edge"
+            ));
+        }
+    }
+
+    // Rule 5: construction_platform capability requires >=1 outgoing edge.
+    // Outgoing = own upgrade_to OR any other def's self-declared upgrade_from
+    // pointing at us.
+    let mut outbound_from: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    for def in registry.definitions.values() {
+        if !def.upgrade_to.is_empty() {
+            outbound_from.insert(def.id.clone());
+        }
+    }
+    for def in registry.definitions.values() {
+        if let Some(uf) = &def.upgrade_from {
+            outbound_from.insert(uf.target_id.clone());
+        }
+    }
+    for (id, def) in &registry.definitions {
+        if def.is_construction_platform() && !outbound_from.contains(id) {
+            report.errors.push(format!(
+                "deliverable '{id}' has construction_platform capability but no outgoing \
+                 upgrade edge — it cannot be upgraded to anything"
+            ));
+        }
+    }
+
+    // Build `effective_edges` regardless; callers check `report.is_ok()`.
+    let conflicts = registry.rebuild_effective_edges();
+    for (s, t) in conflicts {
+        // rebuild_effective_edges may also detect conflicts via both-sides
+        // declaration; surface them here only if we haven't already above.
+        let msg = format!(
+            "upgrade edge '{s}' -> '{t}' declared on BOTH sides (upgrade_to and upgrade_from); using upgrade_to values"
+        );
+        if !report.warnings.iter().any(|w| w == &msg) {
+            report.warnings.push(msg);
+        }
+    }
+
+    report
+}
+
 /// Parse structure definitions from Lua accumulators, falling back to defaults.
 /// Scripts are loaded by `load_all_scripts`; this system only parses the results.
 pub fn load_structure_definitions(
     engine: Res<crate::scripting::ScriptEngine>,
     mut registry: ResMut<StructureRegistry>,
 ) {
+    let insert_defaults = |registry: &mut StructureRegistry| {
+        for def in default_structure_definitions() {
+            registry.insert(def);
+        }
+    };
+
     match crate::scripting::structure_api::parse_structure_definitions(engine.lua()) {
         Ok(defs) if !defs.is_empty() => {
             let count = defs.len();
@@ -717,16 +873,21 @@ pub fn load_structure_definitions(
         }
         Ok(_) => {
             info!("No structure definitions found in scripts; using defaults");
-            for def in default_structure_definitions() {
-                registry.insert(def);
-            }
+            insert_defaults(&mut registry);
         }
         Err(e) => {
             warn!("Failed to parse structure definitions: {e}; using defaults");
-            for def in default_structure_definitions() {
-                registry.insert(def);
-            }
+            insert_defaults(&mut registry);
         }
+    }
+
+    // #223: Validate the loaded graph and (re)build effective_edges.
+    let report = validate_and_build_edges(&mut registry);
+    for w in &report.warnings {
+        warn!("Deliverable registry: {w}");
+    }
+    for e in &report.errors {
+        error!("Deliverable registry: {e}");
     }
 }
 
@@ -930,6 +1091,207 @@ mod tests {
         // B is not a DeepSpaceStructure
         let b = world.spawn_empty().id();
         assert!(pair_relay_command(&mut world, a, b, CommDirection::Bidirectional).is_err());
+    }
+
+    // --- #223: Validation tests ---
+
+    fn mk_def(id: &str) -> StructureDefinition {
+        StructureDefinition {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: String::new(),
+            max_hp: 10.0,
+            capabilities: HashMap::new(),
+            energy_drain: Amt::ZERO,
+            prerequisites: None,
+            deliverable: None,
+            upgrade_to: Vec::new(),
+            upgrade_from: None,
+        }
+    }
+
+    fn mk_buildable(id: &str, minerals: u64) -> StructureDefinition {
+        let mut def = mk_def(id);
+        def.deliverable = Some(DeliverableMetadata {
+            cost: ResourceCost {
+                minerals: Amt::units(minerals),
+                energy: Amt::ZERO,
+            },
+            build_time: 10,
+            cargo_size: 1,
+            scrap_refund: 0.5,
+        });
+        def
+    }
+
+    fn mk_platform(id: &str) -> StructureDefinition {
+        let mut def = mk_buildable(id, 100);
+        def.capabilities.insert(
+            "construction_platform".to_string(),
+            CapabilityParams::default(),
+        );
+        def
+    }
+
+    #[test]
+    fn test_validate_dangling_target_errors() {
+        let mut reg = DeliverableRegistry::default();
+        let mut src = mk_buildable("kit", 100);
+        src.upgrade_to.push(UpgradeEdge {
+            target_id: "ghost".to_string(),
+            cost: ResourceCost::default(),
+            build_time: 10,
+        });
+        reg.insert(src);
+        let report = validate_and_build_edges(&mut reg);
+        assert!(!report.is_ok());
+        assert!(report.errors.iter().any(|e| e.contains("ghost")));
+    }
+
+    #[test]
+    fn test_validate_unreachable_errors() {
+        let mut reg = DeliverableRegistry::default();
+        // isolated: not buildable, no inbound edge.
+        reg.insert(mk_def("orphan"));
+        let report = validate_and_build_edges(&mut reg);
+        assert!(!report.is_ok());
+        assert!(report.errors.iter().any(|e| e.contains("orphan")));
+    }
+
+    #[test]
+    fn test_validate_construction_platform_without_edges_errors() {
+        let mut reg = DeliverableRegistry::default();
+        reg.insert(mk_platform("platform"));
+        let report = validate_and_build_edges(&mut reg);
+        assert!(!report.is_ok());
+        assert!(report.errors.iter().any(|e| e.contains("construction_platform")));
+    }
+
+    #[test]
+    fn test_validate_upgrade_conflict_warning() {
+        let mut reg = DeliverableRegistry::default();
+        let mut kit = mk_platform("kit");
+        kit.upgrade_to.push(UpgradeEdge {
+            target_id: "active".to_string(),
+            cost: ResourceCost {
+                minerals: Amt::units(100),
+                energy: Amt::ZERO,
+            },
+            build_time: 30,
+        });
+        reg.insert(kit);
+
+        let mut active = mk_def("active");
+        active.upgrade_from = Some(UpgradeEdge {
+            target_id: "kit".to_string(),
+            cost: ResourceCost {
+                minerals: Amt::units(100),
+                energy: Amt::ZERO,
+            },
+            build_time: 30,
+        });
+        reg.insert(active);
+
+        let report = validate_and_build_edges(&mut reg);
+        assert!(report.is_ok());
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("declared on BOTH sides"))
+        );
+    }
+
+    #[test]
+    fn test_validate_cost_mismatch_warning() {
+        let mut reg = DeliverableRegistry::default();
+        let mut kit = mk_platform("kit");
+        kit.upgrade_to.push(UpgradeEdge {
+            target_id: "active".to_string(),
+            cost: ResourceCost {
+                minerals: Amt::units(100),
+                energy: Amt::ZERO,
+            },
+            build_time: 30,
+        });
+        reg.insert(kit);
+
+        let mut active = mk_def("active");
+        active.upgrade_from = Some(UpgradeEdge {
+            target_id: "kit".to_string(),
+            cost: ResourceCost {
+                minerals: Amt::units(200), // mismatch!
+                energy: Amt::ZERO,
+            },
+            build_time: 30,
+        });
+        reg.insert(active);
+
+        let report = validate_and_build_edges(&mut reg);
+        assert!(report.is_ok());
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("mismatched cost/build_time"))
+        );
+    }
+
+    #[test]
+    fn test_effective_edges_upgrade_to_wins_on_conflict() {
+        let mut reg = DeliverableRegistry::default();
+        let mut kit = mk_platform("kit");
+        kit.upgrade_to.push(UpgradeEdge {
+            target_id: "active".to_string(),
+            cost: ResourceCost {
+                minerals: Amt::units(100),
+                energy: Amt::ZERO,
+            },
+            build_time: 30,
+        });
+        reg.insert(kit);
+
+        let mut active = mk_def("active");
+        active.upgrade_from = Some(UpgradeEdge {
+            target_id: "kit".to_string(),
+            cost: ResourceCost {
+                minerals: Amt::units(999), // loser
+                energy: Amt::ZERO,
+            },
+            build_time: 99,
+        });
+        reg.insert(active);
+
+        let _ = validate_and_build_edges(&mut reg);
+        let edges = reg.outgoing_edges("kit");
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].target_id, "active");
+        assert_eq!(edges[0].cost.minerals, Amt::units(100));
+        assert_eq!(edges[0].build_time, 30);
+    }
+
+    #[test]
+    fn test_effective_edges_inverse_upgrade_from_merged() {
+        // If no `upgrade_to` declares the edge, the inverse `upgrade_from`
+        // should be promoted into `effective_edges` for routing.
+        let mut reg = DeliverableRegistry::default();
+        reg.insert(mk_platform("kit"));
+        let mut active = mk_def("active");
+        active.upgrade_from = Some(UpgradeEdge {
+            target_id: "kit".to_string(),
+            cost: ResourceCost {
+                minerals: Amt::units(500),
+                energy: Amt::ZERO,
+            },
+            build_time: 42,
+        });
+        reg.insert(active);
+        let _ = validate_and_build_edges(&mut reg);
+        let edges = reg.outgoing_edges("kit");
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].target_id, "active");
+        assert_eq!(edges[0].cost.minerals, Amt::units(500));
+        assert_eq!(edges[0].build_time, 42);
     }
 
     #[test]

--- a/macrocosmo/src/modifier.rs
+++ b/macrocosmo/src/modifier.rs
@@ -272,6 +272,13 @@ impl CachedValue {
         current_gens != self.generations
     }
 
+    /// Read-only access to the last cached value (without recomputing).
+    /// Call `get` to refresh; call this for read-only contexts (e.g. queries
+    /// that can't take `&mut`).
+    pub fn cached(&self) -> Amt {
+        self.cached
+    }
+
     /// Compute the combined value from multiple scopes.
     /// First scope: base + base_add from its modifiers.
     /// All scopes: multipliers and adds are combined.

--- a/macrocosmo/src/scripting/globals.rs
+++ b/macrocosmo/src/scripting/globals.rs
@@ -104,9 +104,15 @@ pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
     register_define_fn(lua, "module", "_module_definitions")?;
     register_define_fn(lua, "ship_design", "_ship_design_definitions")?;
 
-    // --- Structure definition ---
-
+    // --- Structure & Deliverable definition ---
+    //
+    // #223: `define_structure` is the world-side entry (not shipyard-buildable).
+    // `define_deliverable` is the shipyard-buildable superset — adds `cost`,
+    // `build_time`, `cargo_size`, `scrap_refund`, `upgrade_to`, `upgrade_from`.
+    // Both feed `parse_structure_definitions`, which dispatches on which
+    // accumulator they came from.
     register_define_fn(lua, "structure", "_structure_definitions")?;
+    register_define_fn(lua, "deliverable", "_deliverable_definitions")?;
 
     // --- Anomaly definition ---
 

--- a/macrocosmo/src/scripting/structure_api.rs
+++ b/macrocosmo/src/scripting/structure_api.rs
@@ -1,67 +1,138 @@
 use std::collections::HashMap;
 
 use crate::amount::Amt;
-use crate::deep_space::{CapabilityParams, ResourceCost, StructureDefinition};
+use crate::deep_space::{
+    CapabilityParams, DeliverableMetadata, ResourceCost, StructureDefinition, UpgradeEdge,
+};
 use crate::scripting::condition_parser::parse_prerequisites_field;
+use crate::scripting::helpers::extract_id_from_lua_value;
 
-/// Parse structure definitions from the Lua `_structure_definitions` global table.
-/// Each entry should have at minimum `id` and `name` fields.
+/// Parse structure + deliverable definitions from the Lua globals.
+///
+/// Pulls from two accumulators:
+///   - `_structure_definitions` — populated by `define_structure { ... }`;
+///     produces `DeliverableDefinition` with `deliverable = None` unless the
+///     script supplies `cost` (legacy backwards-compat path).
+///   - `_deliverable_definitions` — populated by `define_deliverable { ... }`;
+///     produces `DeliverableDefinition` with `deliverable = Some(_)`.
 pub fn parse_structure_definitions(lua: &mlua::Lua) -> Result<Vec<StructureDefinition>, mlua::Error> {
-    let defs: mlua::Table = lua.globals().get("_structure_definitions")?;
     let mut result = Vec::new();
 
-    for pair in defs.pairs::<i64, mlua::Table>() {
+    // Pass 1: `define_structure` — world-side structures.
+    let structures: mlua::Table = lua.globals().get("_structure_definitions")?;
+    for pair in structures.pairs::<i64, mlua::Table>() {
         let (_, table) = pair?;
+        result.push(parse_one(&table, /* deliverable_api */ false)?);
+    }
 
-        let id: String = table.get("id")?;
-        let name: String = table.get("name")?;
-        let description: String = table.get::<Option<String>>("description")?.unwrap_or_default();
-        let max_hp: f64 = table.get::<Option<f64>>("max_hp")?.unwrap_or(100.0);
-
-        // Parse cost as a sub-table: { minerals = N, energy = N }
-        let cost = parse_cost_table(&table)?;
-
-        let build_time: i64 = table.get::<Option<i64>>("build_time")?.unwrap_or(10);
-
-        let energy_drain_raw: f64 = table.get::<Option<f64>>("energy_drain")?.unwrap_or(0.0);
-        // energy_drain is specified in millis in Lua (e.g. 100 = 0.1 units)
-        let energy_drain = Amt::milli(energy_drain_raw as u64);
-
-        // Parse prerequisites as an optional Condition table (shared helper).
-        let prerequisites = parse_prerequisites_field(&table)?;
-
-        // Parse capabilities as a table of tables: { cap_name = { range = N }, ... }
-        let capabilities = parse_capabilities_map(&table)?;
-
-        result.push(StructureDefinition {
-            id,
-            name,
-            description,
-            max_hp,
-            cost,
-            build_time,
-            energy_drain,
-            prerequisites,
-            capabilities,
-        });
+    // Pass 2: `define_deliverable` — shipyard-buildable deliverables.
+    // The accumulator is optional (older scripts may not register it).
+    if let Ok(deliverables) = lua.globals().get::<mlua::Table>("_deliverable_definitions") {
+        for pair in deliverables.pairs::<i64, mlua::Table>() {
+            let (_, table) = pair?;
+            result.push(parse_one(&table, /* deliverable_api */ true)?);
+        }
     }
 
     Ok(result)
 }
 
-/// Parse the `cost = { minerals = N, energy = N }` sub-table.
-fn parse_cost_table(table: &mlua::Table) -> Result<ResourceCost, mlua::Error> {
+/// Parse a single definition table.
+///
+/// `deliverable_api = true` means the table was produced by `define_deliverable`
+/// (meaning: shipyard-buildable). In that case `cost` is required (unless
+/// omitted intentionally for an upgrade-only target, but then `upgrade_from`
+/// must be present — this invariant is checked at the registry level).
+///
+/// `deliverable_api = false` means `define_structure` (world-side only). `cost`
+/// is honoured for legacy scripts but no DeliverableMetadata is synthesised.
+fn parse_one(table: &mlua::Table, deliverable_api: bool) -> Result<StructureDefinition, mlua::Error> {
+    let id: String = table.get("id")?;
+    let name: String = table.get::<Option<String>>("name")?.unwrap_or_else(|| id.clone());
+    let description: String = table.get::<Option<String>>("description")?.unwrap_or_default();
+    let max_hp: f64 = table.get::<Option<f64>>("max_hp")?.unwrap_or(100.0);
+
+    let energy_drain_raw: f64 = table.get::<Option<f64>>("energy_drain")?.unwrap_or(0.0);
+    let energy_drain = Amt::milli(energy_drain_raw as u64);
+
+    let prerequisites = parse_prerequisites_field(table)?;
+    let capabilities = parse_capabilities_map(table)?;
+
+    // `cost` may be Nil (upgrade-only target), a table (minerals/energy), or missing.
+    let cost_opt = parse_cost_opt(table)?;
+
+    // Deliverable metadata (only populated when API-level or legacy cost present).
+    let deliverable = if deliverable_api {
+        // Per issue: `cost = nil` is valid for `define_deliverable` when the
+        // deliverable is upgrade-only (validated at registry level). When
+        // `cost` is provided, the deliverable is shipyard-buildable.
+        match cost_opt {
+            Some(cost) => {
+                let build_time: i64 = table.get::<Option<i64>>("build_time")?.unwrap_or(10);
+                let cargo_size: u32 = table.get::<Option<u32>>("cargo_size")?.unwrap_or(1);
+                let scrap_refund: f32 =
+                    table.get::<Option<f64>>("scrap_refund")?.unwrap_or(0.0) as f32;
+                Some(DeliverableMetadata {
+                    cost,
+                    build_time,
+                    cargo_size,
+                    scrap_refund: scrap_refund.clamp(0.0, 1.0),
+                })
+            }
+            None => None,
+        }
+    } else {
+        // Legacy `define_structure`: synthesise metadata when script supplies
+        // `cost` (pre-#223 scripts did this). This preserves existing
+        // behaviour. New-style scripts should prefer `define_deliverable`.
+        match cost_opt {
+            Some(cost) => {
+                let build_time: i64 = table.get::<Option<i64>>("build_time")?.unwrap_or(10);
+                let cargo_size: u32 = table.get::<Option<u32>>("cargo_size")?.unwrap_or(1);
+                let scrap_refund: f32 =
+                    table.get::<Option<f64>>("scrap_refund")?.unwrap_or(0.0) as f32;
+                Some(DeliverableMetadata {
+                    cost,
+                    build_time,
+                    cargo_size,
+                    scrap_refund: scrap_refund.clamp(0.0, 1.0),
+                })
+            }
+            None => None,
+        }
+    };
+
+    let upgrade_to = parse_upgrade_to(table)?;
+    let upgrade_from = parse_upgrade_from(table)?;
+
+    Ok(StructureDefinition {
+        id,
+        name,
+        description,
+        max_hp,
+        energy_drain,
+        prerequisites,
+        capabilities,
+        deliverable,
+        upgrade_to,
+        upgrade_from,
+    })
+}
+
+/// Parse the `cost = { minerals = N, energy = N }` sub-table if present.
+/// Returns `None` when the key is missing OR explicitly set to `nil`.
+fn parse_cost_opt(table: &mlua::Table) -> Result<Option<ResourceCost>, mlua::Error> {
     let cost_value: mlua::Value = table.get("cost")?;
     match cost_value {
         mlua::Value::Table(cost_table) => {
             let minerals_raw: f64 = cost_table.get::<Option<f64>>("minerals")?.unwrap_or(0.0);
             let energy_raw: f64 = cost_table.get::<Option<f64>>("energy")?.unwrap_or(0.0);
-            Ok(ResourceCost {
+            Ok(Some(ResourceCost {
                 minerals: Amt::from_f64(minerals_raw),
                 energy: Amt::from_f64(energy_raw),
-            })
+            }))
         }
-        mlua::Value::Nil => Ok(ResourceCost::default()),
+        mlua::Value::Nil => Ok(None),
         _ => Err(mlua::Error::RuntimeError(
             "Expected table or nil for 'cost' field".to_string(),
         )),
@@ -84,6 +155,64 @@ fn parse_capabilities_map(table: &mlua::Table) -> Result<HashMap<String, Capabil
         mlua::Value::Nil => Ok(HashMap::new()),
         _ => Err(mlua::Error::RuntimeError(
             "Expected table or nil for 'capabilities' field".to_string(),
+        )),
+    }
+}
+
+/// Parse `upgrade_to = { { target = ..., cost = { ... }, build_time = N }, ... }`.
+/// Each entry's `target` may be a string id or a reference table.
+fn parse_upgrade_to(table: &mlua::Table) -> Result<Vec<UpgradeEdge>, mlua::Error> {
+    let value: mlua::Value = table.get("upgrade_to")?;
+    match value {
+        mlua::Value::Nil => Ok(Vec::new()),
+        mlua::Value::Table(list) => {
+            let mut edges = Vec::new();
+            for pair in list.pairs::<i64, mlua::Table>() {
+                let (_, entry) = pair?;
+                let target_val: mlua::Value = entry.get("target")?;
+                let target_id = extract_id_from_lua_value(&target_val)?;
+                let cost = match parse_cost_opt(&entry)? {
+                    Some(c) => c,
+                    None => ResourceCost::default(),
+                };
+                let build_time: i64 = entry.get::<Option<i64>>("build_time")?.unwrap_or(10);
+                edges.push(UpgradeEdge {
+                    target_id,
+                    cost,
+                    build_time,
+                });
+            }
+            Ok(edges)
+        }
+        _ => Err(mlua::Error::RuntimeError(
+            "Expected table or nil for 'upgrade_to' field".to_string(),
+        )),
+    }
+}
+
+/// Parse `upgrade_from = { source = ..., cost = { ... }, build_time = N }`.
+/// Returns `UpgradeEdge` with `target_id` holding the SOURCE id (i.e. the
+/// upstream deliverable this one can be reached from).
+fn parse_upgrade_from(table: &mlua::Table) -> Result<Option<UpgradeEdge>, mlua::Error> {
+    let value: mlua::Value = table.get("upgrade_from")?;
+    match value {
+        mlua::Value::Nil => Ok(None),
+        mlua::Value::Table(entry) => {
+            let source_val: mlua::Value = entry.get("source")?;
+            let source_id = extract_id_from_lua_value(&source_val)?;
+            let cost = match parse_cost_opt(&entry)? {
+                Some(c) => c,
+                None => ResourceCost::default(),
+            };
+            let build_time: i64 = entry.get::<Option<i64>>("build_time")?.unwrap_or(10);
+            Ok(Some(UpgradeEdge {
+                target_id: source_id,
+                cost,
+                build_time,
+            }))
+        }
+        _ => Err(mlua::Error::RuntimeError(
+            "Expected table or nil for 'upgrade_from' field".to_string(),
         )),
     }
 }
@@ -139,9 +268,10 @@ mod tests {
         assert_eq!(defs[0].name, "Sensor Buoy");
         assert_eq!(defs[0].description, "Detects sublight vessel movements.");
         assert_eq!(defs[0].max_hp, 20.0);
-        assert_eq!(defs[0].cost.minerals, Amt::units(50));
-        assert_eq!(defs[0].cost.energy, Amt::units(30));
-        assert_eq!(defs[0].build_time, 15);
+        let meta = defs[0].deliverable.as_ref().expect("legacy cost should synthesise metadata");
+        assert_eq!(meta.cost.minerals, Amt::units(50));
+        assert_eq!(meta.cost.energy, Amt::units(30));
+        assert_eq!(meta.build_time, 15);
         assert!(defs[0].capabilities.contains_key("detect_sublight"));
         assert_eq!(defs[0].capabilities["detect_sublight"].range, 3.0);
         assert_eq!(defs[0].energy_drain, Amt::milli(100));
@@ -183,10 +313,9 @@ mod tests {
         assert_eq!(defs[0].id, "basic");
         assert_eq!(defs[0].name, "Basic Structure");
         assert_eq!(defs[0].description, "");
-        assert_eq!(defs[0].max_hp, 100.0); // default
-        assert_eq!(defs[0].cost.minerals, Amt::ZERO);
-        assert_eq!(defs[0].cost.energy, Amt::ZERO);
-        assert_eq!(defs[0].build_time, 10); // default
+        assert_eq!(defs[0].max_hp, 100.0);
+        // No cost → no deliverable metadata for minimal structures.
+        assert!(defs[0].deliverable.is_none());
         assert!(defs[0].capabilities.is_empty());
         assert_eq!(defs[0].energy_drain, Amt::ZERO);
         assert!(defs[0].prerequisites.is_none());
@@ -298,5 +427,142 @@ mod tests {
 
         let interdictor = map.get("interdictor").expect("interdictor should exist");
         assert!(interdictor.capabilities.contains_key("ftl_interdiction"));
+    }
+
+    // --- #223: define_deliverable tests ---
+
+    #[test]
+    fn test_parse_define_deliverable_with_cost() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_deliverable {
+                id = "sensor_buoy",
+                name = "Sensor Buoy",
+                cost = { minerals = 50, energy = 30 },
+                build_time = 15,
+                cargo_size = 1,
+                max_hp = 20,
+                energy_drain = 100,
+                scrap_refund = 0.5,
+                capabilities = { detect_sublight = { range = 3.0 } },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_structure_definitions(lua).unwrap();
+        let buoy = defs.iter().find(|d| d.id == "sensor_buoy").unwrap();
+        let meta = buoy
+            .deliverable
+            .as_ref()
+            .expect("define_deliverable with cost → metadata present");
+        assert_eq!(meta.cost.minerals, Amt::units(50));
+        assert_eq!(meta.cost.energy, Amt::units(30));
+        assert_eq!(meta.build_time, 15);
+        assert_eq!(meta.cargo_size, 1);
+        assert!((meta.scrap_refund - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_parse_define_structure_no_cost() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_structure {
+                id = "debris_wreck",
+                name = "Debris Wreck",
+                max_hp = 1,
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_structure_definitions(lua).unwrap();
+        let wreck = defs.iter().find(|d| d.id == "debris_wreck").unwrap();
+        assert!(
+            wreck.deliverable.is_none(),
+            "define_structure without cost → no deliverable metadata"
+        );
+    }
+
+    #[test]
+    fn test_parse_upgrade_to_with_forward_ref() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_deliverable {
+                id = "defense_platform_kit",
+                name = "Defense Platform Kit",
+                cost = { minerals = 200, energy = 100 },
+                build_time = 20,
+                cargo_size = 3,
+                max_hp = 80,
+                energy_drain = 50,
+                scrap_refund = 0.3,
+                upgrade_to = {
+                    { target = forward_ref("defense_platform"),
+                      cost = { minerals = 1800, energy = 700 },
+                      build_time = 60 },
+                },
+                capabilities = { construction_platform = {} },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_structure_definitions(lua).unwrap();
+        let kit = defs.iter().find(|d| d.id == "defense_platform_kit").unwrap();
+        assert_eq!(kit.upgrade_to.len(), 1);
+        assert_eq!(kit.upgrade_to[0].target_id, "defense_platform");
+        assert_eq!(kit.upgrade_to[0].cost.minerals, Amt::units(1800));
+        assert_eq!(kit.upgrade_to[0].cost.energy, Amt::units(700));
+        assert_eq!(kit.upgrade_to[0].build_time, 60);
+        assert!(kit.is_construction_platform());
+    }
+
+    #[test]
+    fn test_parse_upgrade_from_with_forward_ref() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_deliverable {
+                id = "new_structure",
+                name = "New Structure",
+                upgrade_from = {
+                    source = forward_ref("universal_platform"),
+                    cost = { minerals = 500, energy = 300 },
+                    build_time = 40,
+                },
+                capabilities = {},
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_structure_definitions(lua).unwrap();
+        let ns = defs.iter().find(|d| d.id == "new_structure").unwrap();
+        let uf = ns
+            .upgrade_from
+            .as_ref()
+            .expect("upgrade_from should parse");
+        assert_eq!(uf.target_id, "universal_platform");
+        assert_eq!(uf.cost.minerals, Amt::units(500));
+        assert_eq!(uf.cost.energy, Amt::units(300));
+        assert_eq!(uf.build_time, 40);
+        // No cost on the deliverable itself → not shipyard-buildable.
+        assert!(ns.deliverable.is_none());
     }
 }

--- a/macrocosmo/src/ship/command.rs
+++ b/macrocosmo/src/ship/command.rs
@@ -429,7 +429,27 @@ pub fn process_command_queue(
                         queue.sync_prediction(ship_pos.as_array(), docked_system);
                     }
                     QueuedCommand::MoveToCoordinates { .. } | QueuedCommand::MoveTo { .. } => {} // handled above
+                    // #223: Deliverable-side commands are handled by
+                    // `super::deliverable_ops::process_deliverable_commands`.
+                    // This arm is unreachable via the outer match, but the
+                    // exhaustive compiler still needs the variants enumerated.
+                    QueuedCommand::LoadDeliverable { .. }
+                    | QueuedCommand::DeployDeliverable { .. }
+                    | QueuedCommand::TransferToStructure { .. }
+                    | QueuedCommand::LoadFromScrapyard { .. } => {
+                        // handled by deliverable_ops
+                    }
                 }
+            }
+            // #223: Deliverable-side commands are processed by
+            // `super::deliverable_ops::process_deliverable_commands`, which
+            // runs as its own system. We skip them here and leave them at
+            // the head of the queue.
+            QueuedCommand::LoadDeliverable { .. }
+            | QueuedCommand::DeployDeliverable { .. }
+            | QueuedCommand::TransferToStructure { .. }
+            | QueuedCommand::LoadFromScrapyard { .. } => {
+                // no-op; the deliverable ops system consumes these.
             }
         }
     }

--- a/macrocosmo/src/ship/deliverable_ops.rs
+++ b/macrocosmo/src/ship/deliverable_ops.rs
@@ -1,0 +1,349 @@
+//! #223: Deliverable-side command processing.
+//!
+//! Separate from `process_command_queue` (which handles FTL/sublight routing)
+//! because deliverable operations are synchronous, in-place, and don't involve
+//! route planning. Runs BEFORE `process_command_queue` so that any `MoveTo`
+//! auto-queued by this module is dispatched on the same tick.
+//!
+//! Commands handled:
+//!   - `LoadDeliverable { system, stockpile_index }`
+//!   - `DeployDeliverable { position, item_index }`
+//!   - `TransferToStructure { structure, minerals, energy }`
+//!   - `LoadFromScrapyard { structure }`
+//!
+//! See `src/ship/mod.rs` for the variant docs.
+
+use bevy::prelude::*;
+
+use crate::amount::Amt;
+use crate::colony::DeliverableStockpile;
+use crate::components::Position;
+use crate::deep_space::{
+    spawn_deliverable_entity, ConstructionPlatform, DeepSpaceStructure, LifetimeCost, ResourceCost,
+    Scrapyard, StructureRegistry,
+};
+use crate::ship::{Cargo, CargoItem, CommandQueue, QueuedCommand, Ship, ShipState, ShipStats};
+
+/// Maximum position delta (in light-years) for a ship to be considered
+/// "co-located" with a deep-space structure or deploy coordinate.
+pub const DEPLOY_POSITION_EPSILON: f64 = 0.01;
+
+/// Process deliverable-side commands at the head of each ship's queue.
+///
+/// Runs in the `Update` schedule, ordered `.after(advance_game_time)` and
+/// `.before(process_command_queue)` so any auto-queued movement reaches the
+/// FTL planner on the same tick.
+pub fn process_deliverable_commands(
+    mut commands: Commands,
+    clock: Res<crate::time_system::GameClock>,
+    balance: Res<crate::technology::GameBalance>,
+    registry: Res<StructureRegistry>,
+    mut events: MessageWriter<crate::events::GameEvent>,
+    mut ships: Query<(
+        Entity,
+        &Ship,
+        &ShipState,
+        &Position,
+        &mut CommandQueue,
+        &mut Cargo,
+        &ShipStats,
+    )>,
+    mut stockpiles: Query<&mut DeliverableStockpile>,
+    mut platforms: Query<(&Position, &mut ConstructionPlatform), Without<Ship>>,
+    mut scrapyards: Query<(&Position, &mut Scrapyard), Without<Ship>>,
+    structures: Query<(&DeepSpaceStructure, &Position), Without<Ship>>,
+) {
+    let mass_per_slot_raw = balance.mass_per_item_slot().0;
+
+    for (_ship_entity, ship, state, ship_pos, mut queue, mut cargo, stats) in ships.iter_mut() {
+        if queue.commands.is_empty() {
+            continue;
+        }
+        // Peek at head.
+        let head = queue.commands[0].clone();
+        match head {
+            QueuedCommand::LoadDeliverable { system, stockpile_index } => {
+                // Ship must be docked at the system.
+                let docked_system = match state {
+                    ShipState::Docked { system: s } => Some(*s),
+                    _ => None,
+                };
+                if docked_system != Some(system) {
+                    // Inject a MoveTo to that system before this command.
+                    // The existing command is kept; insert the move at position 0.
+                    queue.commands.insert(0, QueuedCommand::MoveTo { system });
+                    continue;
+                }
+                // Find the stockpile.
+                let Ok(mut stockpile) = stockpiles.get_mut(system) else {
+                    warn!("LoadDeliverable: system has no DeliverableStockpile");
+                    queue.commands.remove(0);
+                    continue;
+                };
+                let Some(item) = stockpile.items.get(stockpile_index).cloned() else {
+                    warn!(
+                        "LoadDeliverable: index {} out of range (len={})",
+                        stockpile_index,
+                        stockpile.items.len()
+                    );
+                    queue.commands.remove(0);
+                    continue;
+                };
+                // Check cargo capacity.
+                let size = registry
+                    .get(item.definition_id())
+                    .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
+                    .unwrap_or(1);
+                let cap = stats.cargo_capacity.cached();
+                let lookup = |id: &str| -> Option<u32> {
+                    registry
+                        .get(id)
+                        .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
+                };
+                if !cargo.can_fit(size, cap, &lookup, mass_per_slot_raw) {
+                    warn!(
+                        "LoadDeliverable: ship {} has insufficient cargo capacity for {}",
+                        ship.name,
+                        item.definition_id()
+                    );
+                    queue.commands.remove(0);
+                    continue;
+                }
+                // Load it.
+                stockpile.items.remove(stockpile_index);
+                cargo.items.push(item.clone());
+                queue.commands.remove(0);
+                info!(
+                    "Ship {} loaded {} from system stockpile",
+                    ship.name,
+                    item.definition_id()
+                );
+                events.write(crate::events::GameEvent {
+                    timestamp: clock.elapsed,
+                    kind: crate::events::GameEventKind::ShipBuilt,
+                    description: format!("{} loaded {}", ship.name, item.definition_id()),
+                    related_system: Some(system),
+                });
+            }
+            QueuedCommand::DeployDeliverable { position, item_index } => {
+                // Ship must not be in FTL or surveying. Loitering/Docked OK.
+                let allowed = matches!(
+                    state,
+                    ShipState::Docked { .. } | ShipState::Loitering { .. }
+                );
+                if !allowed {
+                    // Wait until movement completes.
+                    continue;
+                }
+                // Check that ship is at position.
+                let here = ship_pos.as_array();
+                let d = (here[0] - position[0]).powi(2)
+                    + (here[1] - position[1]).powi(2)
+                    + (here[2] - position[2]).powi(2);
+                if d.sqrt() > DEPLOY_POSITION_EPSILON {
+                    queue
+                        .commands
+                        .insert(0, QueuedCommand::MoveToCoordinates { target: position });
+                    continue;
+                }
+                // Execute deployment.
+                let Some(item) = cargo.items.get(item_index).cloned() else {
+                    warn!("DeployDeliverable: item_index out of range");
+                    queue.commands.remove(0);
+                    continue;
+                };
+                let def_id = item.definition_id().to_string();
+                if registry.get(&def_id).is_none() {
+                    warn!("DeployDeliverable: unknown definition {}", def_id);
+                    queue.commands.remove(0);
+                    continue;
+                }
+                let spawned = spawn_deliverable_entity(
+                    &mut commands,
+                    &def_id,
+                    position,
+                    ship.owner,
+                    &registry,
+                );
+                if spawned.is_none() {
+                    warn!("DeployDeliverable: spawn failed for {}", def_id);
+                    queue.commands.remove(0);
+                    continue;
+                }
+                cargo.items.remove(item_index);
+                queue.commands.remove(0);
+                info!("Ship {} deployed {} at {:?}", ship.name, def_id, position);
+                events.write(crate::events::GameEvent {
+                    timestamp: clock.elapsed,
+                    kind: crate::events::GameEventKind::ShipBuilt,
+                    description: format!("{} deployed {}", ship.name, def_id),
+                    related_system: None,
+                });
+            }
+            QueuedCommand::TransferToStructure {
+                structure,
+                minerals,
+                energy,
+            } => {
+                // Ship must be at the structure's position.
+                let Ok((struct_pos, mut platform)) = platforms.get_mut(structure) else {
+                    warn!(
+                        "TransferToStructure: target {:?} is not a ConstructionPlatform",
+                        structure
+                    );
+                    queue.commands.remove(0);
+                    continue;
+                };
+                if ship_pos.distance_to(struct_pos) > DEPLOY_POSITION_EPSILON {
+                    queue.commands.insert(
+                        0,
+                        QueuedCommand::MoveToCoordinates {
+                            target: struct_pos.as_array(),
+                        },
+                    );
+                    continue;
+                }
+                // Clamp transfers by what the ship actually carries.
+                let m = cargo.minerals.min(minerals);
+                let e = cargo.energy.min(energy);
+                if m == Amt::ZERO && e == Amt::ZERO {
+                    queue.commands.remove(0);
+                    continue;
+                }
+                cargo.minerals = cargo.minerals.sub(m);
+                cargo.energy = cargo.energy.sub(e);
+                platform.accumulated.minerals = platform.accumulated.minerals.add(m);
+                platform.accumulated.energy = platform.accumulated.energy.add(e);
+                queue.commands.remove(0);
+                info!(
+                    "Ship {} transferred {}m/{}e to platform {:?}",
+                    ship.name,
+                    m.to_f64(),
+                    e.to_f64(),
+                    structure
+                );
+            }
+            QueuedCommand::LoadFromScrapyard { structure } => {
+                let Ok((scrap_pos, mut scrap)) = scrapyards.get_mut(structure) else {
+                    warn!(
+                        "LoadFromScrapyard: target {:?} has no Scrapyard",
+                        structure
+                    );
+                    queue.commands.remove(0);
+                    continue;
+                };
+                if ship_pos.distance_to(scrap_pos) > DEPLOY_POSITION_EPSILON {
+                    queue.commands.insert(
+                        0,
+                        QueuedCommand::MoveToCoordinates {
+                            target: scrap_pos.as_array(),
+                        },
+                    );
+                    continue;
+                }
+                // Drain as much as the ship can hold. Resources are weightless
+                // relative to the item-mass model (cargo_capacity bounds the
+                // TOTAL mass including resources), so use the same accounting.
+                let cap = stats.cargo_capacity.cached();
+                let lookup = |id: &str| -> Option<u32> {
+                    registry
+                        .get(id)
+                        .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
+                };
+                let current_mass =
+                    cargo.total_mass_with(&lookup, mass_per_slot_raw);
+                let headroom = if current_mass >= cap {
+                    Amt::ZERO
+                } else {
+                    Amt(cap.0 - current_mass.0)
+                };
+                // Split headroom between minerals and energy proportionally.
+                let to_take_m = scrap.remaining.minerals.min(headroom);
+                let headroom_after_m = Amt(headroom.0.saturating_sub(to_take_m.0));
+                let to_take_e = scrap.remaining.energy.min(headroom_after_m);
+
+                if to_take_m == Amt::ZERO && to_take_e == Amt::ZERO {
+                    // No space. Drop the command so the user can retry.
+                    queue.commands.remove(0);
+                    continue;
+                }
+
+                cargo.minerals = cargo.minerals.add(to_take_m);
+                cargo.energy = cargo.energy.add(to_take_e);
+                scrap.remaining.minerals = scrap.remaining.minerals.sub(to_take_m);
+                scrap.remaining.energy = scrap.remaining.energy.sub(to_take_e);
+                queue.commands.remove(0);
+                info!(
+                    "Ship {} salvaged {}m/{}e from scrapyard {:?}",
+                    ship.name,
+                    to_take_m.to_f64(),
+                    to_take_e.to_f64(),
+                    structure
+                );
+            }
+            // Other commands are handled by process_command_queue.
+            _ => {}
+        }
+    }
+
+    // Suppress unused warning for this query — it's kept for future use.
+    let _ = structures;
+}
+
+/// #223: Dismantle a deep-space structure. Removes any existing
+/// `ConstructionPlatform` (lost investment) and installs a `Scrapyard` whose
+/// `remaining = lifetime_cost * scrap_refund`.
+pub fn dismantle_structure(
+    world: &mut World,
+    structure: Entity,
+) -> Result<(), &'static str> {
+    // Gather what we need without the registry mutably borrowed.
+    let (def_id, lifetime) = {
+        let Some(ds) = world.get::<DeepSpaceStructure>(structure) else {
+            return Err("entity is not a DeepSpaceStructure");
+        };
+        let lifetime = world
+            .get::<LifetimeCost>(structure)
+            .map(|lc| lc.0.clone())
+            .unwrap_or_default();
+        (ds.definition_id.clone(), lifetime)
+    };
+    let refund = {
+        let registry = world.resource::<StructureRegistry>();
+        registry
+            .get(&def_id)
+            .and_then(|d| d.deliverable.as_ref().map(|m| m.scrap_refund))
+            .unwrap_or(0.0)
+    };
+    let remaining = lifetime.scale(refund);
+    // Remove markers and install Scrapyard.
+    world.entity_mut(structure).remove::<ConstructionPlatform>();
+    world.entity_mut(structure).insert(Scrapyard {
+        remaining,
+        original_definition_id: def_id,
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_cost_helpers() {
+        let a = ResourceCost {
+            minerals: Amt::units(100),
+            energy: Amt::units(50),
+        };
+        assert!(!a.is_zero());
+        let half = a.scale(0.5);
+        assert_eq!(half.minerals, Amt::units(50));
+        assert_eq!(half.energy, Amt::units(25));
+
+        let zero = a.scale(0.0);
+        assert!(zero.is_zero());
+
+        assert!(a.covers(&half));
+        assert!(!half.covers(&a));
+    }
+}

--- a/macrocosmo/src/ship/deliverable_ops.rs
+++ b/macrocosmo/src/ship/deliverable_ops.rs
@@ -22,7 +22,9 @@ use crate::deep_space::{
     spawn_deliverable_entity, ConstructionPlatform, DeepSpaceStructure, LifetimeCost, ResourceCost,
     Scrapyard, StructureRegistry,
 };
-use crate::ship::{Cargo, CargoItem, CommandQueue, QueuedCommand, Ship, ShipState, ShipStats};
+use crate::ship::{
+    Cargo, CargoItem, CommandQueue, QueuedCommand, Ship, ShipModifiers, ShipState,
+};
 
 /// Maximum position delta (in light-years) for a ship to be considered
 /// "co-located" with a deep-space structure or deploy coordinate.
@@ -46,7 +48,7 @@ pub fn process_deliverable_commands(
         &Position,
         &mut CommandQueue,
         &mut Cargo,
-        &ShipStats,
+        &ShipModifiers,
     )>,
     mut stockpiles: Query<&mut DeliverableStockpile>,
     mut platforms: Query<(&Position, &mut ConstructionPlatform), Without<Ship>>,
@@ -55,7 +57,9 @@ pub fn process_deliverable_commands(
 ) {
     let mass_per_slot_raw = balance.mass_per_item_slot().0;
 
-    for (_ship_entity, ship, state, ship_pos, mut queue, mut cargo, stats) in ships.iter_mut() {
+    for (_ship_entity, ship, state, ship_pos, mut queue, mut cargo, ship_mods) in
+        ships.iter_mut()
+    {
         if queue.commands.is_empty() {
             continue;
         }
@@ -94,7 +98,7 @@ pub fn process_deliverable_commands(
                     .get(item.definition_id())
                     .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
                     .unwrap_or(1);
-                let cap = stats.cargo_capacity.cached();
+                let cap = ship_mods.cargo_capacity.final_value();
                 let lookup = |id: &str| -> Option<u32> {
                     registry
                         .get(id)
@@ -244,7 +248,7 @@ pub fn process_deliverable_commands(
                 // Drain as much as the ship can hold. Resources are weightless
                 // relative to the item-mass model (cargo_capacity bounds the
                 // TOTAL mass including resources), so use the same accounting.
-                let cap = stats.cargo_capacity.cached();
+                let cap = ship_mods.cargo_capacity.final_value();
                 let lookup = |id: &str| -> Option<u32> {
                     registry
                         .get(id)

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -10,6 +10,7 @@ pub mod movement;
 pub mod command;
 pub mod courier_route;
 pub mod pursuit;
+pub mod deliverable_ops;
 
 pub use fleet::*;
 pub use exploration::*;
@@ -45,7 +46,10 @@ impl CommandQueue {
     /// Push a command and update predicted position
     pub fn push(&mut self, cmd: QueuedCommand, system_positions: &impl Fn(Entity) -> Option<[f64; 3]>) {
         match &cmd {
-            QueuedCommand::MoveTo { system } | QueuedCommand::Survey { system } | QueuedCommand::Colonize { system, .. } => {
+            QueuedCommand::MoveTo { system }
+            | QueuedCommand::Survey { system }
+            | QueuedCommand::Colonize { system, .. }
+            | QueuedCommand::LoadDeliverable { system, .. } => {
                 if let Some(pos) = system_positions(*system) {
                     self.predicted_position = pos;
                     self.predicted_system = Some(*system);
@@ -56,6 +60,14 @@ impl CommandQueue {
                 self.predicted_position = *target;
                 self.predicted_system = None;
             }
+            QueuedCommand::DeployDeliverable { position, .. } => {
+                // #223: Deploy parks the ship at `position` in deep space.
+                self.predicted_position = *position;
+                self.predicted_system = None;
+            }
+            // #223: In-place resource actions — no predicted movement change.
+            QueuedCommand::TransferToStructure { .. }
+            | QueuedCommand::LoadFromScrapyard { .. } => {}
         }
         self.commands.push(cmd);
     }
@@ -76,6 +88,36 @@ pub enum QueuedCommand {
     Colonize { system: Entity, planet: Option<Entity> },
     /// #185: Travel sublight to an arbitrary point in deep space and loiter there.
     MoveToCoordinates { target: [f64; 3] },
+    /// #223: Load a deliverable from the docked system's `DeliverableStockpile`
+    /// into this ship's `Cargo`. `stockpile_index` is the zero-based index in
+    /// the stockpile at the time the command is executed; the command is a
+    /// no-op (with warning) if the index is out of range or the ship has no
+    /// room for the item.
+    LoadDeliverable {
+        system: Entity,
+        stockpile_index: usize,
+    },
+    /// #223: Deploy the deliverable at `item_index` within this ship's Cargo
+    /// at the given deep-space coordinate. If the ship is not already at
+    /// `position` within a small epsilon, the command queues a sublight move
+    /// first and re-evaluates on arrival. On deployment, the item is removed
+    /// from Cargo and a new `DeepSpaceStructure` entity is spawned owned by
+    /// the ship's `Owner`.
+    DeployDeliverable {
+        position: [f64; 3],
+        item_index: usize,
+    },
+    /// #223: Transfer resources from this ship's Cargo into a co-located
+    /// `ConstructionPlatform`'s accumulated pool. Ship must be at the same
+    /// position (within epsilon) as the target structure.
+    TransferToStructure {
+        structure: Entity,
+        minerals: Amt,
+        energy: Amt,
+    },
+    /// #223: Drain a co-located `Scrapyard`'s remaining resources into the
+    /// ship's Cargo (clamped by cargo capacity).
+    LoadFromScrapyard { structure: Entity },
 }
 
 /// Initial FTL speed as a multiple of light speed
@@ -97,10 +139,17 @@ impl Plugin for ShipPlugin {
             process_settling,
             process_refitting,
             process_pending_ship_commands,
-            process_command_queue
+            // #223: Deliverable ops run BEFORE the FTL router so any
+            // injected MoveTo/MoveToCoordinates is dispatched this tick.
+            deliverable_ops::process_deliverable_commands
                 .after(sublight_movement_system)
                 .after(process_ftl_travel)
                 .after(process_surveys),
+            process_command_queue
+                .after(sublight_movement_system)
+                .after(process_ftl_travel)
+                .after(process_surveys)
+                .after(deliverable_ops::process_deliverable_commands),
             resolve_combat,
             tick_ship_repair,
             // #117: Courier automation — runs before process_command_queue

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -309,11 +309,86 @@ pub enum ShipState {
     },
 }
 
+/// #223: An item in a ship's cargo hold other than bulk resources.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CargoItem {
+    /// A shipyard-built deliverable awaiting deployment.
+    Deliverable { definition_id: String },
+}
+
+impl CargoItem {
+    /// The id used to look up the carried item's definition in the registry.
+    pub fn definition_id(&self) -> &str {
+        match self {
+            CargoItem::Deliverable { definition_id } => definition_id,
+        }
+    }
+}
+
 /// Cargo hold for Courier ships (and potentially others).
 #[derive(Component, Default, Debug, Clone)]
 pub struct Cargo {
     pub minerals: Amt,
     pub energy: Amt,
+    /// #223: Non-resource items (e.g. deliverables). Each item's mass impact
+    /// on shared `cargo_capacity` is derived from its cargo_size via
+    /// `GameBalance.mass_per_item_slot`.
+    pub items: Vec<CargoItem>,
+}
+
+impl Cargo {
+    /// Raw units of cargo mass per item slot: 1 slot = 1.0 Amt unit by default.
+    /// #223: Kept in sync with `GameBalance.mass_per_item_slot`; the constant
+    /// value is used when the registry is unreachable (fallback).
+    pub const DEFAULT_MASS_PER_ITEM_SLOT_RAW: u64 = 1000; // 1 Amt unit
+
+    /// Total cargo mass (resources + items) as an Amt, given a resolver that
+    /// returns each item's cargo_size via the deliverable registry.
+    pub fn total_mass_with<F: Fn(&str) -> Option<u32>>(
+        &self,
+        cargo_size_lookup: F,
+        mass_per_slot_raw: u64,
+    ) -> Amt {
+        let resource = self.minerals.add(self.energy);
+        let mut item_raw: u64 = 0;
+        for it in &self.items {
+            let size = cargo_size_lookup(it.definition_id()).unwrap_or(0) as u64;
+            item_raw = item_raw.saturating_add(size.saturating_mul(mass_per_slot_raw));
+        }
+        resource.add(Amt(item_raw))
+    }
+
+    /// Check if the cargo can accept another item with `cargo_size` against
+    /// the ship's effective capacity `cap`. Uses the same mass accounting as
+    /// `total_mass_with`.
+    pub fn can_accept_item_size(
+        &self,
+        added_size: u32,
+        cap: Amt,
+        mass_per_slot_raw: u64,
+    ) -> bool {
+        // Without a registry lookup we can't compute item mass for existing
+        // items, so callers must provide it via `total_mass_with` externally.
+        // This helper only checks the additive delta; callers sum the existing
+        // mass themselves when needed.
+        let _ = cap;
+        let _ = mass_per_slot_raw;
+        let _ = added_size;
+        true // not used directly; see Cargo::can_fit below
+    }
+
+    /// Comprehensive fit-check: does adding `added_size` slots stay within cap?
+    pub fn can_fit<F: Fn(&str) -> Option<u32>>(
+        &self,
+        added_size: u32,
+        cap: Amt,
+        cargo_size_lookup: F,
+        mass_per_slot_raw: u64,
+    ) -> bool {
+        let current = self.total_mass_with(cargo_size_lookup, mass_per_slot_raw);
+        let delta = Amt((added_size as u64).saturating_mul(mass_per_slot_raw));
+        current.add(delta) <= cap
+    }
 }
 
 /// #103: Survey data carried by an FTL-capable ship back to the player's system.
@@ -389,6 +464,51 @@ mod tests {
     use super::*;
     use bevy::ecs::world::World;
     use crate::ship_design::{ShipDesignDefinition, ShipDesignRegistry};
+
+    // --- #223: Cargo item mass accounting ---
+
+    #[test]
+    fn test_cargo_mass_accounting_with_items() {
+        let cargo = Cargo {
+            minerals: Amt::units(50),
+            energy: Amt::units(30),
+            items: vec![
+                CargoItem::Deliverable { definition_id: "sensor_buoy".into() },
+                CargoItem::Deliverable { definition_id: "interdictor".into() },
+            ],
+        };
+        // sensor_buoy size=1, interdictor size=3 → 4 slots total.
+        let lookup = |id: &str| -> Option<u32> {
+            match id {
+                "sensor_buoy" => Some(1),
+                "interdictor" => Some(3),
+                _ => None,
+            }
+        };
+        // mass_per_slot = 1000 (1 Amt unit per slot).
+        let mass = cargo.total_mass_with(lookup, 1000);
+        // resource = 80 units, items = 4 slots * 1 unit = 4 units → 84 units.
+        assert_eq!(mass, Amt::units(84));
+    }
+
+    #[test]
+    fn test_cargo_can_fit_respects_capacity() {
+        let cargo = Cargo {
+            minerals: Amt::ZERO,
+            energy: Amt::ZERO,
+            items: vec![CargoItem::Deliverable { definition_id: "big".into() }],
+        };
+        let lookup = |id: &str| -> Option<u32> {
+            match id {
+                "big" => Some(5),
+                _ => None,
+            }
+        };
+        // Capacity = 10 units. Already have 5. Adding size=5 → 10 total: exactly fits.
+        assert!(cargo.can_fit(5, Amt::units(10), lookup, 1000));
+        // Adding size=6 → 11 total: exceeds.
+        assert!(!cargo.can_fit(6, Amt::units(10), lookup, 1000));
+    }
 
     fn test_design_registry() -> ShipDesignRegistry {
         let mut registry = ShipDesignRegistry::default();

--- a/macrocosmo/src/technology/mod.rs
+++ b/macrocosmo/src/technology/mod.rs
@@ -188,6 +188,9 @@ pub struct GameBalance {
     pub base_authority_per_hexadies: ModifiedValue,
     /// Authority cost per hexady per non-capital colony. Base = 0.5
     pub authority_cost_per_colony: ModifiedValue,
+    /// #223: Cargo mass equivalent of a single deliverable cargo_size slot.
+    /// Base = 1.0 (1 slot consumes the same cap as 1 Amt unit of resource).
+    pub mass_per_item_slot: ModifiedValue,
 }
 
 impl Default for GameBalance {
@@ -205,6 +208,7 @@ impl Default for GameBalance {
             colonization_build_time: ModifiedValue::new(Amt::units(90)),
             base_authority_per_hexadies: ModifiedValue::new(Amt::units(1)),
             authority_cost_per_colony: ModifiedValue::new(Amt::new(0, 500)),
+            mass_per_item_slot: ModifiedValue::new(Amt::units(1)),
         }
     }
 }
@@ -247,6 +251,17 @@ impl GameBalance {
         self.authority_cost_per_colony.final_value()
     }
 
+    /// #223: Mass equivalent of one deliverable cargo_size slot (as Amt).
+    pub fn mass_per_item_slot(&self) -> Amt {
+        self.mass_per_item_slot.final_value()
+    }
+
+    /// #223: Same as `mass_per_item_slot()` but returning the raw u64 (for
+    /// inline mass arithmetic inside `Cargo` helpers).
+    pub fn mass_per_item_slot_raw(&self) -> u64 {
+        self.mass_per_item_slot.final_value().raw()
+    }
+
     /// Look up a balance field's `ModifiedValue` by string target name (for
     /// use by the modifier pipeline). Returns `None` if the target is not a
     /// recognised balance field. The target is the part after the
@@ -265,6 +280,7 @@ impl GameBalance {
             "colonization_build_time" => Some(&mut self.colonization_build_time),
             "base_authority_per_hexadies" => Some(&mut self.base_authority_per_hexadies),
             "authority_cost_per_colony" => Some(&mut self.authority_cost_per_colony),
+            "mass_per_item_slot" => Some(&mut self.mass_per_item_slot),
             _ => None,
         }
     }
@@ -417,6 +433,7 @@ pub fn load_game_balance(
     set_integer(&mut balance.colonization_build_time, &table, "colonization_build_time");
     set_decimal(&mut balance.base_authority_per_hexadies, &table, "base_authority_per_hexadies");
     set_decimal(&mut balance.authority_cost_per_colony, &table, "authority_cost_per_colony");
+    set_decimal(&mut balance.mass_per_item_slot, &table, "mass_per_item_slot");
 
     info!("GameBalance loaded from Lua");
 }

--- a/macrocosmo/src/technology/unlocks.rs
+++ b/macrocosmo/src/technology/unlocks.rs
@@ -270,11 +270,12 @@ mod tests {
             name: name.to_string(),
             description: String::new(),
             max_hp: 10.0,
-            cost: ResourceCost::default(),
-            build_time: 10,
             energy_drain: Amt::ZERO,
             prerequisites: cond,
             capabilities: HashMap::new(),
+            deliverable: None,
+            upgrade_to: Vec::new(),
+            upgrade_from: None,
         }
     }
 

--- a/macrocosmo/src/ui/ship_panel.rs
+++ b/macrocosmo/src/ui/ship_panel.rs
@@ -254,6 +254,23 @@ fn format_queued_command(
         QueuedCommand::MoveToCoordinates { target } => {
             format!("Move -> ({:.1}, {:.1}, {:.1})", target[0], target[1], target[2])
         }
+        QueuedCommand::LoadDeliverable { stockpile_index, .. } => {
+            format!("Load deliverable #{}", stockpile_index)
+        }
+        QueuedCommand::DeployDeliverable { position, item_index } => {
+            format!(
+                "Deploy #{} -> ({:.1}, {:.1}, {:.1})",
+                item_index, position[0], position[1], position[2]
+            )
+        }
+        QueuedCommand::TransferToStructure { minerals, energy, .. } => {
+            format!(
+                "Transfer {}m / {}e to structure",
+                minerals.to_f64(),
+                energy.to_f64()
+            )
+        }
+        QueuedCommand::LoadFromScrapyard { .. } => "Salvage scrapyard".to_string(),
     }
 }
 

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -830,6 +830,7 @@ fn draw_right_panel(
                         }
                         if let Some(bq) = build_queue.as_mut() {
                             bq.queue.push(BuildOrder {
+                                kind: crate::colony::BuildKind::default(),
                                 design_id: design_id.clone(),
                                 display_name: display_name.clone(),
                                 minerals_cost,

--- a/macrocosmo/src/visualization/ships.rs
+++ b/macrocosmo/src/visualization/ships.rs
@@ -335,7 +335,8 @@ pub fn draw_ships(
                         let target_screen = match cmd {
                             QueuedCommand::MoveTo { system, .. }
                             | QueuedCommand::Survey { system, .. }
-                            | QueuedCommand::Colonize { system, .. } => {
+                            | QueuedCommand::Colonize { system, .. }
+                            | QueuedCommand::LoadDeliverable { system, .. } => {
                                 let Ok(target_pos) = stars.get(*system) else {
                                     continue;
                                 };
@@ -345,10 +346,16 @@ pub fn draw_ships(
                                 )
                             }
                             // #185: Loitering target — render directly from coordinates.
-                            QueuedCommand::MoveToCoordinates { target } => Vec2::new(
+                            QueuedCommand::MoveToCoordinates { target }
+                            | QueuedCommand::DeployDeliverable { position: target, .. } => Vec2::new(
                                 target[0] as f32 * view.scale,
                                 target[1] as f32 * view.scale,
                             ),
+                            // #223: In-place actions draw no destination marker.
+                            QueuedCommand::TransferToStructure { .. }
+                            | QueuedCommand::LoadFromScrapyard { .. } => {
+                                continue;
+                            }
                         };
 
                         // Dashed path line from previous position to target
@@ -387,6 +394,24 @@ pub fn draw_ships(
                                     Color::srgba(1.0, 1.0, 0.2, 0.5),
                                 );
                             }
+                            // #223: Deliverable deploy marker — orange diamond-ish ring.
+                            QueuedCommand::DeployDeliverable { .. } => {
+                                gizmos.circle_2d(
+                                    target_screen,
+                                    5.0,
+                                    Color::srgba(1.0, 0.6, 0.2, 0.6),
+                                );
+                            }
+                            QueuedCommand::LoadDeliverable { .. } => {
+                                gizmos.circle_2d(
+                                    target_screen,
+                                    4.0,
+                                    Color::srgba(0.2, 0.8, 1.0, 0.5),
+                                );
+                            }
+                            // TransferToStructure / LoadFromScrapyard continue'd above.
+                            QueuedCommand::TransferToStructure { .. }
+                            | QueuedCommand::LoadFromScrapyard { .. } => {}
                         }
 
                         prev_pos = target_screen;

--- a/macrocosmo/tests/colony.rs
+++ b/macrocosmo/tests/colony.rs
@@ -1113,6 +1113,7 @@ fn test_build_queue_requires_shipyard() {
         },
         BuildQueue {
             queue: vec![BuildOrder {
+                kind: macrocosmo::colony::BuildKind::default(),
                 design_id: "explorer_mk1".to_string(),
                 display_name: "Explorer".to_string(),
                 minerals_cost: Amt::units(100),
@@ -1719,6 +1720,7 @@ fn test_134_existing_shipyard_gating_still_works() {
         },
         BuildQueue {
             queue: vec![BuildOrder {
+                kind: macrocosmo::colony::BuildKind::default(),
                 design_id: "explorer_mk1".to_string(),
                 display_name: "Explorer".to_string(),
                 minerals_cost: Amt::units(100),

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -260,6 +260,9 @@ pub fn test_app() -> App {
             process_refitting,
             process_pending_ship_commands,
             tick_courier_routes,
+            // #223: Deliverable ops run before process_command_queue so any
+            // injected MoveTo reaches the router in the same frame.
+            macrocosmo::ship::deliverable_ops::process_deliverable_commands,
             process_command_queue,
             resolve_combat,
             tick_ship_repair,
@@ -324,6 +327,8 @@ pub fn test_app() -> App {
             macrocosmo::deep_space::sensor_buoy_detect_system,
             macrocosmo::deep_space::verify_relay_pairings_system,
             macrocosmo::deep_space::relay_knowledge_propagate_system,
+            macrocosmo::deep_space::tick_platform_upgrade,
+            macrocosmo::deep_space::tick_scrapyard_despawn,
         )
             .after(macrocosmo::time_system::advance_game_time)
             .after(sublight_movement_system)
@@ -433,6 +438,7 @@ pub fn full_test_app() -> App {
             process_refitting,
             process_pending_ship_commands,
             tick_courier_routes,
+            macrocosmo::ship::deliverable_ops::process_deliverable_commands,
             process_command_queue,
             resolve_combat,
             tick_ship_repair,
@@ -487,6 +493,8 @@ pub fn full_test_app() -> App {
             macrocosmo::deep_space::sensor_buoy_detect_system,
             macrocosmo::deep_space::verify_relay_pairings_system,
             macrocosmo::deep_space::relay_knowledge_propagate_system,
+            macrocosmo::deep_space::tick_platform_upgrade,
+            macrocosmo::deep_space::tick_scrapyard_despawn,
         ),
     );
 

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -896,6 +896,7 @@ pub fn spawn_test_ship(
             CommandQueue::default(),
             Cargo::default(),
             ShipModifiers::default(),
+            macrocosmo::ship::ShipStats::default(),
             RulesOfEngagement::default(),
         ))
         .id()

--- a/macrocosmo/tests/deliverable_pipeline.rs
+++ b/macrocosmo/tests/deliverable_pipeline.rs
@@ -1,0 +1,459 @@
+//! #223: End-to-end integration tests for the deliverable placement pipeline.
+//!
+//! Covers:
+//!   - Direct deliverable flow: build at shipyard → stockpile → ship cargo →
+//!     deploy at coordinates → DeepSpaceStructure entity spawned.
+//!   - Platform upgrade flow: deploy ConstructionPlatform kit → ship pours
+//!     resources via TransferToStructure → threshold crossed → capabilities
+//!     active on upgraded structure.
+//!   - Scrapyard / dismantle flow: dismantle active structure → Scrapyard
+//!     present with refund pool → LoadFromScrapyard drains resources →
+//!     entity despawns when empty.
+
+#![cfg(test)]
+#![allow(clippy::missing_docs_in_private_items)]
+
+use std::collections::HashMap;
+
+use bevy::prelude::*;
+
+use macrocosmo::amount::Amt;
+use macrocosmo::colony::DeliverableStockpile;
+use macrocosmo::components::Position;
+use macrocosmo::deep_space::{
+    CapabilityParams, ConstructionPlatform, DeepSpaceStructure, DeliverableMetadata, LifetimeCost,
+    ResourceCost, Scrapyard, StructureDefinition, StructureRegistry, UpgradeEdge,
+};
+use macrocosmo::ship::{
+    deliverable_ops::dismantle_structure, Cargo, CargoItem, CommandQueue, Owner, QueuedCommand,
+    ShipModifiers, ShipState,
+};
+
+mod common;
+
+/// Register a sensor_buoy (direct deliverable) and a defense_platform_kit →
+/// defense_platform (upgrade edge) in the StructureRegistry.
+fn install_test_deliverables(app: &mut App) {
+    let mut registry = app
+        .world_mut()
+        .get_resource_mut::<StructureRegistry>()
+        .expect("StructureRegistry not initialized in test_app");
+    // Direct deliverable with a live capability.
+    registry.insert(StructureDefinition {
+        id: "sensor_buoy".into(),
+        name: "Sensor Buoy".into(),
+        description: String::new(),
+        max_hp: 20.0,
+        capabilities: HashMap::from([(
+            "detect_sublight".to_string(),
+            CapabilityParams { range: 3.0 },
+        )]),
+        energy_drain: Amt::ZERO,
+        prerequisites: None,
+        deliverable: Some(DeliverableMetadata {
+            cost: ResourceCost {
+                minerals: Amt::units(50),
+                energy: Amt::units(30),
+            },
+            build_time: 15,
+            cargo_size: 1,
+            scrap_refund: 0.5,
+        }),
+        upgrade_to: Vec::new(),
+        upgrade_from: None,
+    });
+    // Platform kit with a single upgrade edge.
+    registry.insert(StructureDefinition {
+        id: "defense_platform_kit".into(),
+        name: "Defense Platform Kit".into(),
+        description: String::new(),
+        max_hp: 80.0,
+        capabilities: HashMap::from([(
+            "construction_platform".to_string(),
+            CapabilityParams::default(),
+        )]),
+        energy_drain: Amt::ZERO,
+        prerequisites: None,
+        deliverable: Some(DeliverableMetadata {
+            cost: ResourceCost {
+                minerals: Amt::units(200),
+                energy: Amt::units(100),
+            },
+            build_time: 20,
+            cargo_size: 3,
+            scrap_refund: 0.3,
+        }),
+        upgrade_to: vec![UpgradeEdge {
+            target_id: "defense_platform".into(),
+            cost: ResourceCost {
+                minerals: Amt::units(500),
+                energy: Amt::units(200),
+            },
+            build_time: 60,
+        }],
+        upgrade_from: None,
+    });
+    // Upgrade target — finished defense platform.
+    registry.insert(StructureDefinition {
+        id: "defense_platform".into(),
+        name: "Defense Platform".into(),
+        description: String::new(),
+        max_hp: 200.0,
+        capabilities: HashMap::from([(
+            "detect_sublight".to_string(),
+            CapabilityParams { range: 10.0 },
+        )]),
+        energy_drain: Amt::ZERO,
+        prerequisites: None,
+        deliverable: None, // upgrade-only
+        upgrade_to: Vec::new(),
+        upgrade_from: None,
+    });
+    // Rebuild the effective-edges cache.
+    registry.rebuild_effective_edges();
+}
+
+/// Give a test ship enough cargo capacity to hold one item (via ShipModifiers).
+fn grant_cargo_capacity(app: &mut App, ship: Entity, capacity_units: u64) {
+    let mut mods = app
+        .world_mut()
+        .get_mut::<ShipModifiers>(ship)
+        .expect("ship must have ShipModifiers");
+    mods.cargo_capacity.set_base(Amt::units(capacity_units));
+}
+
+#[test]
+fn test_deliverable_full_pipeline_direct() {
+    let mut app = common::test_app();
+    install_test_deliverables(&mut app);
+
+    let system = common::spawn_test_system(
+        app.world_mut(),
+        "Alpha",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    // Place the ship directly at the system's position (docked).
+    let ship = common::spawn_test_ship(
+        app.world_mut(),
+        "Hauler-1",
+        "courier_mk1",
+        system,
+        [0.0, 0.0, 0.0],
+    );
+    // Run one tick so sync_ship_module_modifiers fires on the newly-spawned
+    // ship (its Changed<Ship> filter will reset cargo_capacity). Then grant
+    // capacity after the reset.
+    app.update();
+    grant_cargo_capacity(&mut app, ship, 10);
+
+    // Seed the stockpile with a pre-built sensor buoy.
+    app.world_mut().entity_mut(system).insert(DeliverableStockpile {
+        items: vec![CargoItem::Deliverable {
+            definition_id: "sensor_buoy".into(),
+        }],
+    });
+
+    // 1) Load command
+    {
+        let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+        q.commands.push(QueuedCommand::LoadDeliverable {
+            system,
+            stockpile_index: 0,
+        });
+    }
+    common::advance_time(&mut app, 1);
+
+    // After load: cargo has the item, stockpile empty.
+    assert!(
+        matches!(
+            app.world().get::<Cargo>(ship).unwrap().items.first(),
+            Some(CargoItem::Deliverable { definition_id }) if definition_id == "sensor_buoy"
+        ),
+        "cargo should have sensor_buoy after load"
+    );
+    let stockpile_empty = app
+        .world()
+        .get::<DeliverableStockpile>(system)
+        .map(|s| s.items.is_empty())
+        .unwrap_or(false);
+    assert!(stockpile_empty, "system stockpile should be empty after load");
+
+    // 2) Deploy command at (5,0,0)
+    let target = [5.0, 0.0, 0.0];
+    {
+        let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+        q.commands.push(QueuedCommand::DeployDeliverable {
+            position: target,
+            item_index: 0,
+        });
+    }
+
+    // Run several ticks to allow the auto-injected MoveToCoordinates to travel.
+    for _ in 0..200 {
+        common::advance_time(&mut app, 10);
+        // Check for deployment.
+        let spawned = app
+            .world_mut()
+            .query::<(&DeepSpaceStructure, &Position)>()
+            .iter(app.world())
+            .any(|(ds, pos)| {
+                ds.definition_id == "sensor_buoy" && (pos.x - target[0]).abs() < 0.1
+            });
+        if spawned {
+            break;
+        }
+    }
+
+    // Deploy should have spawned a DeepSpaceStructure at target.
+    let spawned_at: Vec<[f64; 3]> = app
+        .world_mut()
+        .query::<(&DeepSpaceStructure, &Position)>()
+        .iter(app.world())
+        .filter(|(ds, _)| ds.definition_id == "sensor_buoy")
+        .map(|(_, p)| p.as_array())
+        .collect();
+    assert!(
+        spawned_at.iter().any(|p| (p[0] - target[0]).abs() < 0.1
+            && (p[1] - target[1]).abs() < 0.1
+            && (p[2] - target[2]).abs() < 0.1),
+        "expected a sensor_buoy at {:?}, got {:?}",
+        target,
+        spawned_at
+    );
+
+    // Cargo item consumed.
+    let cargo = app.world().get::<Cargo>(ship).unwrap();
+    assert!(
+        cargo.items.is_empty(),
+        "ship cargo should be empty after deploy, got {:?}",
+        cargo.items
+    );
+}
+
+#[test]
+fn test_deliverable_full_pipeline_platform() {
+    let mut app = common::test_app();
+    install_test_deliverables(&mut app);
+
+    let system = common::spawn_test_system(
+        app.world_mut(),
+        "Alpha",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    let ship = common::spawn_test_ship(
+        app.world_mut(),
+        "Hauler-1",
+        "courier_mk1",
+        system,
+        [0.0, 0.0, 0.0],
+    );
+    // Tick once so sync clears, then set cap (large enough for kit + resources).
+    app.update();
+    grant_cargo_capacity(&mut app, ship, 10_000);
+
+    // Give the ship plenty of bulk resources for Transfer.
+    {
+        let mut cargo = app.world_mut().get_mut::<Cargo>(ship).unwrap();
+        cargo.minerals = Amt::units(1000);
+        cargo.energy = Amt::units(1000);
+    }
+
+    // Deploy a platform_kit.
+    app.world_mut().entity_mut(system).insert(DeliverableStockpile {
+        items: vec![CargoItem::Deliverable {
+            definition_id: "defense_platform_kit".into(),
+        }],
+    });
+    {
+        let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+        q.commands.push(QueuedCommand::LoadDeliverable {
+            system,
+            stockpile_index: 0,
+        });
+    }
+    common::advance_time(&mut app, 1);
+
+    let deploy_pos = [3.0, 0.0, 0.0];
+    {
+        let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+        q.commands.push(QueuedCommand::DeployDeliverable {
+            position: deploy_pos,
+            item_index: 0,
+        });
+    }
+    // Let the ship travel + deploy.
+    for _ in 0..500 {
+        common::advance_time(&mut app, 1);
+        let deployed = app
+            .world_mut()
+            .query::<(&DeepSpaceStructure, &ConstructionPlatform)>()
+            .iter(app.world())
+            .any(|(ds, _)| ds.definition_id == "defense_platform_kit");
+        if deployed {
+            break;
+        }
+    }
+
+    // Find the platform entity.
+    let platform_entity: Entity = app
+        .world_mut()
+        .query_filtered::<Entity, With<ConstructionPlatform>>()
+        .iter(app.world())
+        .next()
+        .expect("platform entity should exist after deployment");
+
+    // Ship pours resources via TransferToStructure (multiple events).
+    for _ in 0..3 {
+        let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+        q.commands.push(QueuedCommand::TransferToStructure {
+            structure: platform_entity,
+            minerals: Amt::units(200),
+            energy: Amt::units(100),
+        });
+    }
+    // Run ticks; each transfer is processed one at a time.
+    for _ in 0..20 {
+        common::advance_time(&mut app, 1);
+        // Stop once the platform has been upgraded (ConstructionPlatform gone).
+        if app.world().get::<ConstructionPlatform>(platform_entity).is_none() {
+            break;
+        }
+    }
+
+    // The platform should now be upgraded to defense_platform.
+    let ds = app
+        .world()
+        .get::<DeepSpaceStructure>(platform_entity)
+        .expect("structure entity still present after upgrade");
+    assert_eq!(
+        ds.definition_id, "defense_platform",
+        "definition should have flipped to the upgrade target"
+    );
+    assert!(
+        app.world()
+            .get::<ConstructionPlatform>(platform_entity)
+            .is_none(),
+        "ConstructionPlatform component should be removed after upgrade"
+    );
+
+    // Lifetime cost should now equal initial kit cost + upgrade edge cost.
+    let lifetime = app
+        .world()
+        .get::<LifetimeCost>(platform_entity)
+        .expect("LifetimeCost should be present");
+    assert_eq!(
+        lifetime.0.minerals,
+        Amt::units(200 + 500),
+        "lifetime minerals = kit + upgrade edge"
+    );
+    assert_eq!(
+        lifetime.0.energy,
+        Amt::units(100 + 200),
+        "lifetime energy = kit + upgrade edge"
+    );
+}
+
+#[test]
+fn test_dismantle_and_scrapyard_drain() {
+    let mut app = common::test_app();
+    install_test_deliverables(&mut app);
+
+    let system = common::spawn_test_system(
+        app.world_mut(),
+        "Alpha",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    // Spawn an active sensor_buoy directly.
+    let buoy_pos = [2.0, 0.0, 0.0];
+    let buoy = app
+        .world_mut()
+        .spawn((
+            DeepSpaceStructure {
+                definition_id: "sensor_buoy".into(),
+                name: "Buoy A".into(),
+                owner: Owner::Neutral,
+            },
+            Position::from(buoy_pos),
+            macrocosmo::deep_space::StructureHitpoints {
+                current: 20.0,
+                max: 20.0,
+            },
+            LifetimeCost(ResourceCost {
+                minerals: Amt::units(50),
+                energy: Amt::units(30),
+            }),
+        ))
+        .id();
+
+    // Spawn a ship adjacent to the buoy.
+    let ship = common::spawn_test_ship(
+        app.world_mut(),
+        "Tug",
+        "courier_mk1",
+        system,
+        buoy_pos,
+    );
+    // Tick once so Changed<Ship> fires the sync, then set cap.
+    app.update();
+    grant_cargo_capacity(&mut app, ship, 100);
+    // Transition the ship to Loitering at buoy's position.
+    *app.world_mut().get_mut::<ShipState>(ship).unwrap() = ShipState::Loitering { position: buoy_pos };
+
+    // Dismantle via world API.
+    app.world_mut()
+        .commands()
+        .queue(move |world: &mut World| {
+            dismantle_structure(world, buoy).expect("dismantle should succeed");
+        });
+    app.update();
+
+    // Structure should now have a Scrapyard with 50 % refund.
+    let scrap = app
+        .world()
+        .get::<Scrapyard>(buoy)
+        .expect("Scrapyard component should be present");
+    assert_eq!(scrap.remaining.minerals, Amt::units(25));
+    assert_eq!(scrap.remaining.energy, Amt::units(15));
+
+    // LoadFromScrapyard drains into ship.
+    {
+        let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+        q.commands
+            .push(QueuedCommand::LoadFromScrapyard { structure: buoy });
+    }
+    common::advance_time(&mut app, 1);
+
+    let cargo = app.world().get::<Cargo>(ship).unwrap();
+    assert!(
+        cargo.minerals > Amt::ZERO || cargo.energy > Amt::ZERO,
+        "ship cargo should have drained resources"
+    );
+
+    // Second tick: Scrapyard becomes empty and entity despawns.
+    // Trigger another load to be sure.
+    if app.world().get::<Scrapyard>(buoy).map(|s| !s.remaining.is_zero()).unwrap_or(false) {
+        let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+        q.commands
+            .push(QueuedCommand::LoadFromScrapyard { structure: buoy });
+        common::advance_time(&mut app, 1);
+    }
+    common::advance_time(&mut app, 1); // tick_scrapyard_despawn will despawn next frame.
+
+    let still_exists = app.world().get_entity(buoy).is_ok();
+    assert!(
+        !still_exists,
+        "scrapyard entity should be despawned after full drain"
+    );
+}

--- a/macrocosmo/tests/knowledge.rs
+++ b/macrocosmo/tests/knowledge.rs
@@ -943,7 +943,7 @@ fn test_knowledge_store_ship_older_does_not_replace() {
 /// detect_sublight only) into the test app's `StructureRegistry`.
 fn install_sensor_buoy_definition(app: &mut App) {
     use macrocosmo::deep_space::{
-        CapabilityParams, ResourceCost, StructureDefinition, StructureRegistry,
+        CapabilityParams, DeliverableMetadata, ResourceCost, StructureDefinition, StructureRegistry,
     };
     use std::collections::HashMap;
     let mut registry = app
@@ -955,14 +955,20 @@ fn install_sensor_buoy_definition(app: &mut App) {
         name: "Sensor Buoy".to_string(),
         description: "Detects sublight vessel movements.".to_string(),
         max_hp: 20.0,
-        cost: ResourceCost::default(),
-        build_time: 15,
         capabilities: HashMap::from([(
             "detect_sublight".to_string(),
             CapabilityParams { range: 3.0 },
         )]),
         energy_drain: Amt::milli(100),
         prerequisites: None,
+        deliverable: Some(DeliverableMetadata {
+            cost: ResourceCost::default(),
+            build_time: 15,
+            cargo_size: 1,
+            scrap_refund: 0.5,
+        }),
+        upgrade_to: Vec::new(),
+        upgrade_from: None,
     });
 }
 
@@ -1530,7 +1536,7 @@ fn test_loitering_ship_knowledge_uses_light_speed_delay() {
 /// Install an ftl_comm_relay structure definition with a configurable range.
 fn install_ftl_comm_relay_definition(app: &mut App, range_ly: f64) {
     use macrocosmo::deep_space::{
-        CapabilityParams, ResourceCost, StructureDefinition, StructureRegistry,
+        CapabilityParams, DeliverableMetadata, ResourceCost, StructureDefinition, StructureRegistry,
     };
     use std::collections::HashMap;
     let mut registry = app
@@ -1542,14 +1548,20 @@ fn install_ftl_comm_relay_definition(app: &mut App, range_ly: f64) {
         name: "FTL Comm Relay".to_string(),
         description: "Pair-based FTL relay".to_string(),
         max_hp: 50.0,
-        cost: ResourceCost::default(),
-        build_time: 20,
         capabilities: HashMap::from([(
             "ftl_comm_relay".to_string(),
             CapabilityParams { range: range_ly },
         )]),
         energy_drain: Amt::milli(500),
         prerequisites: None,
+        deliverable: Some(DeliverableMetadata {
+            cost: ResourceCost::default(),
+            build_time: 20,
+            cargo_size: 2,
+            scrap_refund: 0.4,
+        }),
+        upgrade_to: Vec::new(),
+        upgrade_from: None,
     });
 }
 

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -296,6 +296,7 @@ fn test_build_queue_spawns_ship() {
         },
         BuildQueue {
             queue: vec![BuildOrder {
+                kind: macrocosmo::colony::BuildKind::default(),
                 design_id: "explorer_mk1".to_string(),
                 display_name: "Explorer".to_string(),
                 minerals_cost: Amt::units(50),
@@ -1564,6 +1565,7 @@ fn courier_route_resource_transport_delivers_at_destination() {
     app.world_mut().entity_mut(courier).insert(Cargo {
         minerals: Amt::units(300),
         energy: Amt::units(100),
+        items: Vec::new(),
     });
     let mut route = CourierRoute::new(vec![sys_a, sys_b], CourierMode::ResourceTransport);
     route.current_index = 1; // pretend we just arrived at sys_b


### PR DESCRIPTION
Closes #223.

## Summary
Adds the full shipyard → Cargo → Deploy pipeline for deep-space deliverables:

- **Refactors** `StructureDefinition` into `DeliverableDefinition` with optional `DeliverableMetadata`. Back-compat aliases keep existing call sites working.
- **Adds `define_deliverable`** Lua API alongside `define_structure` (the latter preserved for world-spawn-only entities).
- **Registry-level validation**: both-sides conflicts, cost mismatch, dangling refs, unreachable edges, construction-platform needs edges.
- **Cargo items + DeliverableStockpile**: `CargoItem::Deliverable` rides in ship `Cargo`; a per-star-system `DeliverableStockpile` holds completed builds. Mass accounting shares `cargo_capacity` via `GameBalance.mass_per_item_slot`.
- **`BuildKind::{Ship, Deliverable}`** dispatch in `tick_build_queue`.
- **Deploy path**: 4 new `QueuedCommand` variants (`LoadDeliverable`, `DeployDeliverable`, `TransferToStructure`, `LoadFromScrapyard`) processed by `src/ship/deliverable_ops.rs` before `process_command_queue` so auto-injected moves dispatch same-frame.
- **Platform-based upgrade**: `ConstructionPlatform` gates capabilities while under construction; `TransferToStructure` fills `accumulated`; `tick_platform_upgrade` swaps to target definition when cost covered.
- **Dismantle + Scrapyard**: `dismantle_structure` installs a `Scrapyard` with `lifetime_cost × scrap_refund`; `LoadFromScrapyard` drains into ship Cargo; `tick_scrapyard_despawn` removes when empty.
- **Lifetime-cost tracking** on every structure entity for correct refund accounting across upgrades.
- **Capability gating**: `sensor_buoy_detect_system` + `relay_knowledge_propagate_system` run `Without<ConstructionPlatform>, Without<Scrapyard>`.
- **Scripts migrated** to `define_deliverable`.

Resumes work from stuck agent-a04d7a22; 3 carried-forward commits rebased onto current main (#226 prerequisites unification merged) with conflict resolution keeping both #226 and #223 helper-style parse paths. Unblocks #216/#220/#121.

## Test plan
- [x] `cargo test --workspace` — 1675 passed, 0 failed
- [x] New integration tests in `macrocosmo/tests/deliverable_pipeline.rs`:
  - `test_deliverable_full_pipeline_direct` — stockpile → cargo → deploy spawns `DeepSpaceStructure` at coords.
  - `test_deliverable_full_pipeline_platform` — platform kit deploy → repeated `TransferToStructure` → `ConstructionPlatform` removed, `definition_id` flipped, `LifetimeCost` = kit cost + upgrade cost.
  - `test_dismantle_and_scrapyard_drain` — active structure → dismantle → `Scrapyard` remaining = `lifetime × 0.5` → `LoadFromScrapyard` drains → entity despawns.
- [x] `cargo tree -p macrocosmo-ai` → no `bevy` / `macrocosmo` normal deps (CI ai-core-isolation respected).

## Scope notes
- UI wiring (originally planned C7) is intentionally deferred. The engine plumbing is complete and testable; a follow-up PR can add the Shipyard deliverable panel / ship command buttons / structure context-menu dismantle.