### PR TITLE
#217: 索敵艦コマンド + 報告メカニクス (C-1)

### DIFF
--- a/macrocosmo/scripts/ships/modules.lua
+++ b/macrocosmo/scripts/ships/modules.lua
@@ -131,6 +131,20 @@ local colony_module = define_module {
     cost = { minerals = 300, energy = 200 },
 }
 
+-- #217: Scout module — enables the Scout command and extends passive sensor
+-- range used by the observation snapshot. `sensor.range` feeds GlobalParams
+-- so it also benefits survey range (intentional: scouts are spec'd as
+-- sensor-heavy recon hulls).
+local scout_module = define_module {
+    id = "scout_module",
+    name = "Scout Sensor Array",
+    slot_type = slot_types.utility,
+    modifiers = {
+        { target = "sensor.range", base_add = 1.0 },
+    },
+    cost = { minerals = 80, energy = 50 },
+}
+
 -- Power modules (power slot)
 local fusion_reactor = define_module {
     id = "fusion_reactor",
@@ -166,6 +180,7 @@ return {
     survey_equipment = survey_equipment,
     cargo_bay = cargo_bay,
     colony_module = colony_module,
+    scout_module = scout_module,
     fusion_reactor = fusion_reactor,
     command_array = command_array,
 }

--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -723,6 +723,11 @@ pub fn sensor_buoy_detect_system(
                     ShipSnapshotState::Loitering { position: *position },
                     None,
                 ),
+                // #217: Scouting ship — display like Surveying for sensor observers.
+                crate::ship::ShipState::Scouting { target_system, .. } => (
+                    ShipSnapshotState::Surveying,
+                    Some(*target_system),
+                ),
             };
 
             store.update_ship(ShipSnapshot {
@@ -915,6 +920,11 @@ pub fn relay_knowledge_propagate_system(
                 crate::ship::ShipState::Loitering { position } => (
                     ShipSnapshotState::Loitering { position: *position },
                     None,
+                ),
+                // #217: Scouting ships appear like Surveying at target system.
+                crate::ship::ShipState::Scouting { target_system, .. } => (
+                    ShipSnapshotState::Surveying,
+                    Some(*target_system),
                 ),
             };
 

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -413,6 +413,11 @@ pub fn propagate_knowledge(
             }
             // #185: Loitering — coordinate is encoded in the state itself.
             ShipState::Loitering { position } => Some(*position),
+            // #217: Scouting ships are parked at the target system's
+            // position (they sit in orbit while the observation timer ticks).
+            ShipState::Scouting { target_system, .. } => {
+                positions.get(*target_system).ok().map(|p| p.as_array())
+            }
         };
 
         let Some(ship_pos_arr) = ship_pos_arr else {
@@ -446,6 +451,11 @@ pub fn propagate_knowledge(
             ShipState::Loitering { position } => (
                 ShipSnapshotState::Loitering { position: *position },
                 None,
+            ),
+            // #217: Scouting — surface like Surveying to external observers.
+            ShipState::Scouting { target_system, .. } => (
+                ShipSnapshotState::Surveying,
+                Some(*target_system),
             ),
         };
 

--- a/macrocosmo/src/ship/command.rs
+++ b/macrocosmo/src/ship/command.rs
@@ -355,6 +355,85 @@ pub fn process_command_queue(
                     ship.name, target_arr[0], target_arr[1], target_arr[2]
                 );
             }
+            QueuedCommand::Scout { .. } => {
+                // #217: Consume and dispatch synchronously. If not at the
+                // target yet, auto-insert a MoveTo and retry; else transition
+                // into ShipState::Scouting.
+                let next = queue.commands.remove(0);
+                let QueuedCommand::Scout {
+                    target_system,
+                    observation_duration,
+                    report_mode,
+                } = next
+                else {
+                    unreachable!("outer match guarantees Scout variant");
+                };
+                let Ok((_target_entity, _target_star, _target_pos)) =
+                    systems.get(target_system)
+                else {
+                    warn!("Queued Scout target no longer exists");
+                    queue.sync_prediction(ship_pos.as_array(), docked_system);
+                    continue;
+                };
+                // Non-FTL ships are disallowed from Scout — scouts must
+                // leap to the target. Reject early with a warning.
+                if ship.ftl_range <= 0.0 {
+                    warn!(
+                        "Scout rejected: ship {} has no FTL capability",
+                        ship.name
+                    );
+                    queue.sync_prediction(ship_pos.as_array(), docked_system);
+                    continue;
+                }
+                // Must carry the scout module.
+                if !super::scout::ship_has_scout_module(ship) {
+                    warn!(
+                        "Scout rejected: ship {} lacks a scout module",
+                        ship.name
+                    );
+                    queue.sync_prediction(ship_pos.as_array(), docked_system);
+                    continue;
+                }
+                // If not at target, prepend a MoveTo and re-queue Scout.
+                if docked_system != Some(target_system) {
+                    queue.commands.insert(
+                        0,
+                        QueuedCommand::Scout {
+                            target_system,
+                            observation_duration,
+                            report_mode,
+                        },
+                    );
+                    queue.commands.insert(
+                        0,
+                        QueuedCommand::MoveTo {
+                            system: target_system,
+                        },
+                    );
+                    info!(
+                        "Queue: Ship {} not at Scout target — auto-inserting MoveTo",
+                        ship.name
+                    );
+                    continue;
+                }
+                // #217: origin_system for reporting is the ship's home port
+                // — not the current dock. Otherwise a ship that auto-moved
+                // to target and started scouting would be "home" already
+                // when the report is delivered (bug).
+                let origin_system = ship.home_port;
+                *state = ShipState::Scouting {
+                    target_system,
+                    origin_system,
+                    started_at: clock.elapsed,
+                    completes_at: clock.elapsed + observation_duration,
+                    report_mode,
+                };
+                info!(
+                    "Queue: Ship {} began scouting target (duration {} hexadies, mode {:?})",
+                    ship.name, observation_duration, report_mode
+                );
+                queue.sync_prediction(ship_pos.as_array(), Some(target_system));
+            }
             QueuedCommand::Survey { .. } | QueuedCommand::Colonize { .. } => {
                 // Consume the command and process synchronously.
                 let next = queue.commands.remove(0);
@@ -429,6 +508,8 @@ pub fn process_command_queue(
                         queue.sync_prediction(ship_pos.as_array(), docked_system);
                     }
                     QueuedCommand::MoveToCoordinates { .. } | QueuedCommand::MoveTo { .. } => {} // handled above
+                    // #217: Scout is handled by its own outer arm.
+                    QueuedCommand::Scout { .. } => {}
                     // #223: Deliverable-side commands are handled by
                     // `super::deliverable_ops::process_deliverable_commands`.
                     // This arm is unreachable via the outer match, but the

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -11,6 +11,7 @@ pub mod command;
 pub mod courier_route;
 pub mod pursuit;
 pub mod deliverable_ops;
+pub mod scout;
 
 pub use fleet::*;
 pub use exploration::*;
@@ -55,6 +56,16 @@ impl CommandQueue {
                     self.predicted_system = Some(*system);
                 }
             }
+            // #217: Scout visits the target and — under ReportMode::Return —
+            // comes back. We track the final predicted position as the
+            // target_system's position (FtlComm path stays at target too;
+            // the fallback-to-Return auto-queues a MoveTo home separately).
+            QueuedCommand::Scout { target_system, .. } => {
+                if let Some(pos) = system_positions(*target_system) {
+                    self.predicted_position = pos;
+                    self.predicted_system = Some(*target_system);
+                }
+            }
             QueuedCommand::MoveToCoordinates { target } => {
                 // #185: After a deep-space loiter move, the ship is no longer in any system.
                 self.predicted_position = *target;
@@ -81,6 +92,25 @@ impl CommandQueue {
     }
 }
 
+/// #217: How a scout ship reports its observation back to the empire.
+///
+/// `#[allow(dead_code)]`: the variants are only *constructed* by tests and
+/// (future) UI / AI code that issues Scout commands — no in-engine system
+/// constructs them yet. The enum is exhaustively matched by the scout
+/// pipeline regardless, so the constructors themselves are load-bearing.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReportMode {
+    /// If an FTL Comm Relay covers both the scout position and the player
+    /// empire at observation-completion time, the report is delivered
+    /// instantaneously. Otherwise falls back to `Return` (ship carries the
+    /// report home physically).
+    FtlComm,
+    /// The ship always carries the report back to its `home_port` / origin
+    /// system. The empire only learns of the observation when the ship docks.
+    Return,
+}
+
 #[derive(Clone, Debug)]
 pub enum QueuedCommand {
     MoveTo { system: Entity },
@@ -88,6 +118,19 @@ pub enum QueuedCommand {
     Colonize { system: Entity, planet: Option<Entity> },
     /// #185: Travel sublight to an arbitrary point in deep space and loiter there.
     MoveToCoordinates { target: [f64; 3] },
+    /// #217: Dispatch the ship to `target_system`, observe the area within
+    /// the scout's sensor range for `observation_duration` hexadies, then
+    /// report back via `report_mode`. The ship MUST have a scout module
+    /// equipped and FTL capability; otherwise the command is rejected at
+    /// dispatch time with a warning.
+    ///
+    /// `#[allow(dead_code)]`: constructed by tests and (future) UI / AI.
+    #[allow(dead_code)]
+    Scout {
+        target_system: Entity,
+        observation_duration: i64,
+        report_mode: ReportMode,
+    },
     /// #223: Load a deliverable from the docked system's `DeliverableStockpile`
     /// into this ship's `Cargo`. `stockpile_index` is the zero-based index in
     /// the stockpile at the time the command is executed; the command is a
@@ -164,6 +207,22 @@ impl Plugin for ShipPlugin {
             pursuit::detect_hostiles_system
                 .after(sublight_movement_system)
                 .after(process_ftl_travel)
+                .after(process_command_queue),
+            // #217: Scout observation ticker — transitions a Scouting ship
+            // into Docked + attaches a ScoutReport when the timer expires.
+            // Runs after FTL/sublight movement so a ship that finished
+            // travel and transitioned into Scouting this tick doesn't
+            // double-process.
+            scout::tick_scout_observation
+                .after(process_ftl_travel)
+                .after(sublight_movement_system)
+                .after(process_command_queue),
+            // #217: Scout report delivery — writes to KnowledgeStore on
+            // FTL comm success, or auto-queues return home. Runs after the
+            // observation ticker so a ship that completed observation this
+            // frame can still have its report routed this frame.
+            scout::process_scout_report
+                .after(scout::tick_scout_observation)
                 .after(process_command_queue),
         ).after(crate::time_system::advance_game_time)
          .before(crate::colony::advance_production_tick));
@@ -355,6 +414,19 @@ pub enum ShipState {
     /// which currently only operates on Docked ships in star systems.
     Loitering {
         position: [f64; 3],
+    },
+    /// #217: Scout ship is observing `target_system` for the duration of the
+    /// observation window. On completion, `tick_scout_observation` produces
+    /// a `ScoutReport` component on the ship and transitions it back to
+    /// `Docked { system: target_system }`. From there the ship either
+    /// delivers the report via FTL comm (if in coverage and mode allows) or
+    /// is auto-routed home to `origin_system` to deliver on dock.
+    Scouting {
+        target_system: Entity,
+        origin_system: Entity,
+        started_at: i64,
+        completes_at: i64,
+        report_mode: ReportMode,
     },
 }
 

--- a/macrocosmo/src/ship/pursuit.rs
+++ b/macrocosmo/src/ship/pursuit.rs
@@ -124,6 +124,10 @@ fn ship_position(
             ])
         }
         ShipState::Loitering { position } => Some(*position),
