### PR TITLE
#216: Sensor Buoy + FTL Comm Relay 情報集約 (B-1) — relay 経路での system snapshot 伝搬

### DIFF
--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -806,6 +806,21 @@ pub fn relay_knowledge_propagate_system(
     mut empire_q: Query<&mut crate::knowledge::KnowledgeStore, With<crate::player::PlayerEmpire>>,
     // #145: Forbidden regions that block FTL comm propagation.
     ftl_comm_blocking_regions: Query<&crate::galaxy::ForbiddenRegion>,
+    // #216: Star system data for FTL-relayed SystemKnowledge updates. Mirrors
+    // the queries used by `propagate_knowledge` so the snapshot payload is
+    // identical to the direct-light path.
+    system_q: Query<(
+        Entity,
+        &crate::galaxy::StarSystem,
+        &crate::components::Position,
+        Option<&crate::colony::ResourceStockpile>,
+        Option<&crate::colony::SystemBuildings>,
+    )>,
+    colonies: Query<&crate::colony::Colony>,
+    planets: Query<&crate::galaxy::Planet>,
+    planet_attrs: Query<(&crate::galaxy::Planet, &crate::galaxy::SystemAttributes)>,
+    hostiles: Query<&crate::galaxy::HostilePresence>,
+    building_registry: Res<crate::colony::BuildingRegistry>,
 ) {
     // Build region blockers (pairs segment check); only regions carrying the
     // `blocks_ftl_comm` capability matter here.
@@ -927,6 +942,55 @@ pub fn relay_knowledge_propagate_system(
                 observed_at,
                 hp: hp.hull,
                 hp_max: hp.hull_max,
+                source: ObservationSource::Relay,
+            });
+        }
+
+        // #216: FTL-relayed SystemKnowledge. For every star system within the
+        // SOURCE relay's range, write a fresh SystemKnowledge entry at
+        // FTL speed (observed_at = clock.elapsed, source = Relay) provided
+        // the player is within the PARTNER relay's range (checked above).
+        //
+        // This is the "Sensor Buoy + Relay" aggregation path (B-1): Sensor
+        // Buoy ship observations are already covered by the ship loop above;
+        // here we additionally deliver the system-level snapshot (resources,
+        // colonization, hostile presence, etc.) through the same pair.
+        let observed_at = clock.elapsed;
+        let hostile_map: std::collections::HashMap<Entity, &crate::galaxy::HostilePresence> =
+            hostiles.iter().map(|h| (h.system, h)).collect();
+
+        for (sys_entity, star, sys_pos, stockpile, sys_buildings) in &system_q {
+            let dist = crate::physics::distance_ly(source_pos, sys_pos);
+            if source_range > 0.0 && dist > source_range {
+                continue;
+            }
+
+            // Skip if existing knowledge is at least as fresh.
+            if store
+                .get(sys_entity)
+                .is_some_and(|existing| existing.observed_at >= observed_at)
+            {
+                continue;
+            }
+
+            let snapshot = crate::knowledge::build_system_snapshot(
+                sys_entity,
+                star,
+                sys_pos,
+                stockpile,
+                sys_buildings,
+                &colonies,
+                &planets,
+                &planet_attrs,
+                &hostile_map,
+                &building_registry,
+            );
+
+            store.update(crate::knowledge::SystemKnowledge {
+                system: sys_entity,
+                observed_at,
+                received_at: clock.elapsed,
+                data: snapshot,
                 source: ObservationSource::Relay,
             });
         }

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -246,6 +246,83 @@ fn initialize_capital_knowledge(
     info!("Player knowledge initialized: capital '{}'", capital.name);
 }
 
