### PR TITLE
#233: Derive notifications from KnowledgeStore fact delta (light-speed + relay)

### DIFF
--- a/macrocosmo/src/empire/comms.rs
+++ b/macrocosmo/src/empire/comms.rs
@@ -1,0 +1,29 @@
+//! FTL Comm Relay modifier bundle attached to a `PlayerEmpire` entity (#233).
+//!
+//! Four modifier buckets are currently defined:
+//!
+//! | Field | Tech target | Consumer |
+//! |-------|-------------|----------|
+//! | `empire_relay_range`        | `empire.comm_relay_range`        | `effective_relay_range` (knowledge::facts) |
+//! | `empire_relay_inv_latency`  | `empire.comm_relay_inv_latency`  | `relay_delay_hexadies` (knowledge::facts) |
+//! | `fleet_relay_range`         | `fleet.comm_relay_range`         | reserved — no consumer yet |
+//! | `fleet_relay_inv_latency`   | `fleet.comm_relay_inv_latency`   | reserved — no consumer yet |
+//!
+//! `fleet.*` are storage-only today. They route through the same tech-effect
+//! pipeline so Lua definitions can already declare them; consumers will be
+//! added in a follow-up when per-ship comm modules become relevant.
+
+use bevy::prelude::*;
+
+use crate::modifier::ModifiedValue;
+
+/// Empire-level FTL Comm modifier bundle. See module docs for field meanings.
+#[derive(Component, Default, Debug, Clone)]
+pub struct CommsParams {
+    pub empire_relay_range: ModifiedValue,
+    pub empire_relay_inv_latency: ModifiedValue,
+    /// Reserved: will be consumed by future per-fleet comm modules.
+    pub fleet_relay_range: ModifiedValue,
+    /// Reserved: will be consumed by future per-fleet comm modules.
+    pub fleet_relay_inv_latency: ModifiedValue,
+}

--- a/macrocosmo/src/empire/mod.rs
+++ b/macrocosmo/src/empire/mod.rs
@@ -1,0 +1,9 @@
+//! Empire-level scoped components (#233).
+//!
+//! This module hosts ECS components that belong to the `PlayerEmpire` entity
+//! but are topic-specific enough to deserve their own file. The first such
+//! component is [`CommsParams`], which carries the four FTL-Comm modifier
+//! buckets consumed by the knowledge-fact arrival-time computation.
+pub mod comms;
+
+pub use comms::CommsParams;

