### PR TITLE
#215: 観測情報の鮮度モデル (A4-1) — ObservationSource + PerceivedInfo API

### DIFF
--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -647,7 +647,7 @@ pub fn sensor_buoy_detect_system(
     positions: Query<&crate::components::Position>,
     mut empire_q: Query<&mut crate::knowledge::KnowledgeStore, With<crate::player::PlayerEmpire>>,
 ) {
-    use crate::knowledge::{ShipSnapshot, ShipSnapshotState};
+    use crate::knowledge::{ObservationSource, ShipSnapshot, ShipSnapshotState};
 
     let Ok(mut store) = empire_q.single_mut() else {
         return;
@@ -734,6 +734,7 @@ pub fn sensor_buoy_detect_system(
                 observed_at,
                 hp: hp.hull,
                 hp_max: hp.hull_max,
+                source: ObservationSource::Direct,
             });
         }
     }
@@ -813,7 +814,7 @@ pub fn relay_knowledge_propagate_system(
         .filter(|r| r.has_capability("blocks_ftl_comm"))
         .map(crate::galaxy::RegionBlockSnapshot::from_region)
         .collect();
-    use crate::knowledge::{ShipSnapshot, ShipSnapshotState};
+    use crate::knowledge::{ObservationSource, ShipSnapshot, ShipSnapshotState};
 
     let Ok(mut store) = empire_q.single_mut() else {
         return;
@@ -926,6 +927,7 @@ pub fn relay_knowledge_propagate_system(
                 observed_at,
                 hp: hp.hull,
                 hp_max: hp.hull_max,
+                source: ObservationSource::Relay,
             });
         }
     }

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -1,3 +1,27 @@
+//! Knowledge store + light-speed propagation.
+//!
+//! # Observation freshness model (#215)
+//!
+//! Every [`SystemKnowledge`] / [`ShipSnapshot`] entry carries an
+//! [`ObservationSource`] tag identifying how the entry was obtained:
+//!
+//! * [`ObservationSource::Direct`] — optical / sensor baseline (light-speed).
+//!   Written by `propagate_knowledge`, `sensor_buoy_detect_system`, and ship
+//!   survey/courier delivery paths.
+//! * [`ObservationSource::Relay`] — FTL Comm Relay (#216). Written by
+//!   `relay_knowledge_propagate_system`.
+//! * [`ObservationSource::Scout`] — scout ship reports (#217). Reserved for
+//!   future use.
+//! * [`ObservationSource::Stale`] — **never written by producers**; it is a
+//!   read-side overlay. The [`perceived::perceived_system`] accessor rewrites
+//!   an entry's source to `Stale` when
+//!   `current_time - observed_at >= STALE_THRESHOLD_HEXADIES`.
+//!
+//! Producers should pick exactly one of `Direct / Relay / Scout`. The
+//! convention `observed_at: i64` (integer hexadies) is preserved — the
+//! [`perceived::PerceivedInfo`] facade only renames it to `last_updated`.
+pub mod perceived;
+
 use bevy::prelude::*;
 use std::collections::HashMap;
 
@@ -9,6 +33,30 @@ use crate::physics;
 use crate::player::{Player, StationedAt};
 use crate::ship::{Ship, ShipState};
 use crate::time_system::GameClock;
+
+#[allow(unused_imports)]
+pub use perceived::{FactionId, PerceivedInfo, perceived_fleet, perceived_system};
+
+/// Observation source tag for knowledge entries.
+///
+/// Writers must use `Direct`, `Relay`, or `Scout`. `Stale` is a read-side
+/// overlay applied by [`perceived::perceived_system`] — see module docs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ObservationSource {
+    /// Optical / baseline sensor (light-speed propagation, surveys, sensor buoys).
+    Direct,
+    /// FTL Comm Relay forwarded observation (#216).
+    Relay,
+    /// Scout ship report (#217).
+    Scout,
+    /// Read-side overlay: entry is older than [`STALE_THRESHOLD_HEXADIES`].
+    /// **Do not write this directly** — accessors apply it on read.
+    Stale,
+}
+
+/// Staleness threshold in hexadies (≈10 in-game years). Matches the existing
+/// "VERY OLD" cutoff used by the system panel.
+pub const STALE_THRESHOLD_HEXADIES: i64 = 600;
 
 pub struct KnowledgePlugin;
 