+        // #217: Scouting ships orbit the target system.
+        ShipState::Scouting { target_system, .. } => {
+            positions.get(*target_system).ok().map(|p| p.as_array())
+        }
     }
 }
 

--- a/macrocosmo/src/ship/scout.rs
+++ b/macrocosmo/src/ship/scout.rs
@@ -1,0 +1,610 @@
+//! #217: Scout command — reconnaissance dispatch + report mechanics.
+//!
+//! Flow overview:
+//!
+//! 1. [`QueuedCommand::Scout`](super::QueuedCommand::Scout) is queued on a
+//!    ship that has a Scout module equipped and FTL capability.
+//! 2. `process_command_queue` routes the ship to the target (auto-inserting
+//!    `MoveTo`) and, once docked at the target, transitions the ship into
+//!    [`ShipState::Scouting`](super::ShipState::Scouting).
+//! 3. [`tick_scout_observation`] polls Scouting ships each tick. When
+//!    `completes_at` is reached, it collects a sensor-range snapshot of the
+//!    surrounding hostile ships and deep-space structures, attaches a
+//!    [`ScoutReport`] to the ship, and parks the ship back in
+//!    `ShipState::Docked` at the target system.
+//! 4. [`process_scout_report`] delivers the report:
+//!    - `ReportMode::FtlComm` — if the scout position and the player empire
+//!      are both covered by a paired FTL Comm Relay, write the snapshot into
+//!      the empire's [`KnowledgeStore`] with `source = ObservationSource::Scout`
+//!      immediately. Otherwise falls back to `Return` behavior.
+//!    - `ReportMode::Return` — auto-queues a `MoveTo` to the ship's origin
+//!      system and defers delivery until it docks there. `observed_at` is
+//!      preserved as the time of observation (so the report is "old" by the
+//!      time the ship arrives, which is the whole point of the mechanic).
+
+use bevy::prelude::*;
+use std::collections::HashMap;
+
+use crate::components::Position;
+use crate::galaxy::{HostilePresence, StarSystem};
+use crate::knowledge::{
+    KnowledgeStore, ObservationSource, ShipSnapshot, ShipSnapshotState, SystemKnowledge,
+    SystemSnapshot,
+};
+use crate::physics::distance_ly_arr;
+use crate::player::{Player, PlayerEmpire, StationedAt};
+use crate::time_system::GameClock;
+
+use super::{
+    CommandQueue, QueuedCommand, ReportMode, Ship, ShipHitpoints, ShipState,
+};
+
+/// Fallback sensor range for scout operations (light-years). In the MVP
+/// release the value is a constant; future iterations will derive the range
+/// from the equipped scout module's modifier (#219+).
+pub const SCOUT_SENSOR_RANGE_LY: f64 = 3.0;
+
+/// Canonical module id a ship must carry to accept a `Scout` command.
+/// Defined in `scripts/ships/modules.lua` (`scout_module`). Rust-side code
+/// references this id directly so the gating logic stays deterministic even
+/// if the Lua-side `define_module` call is absent (e.g. the fallback test
+/// registry).
+pub const SCOUT_MODULE_ID: &str = "scout_module";
+
+/// #217: Result of a scout ship's observation window.
+///
+/// Attached to the ship as a component when [`tick_scout_observation`]
+/// finishes its timer. Consumed by [`process_scout_report`] once delivery
+/// conditions are met.
+#[derive(Component, Clone, Debug)]
+pub struct ScoutReport {
+    /// The system that was observed.
+    pub target_system: Entity,
+    /// The ship's cached origin (where it should return if FtlComm fails
+    /// and for `Return` mode). Usually the system the scout was docked at
+    /// when the Scout command started.
+    pub origin_system: Entity,
+    /// When the observation window ended (hexadies). Becomes the snapshot
+    /// `observed_at` on delivery.
+    pub observed_at: i64,
+    /// Delivery channel selected by the player at dispatch time.
+    pub report_mode: ReportMode,
+    /// Snapshot of the target system at observation time.
+    pub system_snapshot: SystemSnapshot,
+    /// Ship snapshots within sensor range at observation time.
+    pub ship_snapshots: Vec<ShipSnapshot>,
+    /// Whether the ship has already been auto-queued home (Return fallback).
+    /// Prevents `process_scout_report` from stacking duplicate `MoveTo`s
+    /// across frames while the ship is in FTL / sublight.
+    pub return_queued: bool,
+}
+
+/// Returns `true` if the ship has any module whose `module_id` matches
+/// [`SCOUT_MODULE_ID`].
+pub fn ship_has_scout_module(ship: &Ship) -> bool {
+    ship.modules.iter().any(|m| m.module_id == SCOUT_MODULE_ID)
+}
+
+/// Returns `true` when the `scout_pos` is within a paired FTL Comm Relay
+/// source range AND the player's current position is within the matching
+/// partner relay's range. This mirrors the gating logic used by
+/// `deep_space::relay_knowledge_propagate_system` but without writing any
+/// knowledge — callers decide whether to treat the pair as "in range".
+///
+/// `relay_range_for(structure_definition_id)` returns the `ftl_comm_relay`
+/// capability range in light-years, or `None` if the structure is not a
+/// relay (e.g. partner was destroyed / unpaired). A range of `0.0` is
+/// treated as "infinite" to match the relay module convention.
+///
+/// #217: Scout FTL comm coverage check. Does NOT modify relay state —
+/// relay propagation itself is owned by #216.
+#[allow(clippy::too_many_arguments)]
+pub fn ftl_comm_covers(
+    scout_pos: [f64; 3],
+    player_pos: [f64; 3],
+    relays: &[RelayCoverageSnapshot],
+) -> bool {
+    for relay in relays {
+        let scout_to_source = distance_ly_arr(scout_pos, relay.source_pos);
+        if relay.source_range > 0.0 && scout_to_source > relay.source_range {
+            continue;
+        }
+        let player_to_partner = distance_ly_arr(player_pos, relay.partner_pos);
+        if relay.partner_range > 0.0 && player_to_partner > relay.partner_range {
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
+/// Minimal snapshot of a single FTL Comm Relay pair for coverage checks.
+/// Collected once per tick by [`collect_relay_coverage`].
+#[derive(Clone, Copy, Debug)]
+pub struct RelayCoverageSnapshot {
+    pub source_pos: [f64; 3],
+    pub partner_pos: [f64; 3],
+    /// Source-side `ftl_comm_relay.range` in light-years. `0.0` means "infinite".
+    pub source_range: f64,
+    /// Partner-side `ftl_comm_relay.range` in light-years. `0.0` means "infinite".
+    pub partner_range: f64,
+}
+
+/// #217: Walk live FTL Comm Relay pairs and return a flat list of coverage
+/// snapshots. Ignores relays whose partner is dead (dangling pairs are
+/// cleaned up by `verify_relay_pairings_system`).
+///
+/// This helper is intentionally lightweight and allocates only a small Vec;
+/// the relay set is single-digit at MVP scope.
+pub fn collect_relay_coverage(
+    registry: &crate::deep_space::StructureRegistry,
+    relays: &Query<
+        (
+            Entity,
+            &crate::deep_space::DeepSpaceStructure,
+            &Position,
+            &crate::deep_space::FTLCommRelay,
+        ),
+        (
+            Without<crate::deep_space::ConstructionPlatform>,
+            Without<crate::deep_space::Scrapyard>,
+        ),
+    >,
+    relay_positions: &Query<&Position, With<crate::deep_space::DeepSpaceStructure>>,
+    partner_structures: &Query<&crate::deep_space::DeepSpaceStructure>,
+) -> Vec<RelayCoverageSnapshot> {
+    let mut out = Vec::new();
+
+    let relay_range_for =
+        |structure: &crate::deep_space::DeepSpaceStructure| -> Option<f64> {
+            let def = registry.get(&structure.definition_id)?;
+            let cap = def.capabilities.get("ftl_comm_relay")?;
+            Some(cap.range)
+        };
+
+    for (_source_entity, source_structure, source_pos, relay) in relays.iter() {
+        let Some(source_range) = relay_range_for(source_structure) else {
+            continue;
+        };
+        let partner_entity = relay.paired_with;
+        let Ok(partner_structure) = partner_structures.get(partner_entity) else {
+            continue;
+        };
+        let Ok(partner_pos) = relay_positions.get(partner_entity) else {
+            continue;
+        };
+        let Some(partner_range) = relay_range_for(partner_structure) else {
+            continue;
+        };
+
+        out.push(RelayCoverageSnapshot {
+            source_pos: source_pos.as_array(),
+            partner_pos: partner_pos.as_array(),
+            source_range,
+            partner_range,
+        });
+    }
+
+    out
+}
+
+/// #217: Observation tick — completes the Scouting timer and writes a
+/// `ScoutReport` component onto the ship. Runs after game time has
+/// advanced.
+///
+/// Implementation note: we can't have both `Query<..&mut ShipState..>` and
+/// a second `Query<..&ShipState..>` in the same system (Bevy B0001). So we
+/// first pass reads every ship's position / state / identity into an owned
+/// snapshot Vec and then uses the mutable query to apply transitions.
+#[allow(clippy::too_many_arguments)]
+pub fn tick_scout_observation(
+    mut commands: Commands,
+    clock: Res<GameClock>,
+    mut ships: Query<(Entity, &Ship, &mut ShipState, &Position, &ShipHitpoints)>,
+    systems: Query<(&StarSystem, &Position), Without<Ship>>,
+    hostiles: Query<&HostilePresence>,
+) {
+    let now = clock.elapsed;
+
+    // Hostile systems lookup.
+    let hostile_map: HashMap<Entity, &HostilePresence> = hostiles
+        .iter()
+        .map(|h| (h.system, h))
+        .collect();
+
+    // First pass: collect an owned snapshot of every ship so we can sensor-
+    // scan without borrowing the mutable query twice. Also identify which
+    // ships are completing their Scouting window this tick.
+    #[derive(Clone)]
+    struct ShipObservation {
+        entity: Entity,
+        name: String,
+        design_id: String,
+        pos: [f64; 3],
+        hull: f64,
+        hull_max: f64,
+        snapshot_state: ShipSnapshotState,
+        last_system: Option<Entity>,
+    }
+    let mut all_ships: Vec<ShipObservation> = Vec::new();
+    let mut completions: Vec<(
+        Entity,
+        Entity, // target_system
+        Entity, // origin_system
+        ReportMode,
+        [f64; 3],
+    )> = Vec::new();
+
+    for (ship_entity, ship, state, ship_pos, hp) in ships.iter() {
+        let (snap_state, last_system) = match state {
+            ShipState::Docked { system } => (ShipSnapshotState::Docked, Some(*system)),
+            ShipState::SubLight { target_system, .. } => {
+                (ShipSnapshotState::InTransit, *target_system)
+            }
+            ShipState::InFTL {
+                destination_system, ..
+            } => (ShipSnapshotState::InTransit, Some(*destination_system)),
+            ShipState::Surveying { target_system, .. } => {
+                (ShipSnapshotState::Surveying, Some(*target_system))
+            }
+            ShipState::Settling { system, .. } => {
+                (ShipSnapshotState::Settling, Some(*system))
+            }
+            ShipState::Refitting { system, .. } => {
+                (ShipSnapshotState::Refitting, Some(*system))
+            }
+            ShipState::Loitering { position } => {
+                (ShipSnapshotState::Loitering { position: *position }, None)
+            }
+            ShipState::Scouting { target_system, .. } => {
+                (ShipSnapshotState::Surveying, Some(*target_system))
+            }
+        };
+        all_ships.push(ShipObservation {
+            entity: ship_entity,
+            name: ship.name.clone(),
+            design_id: ship.design_id.clone(),
+            pos: ship_pos.as_array(),
+            hull: hp.hull,
+            hull_max: hp.hull_max,
+            snapshot_state: snap_state,
+            last_system,
+        });
+
+        if let ShipState::Scouting {
+            target_system,
+            origin_system,
+            completes_at,
+            report_mode,
+            ..
+        } = *state
+        {
+            if now >= completes_at {
+                completions.push((
+                    ship_entity,
+                    target_system,
+                    origin_system,
+                    report_mode,
+                    ship_pos.as_array(),
+                ));
+            }
+        }
+    }
+
+    for (ship_entity, target_system, origin_system, report_mode, scout_pos) in completions {
+        // Build system snapshot — minimal survey-compatible payload.
+        let (system_name, system_pos, surveyed) = match systems.get(target_system) {
+            Ok((s, p)) => (s.name.clone(), p.as_array(), s.surveyed),
+            Err(_) => {
+                warn!("Scout {ship_entity:?}: target system despawned mid-observation");
+                if let Ok((_, _, mut state, _, _)) = ships.get_mut(ship_entity) {
+                    *state = ShipState::Docked {
+                        system: target_system,
+                    };
+                }
+                continue;
+            }
+        };
+
+        let has_hostile_here = hostile_map.contains_key(&target_system);
+        let hostile_strength = hostile_map
+            .get(&target_system)
+            .map(|h| h.strength)
+            .unwrap_or(0.0);
+
+        let system_snapshot = SystemSnapshot {
+            name: system_name,
+            position: system_pos,
+            surveyed,
+            has_hostile: has_hostile_here,
+            hostile_strength,
+            ..default()
+        };
+
+        // Ship snapshots within sensor range, derived from the owned first-pass.
+        let mut ship_snapshots = Vec::new();
+        for obs in &all_ships {
+            if obs.entity == ship_entity {
+                continue;
+            }
+            let dist = distance_ly_arr(scout_pos, obs.pos);
+            if dist > SCOUT_SENSOR_RANGE_LY {
+                continue;
+            }
+            ship_snapshots.push(ShipSnapshot {
+                entity: obs.entity,
+                name: obs.name.clone(),
+                design_id: obs.design_id.clone(),
+                last_known_state: obs.snapshot_state.clone(),
+                last_known_system: obs.last_system,
+                observed_at: now,
+                hp: obs.hull,
+                hp_max: obs.hull_max,
+                source: ObservationSource::Scout,
+            });
+        }
+
+        let contacts = ship_snapshots.len();
+        let report = ScoutReport {
+            target_system,
+            origin_system,
+            observed_at: now,
+            report_mode,
+            system_snapshot,
+            ship_snapshots,
+            return_queued: false,
+        };
+
+        // Park the ship at the target system and attach the report.
+        if let Ok((_, _, mut state, _, _)) = ships.get_mut(ship_entity) {
+            *state = ShipState::Docked {
+                system: target_system,
+            };
+        }
+        commands.entity(ship_entity).try_insert(report);
+        info!(
+            "Scout observation complete: ship {:?} observed system {:?} ({} ship contacts, hostile={})",
+            ship_entity, target_system, contacts, has_hostile_here,
+        );
+    }
+}
+
+/// #217: Scout report delivery. Runs after `tick_scout_observation` and the
+/// command queue systems; either writes to the empire's `KnowledgeStore`
+/// (FtlComm mode with live coverage) or auto-queues a return move to
+/// `origin_system` (Return mode, or FtlComm fallback).
+#[allow(clippy::too_many_arguments)]
+pub fn process_scout_report(
+    mut commands: Commands,
+    clock: Res<GameClock>,
+    mut reports: Query<(
+        Entity,
+        &Ship,
+        &ShipState,
+        &Position,
+        &mut CommandQueue,
+        &mut ScoutReport,
+    )>,
+    mut empire_q: Query<&mut KnowledgeStore, With<PlayerEmpire>>,
+    player_q: Query<&StationedAt, With<Player>>,
+    positions: Query<&Position>,
+    // FTL comm coverage inputs.
+    structure_registry: Res<crate::deep_space::StructureRegistry>,
+    relays: Query<
+        (
+            Entity,
+            &crate::deep_space::DeepSpaceStructure,
+            &Position,
+            &crate::deep_space::FTLCommRelay,
+        ),
+        (
+            Without<crate::deep_space::ConstructionPlatform>,
+            Without<crate::deep_space::Scrapyard>,
+        ),
+    >,
+    relay_positions: Query<&Position, With<crate::deep_space::DeepSpaceStructure>>,
+    partner_structures: Query<&crate::deep_space::DeepSpaceStructure>,
+    system_positions: Query<&Position, With<StarSystem>>,
+) {
+    let Ok(mut store) = empire_q.single_mut() else {
+        return;
+    };
+    let player_pos: Option<[f64; 3]> = player_q
+        .iter()
+        .next()
+        .and_then(|s| positions.get(s.system).ok().map(|p| p.as_array()));
+
+    let coverage = collect_relay_coverage(
+        &structure_registry,
+        &relays,
+        &relay_positions,
+        &partner_structures,
+    );
+
+    for (ship_entity, ship, state, ship_pos, mut queue, mut report) in reports.iter_mut() {
+        let deliver = |store: &mut KnowledgeStore, report: &ScoutReport, source: ObservationSource| {
+            // System knowledge entry.
+            store.update(SystemKnowledge {
+                system: report.target_system,
+                observed_at: report.observed_at,
+                received_at: clock.elapsed,
+                data: report.system_snapshot.clone(),
+                source,
+            });
+            // Ship snapshots.
+            for snap in &report.ship_snapshots {
+                let mut snap = snap.clone();
+                // Keep the original observation time; callers set the source
+                // already, but overwrite for safety when the report was
+                // carried home (still Scout).
+                snap.source = source;
+                store.update_ship(snap);
+            }
+        };
+
+        match report.report_mode {
+            ReportMode::FtlComm => {
+                // Try instant delivery IF:
+                //  1. The ship is still in the target system / at the
+                //     observation position (i.e., it hasn't left), AND
+                //  2. FTL comm coverage includes both scout pos and player.
+                let at_observation_post = matches!(state, ShipState::Docked { .. });
+                let covered = match player_pos {
+                    Some(pp) => ftl_comm_covers(ship_pos.as_array(), pp, &coverage),
+                    None => false,
+                };
+
+                if at_observation_post && covered {
+                    deliver(&mut store, &report, ObservationSource::Scout);
+                    commands.entity(ship_entity).remove::<ScoutReport>();
+                    info!(
+                        "Scout report delivered via FTL Comm: {} -> system {:?}",
+                        ship.name, report.target_system
+                    );
+                    continue;
+                }
+
+                // Fallback path: behave like ReportMode::Return. If the ship
+                // has already made it home, deliver; otherwise auto-queue
+                // move home.
+                if let ShipState::Docked { system } = state {
+                    if *system == report.origin_system {
+                        deliver(&mut store, &report, ObservationSource::Scout);
+                        commands.entity(ship_entity).remove::<ScoutReport>();
+                        info!(
+                            "Scout report (FtlComm fallback -> Return) delivered on dock at origin: {} -> system {:?}",
+                            ship.name, report.target_system
+                        );
+                        continue;
+                    }
+                }
+                if !report.return_queued && queue.commands.is_empty() {
+                    queue.commands.push(QueuedCommand::MoveTo {
+                        system: report.origin_system,
+                    });
+                    queue.sync_prediction(
+                        system_positions
+                            .get(report.origin_system)
+                            .map(|p| p.as_array())
+                            .unwrap_or(ship_pos.as_array()),
+                        Some(report.origin_system),
+                    );
+                    report.return_queued = true;
+                    info!(
+                        "Scout report: FTL Comm out of range; auto-queuing return for {}",
+                        ship.name
+                    );
+                }
+            }
+            ReportMode::Return => {
+                if let ShipState::Docked { system } = state {
+                    if *system == report.origin_system {
+                        deliver(&mut store, &report, ObservationSource::Scout);
+                        commands.entity(ship_entity).remove::<ScoutReport>();
+                        info!(
+                            "Scout report delivered on dock at origin: {} -> system {:?}",
+                            ship.name, report.target_system
+                        );
+                        continue;
+                    }
+                }
+                if !report.return_queued && queue.commands.is_empty() {
+                    queue.commands.push(QueuedCommand::MoveTo {
+                        system: report.origin_system,
+                    });
+                    queue.sync_prediction(
+                        system_positions
+                            .get(report.origin_system)
+                            .map(|p| p.as_array())
+                            .unwrap_or(ship_pos.as_array()),
+                        Some(report.origin_system),
+                    );
+                    report.return_queued = true;
+                    info!(
+                        "Scout report: {} heading home to deliver observation",
+                        ship.name
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ftl_comm_covers_requires_both_ends() {
+        let relays = vec![RelayCoverageSnapshot {
+            source_pos: [0.0, 0.0, 0.0],
+            partner_pos: [100.0, 0.0, 0.0],
+            source_range: 5.0,
+            partner_range: 5.0,
+        }];
+        // Scout at source, player near partner → covered.
+        assert!(ftl_comm_covers(
+            [1.0, 0.0, 0.0],
+            [99.0, 0.0, 0.0],
+            &relays
+        ));
+        // Scout out of source range → not covered.
+        assert!(!ftl_comm_covers(
+            [10.0, 0.0, 0.0],
+            [99.0, 0.0, 0.0],
+            &relays
+        ));
+        // Player out of partner range → not covered.
+        assert!(!ftl_comm_covers(
+            [1.0, 0.0, 0.0],
+            [50.0, 0.0, 0.0],
+            &relays
+        ));
+    }
+
+    #[test]
+    fn ftl_comm_covers_zero_range_is_infinite() {
+        let relays = vec![RelayCoverageSnapshot {
+            source_pos: [0.0, 0.0, 0.0],
+            partner_pos: [100.0, 0.0, 0.0],
+            source_range: 0.0,
+            partner_range: 0.0,
+        }];
+        assert!(ftl_comm_covers(
+            [9999.0, 0.0, 0.0],
+            [-9999.0, 0.0, 0.0],
+            &relays
+        ));
+    }
+
+    #[test]
+    fn ship_has_scout_module_detects_scout() {
+        use super::super::EquippedModule;
+        use super::super::Owner;
+        let ship_no = Ship {
+            name: "n".into(),
+            design_id: "d".into(),
+            hull_id: "h".into(),
+            modules: vec![EquippedModule {
+                slot_type: "utility".into(),
+                module_id: "cargo_bay".into(),
+            }],
+            owner: Owner::Neutral,
+            sublight_speed: 0.0,
+            ftl_range: 0.0,
+            player_aboard: false,
+            home_port: Entity::PLACEHOLDER,
+            design_revision: 0,
+        };
+        assert!(!ship_has_scout_module(&ship_no));
+
+        let ship_yes = Ship {
+            modules: vec![EquippedModule {
+                slot_type: "utility".into(),
+                module_id: SCOUT_MODULE_ID.into(),
+            }],
+            ..ship_no
+        };
+        assert!(ship_has_scout_module(&ship_yes));
+    }
+}

--- a/macrocosmo/src/ui/context_menu.rs
+++ b/macrocosmo/src/ui/context_menu.rs
@@ -69,6 +69,8 @@ pub fn draw_context_menu(
             // #185: Loitering ships have no associated system; commands will be queued
             // and routed via MoveTo (which handles loitering->system sublight).
             ShipState::Loitering { .. } => None,
+            // #217: Scouting ships are parked at the observation target.
+            ShipState::Scouting { target_system, .. } => Some(*target_system),
         };
         (
             ship.name.clone(),

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -1259,6 +1259,7 @@ fn draw_map_tooltips(
                     ShipState::Settling { .. } => "Settling",
                     ShipState::Refitting { .. } => "Refitting",
                     ShipState::Loitering { .. } => "Loitering",
+                    ShipState::Scouting { .. } => "Scouting",
                 };
                 egui::Tooltip::always_open(
                     ctx.clone(),

--- a/macrocosmo/src/ui/outline.rs
+++ b/macrocosmo/src/ui/outline.rs
@@ -18,6 +18,7 @@ fn ship_status_label(state: &ShipState) -> &'static str {
         ShipState::Settling { .. } => "Settling",
         ShipState::Refitting { .. } => "Refitting",
         ShipState::Loitering { .. } => "Loitering",
+        ShipState::Scouting { .. } => "Scouting",
     }
 }
 
@@ -336,6 +337,7 @@ pub fn draw_outline(
                     ShipState::Settling { .. } => "Settling",
                     ShipState::Refitting { .. } => continue,
                     ShipState::Loitering { .. } => "Loitering",
+                    ShipState::Scouting { .. } => "Scouting",
                 };
                 in_transit.push((entity, ship.name.clone(), ship.design_id.clone(), status));
             }

--- a/macrocosmo/src/ui/ship_panel.rs
+++ b/macrocosmo/src/ui/ship_panel.rs
@@ -260,6 +260,27 @@ fn build_status_info(
             ),
             progress: None,
         },
+        // #217: Scouting — display like Surveying but labelled "Scouting".
+        ShipState::Scouting {
+            target_system,
+            started_at,
+            completes_at,
+            ..
+        } => {
+            let total = (completes_at - started_at).max(1);
+            let elapsed = (clock.elapsed - started_at).clamp(0, total);
+            let pct = elapsed as f32 / total as f32;
+            ShipStatusInfo {
+                label: format!(
+                    "Scouting {} ({}/{} hd, {:.0}%)",
+                    system_name(*target_system, stars),
+                    elapsed,
+                    total,
+                    pct * 100.0
+                ),
+                progress: Some((elapsed, total, pct)),
+            }
+        }
     }
 }
 
@@ -305,6 +326,22 @@ fn format_queued_command(
         QueuedCommand::Colonize { .. } => "Colonize".to_string(),
         QueuedCommand::MoveToCoordinates { target } => {
             format!("Move -> ({:.1}, {:.1}, {:.1})", target[0], target[1], target[2])
+        }
+        // #217: Scout command display.
+        QueuedCommand::Scout {
+            target_system,
+            observation_duration,
+            report_mode,
+        } => {
+            format!(
+                "Scout {} ({}hx, {})",
+                system_name(*target_system, stars),
+                observation_duration,
+                match report_mode {
+                    crate::ship::ReportMode::FtlComm => "FTL comm",
+                    crate::ship::ReportMode::Return => "return",
+                }
+            )
         }
         // Deliverable variants are handled above; the catch-all is
         // unreachable in practice.

--- a/macrocosmo/src/visualization/ships.rs
+++ b/macrocosmo/src/visualization/ships.rs
@@ -186,6 +186,14 @@ pub fn draw_ships(
                 // Faint outer halo to distinguish "loitering" from in-transit.
                 gizmos.circle_2d(Vec2::new(cx, cy), 5.5, Color::srgba(r, g, b, 0.25));
             }
+            // #217: Scouting — display at the target system like docked.
+            ShipState::Scouting { target_system, .. } => {
+                docked_counts
+                    .entry(*target_system)
+                    .or_default()
+                    .push(ship.design_id.clone());
+                *system_ship_counts.entry(*target_system).or_insert(0) += 1;
+            }
         }
     }
 
@@ -326,6 +334,12 @@ pub fn draw_ships(
                             position[1] as f32 * view.scale,
                         ))
                     }
+                    // #217: Scouting ships render at the target system.
+                    ShipState::Scouting { target_system, .. } => {
+                        stars.get(*target_system).ok().map(|pos| {
+                            Vec2::new(pos.x as f32 * view.scale, pos.y as f32 * view.scale)
+                        })
+                    }
                 };
 
                 if let Some(mut prev_pos) = current_pos {
@@ -338,6 +352,16 @@ pub fn draw_ships(
                             | QueuedCommand::Colonize { system, .. }
                             | QueuedCommand::LoadDeliverable { system, .. } => {
                                 let Ok(target_pos) = stars.get(*system) else {
+                                    continue;
+                                };
+                                Vec2::new(
+                                    target_pos.x as f32 * view.scale,
+                                    target_pos.y as f32 * view.scale,
+                                )
+                            }
+                            // #217: Scout targets a star system like MoveTo.
+                            QueuedCommand::Scout { target_system, .. } => {
+                                let Ok(target_pos) = stars.get(*target_system) else {
                                     continue;
                                 };
                                 Vec2::new(
@@ -373,6 +397,19 @@ pub fn draw_ships(
                                     target_screen,
                                     4.0,
                                     Color::srgba(r, g, b, 0.5),
+                                );
+                            }
+                            // #217: Scout marker — magenta accent to distinguish from Survey.
+                            QueuedCommand::Scout { .. } => {
+                                gizmos.circle_2d(
+                                    target_screen,
+                                    6.0,
+                                    Color::srgba(1.0, 0.3, 1.0, 0.4),
+                                );
+                                gizmos.circle_2d(
+                                    target_screen,
+                                    3.0,
+                                    Color::srgba(1.0, 0.3, 1.0, 0.6),
                                 );
                             }
                             QueuedCommand::Survey { .. } => {

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -264,6 +264,11 @@ pub fn test_app() -> App {
             // injected MoveTo reaches the router in the same frame.
             macrocosmo::ship::deliverable_ops::process_deliverable_commands,
             process_command_queue,
+            // #217: Scout observation + report. Chained after
+            // process_command_queue so a Scout that began transitioning to
+            // Scouting this tick doesn't get double-processed.
+            macrocosmo::ship::scout::tick_scout_observation,
+            macrocosmo::ship::scout::process_scout_report,
             resolve_combat,
             tick_ship_repair,
             macrocosmo::ship::pursuit::detect_hostiles_system,
@@ -440,6 +445,9 @@ pub fn full_test_app() -> App {
             tick_courier_routes,
             macrocosmo::ship::deliverable_ops::process_deliverable_commands,
             process_command_queue,
+            // #217: Scout observation + delivery.
+            macrocosmo::ship::scout::tick_scout_observation,
+            macrocosmo::ship::scout::process_scout_report,
             resolve_combat,
             tick_ship_repair,
             macrocosmo::ship::pursuit::detect_hostiles_system,

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -2338,3 +2338,360 @@ fn test_loitering_ship_can_leave_via_move_to_system() {
         ),
     }
 }
+
+// --- #217: Scout command + report mechanics ---
+
+/// Spawn an FTL-capable scout ship with a Scout module equipped.
+fn spawn_scout_ship(world: &mut World, system: Entity, pos: [f64; 3]) -> Entity {
+    world
+        .spawn((
+            Ship {
+                name: "Scout-1".into(),
+                design_id: "scout_mk1".into(),
+                hull_id: "scout_hull".into(),
+                modules: vec![EquippedModule {
+                    slot_type: "utility".into(),
+                    module_id: macrocosmo::ship::scout::SCOUT_MODULE_ID.into(),
+                }],
+                owner: Owner::Neutral,
+                sublight_speed: 0.85,
+                ftl_range: 10.0,
+                player_aboard: false,
+                home_port: system,
+                design_revision: 0,
+            },
+            ShipState::Docked { system },
+            Position::from(pos),
+            ShipHitpoints {
+                hull: 40.0,
+                hull_max: 40.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            CommandQueue::default(),
+            Cargo::default(),
+            ShipModifiers::default(),
+            ShipStats::default(),
+            RulesOfEngagement::default(),
+        ))
+        .id()
+}
+
+#[test]
+fn test_scout_command_dispatches_ship() {
+    // Scout command → ship FTLs to target, enters Scouting, completes after
+    // observation_duration.
+    let mut app = test_app();
+    let sys_home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    // Target at 5 ly — within FTL range 10.
+    let sys_target = spawn_test_system(
+        app.world_mut(),
+        "Target",
+        [5.0, 0.0, 0.0],
+        0.5,
+        true, // surveyed so FTL route works
+        false,
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys_home }));
+
+    let ship = spawn_scout_ship(app.world_mut(), sys_home, [0.0, 0.0, 0.0]);
+
+    // Queue a Scout command.
+    {
+        let mut queue = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+        queue.commands.push(QueuedCommand::Scout {
+            target_system: sys_target,
+            observation_duration: 5,
+            report_mode: macrocosmo::ship::ReportMode::Return,
+        });
+    }
+
+    // Tick once — Scout should auto-insert MoveTo and the router should
+    // spawn an FTL task.
+    advance_time(&mut app, 1);
+    // Let the async router resolve.
+    advance_time(&mut app, 1);
+
+    // Advance enough ticks for 5 ly FTL at 10c (30 hd) plus observation.
+    // ceil(5 * 60 / 10) = 30 hd.
+    for _ in 0..80 {
+        advance_time(&mut app, 1);
+        let state = app.world().get::<ShipState>(ship).unwrap();
+        if matches!(state, ShipState::Scouting { .. }) {
+            break;
+        }
+    }
+    let state = app.world().get::<ShipState>(ship).unwrap();
+    match state {
+        ShipState::Scouting {
+            target_system,
+            report_mode,
+            ..
+        } => {
+            assert_eq!(*target_system, sys_target);
+            assert_eq!(*report_mode, macrocosmo::ship::ReportMode::Return);
+        }
+        other => panic!(
+            "Expected ShipState::Scouting after dispatch, got {:?}",
+            std::mem::discriminant(other)
+        ),
+    }
+
+    // Advance observation_duration (5 hd) — scout should complete and
+    // attach a ScoutReport.
+    let mut saw_report = false;
+    for _ in 0..10 {
+        advance_time(&mut app, 1);
+        if app
+            .world()
+            .get::<macrocosmo::ship::scout::ScoutReport>(ship)
+            .is_some()
+        {
+            saw_report = true;
+            break;
+        }
+    }
+    assert!(
+        saw_report,
+        "ScoutReport component should be attached after observation_duration expires"
+    );
+    // Ship must no longer be in Scouting state after the report lands.
+    let state = app.world().get::<ShipState>(ship).unwrap();
+    assert!(
+        !matches!(state, ShipState::Scouting { .. }),
+        "Ship must have exited Scouting state once ScoutReport is attached"
+    );
+}
+
+#[test]
+fn test_scout_report_via_ftl_comm() {
+    // Setup: FTL Comm Relay pair covers both the scout (near relay-B) and
+    // the player (near relay-A). Report must be delivered instantly to
+    // empire KnowledgeStore with source=Scout and observed_at = observation
+    // completion time.
+    use macrocosmo::deep_space::{
+        pair_relay_command, CapabilityParams, CommDirection, DeepSpaceStructure,
+        DeliverableMetadata, ResourceCost, StructureDefinition, StructureHitpoints,
+        StructureRegistry,
+    };
+    use std::collections::HashMap;
+
+    let mut app = test_app();
+
+    // Install ftl_comm_relay definition with 3 ly range.
+    {
+        let mut registry = app.world_mut().resource_mut::<StructureRegistry>();
+        registry.insert(StructureDefinition {
+            id: "ftl_comm_relay".into(),
+            name: "FTL Comm Relay".into(),
+            description: String::new(),
+            max_hp: 50.0,
+            capabilities: HashMap::from([(
+                "ftl_comm_relay".into(),
+                CapabilityParams { range: 3.0 },
+            )]),
+            energy_drain: Amt::milli(500),
+            prerequisites: None,
+            deliverable: Some(DeliverableMetadata {
+                cost: ResourceCost::default(),
+                build_time: 20,
+                cargo_size: 2,
+                scrap_refund: 0.4,
+            }),
+            upgrade_to: Vec::new(),
+            upgrade_from: None,
+        });
+    }
+
+    let sys_home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys_target = spawn_test_system(
+        app.world_mut(),
+        "Target",
+        [20.0, 0.0, 0.0],
+        0.5,
+        true,
+        false,
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys_home }));
+
+    // Relay A near home (within 3 ly of player at home origin).
+    let relay_a = app
+        .world_mut()
+        .spawn((
+            DeepSpaceStructure {
+                definition_id: "ftl_comm_relay".into(),
+                name: "Relay-A".into(),
+                owner: Owner::Neutral,
+            },
+            StructureHitpoints {
+                current: 50.0,
+                max: 50.0,
+            },
+            Position::from([2.0, 0.0, 0.0]),
+        ))
+        .id();
+    // Relay B near target (within 3 ly of target at [20,0,0]).
+    let relay_b = app
+        .world_mut()
+        .spawn((
+            DeepSpaceStructure {
+                definition_id: "ftl_comm_relay".into(),
+                name: "Relay-B".into(),
+                owner: Owner::Neutral,
+            },
+            StructureHitpoints {
+                current: 50.0,
+                max: 50.0,
+            },
+            Position::from([19.0, 0.0, 0.0]),
+        ))
+        .id();
+    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional)
+        .expect("pairing");
+
+    // Scout ship with FTL range 10 — can't reach target in one hop, but
+    // we'll teleport it manually to simplify the test (skip movement logic).
+    let ship = spawn_scout_ship(app.world_mut(), sys_target, [20.0, 0.0, 0.0]);
+
+    // Inject the Scouting state directly (ship already at target, observing).
+    let start_at = app.world().resource::<GameClock>().elapsed;
+    {
+        let mut state = app.world_mut().get_mut::<ShipState>(ship).unwrap();
+        *state = ShipState::Scouting {
+            target_system: sys_target,
+            origin_system: sys_home,
+            started_at: start_at,
+            completes_at: start_at + 3,
+            report_mode: macrocosmo::ship::ReportMode::FtlComm,
+        };
+    }
+
+    // Advance through observation + one report tick.
+    for _ in 0..6 {
+        advance_time(&mut app, 1);
+    }
+
+    // The player empire's KnowledgeStore should now have a Scout-sourced
+    // SystemKnowledge for sys_target with observed_at == completes_at.
+    let empire = empire_entity(app.world_mut());
+    let store = app.world().get::<KnowledgeStore>(empire).expect("store");
+    let k = store
+        .get(sys_target)
+        .expect("target system knowledge should be written via FTL comm");
+    assert_eq!(
+        k.source,
+        ObservationSource::Scout,
+        "FTL-comm delivered scout report must be source=Scout"
+    );
+    assert_eq!(
+        k.observed_at,
+        start_at + 3,
+        "observed_at must match the observation-completion time"
+    );
+
+    // ScoutReport should be consumed on delivery.
+    assert!(
+        app.world()
+            .get::<macrocosmo::ship::scout::ScoutReport>(ship)
+            .is_none(),
+        "ScoutReport must be removed after FtlComm delivery"
+    );
+}
+
+#[test]
+fn test_scout_report_via_return() {
+    // No FTL comm relay coverage — ship must physically return to origin
+    // before the empire learns of the observation. Before return, the
+    // KnowledgeStore must NOT contain a Scout-sourced entry for target.
+    let mut app = test_app();
+    let sys_home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    // Target at 5 ly (FTL-reachable direct jump).
+    let sys_target = spawn_test_system(
+        app.world_mut(),
+        "Target",
+        [5.0, 0.0, 0.0],
+        0.5,
+        true,
+        false,
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys_home }));
+
+    let ship = spawn_scout_ship(app.world_mut(), sys_target, [5.0, 0.0, 0.0]);
+
+    // Directly park the ship in Scouting at target.
+    let start_at = app.world().resource::<GameClock>().elapsed;
+    {
+        let mut state = app.world_mut().get_mut::<ShipState>(ship).unwrap();
+        *state = ShipState::Scouting {
+            target_system: sys_target,
+            origin_system: sys_home,
+            started_at: start_at,
+            completes_at: start_at + 3,
+            report_mode: macrocosmo::ship::ReportMode::Return,
+        };
+    }
+
+    // Advance through observation completion.
+    // completes_at = start_at + 3; clock = start_at + N after N advances,
+    // so after 4 advances we're safely past completion.
+    for _ in 0..4 {
+        advance_time(&mut app, 1);
+    }
+    let expected_observed_at = start_at + 3;
+    // Before the ship has docked back at sys_home, empire must not have
+    // a Scout-sourced knowledge entry for sys_target.
+    {
+        let empire = empire_entity(app.world_mut());
+        let store = app.world().get::<KnowledgeStore>(empire).expect("store");
+        let maybe = store.get(sys_target);
+        // propagate_knowledge may have inserted a Direct entry; ensure
+        // nothing with source=Scout exists yet.
+        if let Some(k) = maybe {
+            assert_ne!(
+                k.source,
+                ObservationSource::Scout,
+                "Return-mode report must not be delivered before the ship docks home"
+            );
+        }
+        assert!(
+            app.world()
+                .get::<macrocosmo::ship::scout::ScoutReport>(ship)
+                .is_some(),
+            "ScoutReport must still be attached while ship is returning"
+        );
+    }
+
+    // Ship should have been auto-queued a MoveTo home. Advance long enough
+    // for FTL: 5 ly at 10c = 30 hd.
+    for _ in 0..100 {
+        advance_time(&mut app, 1);
+        let state = app.world().get::<ShipState>(ship).unwrap();
+        if matches!(state, ShipState::Docked { system } if *system == sys_home) {
+            break;
+        }
+    }
+    // Report should be delivered now.
+    let empire = empire_entity(app.world_mut());
+    let store = app.world().get::<KnowledgeStore>(empire).expect("store");
+    let k = store
+        .get(sys_target)
+        .expect("target knowledge should be written once ship docked home");
+    assert_eq!(
+        k.source,
+        ObservationSource::Scout,
+        "Return-mode report must carry source=Scout when delivered"
+    );
+    assert_eq!(
+        k.observed_at, expected_observed_at,
+        "observed_at should preserve the original observation time (not the delivery time)"
+    );
+    assert!(
+        app.world()
+            .get::<macrocosmo::ship::scout::ScoutReport>(ship)
+            .is_none(),
+        "ScoutReport must be removed after Return-mode delivery"
+    );
+}