--- a/macrocosmo/src/knowledge/facts.rs
+++ b/macrocosmo/src/knowledge/facts.rs
@@ -1,0 +1,651 @@
+//! #233 — `PerceivedFact` / `KnowledgeFact` pipeline.
+//!
+//! This is the "notification-producing delta" side of the knowledge system.
+//! The existing [`KnowledgeStore`](super::KnowledgeStore) holds a *snapshot*
+//! (latest known state per system / ship); this module tracks *events* — one
+//! per discrete observable happening — so the notification UI can render a
+//! single banner per event (rather than having to diff the snapshot store).
+//!
+//! Facts travel through [`PendingFactQueue`] with an `arrives_at` timestamp
+//! computed from light-speed propagation + optional FTL Comm Relay shortcut.
+//! The `notify_from_knowledge_facts` system drains facts whose `arrives_at`
+//! is <= `clock.elapsed` and pushes them into the notification queue.
+//!
+//! See `src/empire/comms.rs` for the [`CommsParams`] component that carries
+//! the `empire_relay_inv_latency` / `empire_relay_range` modifiers consumed
+//! by the helpers in this module.
+//!
+//! Several types here are unused by the main `macrocosmo` binary today —
+//! they are the consumer surface exposed to (a) the integration tests that
+//! exercise the arrival-time math and (b) future callsites that will be
+//! wired in follow-up PRs (scout ships, ship-carried fact pipeline, etc.).
+//! `#[allow(dead_code)]` is applied to the module to silence the binary-only
+//! unused warnings without suppressing genuine dead code elsewhere.
+
+#![allow(dead_code)]
+
+use bevy::prelude::*;
+
+use crate::components::Position;
+use crate::deep_space::{
+    CapabilityParams, ConstructionPlatform, DeepSpaceStructure, DeliverableRegistry, FTLCommRelay,
+    Scrapyard,
+};
+use crate::empire::comms::CommsParams;
+use crate::physics;
+
+use super::ObservationSource;
+
+/// Base FTL multiplier for relay-routed propagation. `relay_delay` at base
+/// evaluates to `light_delay / 10`. `empire_relay_inv_latency` modifiers stack
+/// additively on top of this base.
+pub const FTL_RELAY_BASE_MULTIPLIER: f64 = 10.0;
+
+/// Combat victor designator for [`KnowledgeFact::CombatOutcome`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CombatVictor {
+    /// Player-side victory.
+    Player,
+    /// Hostile-side victory.
+    Hostile,
+}
+
+/// An observable event that can produce a player-facing notification.
+///
+/// Facts are *events*, not snapshots. Each fact carries enough context to
+/// render a single banner (title + description + priority) without needing
+/// to cross-reference the snapshot store.
+#[derive(Clone, Debug)]
+pub enum KnowledgeFact {
+    /// A hostile contact was detected in deep space (#186 pursuit).
+    HostileDetected {
+        target: Entity,
+        detector: Entity,
+        target_pos: [f64; 3],
+        description: String,
+    },
+    /// Combat completed at a star system.
+    CombatOutcome {
+        system: Entity,
+        victor: CombatVictor,
+        detail: String,
+    },
+    /// A star system was fully surveyed.
+    SurveyComplete {
+        system: Entity,
+        system_name: String,
+        detail: String,
+    },
+    /// An anomaly was discovered during a survey.
+    AnomalyDiscovered {
+        system: Entity,
+        anomaly_id: String,
+        detail: String,
+    },
+    /// Non-anomaly survey discovery (legacy exploration event).
+    SurveyDiscovery {
+        system: Entity,
+        detail: String,
+    },
+    /// A ship / structure was built or destroyed.
+    StructureBuilt {
+        system: Option<Entity>,
+        kind: String,
+        name: String,
+        destroyed: bool,
+        detail: String,
+    },
+    /// A colony was founded at a planet.
+    ColonyEstablished {
+        system: Entity,
+        planet: Entity,
+        name: String,
+        detail: String,
+    },
+    /// A colony attempt failed.
+    ColonyFailed {
+        system: Entity,
+        name: String,
+        reason: String,
+    },
+    /// A ship arrived at a system (routine — usually Low priority).
+    ShipArrived {
+        system: Option<Entity>,
+        name: String,
+        detail: String,
+    },
+}
+
+impl KnowledgeFact {
+    /// Short banner title for this fact.
+    pub fn title(&self) -> &'static str {
+        match self {
+            KnowledgeFact::HostileDetected { .. } => "Hostile Detected",
+            KnowledgeFact::CombatOutcome { victor, .. } => match victor {
+                CombatVictor::Player => "Combat Victory",
+                CombatVictor::Hostile => "Combat Defeat",
+            },
+            KnowledgeFact::SurveyComplete { .. } => "Survey Complete",
+            KnowledgeFact::AnomalyDiscovered { .. } => "Anomaly Discovered",
+            KnowledgeFact::SurveyDiscovery { .. } => "Discovery",
+            KnowledgeFact::StructureBuilt { destroyed, .. } => {
+                if *destroyed { "Structure Destroyed" } else { "Structure Built" }
+            }
+            KnowledgeFact::ColonyEstablished { .. } => "Colony Established",
+            KnowledgeFact::ColonyFailed { .. } => "Colony Failed",
+            KnowledgeFact::ShipArrived { .. } => "Ship Arrived",
+        }
+    }
+
+    /// Free-form banner description for this fact.
+    pub fn description(&self) -> String {
+        match self {
+            KnowledgeFact::HostileDetected { description, .. } => description.clone(),
+            KnowledgeFact::CombatOutcome { detail, .. } => detail.clone(),
+            KnowledgeFact::SurveyComplete { detail, .. } => detail.clone(),
+            KnowledgeFact::AnomalyDiscovered { detail, .. } => detail.clone(),
+            KnowledgeFact::SurveyDiscovery { detail, .. } => detail.clone(),
+            KnowledgeFact::StructureBuilt { detail, .. } => detail.clone(),
+            KnowledgeFact::ColonyEstablished { detail, .. } => detail.clone(),
+            KnowledgeFact::ColonyFailed { reason, name, .. } => {
+                format!("Colony '{}' failed: {}", name, reason)
+            }
+            KnowledgeFact::ShipArrived { detail, .. } => detail.clone(),
+        }
+    }
+
+    /// Default notification priority for this fact kind.
+    pub fn priority(&self) -> crate::notifications::NotificationPriority {
+        use crate::notifications::NotificationPriority::*;
+        match self {
+            KnowledgeFact::HostileDetected { .. } => High,
+            KnowledgeFact::CombatOutcome { .. } => High,
+            KnowledgeFact::SurveyComplete { .. } => Medium,
+            KnowledgeFact::AnomalyDiscovered { .. } => High,
+            KnowledgeFact::SurveyDiscovery { .. } => High,
+            KnowledgeFact::StructureBuilt { .. } => Low,
+            KnowledgeFact::ColonyEstablished { .. } => High,
+            KnowledgeFact::ColonyFailed { .. } => High,
+            KnowledgeFact::ShipArrived { .. } => Low,
+        }
+    }
+
+    /// Associated star system (for notification jump-to-system).
+    pub fn related_system(&self) -> Option<Entity> {
+        match self {
+            KnowledgeFact::HostileDetected { .. } => None,
+            KnowledgeFact::CombatOutcome { system, .. } => Some(*system),
+            KnowledgeFact::SurveyComplete { system, .. } => Some(*system),
+            KnowledgeFact::AnomalyDiscovered { system, .. } => Some(*system),
+            KnowledgeFact::SurveyDiscovery { system, .. } => Some(*system),
+            KnowledgeFact::StructureBuilt { system, .. } => *system,
+            KnowledgeFact::ColonyEstablished { system, .. } => Some(*system),
+            KnowledgeFact::ColonyFailed { system, .. } => Some(*system),
+            KnowledgeFact::ShipArrived { system, .. } => *system,
+        }
+    }
+}
+
+/// A [`KnowledgeFact`] plus the timing + provenance metadata the arrival
+/// scheduler needs.
+#[derive(Clone, Debug)]
+pub struct PerceivedFact {
+    pub fact: KnowledgeFact,
+    /// Hexadies at which the event actually happened at its origin.
+    pub observed_at: i64,
+    /// Hexadies at which the notification should surface to the player.
+    pub arrives_at: i64,
+    /// Which channel produced this observation (Direct / Relay / Scout).
+    pub source: ObservationSource,
+    /// World-space origin of the event (for future directionality / UI).
+    pub origin_pos: [f64; 3],
+    /// Optional star system reference (duplicates `fact.related_system()` for
+    /// convenience — callers sometimes have the entity but not the fact yet).
+    pub related_system: Option<Entity>,
+}
+
+/// Resource holding facts waiting for their light-speed / relay arrival time.
+///
+/// Parallel to (not merged with) [`KnowledgeStore`](super::KnowledgeStore).
+/// Responsibility split:
+///   - `KnowledgeStore` → "what is the world like right now, from the
+///     player's vantage point" (snapshot).
+///   - `PendingFactQueue` → "what *happened* that the player will hear about
+///     at time T" (delta).
+#[derive(Resource, Default)]
+pub struct PendingFactQueue {
+    pub facts: Vec<PerceivedFact>,
+}
+
+impl PendingFactQueue {
+    /// Record a new fact. Does not check timing — the scheduler will sort out
+    /// arrival ordering on the next `drain_ready` call.
+    pub fn record(&mut self, fact: PerceivedFact) {
+        self.facts.push(fact);
+    }
+
+    /// Drain all facts whose `arrives_at <= now`, returning them in insertion
+    /// order. Facts still pending remain in the queue.
+    pub fn drain_ready(&mut self, now: i64) -> Vec<PerceivedFact> {
+        let mut ready = Vec::new();
+        let mut i = 0;
+        while i < self.facts.len() {
+            if self.facts[i].arrives_at <= now {
+                ready.push(self.facts.remove(i));
+            } else {
+                i += 1;
+            }
+        }
+        ready
+    }
+
+    /// How many facts are currently pending (not yet arrived).
+    pub fn pending_len(&self) -> usize {
+        self.facts.len()
+    }
+}
+
+/// Snapshot of a single FTL Comm Relay endpoint for arrival-time computation.
+///
+/// Built once per tick by [`collect_relay_snapshots`] so the arrival-time
+/// helpers don't need to touch ECS queries.
+#[derive(Clone, Debug)]
+pub struct RelaySnapshot {
+    pub position: [f64; 3],
+    /// Effective range after `empire_relay_range` modifiers. Zero / negative
+    /// means "this relay is non-operational for coverage purposes".
+    pub range_ly: f64,
+    /// Whether this relay has a live partner (i.e. can actually forward).
+    pub paired: bool,
+}
+
+/// Lightweight snapshot of the empire's relay network. MVP assumption:
+/// **all relays belong to one network**; proper multi-network BFS is future
+/// work. See issue #233 design notes.
+#[derive(Resource, Default, Clone, Debug)]
+pub struct RelayNetwork {
+    pub relays: Vec<RelaySnapshot>,
+}
+
+/// Rebuild [`RelayNetwork`] each tick from live Deep-Space entities.
+///
+/// Skips entities still in construction (`ConstructionPlatform`) or scrapping
+/// (`Scrapyard`). Uses the `empire.comm_relay_range` bonus from [`CommsParams`]
+/// on the `PlayerEmpire` entity when computing effective range.
+pub fn rebuild_relay_network(
+    mut network: ResMut<RelayNetwork>,
+    structures: Query<
+        (
+            Entity,
+            &DeepSpaceStructure,
+            &Position,
+            Option<&FTLCommRelay>,
+        ),
+        (Without<ConstructionPlatform>, Without<Scrapyard>),
+    >,
+    registry: Res<DeliverableRegistry>,
+    empire_q: Query<&CommsParams, With<crate::player::PlayerEmpire>>,
+) {
+    let empire_bonus = empire_q
+        .iter()
+        .next()
+        .map(|c| c.empire_relay_range.final_value().to_f64())
+        .unwrap_or(0.0);
+
+    network.relays.clear();
+    for (_e, structure, pos, relay) in structures.iter() {
+        let Some(def) = registry.get(&structure.definition_id) else {
+            continue;
+        };
+        let Some(cap) = def.capabilities.get("ftl_comm_relay") else {
+            continue;
+        };
+        network.relays.push(RelaySnapshot {
+            position: pos.as_array(),
+            range_ly: effective_relay_range(cap, empire_bonus),
+            paired: relay.is_some(),
+        });
+    }
+}
+
+/// Compute the effective range of a relay. Zero-range capabilities (the Lua
+/// default) are treated as infinite; otherwise the `empire_relay_range`
+/// additive bonus is applied.
+pub fn effective_relay_range(cap: &CapabilityParams, empire_range_bonus: f64) -> f64 {
+    if cap.range <= 0.0 {
+        // A range of zero in Lua means "infinite" — see
+        // `relay_knowledge_propagate_system` doc.
+        f64::INFINITY
+    } else {
+        cap.range + empire_range_bonus
+    }
+}
+
+/// Convert a relay distance into an arrival-delay in hexadies. Applies the
+/// base FTL multiplier plus the `empire_relay_inv_latency` bonus.
+pub fn relay_delay_hexadies(distance_ly: f64, comms: &CommsParams) -> i64 {
+    let base = FTL_RELAY_BASE_MULTIPLIER;
+    let bonus = comms.empire_relay_inv_latency.final_value().to_f64();
+    let multiplier = base + bonus;
+    if multiplier <= 0.0 {
+        return physics::light_delay_hexadies(distance_ly);
+    }
+    let light = physics::light_delay_hexadies(distance_ly) as f64;
+    (light / multiplier).floor() as i64
+}
+
+/// Find the nearest relay that covers `point`, returning `(position, index)`.
+/// A relay "covers" `point` when `point` lies within its effective range, or
+/// its range is infinite. Returns `None` if no relay covers `point`.
+fn nearest_covering_relay(
+    point: [f64; 3],
+    relays: &[RelaySnapshot],
+) -> Option<(usize, [f64; 3], f64)> {
+    let mut best: Option<(usize, [f64; 3], f64)> = None;
+    for (i, relay) in relays.iter().enumerate() {
+        if !relay.paired {
+            continue;
+        }
+        let dist = physics::distance_ly_arr(point, relay.position);
+        let covered = !relay.range_ly.is_finite() || dist <= relay.range_ly;
+        if !covered {
+            continue;
+        }
+        if best.is_none() || dist < best.as_ref().unwrap().2 {
+            best = Some((i, relay.position, dist));
+        }
+    }
+    best
+}
+
+/// Result of the arrival-time computation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ArrivalPlan {
+    pub arrives_at: i64,
+    pub source: ObservationSource,
+}
+
+/// Compute when a fact observed at `origin` will arrive at `player`.
+///
+/// Two-stage model:
+/// 1. If origin and player are both covered by (any) relay in the network,
+///    and at least two relays are paired, the path is
+///    `origin → relay_o (light) → relay_p (FTL) → player (light)`. Source is
+///    `Relay`.
+/// 2. Otherwise fall back to a pure light-speed path (`Direct`).
+///
+/// **MVP**: single-empire assumption → any pair of covering relays is
+/// treated as connected. Proper network BFS is future work (#233 note).
+pub fn compute_fact_arrival(
+    observed_at: i64,
+    origin: [f64; 3],
+    player: [f64; 3],
+    relays: &[RelaySnapshot],
+    comms: &CommsParams,
+) -> ArrivalPlan {
+    // Pure light-speed fallback.
+    let light_distance = physics::distance_ly_arr(origin, player);
+    let light_delay = physics::light_delay_hexadies(light_distance);
+    let direct = ArrivalPlan {
+        arrives_at: observed_at + light_delay,
+        source: ObservationSource::Direct,
+    };
+
+    // Try relay path.
+    let Some((o_idx, relay_o_pos, origin_to_relay_dist)) =
+        nearest_covering_relay(origin, relays)
+    else {
+        return direct;
+    };
+    let Some((p_idx, relay_p_pos, player_to_relay_dist)) =
+        nearest_covering_relay(player, relays)
+    else {
+        return direct;
+    };
+
+    let relay_delay = if o_idx == p_idx {
+        // Same relay on both ends — no FTL hop needed.
+        0
+    } else {
+        let relay_distance = physics::distance_ly_arr(relay_o_pos, relay_p_pos);
+        relay_delay_hexadies(relay_distance, comms)
+    };
+
+    let endpoint_light = physics::light_delay_hexadies(origin_to_relay_dist)
+        + physics::light_delay_hexadies(player_to_relay_dist);
+    let relay_total = relay_delay + endpoint_light;
+
+    if relay_total < light_delay {
+        ArrivalPlan {
+            arrives_at: observed_at + relay_total,
+            source: ObservationSource::Relay,
+        }
+    } else {
+        direct
+    }
+}
+
+/// Common helper that funnels both systems-1 (fact) and systems-2 (local)
+/// producers through the same decision point. Returns the computed
+/// `(arrives_at, source)` so callers can also populate a `GameEvent` if they
+/// dual-write.
+///
+/// - If `player_aboard` or `origin_pos == player_pos`, the event is treated
+///   as local and pushed directly into the notification queue (systems-2);
+///   the returned `arrives_at == observed_at`, `source = Direct`.
+/// - Otherwise the fact is routed through `PendingFactQueue` with an arrival
+///   time from [`compute_fact_arrival`].
+#[allow(clippy::too_many_arguments)]
+pub fn record_fact_or_local(
+    fact: KnowledgeFact,
+    origin_pos: [f64; 3],
+    observed_at: i64,
+    player_aboard: bool,
+    player_pos: [f64; 3],
+    queue: &mut PendingFactQueue,
+    notifications: &mut crate::notifications::NotificationQueue,
+    relays: &[RelaySnapshot],
+    comms: &CommsParams,
+) -> (i64, ObservationSource) {
+    // Local path: player is on-site so they perceive the event immediately.
+    // No light-speed / relay delay applies.
+    let is_local = player_aboard || origin_pos == player_pos;
+
+    if is_local {
+        notifications.push(
+            fact.title().to_string(),
+            fact.description(),
+            None,
+            fact.priority(),
+            fact.related_system(),
+        );
+        return (observed_at, ObservationSource::Direct);
+    }
+
+    let plan = compute_fact_arrival(observed_at, origin_pos, player_pos, relays, comms);
+    let related_system = fact.related_system();
+    queue.record(PerceivedFact {
+        fact,
+        observed_at,
+        arrives_at: plan.arrives_at,
+        source: plan.source,
+        origin_pos,
+        related_system,
+    });
+    (plan.arrives_at, plan.source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::amount::SignedAmt;
+    use crate::modifier::Modifier;
+
+    fn empty_comms() -> CommsParams {
+        CommsParams::default()
+    }
+
+    #[test]
+    fn relay_delay_base_multiplier() {
+        // 1 LY light delay = 60 hd; base multiplier 10 → 6 hd.
+        assert_eq!(relay_delay_hexadies(1.0, &empty_comms()), 6);
+    }
+
+    #[test]
+    fn relay_delay_with_inv_latency_bonus() {
+        // multiplier 10 + 5 = 15 → 60 / 15 = 4 hd.
+        let mut comms = empty_comms();
+        comms.empire_relay_inv_latency.push_modifier(Modifier {
+            id: "test:inv_latency".into(),
+            label: "Test".into(),
+            base_add: SignedAmt::from_f64(5.0),
+            multiplier: SignedAmt::ZERO,
+            add: SignedAmt::ZERO,
+            expires_at: None,
+            on_expire_event: None,
+        });
+        assert_eq!(relay_delay_hexadies(1.0, &comms), 4);
+    }
+
+    #[test]
+    fn compute_arrival_no_relays_is_light_speed() {
+        let origin = [0.0, 0.0, 0.0];
+        let player = [10.0, 0.0, 0.0];
+        let plan = compute_fact_arrival(0, origin, player, &[], &empty_comms());
+        assert_eq!(plan.source, ObservationSource::Direct);
+        assert_eq!(plan.arrives_at, 600); // 10 ly × 60 hd/ly
+    }
+
+    #[test]
+    fn compute_arrival_relay_is_faster() {
+        // Both origin and player under coverage of separate, paired relays.
+        let origin = [0.0, 0.0, 0.0];
+        let player = [50.0, 0.0, 0.0];
+        let relay_o = RelaySnapshot {
+            position: [1.0, 0.0, 0.0],
+            range_ly: 5.0,
+            paired: true,
+        };
+        let relay_p = RelaySnapshot {
+            position: [49.0, 0.0, 0.0],
+            range_ly: 5.0,
+            paired: true,
+        };
+        let relays = vec![relay_o, relay_p];
+
+        let plan = compute_fact_arrival(0, origin, player, &relays, &empty_comms());
+        assert_eq!(plan.source, ObservationSource::Relay);
+        // Light endpoint o→relay_o = 60 hd, player→relay_p = 60 hd.
+        // Relay hop 48 ly → light 2880 hd / 10 = 288 hd.
+        // Total 60 + 288 + 60 = 408 hd; direct light = 3000 hd.
+        assert!(plan.arrives_at < 3000);
+    }
+
+    #[test]
+    fn compute_arrival_falls_back_when_unpaired() {
+        let origin = [0.0, 0.0, 0.0];
+        let player = [50.0, 0.0, 0.0];
+        let relay_o = RelaySnapshot {
+            position: [1.0, 0.0, 0.0],
+            range_ly: 5.0,
+            paired: false, // unpaired → skipped
+        };
+        let relays = vec![relay_o];
+
+        let plan = compute_fact_arrival(0, origin, player, &relays, &empty_comms());
+        assert_eq!(plan.source, ObservationSource::Direct);
+        assert_eq!(plan.arrives_at, 3000);
+    }
+
+    #[test]
+    fn pending_queue_drain_ready_respects_arrival_time() {
+        let mut q = PendingFactQueue::default();
+        q.record(PerceivedFact {
+            fact: KnowledgeFact::SurveyComplete {
+                system: Entity::PLACEHOLDER,
+                system_name: "A".into(),
+                detail: "A".into(),
+            },
+            observed_at: 0,
+            arrives_at: 100,
+            source: ObservationSource::Direct,
+            origin_pos: [0.0; 3],
+            related_system: None,
+        });
+        q.record(PerceivedFact {
+            fact: KnowledgeFact::SurveyComplete {
+                system: Entity::PLACEHOLDER,
+                system_name: "B".into(),
+                detail: "B".into(),
+            },
+            observed_at: 0,
+            arrives_at: 200,
+            source: ObservationSource::Direct,
+            origin_pos: [0.0; 3],
+            related_system: None,
+        });
+
+        let drained = q.drain_ready(150);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(q.pending_len(), 1);
+
+        let drained = q.drain_ready(250);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(q.pending_len(), 0);
+    }
+
+    #[test]
+    fn record_fact_or_local_bypasses_queue_when_player_aboard() {
+        let mut queue = PendingFactQueue::default();
+        let mut notifs = crate::notifications::NotificationQueue::new();
+        let comms = empty_comms();
+        let fact = KnowledgeFact::CombatOutcome {
+            system: Entity::PLACEHOLDER,
+            victor: CombatVictor::Player,
+            detail: "On-site victory".into(),
+        };
+        let (arrives_at, src) = record_fact_or_local(
+            fact,
+            [100.0, 0.0, 0.0],
+            50,
+            true, // player aboard
+            [0.0, 0.0, 0.0],
+            &mut queue,
+            &mut notifs,
+            &[],
+            &comms,
+        );
+        assert_eq!(arrives_at, 50);
+        assert_eq!(src, ObservationSource::Direct);
+        assert_eq!(queue.pending_len(), 0);
+        assert_eq!(notifs.items.len(), 1);
+    }
+
+    #[test]
+    fn record_fact_or_local_queues_remote_event() {
+        let mut queue = PendingFactQueue::default();
+        let mut notifs = crate::notifications::NotificationQueue::new();
+        let comms = empty_comms();
+        let fact = KnowledgeFact::HostileDetected {
+            target: Entity::PLACEHOLDER,
+            detector: Entity::PLACEHOLDER,
+            target_pos: [50.0, 0.0, 0.0],
+            description: "Hostile".into(),
+        };
+        let (arrives_at, src) = record_fact_or_local(
+            fact,
+            [50.0, 0.0, 0.0],
+            0,
+            false,
+            [0.0, 0.0, 0.0],
+            &mut queue,
+            &mut notifs,
+            &[],
+            &comms,
+        );
+        assert_eq!(src, ObservationSource::Direct);
+        assert_eq!(arrives_at, 50 * 60); // 50 ly × 60 hd
+        assert_eq!(queue.pending_len(), 1);
+        assert_eq!(notifs.items.len(), 0);
+    }
+}

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -20,10 +20,18 @@
 //! Producers should pick exactly one of `Direct / Relay / Scout`. The
 //! convention `observed_at: i64` (integer hexadies) is preserved — the
 //! [`perceived::PerceivedInfo`] facade only renames it to `last_updated`.
+pub mod facts;
 pub mod perceived;
 
 use bevy::prelude::*;
 use std::collections::HashMap;
+
+#[allow(unused_imports)]
+pub use facts::{
+    compute_fact_arrival, effective_relay_range, rebuild_relay_network, record_fact_or_local,
+    relay_delay_hexadies, ArrivalPlan, CombatVictor, KnowledgeFact, PendingFactQueue,
+    PerceivedFact, RelayNetwork, RelaySnapshot, FTL_RELAY_BASE_MULTIPLIER,
+};
 
 use crate::amount::Amt;
 use crate::colony::ResourceStockpile;
@@ -62,7 +70,8 @@ pub struct KnowledgePlugin;
 
 impl Plugin for KnowledgePlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
+        app.init_resource::<RelayNetwork>()
+            .add_systems(
                 Startup,
                 initialize_capital_knowledge
                     .after(crate::galaxy::generate_galaxy)
@@ -72,7 +81,7 @@ impl Plugin for KnowledgePlugin {
             .add_systems(Update, propagate_knowledge)
             .add_systems(
                 Update,
-                snapshot_production_knowledge
+                (rebuild_relay_network, snapshot_production_knowledge)
                     .after(crate::time_system::advance_game_time),
             );
     }

--- a/macrocosmo/src/lib.rs
+++ b/macrocosmo/src/lib.rs
@@ -7,6 +7,7 @@ pub mod components;
 pub mod condition;
 pub mod deep_space;
 pub mod effect;
+pub mod empire;
 pub mod event_system;
 pub mod events;
 pub mod faction;

--- a/macrocosmo/src/main.rs
+++ b/macrocosmo/src/main.rs
@@ -7,6 +7,7 @@ mod components;
 mod condition;
 mod deep_space;
 mod effect;
+mod empire;
 mod event_system;
 mod events;
 mod faction;

--- a/macrocosmo/src/notifications.rs
+++ b/macrocosmo/src/notifications.rs
@@ -13,8 +13,9 @@
 use bevy::prelude::*;
 
 use crate::events::{GameEvent, GameEventKind};
+use crate::knowledge::{PendingFactQueue, PerceivedFact};
 use crate::scripting::ScriptEngine;
-use crate::time_system::GameSpeed;
+use crate::time_system::{GameClock, GameSpeed};
 
 /// Severity / behavior class for a banner notification.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -229,14 +230,36 @@ fn title_for_event_kind(kind: &GameEventKind) -> &'static str {
     }
 }
 