@@ -36,6 +84,8 @@ pub struct SystemKnowledge {
     pub observed_at: i64,
     pub received_at: i64,
     pub data: SystemSnapshot,
+    /// #215: Which channel produced this observation.
+    pub source: ObservationSource,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -78,6 +128,8 @@ pub struct ShipSnapshot {
     pub observed_at: i64,
     pub hp: f64,
     pub hp_max: f64,
+    /// #215: Which channel produced this observation.
+    pub source: ObservationSource,
 }
 
 /// Simplified ship state for knowledge snapshots.
@@ -188,6 +240,7 @@ fn initialize_capital_knowledge(
         observed_at: 0,
         received_at: 0,
         data: snapshot,
+        source: ObservationSource::Direct,
     });
 
     info!("Player knowledge initialized: capital '{}'", capital.name);
@@ -310,6 +363,7 @@ pub fn propagate_knowledge(
             observed_at,
             received_at: clock.elapsed,
             data: snapshot,
+            source: ObservationSource::Direct,
         });
     }
 
@@ -404,6 +458,7 @@ pub fn propagate_knowledge(
             observed_at,
             hp: hp.hull,
             hp_max: hp.hull_max,
+            source: ObservationSource::Direct,
         });
     }
 }
@@ -487,6 +542,7 @@ mod tests {
             observed_at,
             received_at: observed_at,
             data: SystemSnapshot::default(),
+            source: ObservationSource::Direct,
         }
     }
 

--- a/macrocosmo/src/knowledge/perceived.rs
+++ b/macrocosmo/src/knowledge/perceived.rs
@@ -1,0 +1,98 @@
+//! #215: Read-side facade over [`KnowledgeStore`] that exposes observation
+//! freshness (`last_updated`, `age`, `is_stale`) and applies the [`Stale`]
+//! overlay on entries older than [`STALE_THRESHOLD_HEXADIES`].
+//!
+//! Producers continue to write `Direct / Relay / Scout` sources into the
+//! store; [`perceived_system`] / [`perceived_fleet`] rewrite the source to
+//! [`ObservationSource::Stale`] on read when the entry is too old. The
+//! underlying stored entry is not mutated.
+//!
+//! [`Stale`]: ObservationSource::Stale
+
+use bevy::prelude::Entity;
+
+use super::{
+    KnowledgeStore, ObservationSource, STALE_THRESHOLD_HEXADIES, ShipSnapshot, SystemSnapshot,
+};
+
+/// Faction identifier alias. Promoted to a newtype once #163 lands.
+pub type FactionId = Entity;
+
+/// A snapshot of observed information with freshness metadata.
+///
+/// `last_updated` is the spec-facing name for the underlying `observed_at`
+/// field — same integer-hexadies timebase, different alias.
+#[derive(Clone, Debug)]
+pub struct PerceivedInfo<T> {
+    pub value: T,
+    /// Game time (hexadies) at which the observation was made. Equivalent to
+    /// the underlying `observed_at` on [`SystemKnowledge`] / [`ShipSnapshot`].
+    pub last_updated: i64,
+    pub source: ObservationSource,
+}
+
+#[allow(dead_code)] // Consumed by integration tests + future UI/AI code (#216/#217).
+impl<T> PerceivedInfo<T> {
+    /// Age of the observation relative to `now` (hexadies).
+    pub fn age(&self, now: i64) -> i64 {
+        now - self.last_updated
+    }
+
+    /// Whether this observation is considered stale. Returns `true` if the
+    /// source was already tagged stale (defensive) or if the age has reached
+    /// [`STALE_THRESHOLD_HEXADIES`].
+    pub fn is_stale(&self, now: i64) -> bool {
+        self.source == ObservationSource::Stale || self.age(now) >= STALE_THRESHOLD_HEXADIES
+    }
+}
+
+/// Read a system observation from the knowledge store, overlaying the source
+/// to [`ObservationSource::Stale`] when the entry exceeds the freshness
+/// threshold.
+pub fn perceived_system(
+    store: &KnowledgeStore,
+    system: Entity,
+    now: i64,
+) -> Option<PerceivedInfo<SystemSnapshot>> {
+    let entry = store.get(system)?;
+    let age = now - entry.observed_at;
+    let source = if age >= STALE_THRESHOLD_HEXADIES {
+        ObservationSource::Stale
+    } else {
+        entry.source
+    };
+    Some(PerceivedInfo {
+        value: entry.data.clone(),
+        last_updated: entry.observed_at,
+        source,
+    })
+}
+
+/// Return all ship observations in the store, with the staleness overlay
+/// applied per-entry.
+///
+/// TODO(#163): filter by `_target` faction once `ShipSnapshot` carries owner
+/// information. Currently returns every ship snapshot regardless of faction.
+#[allow(dead_code)] // Consumed by integration tests + future UI/AI code (#216/#217).
+pub fn perceived_fleet(
+    store: &KnowledgeStore,
+    _target: FactionId,
+    now: i64,
+) -> Vec<PerceivedInfo<ShipSnapshot>> {
+    store
+        .iter_ships()
+        .map(|(_, snap)| {
+            let age = now - snap.observed_at;
+            let source = if age >= STALE_THRESHOLD_HEXADIES {
+                ObservationSource::Stale
+            } else {
+                snap.source
+            };
+            PerceivedInfo {
+                value: snap.clone(),
+                last_updated: snap.observed_at,
+                source,
+            }
+        })
+        .collect()
+}