### PR DESCRIPTION
## Summary

- #212 偵察 epic の Active Scouting レイヤ。`QueuedCommand::Scout { target_system, observation_duration, report_mode }` を追加
- Scout ship が FTL で現地派遣 → `observation_duration` 観測 → 報告経路で自陣 KnowledgeStore に反映
- source = `ObservationSource::Scout` (#215 で reserve 済、本 PR で書き込み経路を実装)

## 設計

- **報告モード**:
  - `ReportMode::FtlComm` — 現地が FTL Comm Relay 範囲内なら観測完了と同時に empire KnowledgeStore に書き込み、範囲外なら Return fallback
  - `ReportMode::Return` — ship が `home_port` system に docked したタイミングで書き込み
- **observed_at の意味論**: Return モードでも `observed_at = 観測完了時刻` で記録 (到達時刻ではない)。"古い情報を持ち帰る" のが意図
- **艦種**: 既存艦への `scout_module` (sensor.range += 1.0) 装備で Scout コマンド許可。モジュール無しは dispatch 時に拒否
- **非 FTL 艦は拒否**: `ship.ftl_range <= 0.0` ガード。本 issue の scope は FTL scout のみ

## 変更ファイル (14 files, +1246)

- 新規: `src/ship/scout.rs` (+610) — core scout logic + 3 unit tests + `collect_relay_coverage` helper + `ship_has_scout_module`
- `src/ship/mod.rs` (+72): `ReportMode`, `QueuedCommand::Scout`, `ShipState::Scouting`, plugin wiring
- `src/ship/command.rs` (+81): Scout dispatch — FTL + module validation、auto-MoveTo、`origin_system = home_port`
- `scripts/ships/modules.lua` (+15): `scout_module` utility-slot 定義
- `tests/ship.rs` (+357): 3 新 integration tests + `spawn_scout_ship` helper
- `tests/common/mod.rs` (+8): scout systems を test_app() / full_test_app() 両方に登録
- `ShipState::Scouting` exhaustive match 対応 (8 ファイル) — deep_space / knowledge / pursuit / ui 系 / visualization

## Test plan

- [x] `test_scout_command_dispatches_ship` — Scout queued → auto-MoveTo → FTL → Scouting → timer 完了で ScoutReport 添付
- [x] `test_scout_report_via_ftl_comm` — relay 範囲内で observed_at=completes_at, source=Scout で empire に即時反映
- [x] `test_scout_report_via_return` — relay 範囲外では home_port 帰還後に書き込み、observed_at は観測時刻 (古い情報)
- [x] src/ship/scout.rs 内の 3 unit tests: `ftl_comm_covers_*`, `ship_has_scout_module_*`
- [x] `cargo test -p macrocosmo`: 611 lib (+3 from 608) + ship 45 (+3 from 42) + 全 integration 全 pass
- [x] warning 新規なし

## Follow-up (明示的 scope 外)

- **UI**: Scout command 発行ボタン (context_menu) は別 issue。本 PR は `format_queued_command` + state display のみ
- **#163 Faction**: 現状は faction owner filter 未実装、全 ship/structure を観測対象。Faction 実装後に filter 追加
- **Sensor range dynamic**: hardcode `SCOUT_SENSOR_RANGE_LY = 3.0`。`scout_module` が `sensor.range += 1.0` を GlobalParams に追加するが `tick_scout_observation` は未消費。後続 refactor で empire bonus を thread
- **Non-FTL scouts**: 将来 sublight scout が欲しい場合は `ship.ftl_range <= 0.0` check を緩和

## #216 との関係

- `deep_space/mod.rs` / `knowledge/mod.rs` を両者が触るが disjoint regions で auto-merge clean
- Scout は `collect_relay_coverage()` helper で FTL Comm 判定を読み取るのみ。`relay_knowledge_propagate_system` には手を付けず

🤖 Generated with [Claude Code](https://claude.com/claude-code)