-/// System that mirrors important `GameEvent`s into the notification queue.
+/// #233: Whitelist of `GameEventKind` variants still routed through the
+/// legacy `GameEvent → NotificationQueue` path. All other world-facing kinds
+/// now flow through `PendingFactQueue` (light-speed / relay-delayed).
+///
+/// The whitelist is intentionally narrow: only events whose information
+/// *cannot* be delayed without breaking the gameplay contract. The player
+/// respawn is an engine-level fact (not a remote observation) and the
+/// resource alert is a capital-aggregated warning with no light-speed origin.
+pub fn is_legacy_whitelisted(kind: &GameEventKind) -> bool {
+    matches!(
+        kind,
+        GameEventKind::PlayerRespawn | GameEventKind::ResourceAlert,
+    )
+}
+
+/// System that mirrors **whitelisted** `GameEvent`s into the notification
+/// queue (#233). Non-whitelisted world events are routed through the
+/// `PendingFactQueue` pipeline instead — this system intentionally ignores
+/// them to avoid double-notifications in the dual-write transition window.
+///
 /// Runs alongside (not instead of) `collect_events` so the event log is
-/// preserved.
+/// preserved for every `GameEvent`.
 pub fn auto_notify_from_events(
     mut reader: MessageReader<GameEvent>,
     mut queue: ResMut<NotificationQueue>,
 ) {
     for event in reader.read() {
+        if !is_legacy_whitelisted(&event.kind) {
+            continue;
+        }
         if let Some(priority) = priority_for_event_kind(&event.kind) {
             queue.push(
                 title_for_event_kind(&event.kind).to_string(),
@@ -245,6 +268,32 @@ pub fn auto_notify_from_events(
                 priority,
                 event.related_system,
             );
+        }
+    }
+}
+
+/// #233: Drain facts whose arrival time has been reached and push them into
+/// the notification queue. Runs after `advance_game_time` so fresh facts
+/// written the same tick can arrive at `observed_at == clock.elapsed`.
+///
+/// This is the systems-1 counterpart of `auto_notify_from_events`. Together
+/// the two cover the full notification surface area while keeping the
+/// light-speed contract intact for remote observations.
+pub fn notify_from_knowledge_facts(
+    clock: Res<GameClock>,
+    mut queue: ResMut<PendingFactQueue>,
+    mut notifications: ResMut<NotificationQueue>,
+    mut speed: ResMut<GameSpeed>,
+) {
+    let ready = queue.drain_ready(clock.elapsed);
+    for PerceivedFact { fact, .. } in ready {
+        let priority = fact.priority();
+        let title = fact.title().to_string();
+        let description = fact.description();
+        let related = fact.related_system();
+        let id = notifications.push(title, description, None, priority, related);
+        if id.is_some() && priority.pauses_game() {
+            speed.pause();
         }
     }
 }
@@ -307,10 +356,11 @@ pub struct NotificationsPlugin;
 impl Plugin for NotificationsPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(NotificationQueue::new())
+            .init_resource::<PendingFactQueue>()
             .add_systems(Update, (tick_notifications, auto_notify_from_events))
             .add_systems(
                 Update,
-                drain_pending_notifications
+                (notify_from_knowledge_facts, drain_pending_notifications)
                     .after(crate::time_system::advance_game_time),
             );
     }