--- a/macrocosmo/src/ship/survey.rs
+++ b/macrocosmo/src/ship/survey.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 use crate::events::{GameEvent, GameEventKind};
 use crate::galaxy::{Anomalies, HostilePresence, StarSystem, SystemAttributes};
-use crate::knowledge::{KnowledgeStore, SystemKnowledge, SystemSnapshot};
+use crate::knowledge::{KnowledgeStore, ObservationSource, SystemKnowledge, SystemSnapshot};
 use crate::physics::{distance_ly_arr, light_delay_hexadies};
 use crate::player::{Player, PlayerEmpire, StationedAt};
 use crate::ship_design::ShipDesignRegistry;
@@ -319,6 +319,7 @@ pub fn deliver_survey_results(
                         surveyed: true,
                         ..default()
                     },
+                    source: ObservationSource::Direct,
                 });
             }
         }

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -1188,9 +1188,28 @@ fn draw_map_tooltips(
                 }
                 if !is_local {
                     if let Some(k) = k_data {
+                        // #215: Tag tooltip freshness with observation source
+                        // so the player can see at a glance whether intel came
+                        // via direct light-speed, relay, or scout, and whether
+                        // it has aged past the stale threshold.
                         let age = clock.elapsed - k.observed_at;
                         let years = age as f64 / crate::time_system::HEXADIES_PER_YEAR as f64;
-                        ui.label(egui::RichText::new(format!("Info age: {:.1} yr", years)).weak().small());
+                        let overlay_source = if age >= crate::knowledge::STALE_THRESHOLD_HEXADIES {
+                            crate::knowledge::ObservationSource::Stale
+                        } else {
+                            k.source
+                        };
+                        let tag = match overlay_source {
+                            crate::knowledge::ObservationSource::Direct => "[DIR]",
+                            crate::knowledge::ObservationSource::Relay => "[REL]",
+                            crate::knowledge::ObservationSource::Scout => "[SCT]",
+                            crate::knowledge::ObservationSource::Stale => "[STALE]",
+                        };
+                        ui.label(
+                            egui::RichText::new(format!("Info age: {:.1} yr {}", years, tag))
+                                .weak()
+                                .small(),
+                        );
                     } else if !star.is_capital {
                         ui.label(egui::RichText::new("No intelligence").weak().italics());
                     }

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -339,18 +339,27 @@ fn draw_left_panel(
         ui.label("Approximate position only. Survey required.");
     }
 
-    if let Some(age) = knowledge.info_age(sel_entity, clock.elapsed) {
+    if let Some(perceived) = crate::knowledge::perceived_system(knowledge, sel_entity, clock.elapsed) {
+        let age = perceived.age(clock.elapsed);
         let years = age as f64 / HEXADIES_PER_YEAR as f64;
         let freshness = if age < 60 {
             "FRESH"
         } else if age < 300 {
             "AGING"
-        } else if age < 600 {
+        } else if age < crate::knowledge::STALE_THRESHOLD_HEXADIES {
             "OLD"
         } else {
             "VERY OLD"
         };
-        ui.label(format!("Info age: {} hd ({:.1} yr) [{}]", age, years, freshness));
+        let source_tag = observation_source_tag(perceived.source);
+        let color = observation_freshness_color(age);
+        ui.label(
+            egui::RichText::new(format!(
+                "Info age: {} hd ({:.1} yr) [{}] {}",
+                age, years, freshness, source_tag
+            ))
+            .color(color),
+        );
     }
 
     // --- Resource stockpile ---
@@ -388,8 +397,33 @@ fn draw_left_panel(
                 }
             }
             if snap.has_hostile {
-                ui.label(egui::RichText::new(format!("Hostile presence (str: {:.1})", snap.hostile_strength))
-                    .color(egui::Color32::from_rgb(255, 100, 100)));
+                // #215: tag hostile observation with source + freshness colouring
+                // so the player can judge how trustworthy the reading is.
+                let age = clock.elapsed - k.observed_at;
+                let overlay_source = if age >= crate::knowledge::STALE_THRESHOLD_HEXADIES {
+                    crate::knowledge::ObservationSource::Stale
+                } else {
+                    k.source
+                };
+                let source_tag = observation_source_tag(overlay_source);
+                // Tint the hostile red toward grey as the observation ages so
+                // fresh threats pop while stale sightings are visibly dimmed.
+                let color = if age < 60 {
+                    egui::Color32::from_rgb(255, 100, 100)
+                } else if age < 300 {
+                    egui::Color32::from_rgb(220, 120, 120)
+                } else if age < crate::knowledge::STALE_THRESHOLD_HEXADIES {
+                    egui::Color32::from_rgb(180, 110, 110)
+                } else {
+                    egui::Color32::from_rgb(140, 80, 70)
+                };
+                ui.label(
+                    egui::RichText::new(format!(
+                        "Hostile presence (str: {:.1}) {}",
+                        snap.hostile_strength, source_tag
+                    ))
+                    .color(color),
+                );
             }
             if snap.has_port {
                 ui.label("Port facility present");
@@ -1175,4 +1209,34 @@ pub fn ship_build_host_colony(
         .iter()
         .find(|(_, sys)| *sys == system_entity)
         .map(|(colony, _)| *colony)
+}
+
+// ---------------------------------------------------------------------------
+// #215: Observation-source / freshness visuals
+// ---------------------------------------------------------------------------
+
+/// Short tag displayed next to an observation, identifying its channel.
+fn observation_source_tag(source: crate::knowledge::ObservationSource) -> &'static str {
+    use crate::knowledge::ObservationSource;
+    match source {
+        ObservationSource::Direct => "[DIR]",
+        ObservationSource::Relay => "[REL]",
+        ObservationSource::Scout => "[SCT]",
+        ObservationSource::Stale => "[STALE]",
+    }
+}
+
+/// Freshness colour for the "info age" line. Fresher observations render in
+/// the default text colour; older ones shade toward grey / red-brown as they
+/// approach the [`crate::knowledge::STALE_THRESHOLD_HEXADIES`] cutoff.
+fn observation_freshness_color(age: i64) -> egui::Color32 {
+    if age < 60 {
+        egui::Color32::from_rgb(220, 220, 220)
+    } else if age < 300 {
+        egui::Color32::from_rgb(180, 180, 180)
+    } else if age < crate::knowledge::STALE_THRESHOLD_HEXADIES {
+        egui::Color32::from_rgb(130, 130, 130)
+    } else {
+        egui::Color32::from_rgb(160, 90, 70)
+    }
 }

--- a/macrocosmo/tests/knowledge.rs
+++ b/macrocosmo/tests/knowledge.rs
@@ -881,6 +881,7 @@ fn test_knowledge_store_ship_update_newer_replaces() {
         observed_at: 10,
         hp: 100.0,
         hp_max: 100.0,
+        source: ObservationSource::Direct,
     });
 
     store.update_ship(ShipSnapshot {
@@ -892,6 +893,7 @@ fn test_knowledge_store_ship_update_newer_replaces() {
         observed_at: 20,
         hp: 80.0,
         hp_max: 100.0,
+        source: ObservationSource::Direct,
     });
 
     let snap = store.get_ship(entity).unwrap();
@@ -919,6 +921,7 @@ fn test_knowledge_store_ship_older_does_not_replace() {
         observed_at: 20,
         hp: 80.0,
         hp_max: 100.0,
+        source: ObservationSource::Direct,
     });
 
     store.update_ship(ShipSnapshot {
@@ -930,6 +933,7 @@ fn test_knowledge_store_ship_older_does_not_replace() {
         observed_at: 10,
         hp: 100.0,
         hp_max: 100.0,
+        source: ObservationSource::Direct,
     });
 
     let snap = store.get_ship(entity).unwrap();
@@ -1858,5 +1862,133 @@ fn test_ftl_comm_relay_chain_a_b_c_hops() {
         .get_ship(ship_entity)
         .expect("Chain A↔B1, B2↔C should deliver remote ship to player at FTL speed");
     assert_eq!(snap.observed_at, 50);
+}
+
+// ---------------------------------------------------------------------------
+// #215: Observation freshness model (PerceivedInfo / ObservationSource)
+// ---------------------------------------------------------------------------
+
+/// After propagating knowledge across 10 ly and waiting long enough for
+/// the light to arrive, `perceived_system` should report `last_updated`
+/// equal to the observation moment and a correctly computed age.
+#[test]
+fn test_perceived_info_reports_last_updated() {
+    let mut app = test_app();
+
+    let sys_capital = spawn_test_system(
+        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
+    );
+    let sys_distant = spawn_test_system(
+        app.world_mut(), "Distant", [10.0, 0.0, 0.0], 0.7, true, false,
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+
+    // 10 ly of light delay = 600 hexadies. Advance exactly that far — the
+    // observation snapped this tick was made at t=0 (current - delay).
+    advance_time(&mut app, 600);
+
+    let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let empire = empire_entity(app.world_mut());
+    let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+    let perceived = macrocosmo::knowledge::perceived_system(store, sys_distant, now)
+        .expect("perceived_system should return the Distant snapshot");
+
+    // `observed_at` is the light-departure time. For a 10 ly target the
+    // first observation should be snapped at t = now - 600.
+    assert_eq!(perceived.last_updated, now - 600,
+        "last_updated must match observed_at (light-departure hexadies)");
+    assert_eq!(perceived.age(now), 600);
+    // At exactly the threshold the overlay flips to Stale.
+    assert!(perceived.is_stale(now),
+        "age == STALE_THRESHOLD_HEXADIES should overlay source to Stale");
+}
+
+/// Propagated observations are tagged `Direct`. Once enough in-game time
+/// passes (age >= STALE_THRESHOLD_HEXADIES), `perceived_system` overlays
+/// the source to `Stale` without mutating the underlying entry.
+#[test]
+fn test_perceived_info_source_reflects_origin() {
+    let mut app = test_app();
+
+    let sys_capital = spawn_test_system(
+        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
+    );
+    let sys_b = spawn_test_system(
+        app.world_mut(), "Near", [2.0, 0.0, 0.0], 0.7, true, false,
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+
+    // 2 ly → 120 hd delay. Advance past that so the Direct observation lands.
+    advance_time(&mut app, 200);
+
+    let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let empire = empire_entity(app.world_mut());
+    {
+        let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+        // Underlying entry carries Direct source.
+        let entry = store.get(sys_b).expect("Near system should be observed by now");
+        assert_eq!(entry.source, macrocosmo::knowledge::ObservationSource::Direct);
+
+        let perceived = macrocosmo::knowledge::perceived_system(store, sys_b, now).unwrap();
+        assert_eq!(perceived.source, macrocosmo::knowledge::ObservationSource::Direct);
+        assert!(!perceived.is_stale(now));
+    }
+
+    // Jump to a far-future "now" that exceeds the stale threshold. The
+    // stored entry still says Direct, but the overlay should return Stale.
+    let distant_now = now + macrocosmo::knowledge::STALE_THRESHOLD_HEXADIES + 10;
+    {
+        let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+        let entry_after = store.get(sys_b).unwrap();
+        assert_eq!(entry_after.source, macrocosmo::knowledge::ObservationSource::Direct,
+            "underlying source must not be mutated by overlay");
+
+        let perceived = macrocosmo::knowledge::perceived_system(store, sys_b, distant_now).unwrap();
+        assert_eq!(perceived.source, macrocosmo::knowledge::ObservationSource::Stale,
+            "accessor overlays source=Stale when age >= STALE_THRESHOLD_HEXADIES");
+        assert!(perceived.is_stale(distant_now));
+    }
+}
+
+/// An entry written with `ObservationSource::Relay` (e.g. from an FTL comm
+/// relay at #216) should flow through `perceived_system` unchanged until
+/// it ages out, at which point the overlay replaces it with `Stale`.
+#[test]
+fn test_perceived_info_relay_source() {
+    use bevy::ecs::world::World;
+
+    let mut world = World::new();
+    let sys_entity = world.spawn_empty().id();
+    let mut store = KnowledgeStore::default();
+    store.update(SystemKnowledge {
+        system: sys_entity,
+        observed_at: 100,
+        received_at: 100,
+        data: SystemSnapshot {
+            name: "Relayed".to_string(),
+            position: [5.0, 0.0, 0.0],
+            surveyed: true,
+            ..Default::default()
+        },
+        source: ObservationSource::Relay,
+    });
+
+    // Fresh observation — the relay source should round-trip.
+    let fresh = macrocosmo::knowledge::perceived_system(&store, sys_entity, 150).unwrap();
+    assert_eq!(fresh.source, ObservationSource::Relay);
+    assert_eq!(fresh.last_updated, 100);
+    assert_eq!(fresh.age(150), 50);
+    assert!(!fresh.is_stale(150));
+
+    // Age the observation past the staleness cutoff — overlay kicks in.
+    let stale_now = 100 + macrocosmo::knowledge::STALE_THRESHOLD_HEXADIES + 1;
+    let stale = macrocosmo::knowledge::perceived_system(&store, sys_entity, stale_now).unwrap();
+    assert_eq!(stale.source, ObservationSource::Stale);
+    assert!(stale.is_stale(stale_now));
+
+    // perceived_fleet is empty (no ship snapshots) but should not panic and
+    // should not filter anything out yet (owner tracking TODO per #163).
+    let fleet = macrocosmo::knowledge::perceived_fleet(&store, sys_entity, stale_now);
+    assert!(fleet.is_empty());
 }
 

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -1721,6 +1721,7 @@ fn courier_route_knowledge_relay_delivers_pre_loaded_cargo() {
                 surveyed: false,
                 ..Default::default()
             },
+            source: macrocosmo::knowledge::ObservationSource::Direct,
         });
     }
 