+/// #216: Build a `SystemSnapshot` describing the observed state of a star
+/// system. Shared by `propagate_knowledge` (light-speed direct) and
+/// `relay_knowledge_propagate_system` (FTL relay) so that relay-delivered
+/// snapshots carry the same payload fields as direct observations.
+///
+/// `hostile_map` is an `entity → HostilePresence` lookup the caller builds
+/// once per tick; passing it in lets both call sites share the allocation.
+pub fn build_system_snapshot(
+    entity: Entity,
+    star: &StarSystem,
+    sys_pos: &Position,
+    stockpile: Option<&ResourceStockpile>,
+    sys_buildings: Option<&crate::colony::SystemBuildings>,
+    colonies: &Query<&crate::colony::Colony>,
+    planets: &Query<&crate::galaxy::Planet>,
+    planet_attrs: &Query<(&crate::galaxy::Planet, &crate::galaxy::SystemAttributes)>,
+    hostile_map: &HashMap<Entity, &crate::galaxy::HostilePresence>,
+    building_registry: &crate::colony::BuildingRegistry,
+) -> SystemSnapshot {
+    // Derive colonized status from whether any colony has a planet in this system
+    let is_colonized = colonies
+        .iter()
+        .any(|c| c.system(planets) == Some(entity));
+
+    // Resource snapshot from StarSystem's stockpile (#106)
+    let (minerals, energy, food, authority) = stockpile
+        .map(|s| (s.minerals, s.energy, s.food, s.authority))
+        .unwrap_or((Amt::ZERO, Amt::ZERO, Amt::ZERO, Amt::ZERO));
+
+    // #176: Hostile presence
+    let hostile = hostile_map.get(&entity);
+    let has_hostile = hostile.is_some();
+    let hostile_strength = hostile.map(|h| h.strength).unwrap_or(0.0);
+
+    // #176: System buildings info (capability-based check via BuildingRegistry)
+    let has_port = sys_buildings.map(|sb| sb.has_port(building_registry)).unwrap_or(false);
+    let has_shipyard = sys_buildings.map(|sb| sb.has_shipyard(building_registry)).unwrap_or(false);
+
+    // #176: System attributes — derive from best planet in the system
+    let best_attrs = planet_attrs
+        .iter()
+        .filter(|(p, _)| p.system == entity)
+        .map(|(_, a)| a)
+        .max_by(|a, b| a.habitability.partial_cmp(&b.habitability).unwrap_or(std::cmp::Ordering::Equal));
+    let (habitability, mineral_richness, energy_potential, research_potential, max_building_slots) =
+        best_attrs
+            .map(|a| (
+                Some(a.habitability),
+                Some(a.mineral_richness),
+                Some(a.energy_potential),
+                Some(a.research_potential),
+                Some(a.max_building_slots),
+            ))
+            .unwrap_or((None, None, None, None, None));
+
+    SystemSnapshot {
+        name: star.name.clone(),
+        position: sys_pos.as_array(),
+        surveyed: star.surveyed,
+        colonized: is_colonized,
+        minerals,
+        energy,
+        food,
+        authority,
+        has_hostile,
+        hostile_strength,
+        has_port,
+        has_shipyard,
+        habitability,
+        mineral_richness,
+        energy_potential,
+        research_potential,
+        max_building_slots,
+        ..SystemSnapshot::default()
+    }
+}
+
 pub fn propagate_knowledge(
     clock: Res<GameClock>,
     player_q: Query<&StationedAt, With<Player>>,
@@ -301,62 +378,18 @@ pub fn propagate_knowledge(
             continue;
         }
 
-        // Derive colonized status from whether any colony has a planet in this system
-        let is_colonized = colonies
-            .iter()
-            .any(|c| c.system(&planets) == Some(entity));
-
-        // Resource snapshot from StarSystem's stockpile (#106)
-        let (minerals, energy, food, authority) = stockpile
-            .map(|s| (s.minerals, s.energy, s.food, s.authority))
-            .unwrap_or((Amt::ZERO, Amt::ZERO, Amt::ZERO, Amt::ZERO));
-
-        // #176: Hostile presence
-        let hostile = hostile_map.get(&entity);
-        let has_hostile = hostile.is_some();
-        let hostile_strength = hostile.map(|h| h.strength).unwrap_or(0.0);
-
-        // #176: System buildings info (capability-based check via BuildingRegistry)
-        let has_port = sys_buildings.map(|sb| sb.has_port(&building_registry)).unwrap_or(false);
-        let has_shipyard = sys_buildings.map(|sb| sb.has_shipyard(&building_registry)).unwrap_or(false);
-
-        // #176: System attributes — derive from best planet in the system
-        let best_attrs = planet_attrs
-            .iter()
-            .filter(|(p, _)| p.system == entity)
-            .map(|(_, a)| a)
-            .max_by(|a, b| a.habitability.partial_cmp(&b.habitability).unwrap_or(std::cmp::Ordering::Equal));
-        let (habitability, mineral_richness, energy_potential, research_potential, max_building_slots) =
-            best_attrs
-                .map(|a| (
-                    Some(a.habitability),
-                    Some(a.mineral_richness),
-                    Some(a.energy_potential),
-                    Some(a.research_potential),
-                    Some(a.max_building_slots),
-                ))
-                .unwrap_or((None, None, None, None, None));
-
-        let snapshot = SystemSnapshot {
-            name: star.name.clone(),
-            position: sys_pos.as_array(),
-            surveyed: star.surveyed,
-            colonized: is_colonized,
-            minerals,
-            energy,
-            food,
-            authority,
-            has_hostile,
-            hostile_strength,
-            has_port,
-            has_shipyard,
-            habitability,
-            mineral_richness,
-            energy_potential,
-            research_potential,
-            max_building_slots,
-            ..default()
-        };
+        let snapshot = build_system_snapshot(
+            entity,
+            star,
+            sys_pos,
+            stockpile,
+            sys_buildings,
+            &colonies,
+            &planets,
+            &planet_attrs,
+            &hostile_map,
+            &building_registry,
+        );
 
         store.update(SystemKnowledge {
             system: entity,

--- a/macrocosmo/tests/knowledge.rs
+++ b/macrocosmo/tests/knowledge.rs
@@ -1992,3 +1992,217 @@ fn test_perceived_info_relay_source() {
     assert!(fleet.is_empty());
 }
 
+// ---------------------------------------------------------------------------
+// #216: Sensor Buoy + FTL Comm Relay information aggregation (B-1)
+// ---------------------------------------------------------------------------
+//
+// When an FTL Comm Relay network links a remote system to the player's
+// capital, the player's KnowledgeStore receives FTL-speed SystemKnowledge
+// updates (observed_at = now, source = Relay) for every star system inside
+// any paired source relay's `ftl_comm_relay` range. This is the aggregation
+// path described in the #216 spec: Sensor Buoy ship observations already take
+// the relay shortcut (covered by #119 tests), and the system-level snapshot
+// (resources, colonization, hostile presence, …) now follows the same route.
+
+#[test]
+fn test_sensor_buoy_info_propagates_via_relay() {
+    // Player at capital [0, 0, 0]. Remote system at [30, 0, 0] — 30 ly of
+    // light delay (~1800 hexadies). At t = 100 hd the remote system is
+    // still 1700 hd away by the light-speed path, so any SystemKnowledge
+    // entry for it must have been delivered via the FTL relay.
+    //
+    // Topology:
+    //   Relay-A @ [28, 0, 0]  (near remote system, range 5 ly)
+    //   Relay-B @ [1, 0, 0]   (near player, range 5 ly)
+    //   Bidirectional pair — each endpoint sends.
+    //   Sensor Buoy @ [30, 0, 0] co-located with the remote system.
+    use macrocosmo::deep_space::{CommDirection, pair_relay_command};
+
+    let mut app = test_app();
+    install_sensor_buoy_definition(&mut app);
+    install_ftl_comm_relay_definition(&mut app, 5.0);
+
+    let sys_capital = spawn_test_system(
+        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
+    );
+    let sys_remote = spawn_test_system(
+        app.world_mut(), "Remote", [30.0, 0.0, 0.0], 0.5, true, false,
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+
+    // Sensor buoy watches the remote system (not required for the system
+    // snapshot path itself, but models the "Sensor Buoy → Relay" spec).
+    spawn_sensor_buoy(app.world_mut(), [30.0, 0.0, 0.0]);
+
+    let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [28.0, 0.0, 0.0]);
+    let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [1.0, 0.0, 0.0]);
+    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional).unwrap();
+
+    advance_time(&mut app, 100);
+    let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let empire = empire_entity(app.world_mut());
+    let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+
+    let entry = store
+        .get(sys_remote)
+        .expect("Relay network should deliver a SystemKnowledge entry for the remote system");
+    assert_eq!(
+        entry.source,
+        ObservationSource::Relay,
+        "relay-delivered entry must be tagged Relay"
+    );
+    assert_eq!(
+        entry.observed_at, now,
+        "FTL relay delivers with no light-speed delay (observed_at == now)"
+    );
+    // Sanity: the snapshot payload identifies the correct remote system.
+    assert_eq!(entry.data.name, "Remote");
+    assert_eq!(entry.data.position, [30.0, 0.0, 0.0]);
+    // Direct propagate_knowledge cannot have fired yet (1800 hd light delay).
+    // If the entry's observed_at == now, it MUST be the relay path.
+    assert!(
+        now < 1800,
+        "precondition: test runs before light-speed path could deliver"
+    );
+}
+
+#[test]
+fn test_relay_destruction_degrades_info_freshness() {
+    // Same topology as above. While the relay chain is live, the remote
+    // system's SystemKnowledge stays maximally fresh (observed_at == now,
+    // source == Relay). After destroying Relay-B, subsequent ticks must not
+    // continue to publish Relay-sourced updates for the remote system; the
+    // player has to wait for the direct light-speed path — and when it
+    // eventually lands, source flips to Direct.
+    use macrocosmo::deep_space::{CommDirection, FTLCommRelay, pair_relay_command};
+
+    let mut app = test_app();
+    install_sensor_buoy_definition(&mut app);
+    install_ftl_comm_relay_definition(&mut app, 5.0);
+
+    let sys_capital = spawn_test_system(
+        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
+    );
+    let sys_remote = spawn_test_system(
+        app.world_mut(), "Remote", [30.0, 0.0, 0.0], 0.5, true, false,
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    spawn_sensor_buoy(app.world_mut(), [30.0, 0.0, 0.0]);
+
+    let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [28.0, 0.0, 0.0]);
+    let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [1.0, 0.0, 0.0]);
+    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional).unwrap();
+
+    // Phase 1: chain is live. Remote system is known via relay at t=100.
+    advance_time(&mut app, 100);
+    let fresh_observed_at;
+    {
+        let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+        let empire = empire_entity(app.world_mut());
+        let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+        let entry = store.get(sys_remote).expect("relay delivers phase-1 snapshot");
+        assert_eq!(entry.source, ObservationSource::Relay);
+        assert_eq!(entry.observed_at, now);
+        fresh_observed_at = entry.observed_at;
+    }
+
+    // Phase 2: destroy one end of the chain. verify_relay_pairings_system
+    // strips the partner's FTLCommRelay component on the next tick.
+    app.world_mut().despawn(relay_b);
+    advance_time(&mut app, 1);
+    assert!(
+        app.world().get::<FTLCommRelay>(relay_a).is_none(),
+        "despawning relay_b must unpair relay_a"
+    );
+
+    // Phase 3: advance well past phase-1 but still FAR shorter than the
+    // light-speed travel time (30 ly ≈ 1800 hd). The relay path is gone, so
+    // the stored observed_at must NOT advance and the source must remain
+    // Relay (the prior entry; nothing wrote over it).
+    advance_time(&mut app, 500);
+    {
+        let empire = empire_entity(app.world_mut());
+        let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+        let entry = store.get(sys_remote).expect("prior relay snapshot still present");
+        assert_eq!(
+            entry.observed_at, fresh_observed_at,
+            "no new relay writes after chain destroyed — observed_at must stall"
+        );
+        assert_eq!(
+            entry.source,
+            ObservationSource::Relay,
+            "the stalled snapshot still carries its original Relay tag"
+        );
+    }
+
+    // Phase 4: advance past the 1800 hd light-speed delay from player to the
+    // remote system (30 ly). Now the direct path delivers with source=Direct.
+    // That confirms the "light-speed fallback" aspect of the spec.
+    advance_time(&mut app, 2000);
+    {
+        let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+        let empire = empire_entity(app.world_mut());
+        let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+        let entry = store.get(sys_remote).expect("direct light-speed path eventually lands");
+        assert_eq!(
+            entry.source,
+            ObservationSource::Direct,
+            "after chain destruction, freshness is restored only via the light-speed path"
+        );
+        assert!(
+            entry.observed_at > fresh_observed_at,
+            "direct path eventually supersedes the stalled relay snapshot"
+        );
+        assert!(
+            entry.observed_at < now,
+            "direct observation carries the light-speed delay (observed_at < now)"
+        );
+    }
+}
+
+#[test]
+fn test_relay_chain_aggregates_system_resources() {
+    // Bonus coverage: verify that the relay-delivered SystemKnowledge carries
+    // the remote system's `ResourceStockpile` contents — this is the
+    // "information aggregation" the #216 spec calls out. Without the relay
+    // path this data would only arrive at light-speed.
+    use macrocosmo::deep_space::{CommDirection, pair_relay_command};
+
+    let mut app = test_app();
+    install_ftl_comm_relay_definition(&mut app, 5.0);
+
+    let sys_capital = spawn_test_system(
+        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
+    );
+    let sys_remote = spawn_test_system(
+        app.world_mut(), "RemoteColony", [30.0, 0.0, 0.0], 0.6, true, false,
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+
+    // Attach a stockpile to the remote system so the snapshot has non-trivial
+    // content to verify.
+    app.world_mut().entity_mut(sys_remote).insert(ResourceStockpile {
+        minerals: Amt::units(777),
+        energy: Amt::units(321),
+        research: Amt::ZERO,
+        food: Amt::units(50),
+        authority: Amt::units(10),
+    });
+
+    let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [28.0, 0.0, 0.0]);
+    let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [1.0, 0.0, 0.0]);
+    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional).unwrap();
+
+    advance_time(&mut app, 50);
+    let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let empire = empire_entity(app.world_mut());
+    let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+    let entry = store.get(sys_remote).expect("relay delivers remote system snapshot");
+    assert_eq!(entry.source, ObservationSource::Relay);
+    assert_eq!(entry.observed_at, now);
+    assert_eq!(entry.data.minerals, Amt::units(777));
+    assert_eq!(entry.data.energy, Amt::units(321));
+    assert_eq!(entry.data.food, Amt::units(50));
+    assert_eq!(entry.data.authority, Amt::units(10));
+}
+


