### PR TITLE
Fix #250: production rate visible while paused + remove legacy base

### DIFF
--- a/macrocosmo/src/colony/colonization.rs
+++ b/macrocosmo/src/colony/colonization.rs
@@ -81,11 +81,16 @@ pub fn spawn_capital_colony(
             population: 100.0,
             growth_rate: 0.01,
         },
+        // #250: Production starts at zero; all output comes from buildings
+        // (automation modifiers) + pop-driven job contributions, never from
+        // a hidden base rate. Legacy code seeded this with +5 everywhere,
+        // causing empty colonies to "self-produce" and masking the real
+        // job-system pipeline.
         Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-            food_per_hexadies: ModifiedValue::new(Amt::units(5)),
+            minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
         BuildQueue {
             queue: Vec::new(),
@@ -171,16 +176,12 @@ pub fn tick_colonization_queue(
                 source.population -= transfer;
             }
 
-            // Get planet attributes for production rates
-            let (planet_name, minerals_rate, energy_rate, research_rate, num_slots) =
+            // Get planet attributes (only num_slots is used; #250 removed
+            // the legacy per-attribute base production — all output now
+            // flows through building + job modifiers).
+            let (planet_name, num_slots) =
                 if let Ok((_, planet, attrs)) = planet_query.get(order.target_planet) {
-                    (
-                        planet.name.clone(),
-                        crate::ship::resource_production_rate(attrs.mineral_richness),
-                        crate::ship::resource_production_rate(attrs.energy_potential),
-                        crate::ship::resource_production_rate(attrs.research_potential),
-                        attrs.max_building_slots as usize,
-                    )
+                    (planet.name.clone(), attrs.max_building_slots as usize)
                 } else {
                     continue;
                 };
@@ -193,10 +194,11 @@ pub fn tick_colonization_queue(
                     population: order.initial_population,
                     growth_rate: 0.005,
                 },
+                // #250: see comment in spawn_capital_colony above.
                 Production {
-                    minerals_per_hexadies: crate::modifier::ModifiedValue::new(minerals_rate),
-                    energy_per_hexadies: crate::modifier::ModifiedValue::new(energy_rate),
-                    research_per_hexadies: crate::modifier::ModifiedValue::new(research_rate),
+                    minerals_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
+                    energy_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
+                    research_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
                     food_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
                 },
                 BuildQueue { queue: Vec::new() },

--- a/macrocosmo/src/colony/mod.rs
+++ b/macrocosmo/src/colony/mod.rs
@@ -41,6 +41,23 @@ impl Plugin for ColonyPlugin {
                     spawn_capital_colony.after(crate::galaxy::generate_galaxy),
                 ),
             )
