### PR TITLE
#252: Add Pop management tab to colony panel

### DIFF
--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -47,6 +47,16 @@ use params::{
 #[derive(Resource, Default)]
 pub struct ResearchPanelOpen(pub bool);
 
+/// #252: Selected tab in the colony detail panel. `Overview` retains the
+/// pre-existing income/buildings view; `PopManagement` shows population
+/// breakdown, job slot assignments, and per-job production contributions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ColonyPanelTab {
+    #[default]
+    Overview,
+    PopManagement,
+}
+
 /// Intermediate resource holding pre-computed UI data shared across systems.
 /// Written by `compute_ui_state`, read by drawing systems.
 #[derive(Resource, Default)]
@@ -63,6 +73,8 @@ pub struct UiState {
     pub net_food: SignedAmt,
     pub net_authority: SignedAmt,
     pub capital_stockpile: Option<(Amt, Amt)>,
+    /// #252: Which tab is active in the colony detail window.
+    pub colony_panel_tab: ColonyPanelTab,
 }
 
 pub struct UiPlugin;
@@ -484,7 +496,7 @@ fn draw_main_panels_system(
     mut commands: Commands,
     mut contexts: EguiContexts,
     clock: Res<GameClock>,
-    ui_state: Res<UiState>,
+    mut ui_state: ResMut<UiState>,
     mut selection: MainPanelSelection,
     registries: MainPanelRegistries,
     building_registry: Res<BuildingRegistry>,
@@ -581,6 +593,7 @@ fn draw_main_panels_system(
         &stars,
         &player_q,
         &mut colonies,
+        &world.colony_pop_view,
         &mut world.stockpiles,
         &mut ships_query,
         &world.positions,
@@ -596,6 +609,8 @@ fn draw_main_panels_system(
         &world.colonization_queues,
         &mut colonization_actions,
         &building_registry,
+        &registries.job_registry,
+        &mut ui_state.colony_panel_tab,
         &world.anomalies,
         &world.deliverable_stockpiles,
         &world.deep_space_structures,

--- a/macrocosmo/src/ui/params.rs
+++ b/macrocosmo/src/ui/params.rs
@@ -2,9 +2,10 @@ use bevy::prelude::*;
 use bevy::ecs::system::SystemParam;
 
 use crate::colony::{
-    ColonizationQueue, DeliverableStockpile, ResourceCapacity, ResourceStockpile,
+    ColonizationQueue, ColonyJobRates, DeliverableStockpile, ResourceCapacity, ResourceStockpile,
     SystemBuildingQueue, SystemBuildings,
 };
+use crate::species::{ColonyJobs, ColonyPopulation, JobRegistry};
 use crate::components::Position;
 use crate::deep_space::{ConstructionPlatform, DeepSpaceStructure, Scrapyard};
 use crate::galaxy::{Anomalies, HostilePresence, Planet, StarSystem, SystemAttributes};
@@ -47,6 +48,20 @@ pub struct MainPanelWorldQueries<'w, 's> {
             Option<&'static Scrapyard>,
         ),
     >,
+    /// #252: Read-only colony pop/job view for the Pop management tab on
+    /// the colony detail panel. Separated from the main mutable `colonies`
+    /// query in `draw_main_panels_system` to avoid B0001 conflicts and to
+    /// keep that query's tuple arity stable.
+    pub colony_pop_view: Query<
+        'w,
+        's,
+        (
+            Entity,
+            Option<&'static ColonyPopulation>,
+            Option<&'static ColonyJobs>,
+            Option<&'static ColonyJobRates>,
+        ),
+    >,
 }
 
 #[derive(SystemParam)]
@@ -80,4 +95,6 @@ pub struct MainPanelRegistries<'w> {
     pub hull_registry: Res<'w, HullRegistry>,
     pub module_registry: Res<'w, ModuleRegistry>,
     pub design_registry: Res<'w, ShipDesignRegistry>,
+    /// #252: Job registry — consumed by the colony panel Pop management tab.
+    pub job_registry: Res<'w, JobRegistry>,
 }

--- a/macrocosmo/src/ui/system_panel/colony_detail.rs
+++ b/macrocosmo/src/ui/system_panel/colony_detail.rs
@@ -1,15 +1,105 @@
 use bevy::prelude::*;
 use bevy_egui::egui;
 
-use crate::colony::{BuildQueue, BuildingOrder, BuildingQueue, Buildings, Colony, ConstructionParams, DemolitionOrder, FoodConsumption, MaintenanceCost, Production, ResourceStockpile, UpgradeOrder};
+use crate::colony::{BuildQueue, BuildingOrder, BuildingQueue, Buildings, Colony, ColonyJobRates, ConstructionParams, DemolitionOrder, FoodConsumption, MaintenanceCost, Production, ResourceStockpile, UpgradeOrder};
 use crate::scripting::building_api::{BuildingId, BuildingRegistry};
 use crate::galaxy::SystemAttributes;
-use crate::amount::Amt;
+use crate::amount::{Amt, SignedAmt};
 use crate::ship::{Cargo, Ship, ShipHitpoints, ShipState, SurveyData};
+use crate::species::{ColonyJobs, ColonyPopulation, JobRegistry, JobSlot};
+use crate::ui::ColonyPanelTab;
 
 /// Draws colony detail for a specific planet. Called within a ScrollArea.
+///
+/// #252: Tab-switchable between "概要" (existing Income/Buildings view) and
+/// "Pop 管理" (population breakdown + job slot assignments + per-job
+/// contributions). Tab state lives in `UiState::colony_panel_tab`.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_colony_detail(
+    ui: &mut egui::Ui,
+    planet_entity: Entity,
+    system_entity: Entity,
+    planet_attrs: Option<&SystemAttributes>,
+    colonies: &mut Query<(
+        Entity,
+        &Colony,
+        Option<&Production>,
+        Option<&mut BuildQueue>,
+        Option<&Buildings>,
+        Option<&mut BuildingQueue>,
+        Option<&MaintenanceCost>,
+        Option<&FoodConsumption>,
+    )>,
+    colony_pop_view: &Query<(
+        Entity,
+        Option<&ColonyPopulation>,
+        Option<&ColonyJobs>,
+        Option<&ColonyJobRates>,
+    )>,
+    system_stockpiles: &mut Query<(&mut ResourceStockpile, Option<&crate::colony::ResourceCapacity>), With<crate::galaxy::StarSystem>>,
+    ships_query: &mut Query<(Entity, &mut Ship, &mut ShipState, Option<&mut Cargo>, &ShipHitpoints, Option<&SurveyData>)>,
+    construction_params: &ConstructionParams,
+    planets: &Query<&crate::galaxy::Planet>,
+    _hull_registry: &crate::ship_design::HullRegistry,
+    _module_registry: &crate::ship_design::ModuleRegistry,
+    design_registry: &crate::ship_design::ShipDesignRegistry,
+    building_registry: &BuildingRegistry,
+    job_registry: &JobRegistry,
+    colony_panel_tab: &mut ColonyPanelTab,
+) {
+    ui.label(
+        egui::RichText::new("Colony")
+            .strong()
+            .color(egui::Color32::from_rgb(100, 200, 100)),
+    );
+
+    // #252: Tab selector.
+    ui.horizontal(|ui| {
+        if ui
+            .selectable_label(*colony_panel_tab == ColonyPanelTab::Overview, "概要")
+            .clicked()
+        {
+            *colony_panel_tab = ColonyPanelTab::Overview;
+        }
+        if ui
+            .selectable_label(*colony_panel_tab == ColonyPanelTab::PopManagement, "Pop 管理")
+            .clicked()
+        {
+            *colony_panel_tab = ColonyPanelTab::PopManagement;
+        }
+    });
+    ui.separator();
+
+    match *colony_panel_tab {
+        ColonyPanelTab::Overview => draw_overview_tab(
+            ui,
+            planet_entity,
+            system_entity,
+            planet_attrs,
+            colonies,
+            system_stockpiles,
+            ships_query,
+            construction_params,
+            planets,
+            design_registry,
+            building_registry,
+        ),
+        ColonyPanelTab::PopManagement => draw_pop_management_tab(
+            ui,
+            planet_entity,
+            colonies,
+            colony_pop_view,
+            job_registry,
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Overview tab (existing Income / Maintenance / Stockpile / Buildings view)
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn draw_overview_tab(
     ui: &mut egui::Ui,
     planet_entity: Entity,
     system_entity: Entity,
@@ -28,17 +118,9 @@ pub(super) fn draw_colony_detail(
     ships_query: &mut Query<(Entity, &mut Ship, &mut ShipState, Option<&mut Cargo>, &ShipHitpoints, Option<&SurveyData>)>,
     construction_params: &ConstructionParams,
     planets: &Query<&crate::galaxy::Planet>,
-    _hull_registry: &crate::ship_design::HullRegistry,
-    _module_registry: &crate::ship_design::ModuleRegistry,
     design_registry: &crate::ship_design::ShipDesignRegistry,
     building_registry: &BuildingRegistry,
 ) {
-    ui.label(
-        egui::RichText::new("Colony")
-            .strong()
-            .color(egui::Color32::from_rgb(100, 200, 100)),
-    );
-
     for (_colony_entity, colony, production, _build_queue, buildings, mut building_queue, maintenance_cost, food_consumption) in
         colonies.iter_mut()
     {
@@ -48,7 +130,6 @@ pub(super) fn draw_colony_detail(
 
         // #69: Show population with carrying capacity
         let carrying_cap = {
-            use crate::amount::Amt;
             use crate::galaxy::{BASE_CARRYING_CAPACITY, FOOD_PER_POP_PER_HEXADIES};
             let hab_score = planet_attrs.map(|a| a.habitability).unwrap_or(0.5);
             let k_habitat = BASE_CARRYING_CAPACITY * hab_score;
@@ -63,7 +144,6 @@ pub(super) fn draw_colony_detail(
         ui.label(format!("Population: {:.0} / {:.0}", colony.population, carrying_cap));
 
         if let Some(prod) = production {
-            use crate::amount::SignedAmt;
             let green = egui::Color32::from_rgb(100, 200, 100);
             let red = egui::Color32::from_rgb(255, 100, 100);
 
@@ -71,26 +151,26 @@ pub(super) fn draw_colony_detail(
 
             // Food: production - consumption
             let food_prod = prod.food_per_hexadies.final_value();
-            let food_cons = food_consumption.map(|fc| fc.food_per_hexadies.final_value()).unwrap_or(crate::amount::Amt::ZERO);
+            let food_cons = food_consumption.map(|fc| fc.food_per_hexadies.final_value()).unwrap_or(Amt::ZERO);
             let food_net = SignedAmt::from_amt(food_prod).add(SignedAmt(0 - SignedAmt::from_amt(food_cons).raw()));
             let food_color = if food_net.raw() > 0 { green } else if food_net.raw() < 0 { red } else { egui::Color32::GRAY };
             ui.horizontal(|ui| {
                 ui.label("  Food:    ");
                 ui.label(egui::RichText::new(food_net.display_compact()).color(food_color));
-                if food_cons > crate::amount::Amt::ZERO {
+                if food_cons > Amt::ZERO {
                     ui.label(format!("(produce {}, consume {})", food_prod.display_compact(), food_cons.display_compact()));
                 }
             });
 
             // Energy: production - maintenance
             let energy_prod = prod.energy_per_hexadies.final_value();
-            let maint = maintenance_cost.map(|mc| mc.energy_per_hexadies.final_value()).unwrap_or(crate::amount::Amt::ZERO);
+            let maint = maintenance_cost.map(|mc| mc.energy_per_hexadies.final_value()).unwrap_or(Amt::ZERO);
             let energy_net = SignedAmt::from_amt(energy_prod).add(SignedAmt(0 - SignedAmt::from_amt(maint).raw()));
             let energy_color = if energy_net.raw() > 0 { green } else if energy_net.raw() < 0 { red } else { egui::Color32::GRAY };
             ui.horizontal(|ui| {
                 ui.label("  Energy:  ");
                 ui.label(egui::RichText::new(energy_net.display_compact()).color(energy_color));
-                if maint > crate::amount::Amt::ZERO {
+                if maint > Amt::ZERO {
                     ui.label(format!("(produce {}, maintain {})", energy_prod.display_compact(), maint.display_compact()));
                 }
             });
@@ -124,7 +204,6 @@ pub(super) fn draw_colony_detail(
 
         // #51/#64: Maintenance cost summary
         {
-            use crate::amount::Amt;
             let mut building_maintenance = Amt::ZERO;
             if let Some(b) = buildings {
                 for slot in &b.slots {
@@ -371,5 +450,324 @@ pub(super) fn draw_colony_detail(
         }
 
         break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #252: Pop management tab
+// ---------------------------------------------------------------------------
+
+/// One job slot's display info, plus its per-target production contribution.
+///
+/// `contributions` holds `(target, total_per_hd)` where `total_per_hd` equals
+/// `rate.final_value().to_f64() × slot.assigned` for that `(job, target)`
+/// bucket in `ColonyJobRates`. Targets are sorted for stable UI order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JobSlotSummary {
+    pub job_id: String,
+    pub label: String,
+    pub assigned: u32,
+    pub capacity: u32,
+    /// `(target, contribution_per_hd)` sorted by target.
+    pub contributions: Vec<(String, f64)>,
+}
+
+/// Pure aggregation helper used by the Pop management tab — extracted so it
+/// can be unit-tested without needing an egui context.
+///
+/// Returns one entry per slot in `jobs.slots` (preserving slot order), each
+/// carrying the display label from `job_registry` (falling back to the raw
+/// `job_id` when unknown) and the list of per-target contributions computed
+/// from `ColonyJobRates`.
+pub fn summarize_pop_view(
+    jobs: &ColonyJobs,
+    rates: &ColonyJobRates,
+    job_registry: &JobRegistry,
+) -> Vec<JobSlotSummary> {
+    jobs.slots
+        .iter()
+        .map(|slot: &JobSlot| {
+            let label = job_registry
+                .get(&slot.job_id)
+                .map(|d| d.label.clone())
+                .unwrap_or_else(|| slot.job_id.clone());
+            let mut contributions: Vec<(String, f64)> = rates
+                .iter()
+                .filter(|(j, _, _)| j.as_str() == slot.job_id.as_str())
+                .map(|(_, target, mv)| {
+                    let per_pop = mv.final_value().to_f64();
+                    (target.clone(), per_pop * slot.assigned as f64)
+                })
+                .collect();
+            contributions.sort_by(|a, b| a.0.cmp(&b.0));
+            JobSlotSummary {
+                job_id: slot.job_id.clone(),
+                label,
+                assigned: slot.assigned,
+                capacity: slot.capacity,
+                contributions,
+            }
+        })
+        .collect()
+}
+
+/// Strip the `colony.` prefix and `_per_hexadies` suffix for compact display
+/// (`colony.minerals_per_hexadies` -> `minerals`). Falls back to the raw
+/// target when the pattern doesn't match (e.g. future non-aggregate targets).
+fn short_target_label(target: &str) -> &str {
+    let s = target.strip_prefix("colony.").unwrap_or(target);
+    s.strip_suffix("_per_hexadies").unwrap_or(s)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_pop_management_tab(
+    ui: &mut egui::Ui,
+    planet_entity: Entity,
+    colonies: &mut Query<(
+        Entity,
+        &Colony,
+        Option<&Production>,
+        Option<&mut BuildQueue>,
+        Option<&Buildings>,
+        Option<&mut BuildingQueue>,
+        Option<&MaintenanceCost>,
+        Option<&FoodConsumption>,
+    )>,
+    colony_pop_view: &Query<(
+        Entity,
+        Option<&ColonyPopulation>,
+        Option<&ColonyJobs>,
+        Option<&ColonyJobRates>,
+    )>,
+    job_registry: &JobRegistry,
+) {
+    // Resolve the colony entity for this planet via the mutable colonies query
+    // (read-only here — we only need its Entity). Iterating this way avoids
+    // creating a second mutable alias of `Colony`.
+    let colony_entity: Option<Entity> = colonies
+        .iter()
+        .find(|(_, c, _, _, _, _, _, _)| c.planet == planet_entity)
+        .map(|(e, _, _, _, _, _, _, _)| e);
+
+    let Some(colony_entity) = colony_entity else {
+        ui.label("(no colony)");
+        return;
+    };
+
+    let Ok((_, pop_opt, jobs_opt, rates_opt)) = colony_pop_view.get(colony_entity) else {
+        ui.label("(no population data)");
+        return;
+    };
+
+    // --- Population block ---
+    let pop_default = ColonyPopulation::default();
+    let pop = pop_opt.unwrap_or(&pop_default);
+    ui.label(egui::RichText::new("Population").strong());
+    ui.label(format!("  Total: {}", pop.total()));
+
+    if pop.species.is_empty() {
+        ui.label("  (no species data)");
+    } else {
+        let mut species_sorted: Vec<&crate::species::ColonySpecies> = pop.species.iter().collect();
+        species_sorted.sort_by(|a, b| a.species_id.cmp(&b.species_id));
+        for sp in species_sorted {
+            ui.label(format!("    {}: {}", sp.species_id, sp.population));
+        }
+    }
+    ui.separator();
+
+    // --- Jobs block ---
+    ui.label(egui::RichText::new("Jobs").strong());
+
+    let jobs_default = ColonyJobs::default();
+    let rates_default = ColonyJobRates::default();
+    let jobs = jobs_opt.unwrap_or(&jobs_default);
+    let rates = rates_opt.unwrap_or(&rates_default);
+
+    if jobs.slots.is_empty() {
+        ui.label("  (no job slots on this colony)");
+    } else {
+        let summaries = summarize_pop_view(jobs, rates, job_registry);
+        for summary in &summaries {
+            ui.horizontal(|ui| {
+                ui.label(format!(
+                    "  {}: {} / {}",
+                    summary.label, summary.assigned, summary.capacity
+                ));
+            });
+            if summary.assigned > 0 {
+                for (target, value) in &summary.contributions {
+                    if *value == 0.0 {
+                        continue;
+                    }
+                    let sign = if *value > 0.0 { "+" } else { "" };
+                    ui.label(format!(
+                        "      {}{:.1} {}",
+                        sign,
+                        value,
+                        short_target_label(target)
+                    ));
+                }
+            }
+        }
+    }
+
+    // Unemployed = total pop minus sum of assigned.
+    let total_pop = pop.total();
+    let employed = jobs.total_employed();
+    let unemployed = total_pop.saturating_sub(employed);
+    ui.separator();
+    let color = if unemployed > 0 {
+        egui::Color32::from_rgb(220, 180, 80)
+    } else {
+        egui::Color32::GRAY
+    };
+    ui.label(egui::RichText::new(format!("Unemployed: {}", unemployed)).color(color));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modifier::{Modifier, ModifiedValue};
+    use crate::amount::SignedAmt;
+    use crate::species::{JobDefinition, JobSlot};
+
+    fn make_bucket(base_add_f64: f64) -> ModifiedValue {
+        let mut mv = ModifiedValue::default();
+        mv.push_modifier(Modifier {
+            id: "test".to_string(),
+            label: "test".to_string(),
+            base_add: SignedAmt::from_f64(base_add_f64),
+            multiplier: SignedAmt::ZERO,
+            add: SignedAmt::ZERO,
+            expires_at: None,
+            on_expire_event: None,
+        });
+        mv
+    }
+
+    #[test]
+    fn summarize_pop_view_basic_contribution() {
+        let mut registry = JobRegistry::default();
+        registry.insert(JobDefinition {
+            id: "miner".to_string(),
+            label: "Miner".to_string(),
+            description: String::new(),
+            modifiers: Vec::new(),
+        });
+
+        let jobs = ColonyJobs {
+            slots: vec![JobSlot {
+                job_id: "miner".to_string(),
+                capacity: 5,
+                assigned: 3,
+                capacity_from_buildings: 5,
+            }],
+        };
+
+        let mut rates = ColonyJobRates::default();
+        *rates.bucket_mut("miner", "colony.minerals_per_hexadies") = make_bucket(0.6);
+
+        let summary = summarize_pop_view(&jobs, &rates, &registry);
+        assert_eq!(summary.len(), 1);
+        assert_eq!(summary[0].job_id, "miner");
+        assert_eq!(summary[0].label, "Miner");
+        assert_eq!(summary[0].assigned, 3);
+        assert_eq!(summary[0].capacity, 5);
+        assert_eq!(summary[0].contributions.len(), 1);
+        let (target, value) = &summary[0].contributions[0];
+        assert_eq!(target, "colony.minerals_per_hexadies");
+        // 0.6 per pop × 3 assigned = 1.8
+        assert!((value - 1.8).abs() < 1e-6, "got {}", value);
+    }
+
+    #[test]
+    fn summarize_pop_view_unknown_job_falls_back_to_id() {
+        let registry = JobRegistry::default();
+        let jobs = ColonyJobs {
+            slots: vec![JobSlot {
+                job_id: "ghost_job".to_string(),
+                capacity: 2,
+                assigned: 0,
+                capacity_from_buildings: 2,
+            }],
+        };
+        let rates = ColonyJobRates::default();
+
+        let summary = summarize_pop_view(&jobs, &rates, &registry);
+        assert_eq!(summary[0].label, "ghost_job");
+        assert!(summary[0].contributions.is_empty());
+    }
+
+    #[test]
+    fn summarize_pop_view_zero_assigned_still_lists_slot_with_empty_contributions() {
+        let mut registry = JobRegistry::default();
+        registry.insert(JobDefinition {
+            id: "farmer".to_string(),
+            label: "Farmer".to_string(),
+            description: String::new(),
+            modifiers: Vec::new(),
+        });
+        let jobs = ColonyJobs {
+            slots: vec![JobSlot {
+                job_id: "farmer".to_string(),
+                capacity: 4,
+                assigned: 0,
+                capacity_from_buildings: 4,
+            }],
+        };
+        let mut rates = ColonyJobRates::default();
+        *rates.bucket_mut("farmer", "colony.food_per_hexadies") = make_bucket(0.5);
+
+        let summary = summarize_pop_view(&jobs, &rates, &registry);
+        assert_eq!(summary.len(), 1);
+        assert_eq!(summary[0].assigned, 0);
+        // contribution = 0.5 × 0 = 0.0 — still present in the list.
+        assert_eq!(summary[0].contributions.len(), 1);
+        assert!((summary[0].contributions[0].1 - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn summarize_pop_view_multiple_targets_sorted_by_target() {
+        let mut registry = JobRegistry::default();
+        registry.insert(JobDefinition {
+            id: "scientist".to_string(),
+            label: "Scientist".to_string(),
+            description: String::new(),
+            modifiers: Vec::new(),
+        });
+        let jobs = ColonyJobs {
+            slots: vec![JobSlot {
+                job_id: "scientist".to_string(),
+                capacity: 2,
+                assigned: 2,
+                capacity_from_buildings: 2,
+            }],
+        };
+        let mut rates = ColonyJobRates::default();
+        *rates.bucket_mut("scientist", "colony.research_per_hexadies") = make_bucket(1.0);
+        *rates.bucket_mut("scientist", "colony.energy_per_hexadies") = make_bucket(0.2);
+
+        let summary = summarize_pop_view(&jobs, &rates, &registry);
+        let targets: Vec<&str> = summary[0]
+            .contributions
+            .iter()
+            .map(|(t, _)| t.as_str())
+            .collect();
+        assert_eq!(
+            targets,
+            vec!["colony.energy_per_hexadies", "colony.research_per_hexadies"]
+        );
+    }
+
+    #[test]
+    fn short_target_label_strips_common_prefix_and_suffix() {
+        assert_eq!(short_target_label("colony.minerals_per_hexadies"), "minerals");
+        assert_eq!(short_target_label("colony.food_per_hexadies"), "food");
+        assert_eq!(short_target_label("custom_target"), "custom_target");
     }
 }

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -114,6 +114,12 @@ pub fn draw_system_panel(
         Option<&MaintenanceCost>,
         Option<&FoodConsumption>,
     )>,
+    colony_pop_view: &Query<(
+        Entity,
+        Option<&crate::species::ColonyPopulation>,
+        Option<&crate::species::ColonyJobs>,
+        Option<&crate::colony::ColonyJobRates>,
+    )>,
     system_stockpiles: &mut Query<(&mut ResourceStockpile, Option<&ResourceCapacity>), With<StarSystem>>,
     ships_query: &mut Query<(Entity, &mut Ship, &mut ShipState, Option<&mut Cargo>, &ShipHitpoints, Option<&SurveyData>)>,
     positions: &Query<&Position>,
@@ -129,6 +135,8 @@ pub fn draw_system_panel(
     colonization_queues: &Query<&ColonizationQueue>,
     colonization_actions_out: &mut Vec<ColonizationAction>,
     building_registry: &BuildingRegistry,
+    job_registry: &crate::species::JobRegistry,
+    colony_panel_tab: &mut crate::ui::ColonyPanelTab,
     anomalies_q: &Query<&crate::galaxy::Anomalies>,
     deliverable_stockpiles: &Query<&DeliverableStockpile, With<StarSystem>>,
     deep_space_structures: &Query<(
@@ -378,6 +386,7 @@ pub fn draw_system_panel(
         &colonized_planets,
         stars,
         colonies,
+        colony_pop_view,
         system_stockpiles,
         ships_query,
         construction_params,
@@ -387,6 +396,8 @@ pub fn draw_system_panel(
         module_registry,
         design_registry,
         building_registry,
+        job_registry,
+        colony_panel_tab,
     );
 }
 

--- a/macrocosmo/src/ui/system_panel/planet_window.rs
+++ b/macrocosmo/src/ui/system_panel/planet_window.rs
@@ -29,6 +29,12 @@ pub(super) fn draw_planet_window(
         Option<&MaintenanceCost>,
         Option<&FoodConsumption>,
     )>,
+    colony_pop_view: &Query<(
+        Entity,
+        Option<&crate::species::ColonyPopulation>,
+        Option<&crate::species::ColonyJobs>,
+        Option<&crate::colony::ColonyJobRates>,
+    )>,
     system_stockpiles: &mut Query<(&mut ResourceStockpile, Option<&ResourceCapacity>), With<StarSystem>>,
     ships_query: &mut Query<(Entity, &mut Ship, &mut ShipState, Option<&mut Cargo>, &ShipHitpoints, Option<&SurveyData>)>,
     construction_params: &ConstructionParams,
@@ -38,6 +44,8 @@ pub(super) fn draw_planet_window(
     module_registry: &crate::ship_design::ModuleRegistry,
     design_registry: &crate::ship_design::ShipDesignRegistry,
     building_registry: &BuildingRegistry,
+    job_registry: &crate::species::JobRegistry,
+    colony_panel_tab: &mut crate::ui::ColonyPanelTab,
 ) {
     let Some(sel_planet_entity) = selected_planet.0 else {
         return;
@@ -95,6 +103,7 @@ pub(super) fn draw_planet_window(
                             system_entity,
                             planet_attrs,
                             colonies,
+                            colony_pop_view,
                             system_stockpiles,
                             ships_query,
                             construction_params,
@@ -103,6 +112,8 @@ pub(super) fn draw_planet_window(
                             module_registry,
                             design_registry,
                             building_registry,
+                            job_registry,
+                            colony_panel_tab,
                         );
                     });
             } else {


### PR DESCRIPTION
## Summary

- #252: Tab-switch the colony detail panel between **概要** (existing Income / Maintenance / Stockpile / Buildings view, logic unchanged) and **Pop 管理**.
- **Pop 管理** shows: total pop + per-species breakdown, each job slot (`label / assigned / capacity` + per-target production contribution `±X.Y <target>`), and unemployed count.
- Tab state lives in `UiState::colony_panel_tab` (`ColonyPanelTab` enum, `Overview` default).

## Implementation notes

- `summarize_pop_view(jobs, rates, registry)` is extracted as a pure function so the aggregation logic is unit-testable without an egui context.
- Plumbing uses the existing `SystemParam` bundle pattern in `src/ui/params.rs`: `MainPanelWorldQueries` gains a read-only `colony_pop_view` query and `MainPanelRegistries` gains `JobRegistry` — this keeps `draw_main_panels_system` under Bevy's 16-param limit.
- Existing 8-tuple `colonies` query is kept intact so downstream iterators (outline, ship_panel, compute_ui_state) don't need to change. Pop/jobs/rates live in a separate read-only sibling query — no B0001 risk.
- Overview tab body is a verbatim move of the pre-existing `draw_colony_detail` logic — no functional change to income/buildings display.

## Changed files

- `macrocosmo/src/ui/mod.rs` — `ColonyPanelTab` enum, `UiState::colony_panel_tab`, `draw_main_panels_system` takes `ResMut<UiState>`.
- `macrocosmo/src/ui/params.rs` — `colony_pop_view` query in `MainPanelWorldQueries`, `job_registry` in `MainPanelRegistries`.
- `macrocosmo/src/ui/system_panel/mod.rs` — thread new args through `draw_system_panel` and the `draw_planet_window` call.
- `macrocosmo/src/ui/system_panel/planet_window.rs` — thread new args through to `draw_colony_detail`.
- `macrocosmo/src/ui/system_panel/colony_detail.rs` — tab selector; `draw_overview_tab` (unchanged logic); `draw_pop_management_tab`; `summarize_pop_view` pure fn + 5 unit tests.

## Test plan

- [x] `cargo test -p macrocosmo` — all tests pass (646 + 641 lib/bin + integration).
- [x] 5 new unit tests in `ui::system_panel::colony_detail::tests`:
  - `summarize_pop_view_basic_contribution`
  - `summarize_pop_view_unknown_job_falls_back_to_id`
  - `summarize_pop_view_zero_assigned_still_lists_slot_with_empty_contributions`
  - `summarize_pop_view_multiple_targets_sorted_by_target`
  - `short_target_label_strips_common_prefix_and_suffix`
- [x] `cargo build -p macrocosmo` — no new warnings (210 pre-existing, unchanged).
- [x] `all_systems_no_query_conflict` integration test passes (no B0001).
- [ ] 実機確認: open colony panel → switch tabs → verify species & job rows render with correct counts and contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)