### PR TITLE
#232: Fix stalled build progress — tick build_time only when resources transfer

### DIFF
--- a/macrocosmo/src/colony/build_tick.rs
+++ b/macrocosmo/src/colony/build_tick.rs
@@ -1,0 +1,90 @@
+//! #232: Shared helper for gated build-time ticking.
+//!
+//! Background: construction / upgrade queues advance `build_time_remaining`
+//! one hexadies at a time inside the per-tick inner loop. The naive
+//! `build_time_remaining -= 1` runs every tick regardless of whether the
+//! order made progress, so when a star system stockpile is empty the
+//! timer keeps draining and eventually sinks below zero while the order
+//! never completes (the completion check also requires the remaining
+//! resource balances to be zero). The UI then displays a finished
+//! countdown on a stalled order.
+//!
+//! This module centralizes the tick rule so all three sites (planet
+//! building construction, planet building upgrade, system building
+//! upgrade — and for consistency the system building construction loop
+//! that shares the same shape) agree on when the clock is allowed to
+//! advance.
+
+/// Advance `remaining` by one hexadies iff the order either received
+/// resources this tick (`transferred == true`) or no longer needs any
+/// resources (`no_more_needed == true`). Returns whether the counter was
+/// decremented — useful for tests and for any caller that wants to log
+/// stalled progress.
+///
+/// When both flags are `false` the order is stalled (starved of resources)
+/// and the timer must stay pinned. This matches the design intent that an
+/// under-resourced build cannot complete just because time has passed.
+pub(crate) fn maybe_tick_build_time(
+    remaining: &mut i64,
+    transferred: bool,
+    no_more_needed: bool,
+) -> bool {
+    if transferred || no_more_needed {
+        *remaining -= 1;
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ticks_when_resources_transferred() {
+        let mut remaining = 10;
+        let ticked = maybe_tick_build_time(&mut remaining, true, false);
+        assert!(ticked);
+        assert_eq!(remaining, 9);
+    }
+
+    #[test]
+    fn ticks_when_no_more_needed() {
+        // Zero-cost or already-paid orders: the only thing left is to
+        // wait out the clock.
+        let mut remaining = 5;
+        let ticked = maybe_tick_build_time(&mut remaining, false, true);
+        assert!(ticked);
+        assert_eq!(remaining, 4);
+    }
+
+    #[test]
+    fn ticks_when_both_true() {
+        // Both: resources trickled in AND the order is now fully paid.
+        let mut remaining = 3;
+        let ticked = maybe_tick_build_time(&mut remaining, true, true);
+        assert!(ticked);
+        assert_eq!(remaining, 2);
+    }
+
+    #[test]
+    fn does_not_tick_when_stalled() {
+        // Starved tick: no transfer, resources still required.
+        let mut remaining = 4;
+        let ticked = maybe_tick_build_time(&mut remaining, false, false);
+        assert!(!ticked);
+        assert_eq!(remaining, 4);
+    }
+
+    #[test]
+    fn stalled_counter_does_not_underflow_past_zero_without_progress() {
+        // Simulates the buggy pre-#232 path: many stalled ticks in a
+        // row must not drain the counter.
+        let mut remaining = 2;
+        for _ in 0..1000 {
+            maybe_tick_build_time(&mut remaining, false, false);
+        }
+        assert_eq!(remaining, 2);
+    }
+}

--- a/macrocosmo/src/colony/building_queue.rs
+++ b/macrocosmo/src/colony/building_queue.rs
@@ -376,7 +376,19 @@ pub fn tick_building_queue(
             available_energy = available_energy.sub(energy_transfer);
             energy_consumed = energy_consumed.add(energy_transfer);
 
-            order.build_time_remaining -= 1;
+            // #232: Only advance the countdown when resources actually moved
+            // this tick, or when no resources are needed anymore. Otherwise
+            // a starved build would have its timer drain past zero while
+            // the completion check (which also requires 0 remaining cost)
+            // keeps blocking completion.
+            let transferred = minerals_transfer > Amt::ZERO || energy_transfer > Amt::ZERO;
+            let no_more_needed = order.minerals_remaining == Amt::ZERO
+                && order.energy_remaining == Amt::ZERO;
+            super::build_tick::maybe_tick_build_time(
+                &mut order.build_time_remaining,
+                transferred,
+                no_more_needed,
+            );
 
             if bq.queue[0].minerals_remaining == Amt::ZERO
                 && bq.queue[0].energy_remaining == Amt::ZERO
@@ -456,7 +468,16 @@ pub fn tick_building_queue(
                 available_energy = available_energy.sub(energy_transfer);
                 energy_consumed = energy_consumed.add(energy_transfer);
 
-                upgrade.build_time_remaining -= 1;
+                // #232: See construction-queue branch above — only tick the
+                // timer when progress is happening or no progress is needed.
+                let transferred = minerals_transfer > Amt::ZERO || energy_transfer > Amt::ZERO;
+                let no_more_needed = upgrade.minerals_remaining == Amt::ZERO
+                    && upgrade.energy_remaining == Amt::ZERO;
+                super::build_tick::maybe_tick_build_time(
+                    &mut upgrade.build_time_remaining,
+                    transferred,
+                    no_more_needed,
+                );
 
                 if upgrade.minerals_remaining == Amt::ZERO
                     && upgrade.energy_remaining == Amt::ZERO

--- a/macrocosmo/src/colony/mod.rs
+++ b/macrocosmo/src/colony/mod.rs
@@ -8,6 +8,7 @@ pub use crate::scripting::building_api::{BuildingId, BuildingRegistry};
 use crate::scripting::building_api::parse_building_definitions;
 
 pub mod authority;
+pub mod build_tick;
 pub mod building_queue;
 pub mod colonization;
 pub mod maintenance;

--- a/macrocosmo/src/colony/system_buildings.rs
+++ b/macrocosmo/src/colony/system_buildings.rs
@@ -269,7 +269,18 @@ pub fn tick_system_building_queue(
             available_energy = available_energy.sub(energy_transfer);
             energy_consumed = energy_consumed.add(energy_transfer);
 
-            order.build_time_remaining -= 1;
+            // #232: Gate timer advance on actual progress (see
+            // build_tick::maybe_tick_build_time docstring). Mirrors the
+            // planet-level building queue so starved system builds don't
+            // sink into negative-time limbo.
+            let transferred = minerals_transfer > Amt::ZERO || energy_transfer > Amt::ZERO;
+            let no_more_needed = order.minerals_remaining == Amt::ZERO
+                && order.energy_remaining == Amt::ZERO;
+            super::build_tick::maybe_tick_build_time(
+                &mut order.build_time_remaining,
+                transferred,
+                no_more_needed,
+            );
 
             if bq.queue[0].minerals_remaining == Amt::ZERO
                 && bq.queue[0].energy_remaining == Amt::ZERO
@@ -332,7 +343,15 @@ pub fn tick_system_building_queue(
                 available_energy = available_energy.sub(energy_transfer);
                 energy_consumed = energy_consumed.add(energy_transfer);
 
-                upgrade.build_time_remaining -= 1;
+                // #232: Gate timer advance on actual progress.
+                let transferred = minerals_transfer > Amt::ZERO || energy_transfer > Amt::ZERO;
+                let no_more_needed = upgrade.minerals_remaining == Amt::ZERO
+                    && upgrade.energy_remaining == Amt::ZERO;
+                super::build_tick::maybe_tick_build_time(
+                    &mut upgrade.build_time_remaining,
+                    transferred,
+                    no_more_needed,
+                );
 
                 if upgrade.minerals_remaining == Amt::ZERO
                     && upgrade.energy_remaining == Amt::ZERO

--- a/macrocosmo/tests/colony.rs
+++ b/macrocosmo/tests/colony.rs
@@ -1745,3 +1745,389 @@ fn test_134_existing_shipyard_gating_still_works() {
     let count = ship_q.iter(app.world()).count();
     assert_eq!(count, 0, "No shipyard in the system: ship must not spawn");
 }
+
+// -----------------------------------------------------------------------------
+// #232: Gated build-time ticking — regression tests.
+//
+// Before the fix, `build_time_remaining -= 1` ran unconditionally every tick
+// regardless of whether the star system could spare any minerals / energy.
+// With an empty stockpile the timer kept draining below zero while the
+// completion check (which also demands 0 remaining resource cost) kept
+// blocking completion — so the UI displayed a finished countdown on a
+// stalled order forever.
+// -----------------------------------------------------------------------------
+
+/// Planet-level new construction must NOT advance build_time_remaining when
+/// the star system stockpile has nothing to contribute AND the order still
+/// needs resources.
+#[test]
+fn test_construction_does_not_progress_when_stockpile_empty() {
+    let mut app = test_app();
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Starved-Construction",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    let planet_sys = find_planet(app.world_mut(), sys);
+    // Deliberately empty stockpile (food > 0 so the colony doesn't starve;
+    // building-queue tick only cares about minerals/energy).
+    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+        minerals: Amt::ZERO,
+        energy: Amt::ZERO,
+        research: Amt::ZERO,
+        food: Amt::units(100),
+        authority: Amt::ZERO,
+    });
+
+    let build_time = 10;
+    let colony_entity = app
+        .world_mut()
+        .spawn((
+            Colony { planet: planet_sys, population: 10.0, growth_rate: 0.0 },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue { queue: Vec::new() },
+            Buildings { slots: vec![None, None, None, None] },
+            BuildingQueue {
+                queue: vec![BuildingOrder {
+                    building_id: BuildingId::new("mine"),
+                    target_slot: 0,
+                    minerals_remaining: Amt::units(150),
+                    energy_remaining: Amt::units(50),
+                    build_time_remaining: build_time,
+                }],
+                demolition_queue: Vec::new(),
+                upgrade_queue: Vec::new(),
+            },
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
+
+    // Advance well past the nominal build time; with no resources ever
+    // arriving, the timer must stay pinned and the slot must stay empty.
+    advance_time(&mut app, build_time * 3);
+
+    let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
+    assert_eq!(bq.queue.len(), 1, "order must still be pending: {:?}", bq.queue.len());
+    let order = &bq.queue[0];
+    assert_eq!(
+        order.build_time_remaining, build_time,
+        "Starved order must not drain its timer (got {}, expected {})",
+        order.build_time_remaining, build_time
+    );
+    let buildings = app.world().get::<Buildings>(colony_entity).expect("buildings");
+    assert_eq!(buildings.slots[0], None, "Slot must stay empty while order is starved");
+}
+
+/// Planet-level upgrade order must stall while resources are unavailable.
+#[test]
+fn test_upgrade_does_not_progress_when_stockpile_empty() {
+    let mut app = test_app();
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Starved-Upgrade",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    let planet_sys = find_planet(app.world_mut(), sys);
+    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+        minerals: Amt::ZERO,
+        energy: Amt::ZERO,
+        research: Amt::ZERO,
+        food: Amt::units(100),
+        authority: Amt::ZERO,
+    });
+
+    let build_time = 8;
+    let colony_entity = app
+        .world_mut()
+        .spawn((
+            Colony { planet: planet_sys, population: 10.0, growth_rate: 0.0 },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue { queue: Vec::new() },
+            // Use an empty slot (no pre-existing building) to avoid any
+            // sync_building_modifiers side-effect that would feed the
+            // system stockpile via production bonuses — we want an
+            // unambiguous "no minerals / no energy" scenario for this
+            // starvation test. The upgrade code does not inspect the
+            // current slot; it just writes target_id into it on completion.
+            Buildings { slots: vec![None, None, None, None] },
+            BuildingQueue {
+                queue: Vec::new(),
+                demolition_queue: Vec::new(),
+                upgrade_queue: vec![UpgradeOrder {
+                    slot_index: 0,
+                    target_id: BuildingId::new("advanced_mine"),
+                    minerals_remaining: Amt::units(200),
+                    energy_remaining: Amt::units(80),
+                    build_time_remaining: build_time,
+                }],
+            },
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
+
+    advance_time(&mut app, build_time * 3);
+
+    let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
+    assert_eq!(bq.upgrade_queue.len(), 1, "upgrade order must still be pending");
+    assert_eq!(
+        bq.upgrade_queue[0].build_time_remaining, build_time,
+        "Starved upgrade must not drain its timer"
+    );
+    let buildings = app.world().get::<Buildings>(colony_entity).expect("buildings");
+    assert_eq!(
+        buildings.slots[0], None,
+        "Upgrade must not have replaced the (empty) slot while starved"
+    );
+}
+
+/// Planet-level upgrade must complete once resources eventually arrive,
+/// even after a long starvation period.
+#[test]
+fn test_upgrade_completes_when_resources_finally_arrive() {
+    let mut app = test_app();
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Delayed-Upgrade",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    let planet_sys = find_planet(app.world_mut(), sys);
+    // Start with empty stockpile.
+    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+        minerals: Amt::ZERO,
+        energy: Amt::ZERO,
+        research: Amt::ZERO,
+        food: Amt::units(100),
+        authority: Amt::ZERO,
+    });
+
+    let build_time = 6;
+    let minerals_cost = Amt::units(100);
+    let energy_cost = Amt::units(40);
+    let colony_entity = app
+        .world_mut()
+        .spawn((
+            Colony { planet: planet_sys, population: 10.0, growth_rate: 0.0 },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue { queue: Vec::new() },
+            // Empty slot — see test_upgrade_does_not_progress_when_stockpile_empty
+            // for rationale (avoid sync_building_modifiers back-filling the
+            // stockpile via production bonuses).
+            Buildings { slots: vec![None, None, None, None] },
+            BuildingQueue {
+                queue: Vec::new(),
+                demolition_queue: Vec::new(),
+                upgrade_queue: vec![UpgradeOrder {
+                    slot_index: 0,
+                    target_id: BuildingId::new("advanced_mine"),
+                    minerals_remaining: minerals_cost,
+                    energy_remaining: energy_cost,
+                    build_time_remaining: build_time,
+                }],
+            },
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
+
+    // Starve for a long time — the clock must hold.
+    advance_time(&mut app, 30);
+    {
+        let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
+        assert_eq!(bq.upgrade_queue.len(), 1, "still pending after long starvation");
+        assert_eq!(bq.upgrade_queue[0].build_time_remaining, build_time);
+    }
+
+    // Resources finally arrive in bulk.
+    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+        minerals: minerals_cost.add(Amt::units(50)),
+        energy: energy_cost.add(Amt::units(50)),
+        research: Amt::ZERO,
+        food: Amt::units(100),
+        authority: Amt::ZERO,
+    });
+
+    advance_time(&mut app, build_time + 5);
+
+    let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
+    assert!(
+        bq.upgrade_queue.is_empty(),
+        "upgrade should have completed after resources arrived"
+    );
+    let buildings = app.world().get::<Buildings>(colony_entity).expect("buildings");
+    assert_eq!(
+        buildings.slots[0],
+        Some(BuildingId::new("advanced_mine")),
+        "slot must now hold the upgraded building"
+    );
+}
+
+/// Zero-cost upgrades (e.g. future tech-granted free rename) must still
+/// advance purely on time — `no_more_needed` is already true on tick 1.
+#[test]
+fn test_zero_cost_upgrade_progresses_on_time() {
+    let mut app = test_app();
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "FreeUpgrade",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    let planet_sys = find_planet(app.world_mut(), sys);
+    // Stockpile is zero but so is cost — order should still complete.
+    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+        minerals: Amt::ZERO,
+        energy: Amt::ZERO,
+        research: Amt::ZERO,
+        food: Amt::units(100),
+        authority: Amt::ZERO,
+    });
+
+    let build_time = 4;
+    let colony_entity = app
+        .world_mut()
+        .spawn((
+            Colony { planet: planet_sys, population: 10.0, growth_rate: 0.0 },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue { queue: Vec::new() },
+            Buildings {
+                slots: vec![Some(BuildingId::new("mine")), None, None, None],
+            },
+            BuildingQueue {
+                queue: Vec::new(),
+                demolition_queue: Vec::new(),
+                upgrade_queue: vec![UpgradeOrder {
+                    slot_index: 0,
+                    target_id: BuildingId::new("advanced_mine"),
+                    minerals_remaining: Amt::ZERO,
+                    energy_remaining: Amt::ZERO,
+                    build_time_remaining: build_time,
+                }],
+            },
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
+
+    advance_time(&mut app, build_time + 2);
+
+    let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
+    assert!(
+        bq.upgrade_queue.is_empty(),
+        "zero-cost upgrade should complete on time alone"
+    );
+    let buildings = app.world().get::<Buildings>(colony_entity).expect("buildings");
+    assert_eq!(
+        buildings.slots[0],
+        Some(BuildingId::new("advanced_mine")),
+        "zero-cost upgrade must have replaced the building"
+    );
+}
+
+/// System-level (StarSystem component) upgrade queue shares the same logic
+/// and must also stall when the stockpile is empty.
+#[test]
+fn test_system_upgrade_does_not_progress_when_stockpile_empty() {
+    let mut app = test_app();
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Starved-System-Upgrade",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    // Put SystemBuildings + SystemBuildingQueue directly on the star system.
+    app.world_mut().entity_mut(sys).insert((
+        SystemBuildings {
+            slots: vec![Some(BuildingId::new("shipyard")), None, None],
+        },
+        SystemBuildingQueue {
+            queue: Vec::new(),
+            demolition_queue: Vec::new(),
+            upgrade_queue: vec![UpgradeOrder {
+                slot_index: 0,
+                target_id: BuildingId::new("advanced_shipyard"),
+                minerals_remaining: Amt::units(300),
+                energy_remaining: Amt::units(120),
+                build_time_remaining: 10,
+            }],
+        },
+        ResourceStockpile {
+            minerals: Amt::ZERO,
+            energy: Amt::ZERO,
+            research: Amt::ZERO,
+            food: Amt::units(100),
+            authority: Amt::ZERO,
+        },
+        ResourceCapacity::default(),
+    ));
+
+    advance_time(&mut app, 30);
+
+    let bq = app
+        .world()
+        .get::<SystemBuildingQueue>(sys)
+        .expect("system building queue");
+    assert_eq!(
+        bq.upgrade_queue.len(),
+        1,
+        "system upgrade must still be pending after starvation"
+    );
+    assert_eq!(
+        bq.upgrade_queue[0].build_time_remaining, 10,
+        "timer must not drain while starved"
+    );
+    let sb = app.world().get::<SystemBuildings>(sys).expect("system buildings");
+    assert_eq!(
+        sb.slots[0],
+        Some(BuildingId::new("shipyard")),
+        "slot must still hold the pre-upgrade building"
+    );
+}


### PR DESCRIPTION
## Summary

建造物 construction/upgrade で資源不足時に \`build_time_remaining\` がマイナスに沈む bug を修正。4 箇所で同じパターンを条件付き decrement に。

### 修正方針 (user 確定、案 A)

資源が届いた tick、または資源がもう不要 (完済済) な tick **のみ** \`build_time_remaining\` を減らす:

\`\`\`rust
if transferred || no_more_needed {
    remaining -= 1;
}
\`\`\`

Zero-cost upgrade は \`no_more_needed\` で時間進行、資源不足中は停滞。

## 修正箇所 (4 箇所)

issue 本文では 3 箇所だったが、agent が **同パターンのバグを system_buildings.rs:272 (system building **新規建設**) にも発見**、4 箇所すべて修正:

1. \`building_queue.rs\` 363-401 (planet 新規建設)
2. \`building_queue.rs\` 447-469 (planet upgrade)
3. \`system_buildings.rs\` 256-287 (system 新規建設) ← **追加発見**
4. \`system_buildings.rs\` 323-344 (system upgrade)

## 変更ファイル (5 files, +521 / -4)

- \`src/colony/build_tick.rs\` (新規 90 行) — 共通ヘルパ \`maybe_tick_build_time()\` + 5 unit test
- \`src/colony/mod.rs\` — \`pub mod build_tick\`
- \`src/colony/building_queue.rs\` (+23) — 2 箇所 gate 適用
- \`src/colony/system_buildings.rs\` (+21) — 2 箇所 gate 適用
- \`tests/colony.rs\` (+386) — 5 integration test

## Test plan

- [x] **5 新規 integration test** 全 pass: construction/upgrade の stockpile-empty stall、資源到着で完了、zero-cost 進行
- [x] **5 新規 unit test** (build_tick 本体): 各 branch カバー
- [x] \`cargo test -p macrocosmo\`: **1489 passed / 0 failed**
- [x] warning 新規なし

## 気づき (agent 報告)

テスト書く際の罠: \`Buildings { slots: vec![Some(BuildingId::new("mine")), ...] }\` で mine を置くと \`sync_building_modifiers\` が production_bonus を Production に注入し、tick_production が stockpile に資源追加 → transfer が発生して timer が進む。stall test では slot を None にして回避。コメントで明記済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)