+            // #250: Prime the colony sync pipeline at the end of Startup so
+            // the UI's first frame shows correct production rates. Without
+            // this, sync only runs on Update and `aggregate_job_contributions`
+            // first fires after Startup completes — meaning the first render
+            // reads Production with only the legacy base value loaded.
+            .add_systems(
+                Startup,
+                (
+                    sync_building_modifiers,
+                    crate::species::sync_job_assignment,
+                    sync_species_modifiers,
+                    aggregate_job_contributions,
+                )
+                    .chain()
+                    .after(crate::setup::run_faction_on_game_start)
+                    .after(crate::setup::run_all_factions_on_game_start),
+            )
             .add_systems(
                 Update,
                 (
@@ -52,6 +69,10 @@ impl Plugin for ColonyPlugin {
                     sync_system_building_maintenance,
                     sync_maintenance_modifiers,
                     sync_food_consumption,
+                    // #250: Aggregate job contributions every Update tick,
+                    // independent of `delta`. This guarantees the UI sees a
+                    // correct production rate even while paused.
+                    aggregate_job_contributions,
                     tick_production,
                     tick_maintenance,
                     tick_population_growth,

--- a/macrocosmo/src/colony/production.rs
+++ b/macrocosmo/src/colony/production.rs
@@ -455,55 +455,29 @@ pub fn sync_species_modifiers(
     }
 }
 
-/// #29: tick_production uses ProductionFocus weights and building bonuses.
-/// #44: Research is no longer accumulated in the stockpile; emitted via emit_research.
-/// #73: Non-capital colonies have production reduced when capital authority is depleted.
-/// #241: Production is now a two-stage aggregation:
-/// 1. For each (job, target) bucket in `ColonyJobRates`, `final_value()` × assigned
-///    pops = that job's contribution. Pushed into the corresponding
-///    `colony.<X>_per_hexadies` aggregator as `job_<id>_contribution`.
-/// 2. `Production.<X>_per_hexadies.final_value()` then combines automation
-///    building output, job contributions, species/tech multipliers, and
-///    empire-wide modifiers — all of which landed there via the sync systems
-///    earlier in the pipeline.
-pub fn tick_production(
-    clock: Res<GameClock>,
-    last_tick: Res<LastProductionTick>,
+/// #250: Aggregate per-job production contributions into each colony's
+/// `Production` component. Runs every tick (including while the clock is
+/// paused) so the UI reads a correct rate even with `delta = 0`. Previously
+/// this was Stage 1 inside `tick_production`, but that system early-returns
+/// when `delta <= 0`, which meant the aggregator held only the legacy base
+/// value during pauses and the first Update after Startup — leaving the UI
+/// showing e.g. `Minerals: +5` instead of `base + miner contribution`.
+///
+/// Must run AFTER `sync_building_modifiers` (sets slot capacities),
+/// `sync_job_assignment` (sets `slot.assigned`), and `sync_species_modifiers`
+/// (populates per-job rate buckets) so the values it reads are current.
+/// Must run BEFORE `tick_production` so the accumulator sees the fresh rate.
+pub fn aggregate_job_contributions(
     mut colonies: Query<(
         &Colony,
         &mut Production,
         Option<&ColonyJobRates>,
         Option<&ColonyJobs>,
-        Option<&ProductionFocus>,
     )>,
-    mut stockpiles: Query<(&mut ResourceStockpile, Option<&ResourceCapacity>), With<StarSystem>>,
-    stars: Query<&StarSystem>,
-    planets: Query<&Planet>,
 ) {
-    let delta = clock.elapsed - last_tick.0;
-    if delta <= 0 {
-        return;
-    }
-    let d = delta as u64;
-    let d_amt = Amt::units(d);
-
-    // #73: Check if the capital has an authority deficit.
-    let capital_authority = {
-        let capital_sys = colonies.iter().find_map(|(colony, _, _, _, _)| {
-            colony.system(&planets).filter(|&sys| stars.get(sys).ok().is_some_and(|s| s.is_capital))
-        });
-        capital_sys.and_then(|sys| stockpiles.get(sys).ok().map(|(s, _)| s.authority))
-    };
-    let authority_deficit = matches!(capital_authority, Some(a) if a == Amt::ZERO);
-
-    // Collect production deltas per system
-    let mut system_deltas: std::collections::HashMap<Entity, (Amt, Amt, Amt)> = std::collections::HashMap::new();
-    for (colony, mut prod, rates_opt, jobs_opt, focus) in &mut colonies {
-        let Some(sys) = colony.system(&planets) else { continue };
-
-        // --- Stage 1: push job contributions into colony aggregators ---
-        // Remove any contributions from the previous tick first so changes
-        // (pop shifts, slot changes, etc.) propagate cleanly.
+    for (_colony, mut prod, rates_opt, jobs_opt) in &mut colonies {
+        // Remove any contributions from the previous aggregation first so
+        // changes (pop shifts, slot changes, demolitions, etc.) propagate.
         let remove_job_mods = |mv: &mut ModifiedValue| {
             let ids: Vec<String> = mv
                 .modifiers()
@@ -520,44 +494,85 @@ pub fn tick_production(
         remove_job_mods(&mut prod.research_per_hexadies);
         remove_job_mods(&mut prod.food_per_hexadies);
 
-        if let (Some(rates), Some(jobs)) = (rates_opt, jobs_opt) {
-            // Sum each job's per-target contribution across assigned pops.
-            // Target key -> accumulated contribution. We emit one modifier per
-            // (job, target) pair so that UI can show per-job breakdown later.
-            let mut job_contribs: std::collections::HashMap<(String, String), f64> =
-                std::collections::HashMap::new();
-            for slot in &jobs.slots {
-                if slot.assigned == 0 {
+        let (Some(rates), Some(jobs)) = (rates_opt, jobs_opt) else {
+            continue;
+        };
+
+        // Sum each job's per-target contribution across assigned pops.
+        // Target key -> accumulated contribution. One modifier per (job, target)
+        // pair so the UI can show per-job breakdown later.
+        let mut job_contribs: std::collections::HashMap<(String, String), f64> =
+            std::collections::HashMap::new();
+        for slot in &jobs.slots {
+            if slot.assigned == 0 {
+                continue;
+            }
+            for (job_id, target, mv) in rates.iter() {
+                if job_id != &slot.job_id {
                     continue;
                 }
-                for (job_id, target, mv) in rates.iter() {
-                    if job_id != &slot.job_id {
-                        continue;
-                    }
-                    let rate = mv.final_value().to_f64();
-                    let contribution = rate * slot.assigned as f64;
-                    *job_contribs
-                        .entry((job_id.clone(), target.clone()))
-                        .or_insert(0.0) += contribution;
-                }
-            }
-
-            for ((job_id, target), value) in &job_contribs {
-                if let Some(bucket) = colony_resource_bucket(&mut prod, target) {
-                    bucket.push_modifier(Modifier {
-                        id: format!("job_{}_contribution", job_id),
-                        label: format!("Job '{}' contribution", job_id),
-                        base_add: SignedAmt::from_f64(*value),
-                        multiplier: SignedAmt::ZERO,
-                        add: SignedAmt::ZERO,
-                        expires_at: None,
-                        on_expire_event: None,
-                    });
-                }
+                let rate = mv.final_value().to_f64();
+                let contribution = rate * slot.assigned as f64;
+                *job_contribs
+                    .entry((job_id.clone(), target.clone()))
+                    .or_insert(0.0) += contribution;
             }
         }
 
-        // --- Stage 2: read final_value from colony aggregators ---
+        for ((job_id, target), value) in &job_contribs {
+            if let Some(bucket) = colony_resource_bucket(&mut prod, target) {
+                bucket.push_modifier(Modifier {
+                    id: format!("job_{}_contribution", job_id),
+                    label: format!("Job '{}' contribution", job_id),
+                    base_add: SignedAmt::from_f64(*value),
+                    multiplier: SignedAmt::ZERO,
+                    add: SignedAmt::ZERO,
+                    expires_at: None,
+                    on_expire_event: None,
+                });
+            }
+        }
+    }
+}
+
+/// #29: tick_production uses ProductionFocus weights and building bonuses.
+/// #44: Research is no longer accumulated in the stockpile; emitted via emit_research.
+/// #73: Non-capital colonies have production reduced when capital authority is depleted.
+/// #241/#250: Production is a two-stage aggregation split across systems:
+/// 1. `aggregate_job_contributions` pushes per-job contributions into each
+///    colony's aggregators. Runs every Update (delta-independent) so the UI
+///    sees a correct rate even while paused.
+/// 2. This system multiplies `Production.<X>_per_hexadies.final_value()` by
+///    the elapsed `delta` and applies the result to system stockpiles.
+pub fn tick_production(
+    clock: Res<GameClock>,
+    last_tick: Res<LastProductionTick>,
+    colonies: Query<(&Colony, &Production, Option<&ProductionFocus>)>,
+    mut stockpiles: Query<(&mut ResourceStockpile, Option<&ResourceCapacity>), With<StarSystem>>,
+    stars: Query<&StarSystem>,
+    planets: Query<&Planet>,
+) {
+    let delta = clock.elapsed - last_tick.0;
+    if delta <= 0 {
+        return;
+    }
+    let d = delta as u64;
+    let d_amt = Amt::units(d);
+
+    // #73: Check if the capital has an authority deficit.
+    let capital_authority = {
+        let capital_sys = colonies.iter().find_map(|(colony, _, _)| {
+            colony.system(&planets).filter(|&sys| stars.get(sys).ok().is_some_and(|s| s.is_capital))
+        });
+        capital_sys.and_then(|sys| stockpiles.get(sys).ok().map(|(s, _)| s.authority))
+    };
+    let authority_deficit = matches!(capital_authority, Some(a) if a == Amt::ZERO);
+
+    // Collect production deltas per system
+    let mut system_deltas: std::collections::HashMap<Entity, (Amt, Amt, Amt)> = std::collections::HashMap::new();
+    for (colony, prod, focus) in &colonies {
+        let Some(sys) = colony.system(&planets) else { continue };
+
         let (mw, ew) = match focus {
             Some(f) => (f.minerals_weight, f.energy_weight),
             None => (Amt::units(1), Amt::units(1)),

--- a/macrocosmo/src/setup/mod.rs
+++ b/macrocosmo/src/setup/mod.rs
@@ -348,11 +348,13 @@ fn spawn_colony_on_planet(world: &mut World, planet_entity: Entity, num_slots: u
                 population: 100.0,
                 growth_rate: 0.01,
             },
+            // #250: zero-base production; all output comes from building/job
+            // modifiers via the sync pipeline.
             Production {
-                minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-                energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
-                research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-                food_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
             BuildQueue { queue: Vec::new() },
             Buildings {

--- a/macrocosmo/src/ship/settlement.rs
+++ b/macrocosmo/src/ship/settlement.rs
@@ -99,9 +99,6 @@ pub fn process_settling(
             };
 
             let system_name = star_system.name.clone();
-            let minerals_rate = resource_production_rate(attrs.mineral_richness);
-            let energy_rate = resource_production_rate(attrs.energy_potential);
-            let research_rate = resource_production_rate(attrs.research_potential);
             let num_slots = attrs.max_building_slots as usize;
 
             commands.spawn((
@@ -110,10 +107,13 @@ pub fn process_settling(
                     population: 10.0,
                     growth_rate: 0.005,
                 },
+                // #250: zero-base production; all output comes from building/
+                // job modifiers. Planet attributes (mineral_richness etc.) are
+                // still available for future building/job modifiers to consume.
                 Production {
-                    minerals_per_hexadies: crate::modifier::ModifiedValue::new(minerals_rate),
-                    energy_per_hexadies: crate::modifier::ModifiedValue::new(energy_rate),
-                    research_per_hexadies: crate::modifier::ModifiedValue::new(research_rate),
+                    minerals_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
+                    energy_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
+                    research_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
                     food_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
                 },
                 BuildQueue {
@@ -167,7 +167,7 @@ pub fn process_settling(
                 related_system: Some(system_entity),
             });
 
-            info!("Colony established at {} (M:{}/E:{}/R:{} per sd)", system_name, minerals_rate, energy_rate, research_rate);
+            info!("Colony established at {}", system_name);
 
             // Consume the colony ship
             commands.entity(ship_entity).despawn();
@@ -214,6 +214,11 @@ pub fn process_refitting(
 
 /// Convert a continuous resource level (0.0..1.0) to a production rate in Amt.
 /// Scales linearly: 0.0 -> 0, 1.0 -> 8 units per hexadies.
+///
+/// #250: No longer wired into colony spawn — production now flows through
+/// building + job modifiers. Kept because planet attributes (mineral_richness
+/// etc.) are a likely input for a future attribute-scaled modifier system.
+#[allow(dead_code)]
 pub fn resource_production_rate(level: f64) -> crate::amount::Amt {
     if level <= 0.0 {
         Amt::ZERO

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -331,6 +331,8 @@ pub fn test_app() -> App {
             sync_species_modifiers,
             sync_maintenance_modifiers,
             sync_food_consumption,
+            // #250: rate aggregation is delta-independent; runs every tick.
+            macrocosmo::colony::aggregate_job_contributions,
             tick_production,
             tick_maintenance,
             tick_population_growth,
@@ -511,6 +513,8 @@ pub fn full_test_app() -> App {
             sync_species_modifiers,
             sync_maintenance_modifiers,
             sync_food_consumption,
+            // #250: rate aggregation is delta-independent; runs every tick.
+            macrocosmo::colony::aggregate_job_contributions,
             tick_production,
             tick_maintenance,
             tick_population_growth,

--- a/macrocosmo/tests/job_system.rs
+++ b/macrocosmo/tests/job_system.rs
@@ -568,6 +568,267 @@ fn test_parsed_modifier_detects_job_scope() {
     assert_eq!(pm.job_scope(), None);
 }
 
+// ---------------------------------------------------------------------------
+// #250: After the fix, a freshly-spawned capital's `Production.final_value()`
+// reflects building + job contributions from the very first tick, including
+// while the game is paused (delta = 0). Legacy base values of 5/5/1/5 have
+// been removed — production comes entirely from building/job modifiers.
+// ---------------------------------------------------------------------------
+
+/// Mirror the bundle produced by `spawn_capital_colony` (post-fix) so the
+/// tests below exercise the real spawn path's invariants.
+fn spawn_capital_like_colony(
+    app: &mut App,
+    sys: Entity,
+    buildings: Vec<&str>,
+    population: u32,
+) -> Entity {
+    let planet = find_planet(app.world_mut(), sys);
+    app.world_mut()
+        .spawn((
+            Colony {
+                planet,
+                population: population as f64,
+                growth_rate: 0.01,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue { queue: Vec::new() },
+            Buildings {
+                slots: buildings
+                    .into_iter()
+                    .map(|s| Some(BuildingId::new(s)))
+                    .collect(),
+            },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+            ColonyPopulation {
+                species: vec![ColonySpecies {
+                    species_id: "human".to_string(),
+                    population,
+                }],
+            },
+            ColonyJobs::default(),
+            ColonyJobRates::default(),
+        ))
+        .id()
+}
+
+#[test]
+fn test_issue_250_capital_production_reflects_buildings_and_jobs() {
+    let mut app = test_app();
+    install_basic_jobs(&mut app);
+    app.insert_resource(slot_based_building_registry());
+
+    let sys = spawn_test_system(app.world_mut(), "Issue250", [0.0, 0.0, 0.0], 1.0, true, true);
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
+            minerals: Amt::ZERO,
+            energy: Amt::units(500),
+            research: Amt::ZERO,
+            food: Amt::units(200),
+            authority: Amt::ZERO,
+        },
+        ResourceCapacity::default(),
+    ));
+
+    let colony = spawn_capital_like_colony(&mut app, sys, vec!["mine", "farm"], 100);
+
+    advance_time(&mut app, 1);
+
+    let prod = app.world().get::<Production>(colony).unwrap();
+    // Expected contributions only (no legacy base):
+    //   Minerals: miner 5 × 0.6 = 3
+    //   Food:     farmer 5 × 1.0 = 5
+    //   Energy:   no plant        = 0
+    //   Research: no lab          = 0
+    assert_eq!(
+        prod.minerals_per_hexadies.final_value(),
+        Amt::units(3),
+        "miner contribution should drive minerals"
+    );
+    assert_eq!(
+        prod.food_per_hexadies.final_value(),
+        Amt::units(5),
+        "farmer contribution should drive food"
+    );
+    assert_eq!(
+        prod.energy_per_hexadies.final_value(),
+        Amt::ZERO,
+        "no power plant ⇒ zero energy"
+    );
+    assert_eq!(
+        prod.research_per_hexadies.final_value(),
+        Amt::ZERO,
+        "no researcher ⇒ zero research"
+    );
+}
+
+/// #250 regression: the aggregator must expose the correct rate even when the
+/// clock is paused (`delta = 0`). Before the fix, `tick_production` held the
+/// Stage 1 push, so the UI saw only the legacy base value during pauses.
+#[test]
+fn test_issue_250_aggregator_runs_while_paused() {
+    let mut app = test_app();
+    install_basic_jobs(&mut app);
+    app.insert_resource(slot_based_building_registry());
+
+    let sys = spawn_test_system(app.world_mut(), "PausedProd", [0.0, 0.0, 0.0], 1.0, true, true);
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
+            minerals: Amt::ZERO,
+            energy: Amt::ZERO,
+            research: Amt::ZERO,
+            food: Amt::ZERO,
+            authority: Amt::ZERO,
+        },
+        ResourceCapacity::default(),
+    ));
+
+    let colony = spawn_capital_like_colony(&mut app, sys, vec!["mine", "farm"], 100);
+
+    // Do NOT advance time. Only run one frame so the sync pipeline fires.
+    app.update();
+
+    let prod = app.world().get::<Production>(colony).unwrap();
+    assert_eq!(
+        prod.minerals_per_hexadies.final_value(),
+        Amt::units(3),
+        "aggregator must populate minerals even with delta=0; got {}",
+        prod.minerals_per_hexadies.final_value()
+    );
+    assert_eq!(
+        prod.food_per_hexadies.final_value(),
+        Amt::units(5),
+        "aggregator must populate food even with delta=0"
+    );
+
+    // Stockpile should NOT have been credited (Stage 2 is delta-gated).
+    let stockpile = app.world().get::<ResourceStockpile>(sys).unwrap();
+    assert_eq!(
+        stockpile.minerals,
+        Amt::ZERO,
+        "no time elapsed ⇒ stockpile should not accumulate"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #250: Verify that real Lua definitions (scripts/buildings/basic.lua and
+// scripts/jobs/basic.lua) parse into the expected BuildingDefinition.modifiers
+// and JobDefinition.modifiers. If the Lua side silently drops or misroutes a
+// modifier, the integration test above (which uses hand-built registries)
+// will never catch it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_issue_250_lua_building_modifiers_parse_correctly() {
+    use macrocosmo::scripting::building_api::parse_building_definitions;
+    use macrocosmo::scripting::ScriptEngine;
+
+    let engine = ScriptEngine::new().expect("ScriptEngine::new()");
+    let init = engine.scripts_dir().join("init.lua");
+    engine.load_file(&init).expect("load init.lua");
+
+    let defs = parse_building_definitions(engine.lua()).expect("parse buildings");
+    let ids: Vec<&str> = defs.iter().map(|d| d.id.as_str()).collect();
+    eprintln!("[issue #250] building ids: {ids:?}");
+
+    let mine = defs.iter().find(|d| d.id == "mine").expect("mine not defined");
+    eprintln!("[issue #250] mine.modifiers = {:?}", mine.modifiers);
+    assert!(
+        mine.modifiers.iter().any(|m| m.target == "colony.miner_slot"
+            && (m.base_add - 5.0).abs() < 1e-9),
+        "mine should declare modifier colony.miner_slot base_add=5; got {:?}",
+        mine.modifiers
+    );
+
+    let power = defs
+        .iter()
+        .find(|d| d.id == "power_plant")
+        .expect("power_plant not defined");
+    eprintln!("[issue #250] power_plant.modifiers = {:?}", power.modifiers);
+    assert!(
+        power
+            .modifiers
+            .iter()
+            .any(|m| m.target == "colony.power_worker_slot"
+                && (m.base_add - 5.0).abs() < 1e-9),
+        "power_plant should declare modifier colony.power_worker_slot base_add=5; got {:?}",
+        power.modifiers
+    );
+
+    let farm = defs.iter().find(|d| d.id == "farm").expect("farm not defined");
+    eprintln!("[issue #250] farm.modifiers = {:?}", farm.modifiers);
+    assert!(
+        farm.modifiers.iter().any(|m| m.target == "colony.farmer_slot"
+            && (m.base_add - 5.0).abs() < 1e-9),
+        "farm should declare modifier colony.farmer_slot base_add=5; got {:?}",
+        farm.modifiers
+    );
+}
+
+#[test]
+fn test_issue_250_lua_job_modifiers_parse_correctly() {
+    use macrocosmo::scripting::species_api::parse_job_definitions;
+    use macrocosmo::scripting::ScriptEngine;
+
+    let engine = ScriptEngine::new().expect("ScriptEngine::new()");
+    let init = engine.scripts_dir().join("init.lua");
+    engine.load_file(&init).expect("load init.lua");
+
+    let defs = parse_job_definitions(engine.lua()).expect("parse jobs");
+    let ids: Vec<&str> = defs.iter().map(|d| d.id.as_str()).collect();
+    eprintln!("[issue #250] job ids: {ids:?}");
+
+    let miner = defs.iter().find(|d| d.id == "miner").expect("miner");
+    eprintln!("[issue #250] miner.modifiers = {:?}", miner.modifiers);
+    assert!(
+        miner
+            .modifiers
+            .iter()
+            .any(|m| m.target == "job:miner::colony.minerals_per_hexadies"
+                && (m.base_add - 0.6).abs() < 1e-9),
+        "miner per-pop rate should auto-prefix to job:miner::...; got {:?}",
+        miner.modifiers
+    );
+
+    let power_worker = defs
+        .iter()
+        .find(|d| d.id == "power_worker")
+        .expect("power_worker");
+    eprintln!(
+        "[issue #250] power_worker.modifiers = {:?}",
+        power_worker.modifiers
+    );
+    assert!(
+        power_worker
+            .modifiers
+            .iter()
+            .any(|m| m.target == "job:power_worker::colony.energy_per_hexadies"
+                && (m.base_add - 6.0).abs() < 1e-9),
+        "power_worker per-pop rate should be 6.0; got {:?}",
+        power_worker.modifiers
+    );
+
+    let farmer = defs.iter().find(|d| d.id == "farmer").expect("farmer");
+    eprintln!("[issue #250] farmer.modifiers = {:?}", farmer.modifiers);
+    assert!(
+        farmer
+            .modifiers
+            .iter()
+            .any(|m| m.target == "job:farmer::colony.food_per_hexadies"
+                && (m.base_add - 1.0).abs() < 1e-9),
+        "farmer per-pop rate should be 1.0; got {:?}",
+        farmer.modifiers
+    );
+}
+
 // Required by macrocosmo::modifier::Modifier for the helper above.
 #[allow(dead_code)]
 fn _ensure_modifier_constructible() -> Modifier {


### PR DESCRIPTION
## Summary
- #250 の根本原因は `tick_production` が `delta <= 0` で早期 return し、その中に **Stage 1 (per-job contribution → Production aggregator への push)** も含まれていたこと。PAUSE 中 or Startup 直後の最初の Update は UI が `Production.final_value()` を読んでも legacy base 値 (5/5/1/5) しか見えず、「Minerals +5」「Energy produce 0」等の症状が出ていた。
- Stage 1 を独立 system `aggregate_job_contributions` に切り出し、**毎 Update tick で無条件に走る** ように変更。Stage 2 (stockpile accumulation) は従来通り `delta > 0` ゲート。
- Startup chain にも `sync_building_modifiers → sync_job_assignment → sync_species_modifiers → aggregate_job_contributions` を `after(run_faction_on_game_start)` で 1 回流し、起動直後の UI 初期表示も正常化。
- Colony spawn 全経路の Production base を `Amt::units(5/1)` → `Amt::ZERO` に統一。legacy の base 値は #241 (job system) 移行前の残骸で、建物ゼロのコロニーでも「+5 自動生産」する幽霊ソースになっていた。

## 変更ファイル
- `src/colony/production.rs` — Stage 1 切り出し、`tick_production` を Stage 2 のみに
- `src/colony/mod.rs` — Update chain に `aggregate_job_contributions`、Startup chain 追加
- `src/colony/colonization.rs` — `spawn_capital_colony` + `tick_colonization_queue` の base=0
- `src/setup/mod.rs` — `spawn_colony_on_planet` の base=0
- `src/ship/settlement.rs` — colony_ship 着陸時の base=0。未使用化した `resource_production_rate` に `#[allow(dead_code)]`
- `tests/common/mod.rs` — `test_app` + `full_test_app` の chain に `aggregate_job_contributions`
- `tests/job_system.rs` — 旧 legacy-base reproducer を post-fix invariant に置き換え + PAUSE regression test 追加

## 判明した follow-up (本 PR 外)
- **維持費バランス**: power_worker の per-pop rate = 6.0 は maintenance cost に対して低め。実機では Energy net が常に赤字気味。本 PR では元の 6.0 のまま維持し、balance 調整は別 issue で扱う。

## Test plan
- [x] `cargo test --test job_system` — 14 PASS
- [x] `cargo test` 全体 — 1800+ PASS / 0 FAIL
- [x] 実機 (`cargo run`) で新規ゲーム開始後、PAUSE 中でも Earth の Income/hxd 表示が正しく (Minerals: miner contribution, Energy: power_worker contribution) 反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)