### PR TITLE
#267: Make Selected Ship window draggable (swap anchor → default_pos)

### DIFF
--- a/macrocosmo/src/ui/ship_panel.rs
+++ b/macrocosmo/src/ui/ship_panel.rs
@@ -711,8 +711,12 @@ pub fn draw_ship_panel(
         if has_colony { Some(dock_sys) } else { None }
     });
 
+    let default_pos = {
+        let rect = ctx.screen_rect();
+        egui::pos2(rect.max.x - 270.0, rect.max.y - 130.0)
+    };
     egui::Window::new("Selected Ship")
-        .anchor(egui::Align2::RIGHT_BOTTOM, [-270.0, -130.0])
+        .default_pos(default_pos)
         .resizable(false)
         .collapsible(true)
         .show(ctx, |ui| {


### PR DESCRIPTION
## Summary
- Replace `.anchor(RIGHT_BOTTOM, ...)` with `.default_pos(...)` computed from `ctx.screen_rect()` so the window is draggable after initial placement
- Other anchored windows (modal / toast / centered message) intentionally stay fixed and are not touched

Closes #267

## Test plan
- [ ] Open the Selected Ship window by clicking a ship
- [ ] Drag the window to a new position — should move freely
- [ ] Close and re-open — egui Memory should restore the last drag position
- [ ] Confirm modals and the top-center banner remain fixed

No automated test: egui systems require EguiPlugin rendering context and are excluded from `full_test_app()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)