### PR TITLE
Fix #216/#217 semantic conflict — Scout must dominate Relay source

### DIFF
--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -158,10 +158,32 @@ impl KnowledgeStore {
     }
 
     pub fn update(&mut self, knowledge: SystemKnowledge) {
-        let dominated = self
-            .entries
-            .get(&knowledge.system)
-            .is_some_and(|existing| existing.observed_at >= knowledge.observed_at);
+        let dominated = self.entries.get(&knowledge.system).is_some_and(|existing| {
+            // Scout vs Relay source priority.
+            //
+            // Scout observations carry high-fidelity sensor-range data
+            // (ships + structures snapshot) gathered by a ship physically
+            // deployed to the target. Relay entries are continuous
+            // low-fidelity Sensor-Buoy forwards that #216 writes every tick
+            // with `observed_at = clock.elapsed` for every star system
+            // within a source relay's range. In same-tick races the Relay
+            // write would otherwise overwrite a fresh Scout report.
+            //
+            // Rule: Scout always dominates Relay, regardless of observed_at.
+            // A newer Scout, any Direct observation, or the Stale overlay in
+            // `perceived_system` still take over as expected.
+            if existing.source == ObservationSource::Scout
+                && knowledge.source == ObservationSource::Relay
+            {
+                return true;
+            }
+            if existing.source == ObservationSource::Relay
+                && knowledge.source == ObservationSource::Scout
+            {
+                return false;
+            }
+            existing.observed_at >= knowledge.observed_at
+        });
 
         if !dominated {
             self.entries.insert(knowledge.system, knowledge);

--- a/macrocosmo/tests/knowledge.rs
+++ b/macrocosmo/tests/knowledge.rs
@@ -1992,6 +1992,112 @@ fn test_perceived_info_relay_source() {
     assert!(fleet.is_empty());
 }
 
+/// Regression test for the #216 / #217 semantic clash: Scout reports and
+/// Relay propagation ticks race to write the same system. Relay is a
+/// continuous low-fidelity forward; Scout is a high-fidelity targeted
+/// observation. The store must preserve the Scout entry regardless of
+/// write order — both "incoming Relay vs existing Scout" and "incoming
+/// Scout vs existing Relay" cases resolve in Scout's favour. A newer
+/// Scout or any Direct observation still dominates.
+#[test]
+fn test_relay_does_not_overwrite_scout() {
+    use bevy::ecs::world::World;
+
+    let mut world = World::new();
+    let sys_entity = world.spawn_empty().id();
+    let mut store = KnowledgeStore::default();
+
+    // Scout arrives first with an older observed_at (as FtlComm report would).
+    store.update(SystemKnowledge {
+        system: sys_entity,
+        observed_at: 100,
+        received_at: 100,
+        data: SystemSnapshot {
+            name: "Scouted".to_string(),
+            ..Default::default()
+        },
+        source: ObservationSource::Scout,
+    });
+    assert_eq!(store.get(sys_entity).unwrap().source, ObservationSource::Scout);
+
+    // Relay propagation ticks keep running and try to write a newer entry.
+    store.update(SystemKnowledge {
+        system: sys_entity,
+        observed_at: 105,
+        received_at: 105,
+        data: SystemSnapshot {
+            name: "Relayed".to_string(),
+            ..Default::default()
+        },
+        source: ObservationSource::Relay,
+    });
+
+    // Scout is preserved — Relay cannot dominate it.
+    let k = store.get(sys_entity).unwrap();
+    assert_eq!(k.source, ObservationSource::Scout);
+    assert_eq!(k.observed_at, 100);
+    assert_eq!(k.data.name, "Scouted");
+
+    // Reverse ordering — Relay writes first, then Scout arrives with an
+    // older observed_at (as can happen in same-tick races where the relay
+    // system ran before process_scout_report). Scout must still win.
+    let mut store2 = KnowledgeStore::default();
+    let sys2 = world.spawn_empty().id();
+    store2.update(SystemKnowledge {
+        system: sys2,
+        observed_at: 105,
+        received_at: 105,
+        data: SystemSnapshot {
+            name: "Relayed".to_string(),
+            ..Default::default()
+        },
+        source: ObservationSource::Relay,
+    });
+    store2.update(SystemKnowledge {
+        system: sys2,
+        observed_at: 100,
+        received_at: 100,
+        data: SystemSnapshot {
+            name: "Scouted".to_string(),
+            ..Default::default()
+        },
+        source: ObservationSource::Scout,
+    });
+    let k2 = store2.get(sys2).unwrap();
+    assert_eq!(k2.source, ObservationSource::Scout);
+    assert_eq!(k2.observed_at, 100);
+    assert_eq!(k2.data.name, "Scouted");
+
+    // A newer Scout observation, on the other hand, MUST dominate.
+    store.update(SystemKnowledge {
+        system: sys_entity,
+        observed_at: 200,
+        received_at: 200,
+        data: SystemSnapshot {
+            name: "Scouted2".to_string(),
+            ..Default::default()
+        },
+        source: ObservationSource::Scout,
+    });
+    let k = store.get(sys_entity).unwrap();
+    assert_eq!(k.source, ObservationSource::Scout);
+    assert_eq!(k.observed_at, 200);
+
+    // And a Direct (player-present) observation also dominates Scout when newer.
+    store.update(SystemKnowledge {
+        system: sys_entity,
+        observed_at: 300,
+        received_at: 300,
+        data: SystemSnapshot {
+            name: "DirectObserved".to_string(),
+            ..Default::default()
+        },
+        source: ObservationSource::Direct,
+    });
+    let k = store.get(sys_entity).unwrap();
+    assert_eq!(k.source, ObservationSource::Direct);
+}
+
 // ---------------------------------------------------------------------------
 // #216: Sensor Buoy + FTL Comm Relay information aggregation (B-1)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

両 PR (#234 #216 relay 集約 / #235 #217 scout command) は個別テストで通過したが、統合後に `test_scout_report_via_ftl_comm` が落ちる。根本原因は以下のレース条件:

- #216 の `relay_knowledge_propagate_system` は **毎 tick**、source relay の range 内の全星系に \`observed_at = clock.elapsed, source = Relay\` を書き込む (Sensor Buoy の存在問わず)
- #217 の Scout FtlComm 報告は \`observed_at = completes_at, source = Scout\` を書き込む
- 同 tick では書き順で決着、次 tick 以降は Relay の observed_at が Scout を上回り常に overwrite

## 修正: source 優先度ルール

`KnowledgeStore::update` に **Scout > Relay の優先順位** を追加:

- existing Scout + incoming Relay → Scout 保持 (Relay は dominate しない)
- existing Relay + incoming Scout → Scout 上書き (observed_at 関係なく)
- それ以外は既存の observed_at 比較

### 設計意図

- Scout: sensor-range full snapshot を物理的に艦派遣して取得。高 fidelity、稀、観測時点固定
- Relay: 毎 tick Sensor Buoy forward。低 fidelity、連続、observed_at=now
- Scout データは意味的に Relay より strictly valuable
- 古さは `perceived_system` の Stale overlay (#215) で UI 表示され、Scout 保持で情報が古いまま見える問題は顕在化する
- 新 Scout / Direct 観測は通常どおり dominate

## 変更ファイル (2 files, +132 / -4)

- `src/knowledge/mod.rs`: `KnowledgeStore::update` に対称ルール追加 (comment で意図を明記)
- `tests/knowledge.rs`: `test_relay_does_not_overwrite_scout` regression — 両順序の保持、Scout→Scout 更新、Scout→Direct 優先 を網羅

## Test plan

- [x] `cargo test -p macrocosmo`: 611 lib + 全 integration green
- [x] ship 45 pass (previously-failing `test_scout_report_via_ftl_comm` now passes)
- [x] knowledge 36 pass (+1 regression)
- [x] warning 新規なし

## なぜ #216/#217 側で直さず追加 PR か

- 両 PR は個別仕様として正しく、どちらを直しても "相手側の副作用を知っている" 前提になり PR 単独で review しにくい
- KnowledgeStore の dominate ルールは複数 source を持つ全ての書き込みが通る single source of truth。semantic 調停はここに集約する方が後続の Faction 化 (#163) / source 追加でも再利用可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)