@@ -1745,6 +1746,7 @@ fn courier_route_knowledge_relay_delivers_pre_loaded_cargo() {
                 surveyed: true,
                 ..Default::default()
             },
+            source: macrocosmo::knowledge::ObservationSource::Direct,
         }],
     });
 
@@ -1784,6 +1786,7 @@ fn courier_route_knowledge_relay_pickup_refreshes_received_at() {
                 surveyed: true,
                 ..Default::default()
             },
+            source: macrocosmo::knowledge::ObservationSource::Direct,
         });
     }
 


### PR DESCRIPTION
## Summary

- #212 偵察 epic の baseline。後続 #216 (Relay 集約) / #217 (索敵艦) が source タグ付与のために依存
- `ObservationSource` enum (Direct / Relay / Scout / Stale) + `STALE_THRESHOLD_HEXADIES = 600` を定義
- `PerceivedInfo<T>` read-side facade で鮮度 (last_updated / age / is_stale) を提供、閾値超過で `Stale` を overlay
- UI system panel の `info_age` / `hostile_strength` 行に source タグ + 鮮度色

## 設計判断 (計画レビュー時に確定)

- `observed_at` は内部改名せず、`PerceivedInfo.last_updated` で仕様名に揃える
- `Stale` は read-side overlay (store には Direct/Relay/Scout のみ書き、API が時間経過で Stale を被せる)
- `STALE_THRESHOLD_HEXADIES = 600` (≒10年、既存 system_panel の "VERY OLD" 閾値を共通化)
- `pub type FactionId = Entity` 暫定 alias (#163 Faction で newtype 化予定)
- `perceived_fleet` の target 別フィルタは placeholder (ShipSnapshot に owner 情報無しのため、#163 で対応)
- 敵艦フルツールチップは範囲外、hostile_strength 行拡張のみで Acceptance 充足

## 変更ファイル (8 files, +384 / -9)

- `knowledge/mod.rs`: enum + 定数 + `SystemKnowledge`/`ShipSnapshot` の `source` field + writer 更新
- `knowledge/perceived.rs` (新規): `PerceivedInfo<T>` / `perceived_system` / `perceived_fleet` / `FactionId` alias
- `deep_space/mod.rs`: sensor_buoy → Direct、relay → Relay
- `ship/survey.rs`: 配達時の source 付与
- `ui/system_panel/mod.rs`: `info_age` / `hostile_strength` を `perceived_system` 経由に書き換え + helper
- `ui/mod.rs`: 星系マップツールチップに source タグ
- `tests/knowledge.rs`: 3 件追加、`tests/ship.rs`: source field 反映

## 次 issue への申し送り

- **#216**: relay_knowledge_propagate は ship snapshot には Relay 付与済だが、system snapshot の relay 伝搬はまだ未実装。#216 で system 伝搬実装時に同じ source を付けること
- **#217**: `ObservationSource::Scout` enum バリアントは定義済み / 未使用。索敵艦実装時にこれを書き込む
- **#163**: `FactionId = Entity` 暫定 alias、`ShipSnapshot` に owner 情報が入ったら `perceived_fleet` の filter を実装

## Test plan

- [x] 新規 3 テスト全 pass: `test_perceived_info_reports_last_updated` / `test_perceived_info_source_reflects_origin` / `test_perceived_info_relay_source`
- [x] `cargo test -p macrocosmo`: 600 lib + 32 tests/knowledge + 42 tests/ship 全 pass
- [x] `cargo build -p macrocosmo`: warning 新規追加なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)