@@ -499,14 +549,27 @@ mod tests {
     /// Integration: GameEvents flow into the NotificationQueue through the
     /// auto_notify_from_events system without affecting the event log
     /// pipeline.
+    ///
+    /// #233: Only the whitelisted kinds (PlayerRespawn, ResourceAlert) still
+    /// surface through the legacy `GameEvent → notification` mapping; other
+    /// world events are routed through `PendingFactQueue`.
     #[test]
-    fn auto_notify_pushes_for_high_priority_events() {
+    fn auto_notify_pushes_for_whitelisted_events() {
         let mut app = App::new();
         app.add_message::<GameEvent>();
         app.insert_resource(NotificationQueue::new());
         app.add_systems(Update, auto_notify_from_events);
 
-        // Emit a high-priority event
+        // PlayerRespawn → whitelisted; still banners.
+        app.world_mut().write_message(GameEvent {
+            timestamp: 0,
+            kind: GameEventKind::PlayerRespawn,
+            description: "Flagship destroyed".into(),
+            related_system: None,
+        });
+        // #233: SurveyDiscovery is no longer whitelisted — it must be routed
+        // through the fact queue, so the notification queue should stay empty
+        // for this path.
         app.world_mut().write_message(GameEvent {
             timestamp: 0,
             kind: GameEventKind::SurveyDiscovery,
@@ -525,8 +588,25 @@ mod tests {
 
         let queue = app.world().resource::<NotificationQueue>();
         assert_eq!(queue.items.len(), 1);
-        assert_eq!(queue.items[0].title, "Discovery");
-        assert_eq!(queue.items[0].description, "Found ruins");
+        assert_eq!(queue.items[0].title, "Player Respawn");
         assert_eq!(queue.items[0].priority, NotificationPriority::High);
+    }
+
+    #[test]
+    fn legacy_whitelist_covers_player_respawn_and_resource_alert() {
+        assert!(is_legacy_whitelisted(&GameEventKind::PlayerRespawn));
+        assert!(is_legacy_whitelisted(&GameEventKind::ResourceAlert));
+    }
+
+    #[test]
+    fn legacy_whitelist_excludes_world_events() {
+        assert!(!is_legacy_whitelisted(&GameEventKind::SurveyComplete));
+        assert!(!is_legacy_whitelisted(&GameEventKind::SurveyDiscovery));
+        assert!(!is_legacy_whitelisted(&GameEventKind::ColonyEstablished));
+        assert!(!is_legacy_whitelisted(&GameEventKind::CombatVictory));
+        assert!(!is_legacy_whitelisted(&GameEventKind::CombatDefeat));
+        assert!(!is_legacy_whitelisted(&GameEventKind::HostileDetected));
+        assert!(!is_legacy_whitelisted(&GameEventKind::AnomalyDiscovered));
+        assert!(!is_legacy_whitelisted(&GameEventKind::ColonyFailed));
     }
 }

--- a/macrocosmo/src/player/mod.rs
+++ b/macrocosmo/src/player/mod.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 
 use crate::colony::{AuthorityParams, ConstructionParams};
 use crate::communication::CommandLog;
+use crate::empire::CommsParams;
 use crate::components::Position;
 use crate::galaxy::StarSystem;
 use crate::ship::{Ship, ShipState};
@@ -67,6 +68,7 @@ pub fn spawn_player_empire(mut commands: Commands) {
             CommandLog::default(),
             ScopedFlags::default(),
             PendingColonyTechModifiers::default(),
+            CommsParams::default(),
         ),
     ));
     info!("Player empire entity spawned");

--- a/macrocosmo/src/ship/pursuit.rs
+++ b/macrocosmo/src/ship/pursuit.rs
@@ -36,9 +36,15 @@ use std::collections::HashMap;
 
 use bevy::prelude::*;
 
+use crate::components::Position;
+use crate::empire::CommsParams;
 use crate::events::{GameEvent, GameEventKind};
 use crate::faction::{FactionOwner, FactionRelations};
+use crate::knowledge::{
+    compute_fact_arrival, KnowledgeFact, PendingFactQueue, PerceivedFact, RelayNetwork,
+};
 use crate::physics;
+use crate::player::{Player, PlayerEmpire, StationedAt};
 use crate::time_system::GameClock;
 
 use super::{Owner, RulesOfEngagement, Ship, ShipState};
@@ -163,7 +169,7 @@ pub fn detect_hostiles_system(
     mut commands: Commands,
     clock: Res<GameClock>,
     relations: Res<FactionRelations>,
-    positions: Query<&crate::components::Position>,
+    positions: Query<&Position>,
     ships: Query<(
         Entity,
         &Ship,
@@ -173,6 +179,10 @@ pub fn detect_hostiles_system(
     )>,
     mut detected: Query<&mut DetectedHostiles>,
     mut events: MessageWriter<GameEvent>,
+    mut fact_queue: ResMut<PendingFactQueue>,
+    relay_network: Option<Res<RelayNetwork>>,
+    player_q: Query<&StationedAt, With<Player>>,
+    empire_q: Query<&CommsParams, With<PlayerEmpire>>,
 ) {
     let now = clock.elapsed;
 
@@ -286,19 +296,62 @@ pub fn detect_hostiles_system(
         };
 
         if should_notify {
+            let description = format!(
+                "{} detected hostile {} at ({:.2}, {:.2}, {:.2})",
+                det.detector_name,
+                det.target_name,
+                det.target_pos[0],
+                det.target_pos[1],
+                det.target_pos[2],
+            );
+            // EventLog + auto_pause still receive the raw event (the notification
+            // path is the one gaining light-speed delay).
             events.write(GameEvent {
                 timestamp: now,
                 kind: GameEventKind::HostileDetected,
-                description: format!(
-                    "{} detected hostile {} at ({:.2}, {:.2}, {:.2})",
-                    det.detector_name,
-                    det.target_name,
-                    det.target_pos[0],
-                    det.target_pos[1],
-                    det.target_pos[2],
-                ),
+                description: description.clone(),
                 related_system: None,
             });
+
+            // #233: Notification via PendingFactQueue — 50 ly remote detections
+            // used to alert the player instantly, violating the light-speed
+            // contract. Routing through `compute_fact_arrival` respects that
+            // contract and also enables relay-accelerated propagation when
+            // coverage exists.
+            let player_pos_arr = player_q
+                .iter()
+                .next()
+                .and_then(|s| positions.get(s.system).ok())
+                .map(|p| p.as_array());
+            if let Some(player_pos) = player_pos_arr {
+                let comms_fallback = CommsParams::default();
+                let comms = empire_q.iter().next().unwrap_or(&comms_fallback);
+                let empty_relays: Vec<crate::knowledge::RelaySnapshot> = Vec::new();
+                let relays_slice = relay_network
+                    .as_deref()
+                    .map(|n| n.relays.as_slice())
+                    .unwrap_or(&empty_relays);
+                let plan = compute_fact_arrival(
+                    now,
+                    det.target_pos,
+                    player_pos,
+                    relays_slice,
+                    comms,
+                );
+                fact_queue.record(PerceivedFact {
+                    fact: KnowledgeFact::HostileDetected {
+                        target: det.target,
+                        detector: det.detector,
+                        target_pos: det.target_pos,
+                        description,
+                    },
+                    observed_at: now,
+                    arrives_at: plan.arrives_at,
+                    source: plan.source,
+                    origin_pos: det.target_pos,
+                    related_system: None,
+                });
+            }
         }
     }
 }

--- a/macrocosmo/src/technology/effects.rs
+++ b/macrocosmo/src/technology/effects.rs
@@ -220,6 +220,7 @@ pub fn apply_tech_effects(
             &mut GlobalParams,
             &mut EmpireModifiers,
             Option<&mut PendingColonyTechModifiers>,
+            Option<&mut crate::empire::CommsParams>,
         ),
         With<PlayerEmpire>,
     >,
@@ -237,6 +238,7 @@ pub fn apply_tech_effects(
         mut global_params,
         mut empire_modifiers,
         mut pending_colony_mods,
+        mut comms_params,
     )) = empire_q.single_mut()
     else {
         return;
@@ -249,6 +251,14 @@ pub fn apply_tech_effects(
     let pending_ref: &mut PendingColonyTechModifiers = match &mut pending_colony_mods {
         Some(p) => &mut *p,
         None => &mut scratch_pending,
+    };
+    // #233: Same fallback for CommsParams. Legacy empire entities without the
+    // component get a scratch bucket; the field values still "apply" but have
+    // no runtime effect, preserving forward-compat for old fixtures.
+    let mut scratch_comms = crate::empire::CommsParams::default();
+    let comms_ref: &mut crate::empire::CommsParams = match &mut comms_params {
+        Some(c) => &mut *c,
+        None => &mut scratch_comms,
     };
 
     if recently.techs.is_empty() {
@@ -303,6 +313,7 @@ pub fn apply_tech_effects(
                 &mut balance,
                 &mut empire_modifiers,
                 pending_ref,
+                comms_ref,
                 tech_id,
             );
         }
@@ -339,6 +350,7 @@ pub fn apply_tech_effects(
 }
 
 /// Apply a single DescriptiveEffect to game state.
+#[allow(clippy::too_many_arguments)]
 fn apply_effect(
     effect: &DescriptiveEffect,
     game_flags: &mut GameFlags,
@@ -347,6 +359,7 @@ fn apply_effect(
     balance: &mut GameBalance,
     empire_modifiers: &mut EmpireModifiers,
     pending_colony_mods: &mut PendingColonyTechModifiers,
+    comms_params: &mut crate::empire::CommsParams,
     source_tech_id: &TechId,
 ) {
     match effect {
@@ -385,6 +398,7 @@ fn apply_effect(
                     global_params,
                     empire_modifiers,
                     pending_colony_mods,
+                    comms_params,
                     source_tech_id,
                 );
             }
@@ -417,6 +431,7 @@ fn apply_effect(
                 balance,
                 empire_modifiers,
                 pending_colony_mods,
+                comms_params,
                 source_tech_id,
             );
         }
@@ -432,6 +447,7 @@ fn apply_effect(
 ///   `sync_tech_colony_modifiers`)
 /// - `combat.*`, `diplomacy.*` → warn (target systems not yet implemented)
 /// - Unknown targets → debug (harmless, future work)
+#[allow(clippy::too_many_arguments)]
 fn route_tech_modifier(
     target: &str,
     base_add: f64,
@@ -440,6 +456,7 @@ fn route_tech_modifier(
     global_params: &mut GlobalParams,
     empire_modifiers: &mut EmpireModifiers,
     pending_colony_mods: &mut PendingColonyTechModifiers,
+    comms_params: &mut crate::empire::CommsParams,
     source_tech_id: &TechId,
 ) {
     // 1) Ship/sensor/construction targets → GlobalParams (legacy routes kept).
@@ -447,6 +464,35 @@ fn route_tech_modifier(
         "ship.sublight_speed" | "ship.ftl_speed" | "ship.ftl_range"
         | "sensor.range" | "construction.speed" => {
             apply_modifier_to_params(global_params, target, base_add, multiplier, add);
+            return;
+        }
+        _ => {}
+    }
+
+    // 1b) #233: FTL Comm Relay modifiers → CommsParams.
+    match target {
+        "empire.comm_relay_range"
+        | "empire.comm_relay_inv_latency"
+        | "fleet.comm_relay_range"
+        | "fleet.comm_relay_inv_latency" => {
+            let modifier_id = format!("tech:{}:{}", source_tech_id.0, target);
+            let modifier = Modifier {
+                id: modifier_id,
+                label: format!("From tech '{}'", source_tech_id.0),
+                base_add: SignedAmt::from_f64(base_add),
+                multiplier: SignedAmt::from_f64(multiplier),
+                add: SignedAmt::from_f64(add),
+                expires_at: None,
+                on_expire_event: None,
+            };
+            let slot = match target {
+                "empire.comm_relay_range" => &mut comms_params.empire_relay_range,
+                "empire.comm_relay_inv_latency" => &mut comms_params.empire_relay_inv_latency,
+                "fleet.comm_relay_range" => &mut comms_params.fleet_relay_range,
+                "fleet.comm_relay_inv_latency" => &mut comms_params.fleet_relay_inv_latency,
+                _ => unreachable!(),
+            };
+            slot.push_modifier(modifier);
             return;
         }
         _ => {}
@@ -868,6 +914,7 @@ mod tests {
         };
 
         let tech_id = TechId("test_tech".into());
+        let mut comms = crate::empire::CommsParams::default();
         apply_effect(
             &effect,
             &mut game_flags,
@@ -876,6 +923,7 @@ mod tests {
             &mut balance,
             &mut empire_mods,
             &mut pending,
+            &mut comms,
             &tech_id,
         );
 
@@ -902,6 +950,7 @@ mod tests {
         };
 
         let tech_id = TechId("shrink_survey".into());
+        let mut comms = crate::empire::CommsParams::default();
         apply_effect(
             &effect,
             &mut game_flags,
@@ -910,6 +959,7 @@ mod tests {
             &mut balance,
             &mut empire_mods,
             &mut pending,
+            &mut comms,
             &tech_id,
         );
 
@@ -936,6 +986,7 @@ mod tests {
 
         // Should not panic; logs a warning and leaves balance untouched.
         let tech_id = TechId("buggy_tech".into());
+        let mut comms = crate::empire::CommsParams::default();
         apply_effect(
             &effect,
             &mut game_flags,
@@ -944,6 +995,7 @@ mod tests {
             &mut balance,
             &mut empire_mods,
             &mut pending,
+            &mut comms,
             &tech_id,
         );
 

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -148,6 +148,7 @@ pub fn spawn_test_empire(world: &mut World) -> Entity {
                 KnowledgeStore::default(),
                 CommandLog::default(),
                 ScopedFlags::default(),
+                macrocosmo::empire::CommsParams::default(),
             ),
         ))
         .id()
@@ -267,6 +268,12 @@ pub fn test_app() -> App {
     // values so tests exercise the same baseline behaviour).
     app.init_resource::<technology::GameBalance>();
     app.add_message::<GameEvent>();
+    // #233: Notification pipeline resources consumed by detect_hostiles_system
+    // and friends. Instantiated without the full NotificationsPlugin because
+    // the plugin registers egui-coupled systems that tests don't want.
+    app.init_resource::<macrocosmo::knowledge::PendingFactQueue>();
+    app.init_resource::<macrocosmo::knowledge::RelayNetwork>();
+    app.insert_resource(macrocosmo::notifications::NotificationQueue::new());
     // advance_game_time is a no-op in tests (we manually set clock.elapsed)
     // but must be registered because other systems use .after(advance_game_time)
     app.init_resource::<macrocosmo::ship::routing::RouteCalculationsPending>();
@@ -451,6 +458,11 @@ pub fn full_test_app() -> App {
 
     // --- Routing resource ---
     app.init_resource::<macrocosmo::ship::routing::RouteCalculationsPending>();
+
+    // --- #233 Notification pipeline resources ---
+    app.init_resource::<macrocosmo::knowledge::PendingFactQueue>();
+    app.init_resource::<macrocosmo::knowledge::RelayNetwork>();
+    app.insert_resource(macrocosmo::notifications::NotificationQueue::new());
 
     // --- Ship systems (from ShipPlugin) ---
     app.add_systems(

--- a/macrocosmo/tests/notification_knowledge_pipeline.rs
+++ b/macrocosmo/tests/notification_knowledge_pipeline.rs
@@ -1,0 +1,440 @@
+//! #233 regression tests — notification pipeline derived from KnowledgeStore
+//! fact delta.
+//!
+//! These tests exercise the two-system model:
+//!
+//! 1. World events (HostileDetected, CombatOutcome, SurveyComplete, …) are
+//!    routed through `PendingFactQueue` with a light-speed + relay delay.
+//! 2. Player-local events (PlayerRespawn, ResourceAlert, Lua
+//!    `show_notification`) continue to fire the banner immediately via the
+//!    legacy `auto_notify_from_events` whitelist / `drain_pending_notifications`.
+
+mod common;
+
+use bevy::prelude::*;
+
+use macrocosmo::amount::SignedAmt;
+use macrocosmo::empire::CommsParams;
+use macrocosmo::events::{GameEvent, GameEventKind};
+use macrocosmo::knowledge::{
+    compute_fact_arrival, rebuild_relay_network, relay_delay_hexadies, CombatVictor,
+    KnowledgeFact, ObservationSource, PendingFactQueue, PerceivedFact, RelayNetwork,
+    RelaySnapshot, FTL_RELAY_BASE_MULTIPLIER,
+};
+use macrocosmo::modifier::Modifier;
+use macrocosmo::notifications::{
+    auto_notify_from_events, is_legacy_whitelisted, notify_from_knowledge_facts,
+    NotificationQueue,
+};
+use macrocosmo::player::PlayerEmpire;
+use macrocosmo::time_system::GameClock;
+
+// Small helpers so tests focus on behaviour, not boilerplate.
+
+fn make_app_with_queues() -> App {
+    let mut app = App::new();
+    app.insert_resource(GameClock::new(0));
+    app.init_resource::<PendingFactQueue>();
+    app.init_resource::<RelayNetwork>();
+    app.insert_resource(NotificationQueue::new());
+    app.insert_resource(macrocosmo::time_system::GameSpeed::default());
+    app.add_systems(Update, notify_from_knowledge_facts);
+    app
+}
+
+/// 50 ly away → 3000 hd light delay before the player hears about a hostile.
+#[test]
+fn test_remote_detection_notification_light_speed_delayed() {
+    let mut app = make_app_with_queues();
+    let target = app.world_mut().spawn_empty().id();
+    let detector = app.world_mut().spawn_empty().id();
+
+    // Record the fact directly with a pre-computed arrival time so we don't
+    // need the whole `detect_hostiles_system` setup.
+    let origin = [50.0, 0.0, 0.0];
+    let player = [0.0, 0.0, 0.0];
+    let plan = compute_fact_arrival(0, origin, player, &[], &CommsParams::default());
+    assert_eq!(plan.source, ObservationSource::Direct);
+    assert_eq!(plan.arrives_at, 3000); // 50 ly × 60 hd/ly
+
+    {
+        let mut queue = app.world_mut().resource_mut::<PendingFactQueue>();
+        queue.record(PerceivedFact {
+            fact: KnowledgeFact::HostileDetected {
+                target,
+                detector,
+                target_pos: origin,
+                description: "Enemy sighted".into(),
+            },
+            observed_at: 0,
+            arrives_at: plan.arrives_at,
+            source: plan.source,
+            origin_pos: origin,
+            related_system: None,
+        });
+    }
+
+    // At t=100 the fact must NOT have arrived yet.
+    app.world_mut().resource_mut::<GameClock>().elapsed = 100;
+    app.update();
+    assert_eq!(
+        app.world().resource::<NotificationQueue>().items.len(),
+        0,
+        "Hostile 50 ly away must not notify at t=100 (light delay = 3000)"
+    );
+
+    // At t=3000 it must surface.
+    app.world_mut().resource_mut::<GameClock>().elapsed = 3000;
+    app.update();
+    assert_eq!(
+        app.world().resource::<NotificationQueue>().items.len(),
+        1,
+        "Hostile detection must arrive at t=3000 (50 ly × 60 hd)"
+    );
+}
+
+/// With relay coverage on both endpoints the arrival is dramatically faster.
+#[test]
+fn test_detection_via_relay_network_near_instant() {
+    let origin = [0.0, 0.0, 0.0];
+    let player = [50.0, 0.0, 0.0];
+    let relays = vec![
+        RelaySnapshot {
+            position: [1.0, 0.0, 0.0],
+            range_ly: 5.0,
+            paired: true,
+        },
+        RelaySnapshot {
+            position: [49.0, 0.0, 0.0],
+            range_ly: 5.0,
+            paired: true,
+        },
+    ];
+    let plan = compute_fact_arrival(0, origin, player, &relays, &CommsParams::default());
+    assert_eq!(plan.source, ObservationSource::Relay);
+
+    // Light direct = 3000 hd. Relay path:
+    //   origin→relay_o light (1 ly → 60 hd)
+    // + relay hop (48 ly → light 2880 / 10 = 288 hd)
+    // + relay_p→player light (1 ly → 60 hd)
+    // = 408 hd, ≈ 13.6% of direct.
+    assert!(
+        plan.arrives_at < 3000 / 5,
+        "Relay-routed arrival should be at least 5× faster than direct light: got {}",
+        plan.arrives_at
+    );
+}
+
+/// Player respawn is systems-2 — banner immediately, no light-speed delay.
+#[test]
+fn test_player_respawn_notification_instant() {
+    let mut app = App::new();
+    app.add_message::<GameEvent>();
+    app.insert_resource(NotificationQueue::new());
+    app.add_systems(Update, auto_notify_from_events);
+
+    app.world_mut().write_message(GameEvent {
+        timestamp: 0,
+        kind: GameEventKind::PlayerRespawn,
+        description: "Flagship destroyed".into(),
+        related_system: None,
+    });
+
+    app.update();
+
+    let q = app.world().resource::<NotificationQueue>();
+    assert_eq!(q.items.len(), 1);
+    assert_eq!(q.items[0].title, "Player Respawn");
+}
+
+/// Lua `show_notification` stays in the Lua-drain pipeline (systems-2) and
+/// must not be gated by arrival times. We simulate this by pushing directly
+/// to NotificationQueue — the #233 changes only added a whitelist layer
+/// above `auto_notify_from_events`, leaving `drain_pending_notifications`
+/// untouched.
+#[test]
+fn test_lua_notification_instant() {
+    let mut queue = NotificationQueue::new();
+    // Simulating what drain_pending_notifications does when Lua sets a
+    // High-priority entry.
+    let id = queue.push(
+        "Event",
+        "Something happened",
+        None,
+        macrocosmo::notifications::NotificationPriority::High,
+        None,
+    );
+    assert!(id.is_some());
+    assert_eq!(queue.items.len(), 1);
+    assert!(queue.items[0].remaining_seconds.is_none()); // sticky
+}
+
+/// Survey completion routed through PendingFactQueue surfaces only once
+/// `arrives_at` is reached.
+#[test]
+fn test_survey_result_via_knowledge_store() {
+    let mut app = make_app_with_queues();
+    let sys = app.world_mut().spawn_empty().id();
+
+    let fact = KnowledgeFact::SurveyComplete {
+        system: sys,
+        system_name: "Tau Ceti".into(),
+        detail: "Tau Ceti surveyed".into(),
+    };
+    let origin = [5.0, 0.0, 0.0];
+    let plan = compute_fact_arrival(0, origin, [0.0; 3], &[], &CommsParams::default());
+    app.world_mut()
+        .resource_mut::<PendingFactQueue>()
+        .record(PerceivedFact {
+            fact,
+            observed_at: 0,
+            arrives_at: plan.arrives_at,
+            source: plan.source,
+            origin_pos: origin,
+            related_system: Some(sys),
+        });
+
+    // 5 ly × 60 hd/ly = 300 hd.
+    app.world_mut().resource_mut::<GameClock>().elapsed = 299;
+    app.update();
+    assert_eq!(app.world().resource::<NotificationQueue>().items.len(), 0);
+
+    app.world_mut().resource_mut::<GameClock>().elapsed = 300;
+    app.update();
+    let q = app.world().resource::<NotificationQueue>();
+    assert_eq!(q.items.len(), 1);
+    assert_eq!(q.items[0].title, "Survey Complete");
+    assert_eq!(q.items[0].description, "Tau Ceti surveyed");
+}
+
+/// Combat victory from a remote system is light-speed delayed in the
+/// notification pipeline (fact route), even though the underlying
+/// `CombatVictory` GameEvent still fires immediately for auto-pause.
+#[test]
+fn test_combat_victory_notification_delayed() {
+    let mut app = make_app_with_queues();
+    let sys = app.world_mut().spawn_empty().id();
+
+    let origin = [20.0, 0.0, 0.0];
+    let plan = compute_fact_arrival(0, origin, [0.0; 3], &[], &CommsParams::default());
+    app.world_mut()
+        .resource_mut::<PendingFactQueue>()
+        .record(PerceivedFact {
+            fact: KnowledgeFact::CombatOutcome {
+                system: sys,
+                victor: CombatVictor::Player,
+                detail: "Pirates routed at Epsilon".into(),
+            },
+            observed_at: 0,
+            arrives_at: plan.arrives_at,
+            source: plan.source,
+            origin_pos: origin,
+            related_system: Some(sys),
+        });
+    assert_eq!(plan.arrives_at, 1200); // 20 × 60
+
+    app.world_mut().resource_mut::<GameClock>().elapsed = 1199;
+    app.update();
+    assert_eq!(app.world().resource::<NotificationQueue>().items.len(), 0);
+
+    app.world_mut().resource_mut::<GameClock>().elapsed = 1200;
+    app.update();
+    let q = app.world().resource::<NotificationQueue>();
+    assert_eq!(q.items.len(), 1);
+    assert_eq!(q.items[0].title, "Combat Victory");
+}
+
+/// `compute_fact_arrival` picks the fastest of Direct vs Relay; a covered
+/// relay pair must win over pure light propagation.
+#[test]
+fn test_channel_autoselect_picks_fastest() {
+    let origin = [0.0, 0.0, 0.0];
+    let player = [100.0, 0.0, 0.0];
+
+    // No relay → Direct, slow.
+    let direct = compute_fact_arrival(0, origin, player, &[], &CommsParams::default());
+    assert_eq!(direct.source, ObservationSource::Direct);
+    assert_eq!(direct.arrives_at, 6000);
+
+    // With relays → Relay, fast.
+    let relays = vec![
+        RelaySnapshot {
+            position: [1.0, 0.0, 0.0],
+            range_ly: 10.0,
+            paired: true,
+        },
+        RelaySnapshot {
+            position: [99.0, 0.0, 0.0],
+            range_ly: 10.0,
+            paired: true,
+        },
+    ];
+    let relay_plan = compute_fact_arrival(0, origin, player, &relays, &CommsParams::default());
+    assert_eq!(relay_plan.source, ObservationSource::Relay);
+    assert!(relay_plan.arrives_at < direct.arrives_at);
+}
+
+/// `empire.comm_relay_inv_latency` modifier must raise the FTL multiplier and
+/// shrink the relay delay.
+#[test]
+fn test_empire_comm_relay_inv_latency_increases_speed() {
+    // Baseline: 60 hd / 10 = 6 hd per ly of relay hop.
+    assert_eq!(relay_delay_hexadies(1.0, &CommsParams::default()), 6);
+
+    // +5 inv_latency → multiplier = 10 + 5 = 15 → 60 / 15 = 4 hd.
+    let mut comms = CommsParams::default();
+    comms.empire_relay_inv_latency.push_modifier(Modifier {
+        id: "test".into(),
+        label: "Test tech".into(),
+        base_add: SignedAmt::from_f64(5.0),
+        multiplier: SignedAmt::ZERO,
+        add: SignedAmt::ZERO,
+        expires_at: None,
+        on_expire_event: None,
+    });
+    assert_eq!(relay_delay_hexadies(1.0, &comms), 4);
+
+    // Also verify base_multiplier constant didn't silently drift.
+    assert!((FTL_RELAY_BASE_MULTIPLIER - 10.0).abs() < 1e-9);
+}
+
+/// `empire.comm_relay_range` is consumed by `rebuild_relay_network` via
+/// `effective_relay_range`. We rebuild the network with and without the bonus
+/// and confirm the snapshot range expands.
+#[test]
+fn test_empire_comm_relay_range_extends_coverage() {
+    use macrocosmo::deep_space::{
+        CapabilityParams, DeepSpaceStructure, DeliverableDefinition, DeliverableRegistry,
+    };
+    use macrocosmo::ship::Owner;
+    use std::collections::HashMap;
+
+    let mut app = App::new();
+    app.insert_resource(GameClock::new(0));
+    app.init_resource::<RelayNetwork>();
+    let mut registry = DeliverableRegistry::default();
+    let mut caps = HashMap::new();
+    caps.insert(
+        "ftl_comm_relay".to_string(),
+        CapabilityParams { range: 5.0 },
+    );
+    registry.insert(DeliverableDefinition {
+        id: "relay_test".into(),
+        name: "Test Relay".into(),
+        description: String::new(),
+        max_hp: 100.0,
+        energy_drain: macrocosmo::amount::Amt::ZERO,
+        capabilities: caps,
+        prerequisites: None,
+        deliverable: None,
+        upgrade_to: Vec::new(),
+        upgrade_from: None,
+    });
+    app.insert_resource(registry);
+
+    // Empire entity with default CommsParams (no range bonus).
+    let empire = app
+        .world_mut()
+        .spawn((PlayerEmpire, CommsParams::default()))
+        .id();
+
+    // A standalone (unpaired) relay entity.
+    app.world_mut().spawn((
+        DeepSpaceStructure {
+            definition_id: "relay_test".into(),
+            name: "R1".into(),
+            owner: Owner::Neutral,
+        },
+        macrocosmo::components::Position { x: 0.0, y: 0.0, z: 0.0 },
+    ));
+
+    app.add_systems(Update, rebuild_relay_network);
+    app.update();
+
+    let base_range = app.world().resource::<RelayNetwork>().relays[0].range_ly;
+    assert!((base_range - 5.0).abs() < 1e-9);
+
+    // Apply +2 ly range bonus.
+    {
+        let mut comms = app.world_mut().get_mut::<CommsParams>(empire).unwrap();
+        comms.empire_relay_range.push_modifier(Modifier {
+            id: "range".into(),
+            label: "Test".into(),
+            base_add: SignedAmt::from_f64(2.0),
+            multiplier: SignedAmt::ZERO,
+            add: SignedAmt::ZERO,
+            expires_at: None,
+            on_expire_event: None,
+        });
+    }
+
+    app.update();
+    let extended_range = app.world().resource::<RelayNetwork>().relays[0].range_ly;
+    assert!(
+        (extended_range - 7.0).abs() < 1e-9,
+        "Range should extend from 5 to 7 ly (5 base + 2 empire bonus): got {}",
+        extended_range
+    );
+}
+
+/// `fleet.comm_relay_*` targets currently have no consumer, but must still
+/// route successfully into CommsParams.fleet_* fields. The presence of a
+/// storage-only modifier must not raise a warning.
+#[test]
+fn test_fleet_comm_relay_targets_routed_but_unused() {
+    let mut comms = CommsParams::default();
+    // Simulate what the tech-effect pipeline does for a
+    // `fleet.comm_relay_inv_latency` target.
+    comms.fleet_relay_inv_latency.push_modifier(Modifier {
+        id: "tech:test:fleet.comm_relay_inv_latency".into(),
+        label: "Test fleet tech".into(),
+        base_add: SignedAmt::from_f64(3.0),
+        multiplier: SignedAmt::ZERO,
+        add: SignedAmt::ZERO,
+        expires_at: None,
+        on_expire_event: None,
+    });
+    comms.fleet_relay_range.push_modifier(Modifier {
+        id: "tech:test:fleet.comm_relay_range".into(),
+        label: "Test fleet tech".into(),
+        base_add: SignedAmt::from_f64(1.5),
+        multiplier: SignedAmt::ZERO,
+        add: SignedAmt::ZERO,
+        expires_at: None,
+        on_expire_event: None,
+    });
+
+    // Fields are populated…
+    assert_eq!(comms.fleet_relay_inv_latency.final_value().to_f64(), 3.0);
+    assert_eq!(comms.fleet_relay_range.final_value().to_f64(), 1.5);
+
+    // …but empire consumers are NOT affected (fleet storage is independent).
+    assert_eq!(comms.empire_relay_inv_latency.final_value().to_f64(), 0.0);
+    assert_eq!(comms.empire_relay_range.final_value().to_f64(), 0.0);
+    // Base multiplier is unchanged because empire_relay_inv_latency = 0.
+    assert_eq!(relay_delay_hexadies(1.0, &comms), 6);
+}
+
+/// Sanity: the new whitelist correctly excludes world events and keeps
+/// systems-2 kinds. This locks in the #233 notification routing split.
+#[test]
+fn test_legacy_whitelist_split() {
+    assert!(is_legacy_whitelisted(&GameEventKind::PlayerRespawn));
+    assert!(is_legacy_whitelisted(&GameEventKind::ResourceAlert));
+    for kind in [
+        GameEventKind::HostileDetected,
+        GameEventKind::SurveyComplete,
+        GameEventKind::SurveyDiscovery,
+        GameEventKind::CombatVictory,
+        GameEventKind::CombatDefeat,
+        GameEventKind::AnomalyDiscovered,
+        GameEventKind::ColonyEstablished,
+        GameEventKind::ColonyFailed,
+    ] {
+        assert!(
+            !is_legacy_whitelisted(&kind),
+            "World event {:?} must NOT be whitelisted to legacy path",
+            kind
+        );
+    }
+}

--- a/macrocosmo/tests/pursuit.rs
+++ b/macrocosmo/tests/pursuit.rs
@@ -150,16 +150,33 @@ fn count_hostile_detected(app: &App) -> usize {
         .count()
 }
 
-// Register the notifications plumbing (queue + auto_notify) on top of
-// `test_app_with_event_log` so we can assert notifications too.
+// Register the notifications plumbing (queue + auto_notify + fact drain) on
+// top of `test_app_with_event_log` so we can assert notifications too.
+//
+// #233: `HostileDetected` now surfaces through `PendingFactQueue`, so the
+// pursuit tests that assert on banners need both pipelines registered plus
+// a `Player` entity so `detect_hostiles_system` can compute an arrival time.
 fn test_app_with_notifications() -> App {
     let mut app = test_app_with_event_log();
-    app.insert_resource(NotificationQueue::new());
     app.add_systems(
         Update,
-        macrocosmo::notifications::auto_notify_from_events
+        (
+            macrocosmo::notifications::auto_notify_from_events,
+            macrocosmo::notifications::notify_from_knowledge_facts,
+        )
             .after(macrocosmo::ship::pursuit::detect_hostiles_system),
     );
+    // Spawn a minimal Player + capital system at origin so the new #233 fact
+    // pipeline has a target coordinate. Place the player at the same origin
+    // as the detector so local notifications surface instantly.
+    let system = app
+        .world_mut()
+        .spawn(Position::from([0.0, 0.0, 0.0]))
+        .id();
+    app.world_mut().spawn((
+        macrocosmo::player::Player,
+        macrocosmo::player::StationedAt { system },
+    ));
     app
 }
 
@@ -194,16 +211,31 @@ fn aggressive_sublight_detects_hostile_sublight_in_range() {
         400,
     );
 
+    // Detection is immediate (GameEvent + EventLog); the notification is
+    // routed through PendingFactQueue and surfaces after the light delay
+    // between the target (1 ly away) and the player at origin (~60 hd).
     advance_time(&mut app, 1);
     assert_eq!(count_hostile_detected(&app), 1);
+    // Fact queue should have the HostileDetected fact scheduled for arrival.
+    assert_eq!(
+        app.world()
+            .resource::<macrocosmo::knowledge::PendingFactQueue>()
+            .pending_len(),
+        1,
+        "HostileDetected must be recorded in PendingFactQueue"
+    );
 
-    // Notification banner must have been pushed at high priority.
+    // Advance past the light-speed arrival to drain the fact. Target is ~1 ly
+    // from player and drifting in SubLight, so actual delay is slightly over
+    // 60 hd (distance accumulates). 120 hd is a comfortable margin.
+    advance_time(&mut app, 120);
+
     let q = app.world().resource::<NotificationQueue>();
     let notif = q
         .items
         .iter()
         .find(|n| n.title == "Hostile Detected")
-        .expect("HostileDetected must produce a banner");
+        .expect("HostileDetected must produce a banner after light delay");
     assert_eq!(notif.priority, NotificationPriority::High);
     assert!(notif.description.contains("Scout"));
     assert!(notif.description.contains("Raider"));


### PR DESCRIPTION
## Summary

#212 偵察 epic の最終 sub-issue (後続 callsite migration は分割 PR)。現状 \`auto_notify_from_events\` は GameEvent の timestamp を無視して即時 push していたため **50 ly 先の HostileDetected も即通知される光速違反**が発生。Notification pipeline を 2 系統に分離し、world-event notifications は KnowledgeStore fact delta から derive させて光速遅延 / Relay 網 / ship-carried 伝達 channel を反映させる。

## 設計 (user 確定)

### 1. 2 系統分離

- **系統 1 (fact 経由)**: HostileDetected / CombatVictory / SurveyComplete / AnomalyDiscovered / ShipBuilt 等 — 光速遅延 + Relay で最速 channel auto-select
- **系統 2 (直接 push)**: Lua \`show_notification\` / PlayerRespawn / ResourceAlert — 既存 direct push 維持

### 2. KnowledgeFact + PendingFactQueue

\`\`\`rust
pub struct PerceivedFact { fact, observed_at, arrives_at, source, origin_pos, related_system }
pub enum KnowledgeFact {
    HostileDetected { target, detector, target_pos },
    CombatOutcome { system, victor, detail },
    SurveyComplete, AnomalyDiscovered, SurveyDiscovery,
    StructureBuilt, ColonyEstablished, ColonyFailed,
}
\`\`\`

\`PendingFactQueue\` resource (KnowledgeStore とは分離、snapshot vs delta の責務分離)。

### 3. Relay endpoint model (物理的に整合)

\`origin → nearest_relay (光速) → relay 網 FTL → nearest_relay_to_player (光速) → player\`

- \`relay_delay = floor(light_delay / FTL_RELAY_MULTIPLIER)\`、デフォルト 10x
- Relay 網 connectivity は MVP 単一 network 仮定 (proper BFS は follow-up)

### 4. 4 modifier targets 追加 (CommsParams)

- \`empire.comm_relay_range\` / \`empire.comm_relay_inv_latency\` — tech で relay 網を強化
- \`fleet.comm_relay_range\` / \`fleet.comm_relay_inv_latency\` — 予約 (ship comm module 実装時に consumer 追加)

### 5. EventLog / auto_pause 温存

GameEvent / EventLog / auto_pause_on_event はそのまま。auto_pause は光速遅延しない UX の global 即時判定。Notification のみ KS 経由に移行 (dual-write 当面)。

## 変更ファイル (13 files, +1396 / -25)

- **新規** \`src/knowledge/facts.rs\` (651 行) — PerceivedFact / KnowledgeFact / PendingFactQueue / RelayNetwork / compute_fact_arrival / relay_delay_hexadies / effective_relay_range / record_fact_or_local + 6 unit tests
- **新規** \`src/empire/mod.rs\` + \`src/empire/comms.rs\` — CommsParams component (4 ModifiedValue fields)
- **新規** \`tests/notification_knowledge_pipeline.rs\` (440 行) — 11 integration tests
- \`knowledge/mod.rs\` — facts re-export、RelayNetwork + rebuild_relay_network system 登録
- \`notifications.rs\` — \`is_legacy_whitelisted\` (PlayerRespawn / ResourceAlert のみ)、\`auto_notify_from_events\` gate、新 \`notify_from_knowledge_facts\` system + 2 unit tests
- \`technology/effects.rs\` — 4 modifier target routes
- \`ship/pursuit.rs\` — \`detect_hostiles_system\` を fact 経由に re-wire (50 ly 光速違反を本 PR で解消)
- \`player/mod.rs\` — PlayerEmpire bundle に CommsParams 追加
- \`lib.rs\` / \`main.rs\` / \`tests/common/mod.rs\` — empire module 登録 + test app setup

## 数値確認

- 50 ly HostileDetected without relay → arrives_at = **3000 hd** (Direct)
- 50 ly with paired relays (5 ly coverage each) → **408 hd** (Relay、~7.4x faster)
- relay_delay(1 ly, default) = 6 hd = \`60 / (10 + 0)\`
- relay_delay(1 ly, +5 inv_latency) = 4 hd = \`60 / (10 + 5)\`
- fleet.comm_relay_* → CommsParams.fleet_* に反映、empire_* consumer には影響なし

## Test plan

- [x] 11 新規 integration tests + 6 unit tests + 2 notification unit tests 全 pass
- [x] \`cargo test -p macrocosmo\`: **1545 passed / 0 failed** (baseline 889、+500 以上は #241/#245 tests 含む)
- [x] warning 新規なし

## 繰越し (follow-up issue で続行)

本 PR は core pipeline + **最優先 callsite (pursuit の 50 ly 違反)** を実装。残 callsite は follow-up:

- \`survey.rs\` (7 箇所: SurveyComplete / HostileDetected / AnomalyDiscovered / SurveyDiscovery)
- \`combat.rs\` (CombatVictory / CombatDefeat、Respawn は系統 2 維持)
- \`movement.rs\` (ShipArrived、player_aboard 分岐)
- \`settlement.rs\` (ColonyEstablished)
- \`building_queue.rs\` / \`colonization.rs\` / \`deliverable_ops.rs\` / \`deep_space/mod.rs\` (ShipBuilt / ColonyEstablished / StructureBuilt 系)

これらは現状 \`auto_notify_from_events\` whitelist gate で banner が出ないので double-notification は起きない。fact 経由で banner 化する作業が follow-up。また、proper multi-network relay BFS、fleet.* consumer、ship-carried fact generic pipeline も follow-up。

## 関連

- Closes (部分): #233 本体は完結、残 callsite migration は follow-up issue で
- #212 偵察 epic は follow-up PR 群 merge で完結

🤖 Generated with [Claude Code](https://claude.com/claude-code)