### PR DESCRIPTION
## Summary

- #212 偵察 epic の Relay 集約レイヤ。Sensor Buoy が観測した **SystemSnapshot** が Relay 網経由で自陣 KnowledgeStore に FTL 即時到達する経路を追加
- 既存 ship snapshot の relay 伝搬 (#119 実装済) と並列に、system snapshot 伝搬ループを `relay_knowledge_propagate_system` に追加
- source = `ObservationSource::Relay` (#215 で定義済)
- Relay 破壊時は既存 `verify_relay_pairings_system` (毎 tick) が graph を再構築、光速 fallback へ自然遷移

## 変更ファイル (3 files, +367 / -56)

- `deep_space/mod.rs` (+64): `relay_knowledge_propagate_system` に SystemKnowledge 伝搬ループ追加、必要 query を追加
- `knowledge/mod.rs` (±145): `build_system_snapshot` helper を抽出 → `propagate_knowledge` と relay 両方から共有
- `tests/knowledge.rs` (+214): 新規 3 件

## 設計ポイント

- **Ship relay は既存コード**。「Sensor Buoy 観測 ship が relay 経由で届く」は #119 時点で満たされていた
- **新規は system snapshot の relay 伝搬**。source relay の `ftl_comm_relay` range 内の星系に `observed_at=now, source=Relay` で `KnowledgeStore::update`
- **`KnowledgeStore::update` の dominate 判定** (observed_at 比較) で relay 高速ルート vs 光速ルートの勝敗が自然解決
- **Relay 破壊** は既存 `verify_relay_pairings_system` が担う。despawn された relay に paired_with していた相手の FTLCommRelay component が剥がされ、次 tick から該当ルート消滅

## #217 への申し送り

- `relay_knowledge_propagate_system` は params が 16 個 (Bevy tuple SystemParam 上限)。今後の拡張は SystemParam bundle 化が必要になる可能性
- `knowledge::build_system_snapshot` を公開済 → scout / courier からの snapshot 書き込みでも再利用可能
- `ship/command.rs` には未着手、Scout variant 追加と非競合

## Test plan

- [x] `test_sensor_buoy_info_propagates_via_relay` — 30 ly 先の remote system が relay 網経由で t=100 hd に source=Relay, observed_at=now で到達
- [x] `test_relay_destruction_degrades_info_freshness` — Relay-B despawn 後、光速 fallback (1800 hd 経過後に source=Direct)
- [x] `test_relay_chain_aggregates_system_resources` — relay 経由の SystemSnapshot が ResourceStockpile を正しく運ぶ
- [x] `cargo test -p macrocosmo`: 608 lib + 35 knowledge (+3) 全 pass
- [x] warning 新規なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)