### PR TITLE
#270: Route colony/system build commands through light-speed delay

### DIFF
--- a/macrocosmo/src/colony/mod.rs
+++ b/macrocosmo/src/colony/mod.rs
@@ -88,7 +88,12 @@ impl Plugin for ColonyPlugin {
                     ).chain(),
                 )
                     .chain()
-                    .after(crate::time_system::advance_game_time),
+                    .after(crate::time_system::advance_game_time)
+                    // #270: Arrived RemoteCommand::Colony payloads must be
+                    // applied to the queue before the queue's tick consumes
+                    // orders, otherwise an arrival on the same frame can be
+                    // swallowed in a single tick_building_queue pass.
+                    .after(crate::communication::process_pending_commands),
             )
             .add_systems(Update, (
                 update_sovereignty,

--- a/macrocosmo/src/communication/mod.rs
+++ b/macrocosmo/src/communication/mod.rs
@@ -7,11 +7,35 @@ pub struct CommunicationPlugin;
 
 impl Plugin for CommunicationPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<PendingColonyDispatches>();
         app.add_systems(
-                Update,
-                (process_messages, process_courier_ships, process_pending_commands),
-            );
+            Update,
+            (
+                process_messages,
+                process_courier_ships,
+                // #270: Must drain BEFORE process_pending_commands so
+                // zero-delay (local) dispatches arrive the same frame.
+                dispatch_pending_colony_commands,
+                process_pending_commands,
+            )
+                .chain(),
+        );
     }
+}
+
+/// #270: UI-to-dispatcher queue for colony build commands. UI code pushes
+/// `PendingColonyDispatch` entries from within egui systems;
+/// `dispatch_pending_colony_commands` drains them during `Update` and turns
+/// each entry into a `PendingCommand` with the appropriate light-speed
+/// delay (zero if the player is at the target system).
+#[derive(Resource, Default)]
+pub struct PendingColonyDispatches {
+    pub queue: Vec<PendingColonyDispatch>,
+}
+
+pub struct PendingColonyDispatch {
+    pub target_system: Entity,
+    pub command: ColonyCommand,
 }
 
 /// A message in transit (light-speed or via courier)
@@ -196,6 +220,65 @@ pub struct CommandLogEntry {
     pub sent_at: i64,
     pub arrives_at: i64,
     pub arrived: bool,
+}
+
+/// #270: Drain `PendingColonyDispatches` and turn each entry into a
+/// `PendingCommand` with the appropriate light-speed delay. Runs in
+/// `Update` before `process_pending_commands` so local (zero-delay)
+/// commands are applied the same frame.
+pub fn dispatch_pending_colony_commands(
+    mut commands: Commands,
+    clock: Res<GameClock>,
+    mut queue: ResMut<PendingColonyDispatches>,
+    stars: Query<&crate::components::Position, With<crate::galaxy::StarSystem>>,
+    ship_positions: Query<&crate::components::Position, With<crate::ship::Ship>>,
+    player_q: Query<
+        (&crate::player::StationedAt, Option<&crate::player::AboardShip>),
+        With<crate::player::Player>,
+    >,
+    mut empire_q: Query<&mut CommandLog, With<crate::player::PlayerEmpire>>,
+) {
+    if queue.queue.is_empty() {
+        return;
+    }
+    let Ok(mut command_log) = empire_q.single_mut() else {
+        queue.queue.clear();
+        return;
+    };
+
+    // Resolve player origin position.
+    let origin = player_q
+        .iter()
+        .next()
+        .and_then(|(stationed, aboard)| match aboard {
+            Some(ab) => ship_positions.get(ab.ship).ok().map(|p| p.as_array()),
+            None => stars.get(stationed.system).ok().map(|p| p.as_array()),
+        });
+    let Some(origin) = origin else {
+        warn!("dispatch_pending_colony_commands: cannot resolve player origin, dropping commands");
+        queue.queue.clear();
+        return;
+    };
+
+    for dispatch in queue.queue.drain(..) {
+        let Ok(target_pos) = stars.get(dispatch.target_system) else {
+            warn!(
+                "dispatch_pending_colony_commands: target_system {:?} has no Position",
+                dispatch.target_system
+            );
+            continue;
+        };
+        let destination = target_pos.as_array();
+        send_remote_command(
+            &mut commands,
+            origin,
+            destination,
+            clock.elapsed,
+            RemoteCommand::Colony(dispatch.command),
+            dispatch.target_system,
+            &mut command_log,
+        );
+    }
 }
 
 /// Send a remote command from `origin` to `destination`. The command will

--- a/macrocosmo/src/communication/mod.rs
+++ b/macrocosmo/src/communication/mod.rs
@@ -200,6 +200,20 @@ pub enum ColonyCommandKind {
         design_id: String,
         build_kind: crate::colony::BuildKind,
     },
+    /// Enqueue a deliverable build on `host_colony`'s `BuildQueue`. Carries
+    /// the full payload because deliverable definitions live in
+    /// `StructureRegistry`, not `ShipDesignRegistry` — the arrival handler
+    /// can't re-resolve them from the ship registry. Cost/time are
+    /// frozen at send time.
+    QueueDeliverableBuild {
+        host_colony: Entity,
+        def_id: String,
+        display_name: String,
+        cargo_size: u32,
+        minerals_cost: crate::amount::Amt,
+        energy_cost: crate::amount::Amt,
+        build_time: i64,
+    },
     /// Cancel a ship build order on `host_colony`'s `BuildQueue` at `queue_index`.
     /// NOTE: by-index cancel is best-effort — queues can shift between
     /// dispatch and arrival. Stable order-ids are a follow-up (see #270 plan).
@@ -676,6 +690,36 @@ fn apply_colony_command(
                 energy_invested: Amt::ZERO,
                 build_time_total,
                 build_time_remaining: build_time_total,
+            });
+        }
+        ColonyCommandKind::QueueDeliverableBuild {
+            host_colony,
+            def_id,
+            display_name,
+            cargo_size,
+            minerals_cost,
+            energy_cost,
+            build_time,
+        } => {
+            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
+                warn!(
+                    "QueueDeliverableBuild: host_colony {:?} has no BuildQueue",
+                    host_colony
+                );
+                return;
+            };
+            build_q.queue.push(BuildOrder {
+                kind: crate::colony::BuildKind::Deliverable {
+                    cargo_size: *cargo_size,
+                },
+                design_id: def_id.clone(),
+                display_name: display_name.clone(),
+                minerals_cost: *minerals_cost,
+                minerals_invested: Amt::ZERO,
+                energy_cost: *energy_cost,
+                energy_invested: Amt::ZERO,
+                build_time_total: *build_time,
+                build_time_remaining: *build_time,
             });
         }
         ColonyCommandKind::CancelShipOrder {

--- a/macrocosmo/src/communication/mod.rs
+++ b/macrocosmo/src/communication/mod.rs
@@ -8,13 +8,13 @@ pub struct CommunicationPlugin;
 impl Plugin for CommunicationPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<PendingColonyDispatches>();
+        // Dispatcher chained before process_pending_commands so local
+        // (zero-delay) commands apply within the same Update pass.
         app.add_systems(
             Update,
             (
                 process_messages,
                 process_courier_ships,
-                // #270: Must drain BEFORE process_pending_commands so
-                // zero-delay (local) dispatches arrive the same frame.
                 dispatch_pending_colony_commands,
                 process_pending_commands,
             )
@@ -23,11 +23,9 @@ impl Plugin for CommunicationPlugin {
     }
 }
 
-/// #270: UI-to-dispatcher queue for colony build commands. UI code pushes
-/// `PendingColonyDispatch` entries from within egui systems;
-/// `dispatch_pending_colony_commands` drains them during `Update` and turns
-/// each entry into a `PendingCommand` with the appropriate light-speed
-/// delay (zero if the player is at the target system).
+/// UI-to-dispatcher queue for colony build commands. UI code pushes
+/// `PendingColonyDispatch` entries; `dispatch_pending_colony_commands`
+/// drains and turns each into a `PendingCommand` with light-speed delay.
 #[derive(Resource, Default)]
 pub struct PendingColonyDispatches {
     pub queue: Vec<PendingColonyDispatch>,
@@ -155,29 +153,58 @@ pub struct PendingCommand {
 }
 
 /// The kinds of remote commands a player can issue.
+///
+/// Build-related payloads (`Colony(ColonyCommand)`) are deliberately minimal —
+/// cost/time/refund amounts are re-resolved on arrival from the target's
+/// current `BuildingRegistry` + `ConstructionParams`. `QueueDeliverableBuild`
+/// is the exception (defs live in a separate registry; see variant doc).
 #[derive(Clone, Debug)]
 pub enum RemoteCommand {
     BuildShip { design_id: String },
     SetProductionFocus { minerals: f64, energy: f64, research: f64 },
-    /// #270: Colony or system build/demolish/upgrade/cancel command routed
-    /// through light-speed delay. Cost/time/refund amounts are NOT carried in
-    /// the payload — they are computed on arrival from the current
-    /// `BuildingRegistry` / `ShipDesignRegistry` at the target. This keeps the
-    /// payload small and matches the existing `BuildShip` convention.
     Colony(ColonyCommand),
 }
 
-/// #270: A colony-scoped remote command. `target_planet = Some(planet)`
-/// addresses a planet-level `BuildingQueue`/`Buildings`; `None` addresses the
-/// system-level `SystemBuildingQueue`/`SystemBuildings` on the target system.
+/// A colony-scoped remote command. `target_planet = Some(p)` addresses a
+/// planet-level `BuildingQueue`/`Buildings`; `None` addresses the
+/// system-level `SystemBuildingQueue`/`SystemBuildings` on `target_system`.
+/// Some variants (`QueueShipBuild`, `QueueDeliverableBuild`) carry their
+/// own `host_colony` and ignore `target_planet`.
 #[derive(Clone, Debug)]
 pub struct ColonyCommand {
     pub target_planet: Option<Entity>,
     pub kind: ColonyCommandKind,
 }
 
-/// #270: Payload-free colony command variants. Arrival handler looks up the
-/// current cost/time/refund from registries when applying the command.
+impl RemoteCommand {
+    /// Short player-facing label. Used in CommandLog entries and the
+    /// in-flight list so players don't see raw `{:?}` output with entity
+    /// indices.
+    pub fn describe(&self) -> String {
+        match self {
+            RemoteCommand::BuildShip { design_id } => format!("Build ship: {}", design_id),
+            RemoteCommand::SetProductionFocus { .. } => "Set production focus".to_string(),
+            RemoteCommand::Colony(cc) => match &cc.kind {
+                ColonyCommandKind::QueueBuilding { building_id, target_slot } => {
+                    format!("Build {} → slot {}", building_id, target_slot)
+                }
+                ColonyCommandKind::DemolishBuilding { target_slot } => {
+                    format!("Demolish slot {}", target_slot)
+                }
+                ColonyCommandKind::UpgradeBuilding { slot_index, target_id } => {
+                    format!("Upgrade slot {} → {}", slot_index, target_id)
+                }
+                ColonyCommandKind::QueueShipBuild { design_id, .. } => {
+                    format!("Build ship: {}", design_id)
+                }
+                ColonyCommandKind::QueueDeliverableBuild { display_name, .. } => {
+                    format!("Build deliverable: {}", display_name)
+                }
+            },
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum ColonyCommandKind {
     /// Enqueue construction of `building_id` into `target_slot`.
@@ -192,19 +219,17 @@ pub enum ColonyCommandKind {
         slot_index: usize,
         target_id: String,
     },
-    /// Cancel the (head of the) pending build order targeting `target_slot`.
-    CancelBuildingOrder { target_slot: usize },
     /// Enqueue a ship (or deliverable) build on `host_colony`'s `BuildQueue`.
     QueueShipBuild {
         host_colony: Entity,
         design_id: String,
         build_kind: crate::colony::BuildKind,
     },
-    /// Enqueue a deliverable build on `host_colony`'s `BuildQueue`. Carries
-    /// the full payload because deliverable definitions live in
-    /// `StructureRegistry`, not `ShipDesignRegistry` — the arrival handler
-    /// can't re-resolve them from the ship registry. Cost/time are
-    /// frozen at send time.
+    /// Enqueue a deliverable build on `host_colony`'s `BuildQueue`. Full
+    /// payload (def_id/display_name/cargo_size/cost/time) is frozen at
+    /// send time because deliverable defs live in `StructureRegistry`,
+    /// not `ShipDesignRegistry`, so arrival-time re-resolution would
+    /// require a second registry lookup path.
     QueueDeliverableBuild {
         host_colony: Entity,
         def_id: String,
@@ -213,13 +238,6 @@ pub enum ColonyCommandKind {
         minerals_cost: crate::amount::Amt,
         energy_cost: crate::amount::Amt,
         build_time: i64,
-    },
-    /// Cancel a ship build order on `host_colony`'s `BuildQueue` at `queue_index`.
-    /// NOTE: by-index cancel is best-effort — queues can shift between
-    /// dispatch and arrival. Stable order-ids are a follow-up (see #270 plan).
-    CancelShipOrder {
-        host_colony: Entity,
-        queue_index: usize,
     },
 }
 
@@ -236,10 +254,6 @@ pub struct CommandLogEntry {
     pub arrived: bool,
 }
 
-/// #270: Drain `PendingColonyDispatches` and turn each entry into a
-/// `PendingCommand` with the appropriate light-speed delay. Runs in
-/// `Update` before `process_pending_commands` so local (zero-delay)
-/// commands are applied the same frame.
 pub fn dispatch_pending_colony_commands(
     mut commands: Commands,
     clock: Res<GameClock>,
@@ -311,7 +325,7 @@ pub fn send_remote_command(
     let arrives_at = sent_at + delay;
 
     command_log.entries.push(CommandLogEntry {
-        description: format!("{:?}", command),
+        description: command.describe(),
         sent_at,
         arrives_at,
         arrived: false,
@@ -360,11 +374,11 @@ pub fn process_pending_commands(
         if clock.elapsed >= cmd.arrives_at {
             let delay = cmd.arrives_at - cmd.sent_at;
             info!(
-                "Remote command arrived at target (delay: {} sd): {:?}",
-                delay, cmd.command
+                "Remote command arrived at target (delay: {} sd): {}",
+                delay,
+                cmd.command.describe()
             );
 
-            // #270: Dispatch colony-scoped commands on arrival.
             if let RemoteCommand::Colony(cc) = &cmd.command {
                 apply_colony_command(
                     cc,
@@ -377,11 +391,7 @@ pub fn process_pending_commands(
                     &mut sys_buildings_q,
                 );
             }
-            // NOTE: BuildShip / SetProductionFocus remain as pre-#270 "orphan
-            // API" — no UI wires them today. They'll be wired when the
-            // SetProductionFocus UI lands, tracked separately.
 
-            // Mark the matching log entry as arrived.
             for entry in command_log.entries.iter_mut() {
                 if entry.sent_at == cmd.sent_at
                     && entry.arrives_at == cmd.arrives_at
@@ -397,9 +407,6 @@ pub fn process_pending_commands(
     }
 }
 
-/// #270: Apply a `ColonyCommand` to the target queues. Cost / time / refund
-/// amounts are resolved here from the current registry state — the payload
-/// only carries ids and slot indices.
 fn apply_colony_command(
     cc: &ColonyCommand,
     target_system: Entity,
@@ -473,14 +480,18 @@ fn apply_colony_command(
                         );
                         break;
                     };
-                    let def = br.get(bid.as_str());
-                    let (m_ref, e_ref) =
-                        def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                    let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
+                    let Some(def) = br.get(bid.as_str()) else {
+                        warn!(
+                            "DemolishBuilding (planet): unknown building '{}' in slot {}; dropping order to avoid silent free demolition",
+                            bid, target_slot
+                        );
+                        break;
+                    };
+                    let (m_ref, e_ref) = def.demolition_refund();
                     bq.demolition_queue.push(DemolitionOrder {
                         target_slot: *target_slot,
                         building_id: bid,
-                        time_remaining: demo_time,
+                        time_remaining: def.demolition_time(),
                         minerals_refund: m_ref,
                         energy_refund: e_ref,
                     });
@@ -508,14 +519,18 @@ fn apply_colony_command(
                     );
                     return;
                 };
-                let def = br.get(bid.as_str());
-                let (m_ref, e_ref) =
-                    def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
+                let Some(def) = br.get(bid.as_str()) else {
+                    warn!(
+                        "DemolishBuilding (system): unknown building '{}' in slot {}; dropping order",
+                        bid, target_slot
+                    );
+                    return;
+                };
+                let (m_ref, e_ref) = def.demolition_refund();
                 sbq.demolition_queue.push(DemolitionOrder {
                     target_slot: *target_slot,
                     building_id: bid,
-                    time_remaining: demo_time,
+                    time_remaining: def.demolition_time(),
                     minerals_refund: m_ref,
                     energy_refund: e_ref,
                 });
@@ -618,44 +633,6 @@ fn apply_colony_command(
                 }
             }
         }
-        ColonyCommandKind::CancelBuildingOrder { target_slot } => match cc.target_planet {
-            Some(planet) => {
-                for (colony, _, mut bq, _) in colonies.iter_mut() {
-                    if colony.planet == planet {
-                        if let Some(pos) = bq.queue.iter().position(|o| o.target_slot == *target_slot) {
-                            bq.queue.remove(pos);
-                        } else {
-                            warn!(
-                                "CancelBuildingOrder (planet): no queued order for slot {}",
-                                target_slot
-                            );
-                        }
-                        return;
-                    }
-                }
-                warn!(
-                    "CancelBuildingOrder (planet): no colony on planet {:?}",
-                    planet
-                );
-            }
-            None => {
-                if let Ok((_, mut sbq)) = sys_buildings_q.get_mut(target_system) {
-                    if let Some(pos) = sbq.queue.iter().position(|o| o.target_slot == *target_slot) {
-                        sbq.queue.remove(pos);
-                    } else {
-                        warn!(
-                            "CancelBuildingOrder (system): no queued order for slot {}",
-                            target_slot
-                        );
-                    }
-                } else {
-                    warn!(
-                        "CancelBuildingOrder (system): target_system {:?} missing",
-                        target_system
-                    );
-                }
-            }
-        },
         ColonyCommandKind::QueueShipBuild {
             host_colony,
             design_id,
@@ -672,10 +649,6 @@ fn apply_colony_command(
                 warn!("QueueShipBuild: unknown design_id '{}'", design_id);
                 return;
             };
-            // NOTE: Ship cost/time don't yet run through an empire modifier
-            // the way buildings do (no ship_cost_modifier), so take the
-            // registry values as-is. If such a modifier lands later, apply
-            // it here at arrival time.
             let minerals_cost = design.build_cost_minerals;
             let energy_cost = design.build_cost_energy;
             let build_time_total = sdr.build_time(design_id);
@@ -721,27 +694,6 @@ fn apply_colony_command(
                 build_time_total: *build_time,
                 build_time_remaining: *build_time,
             });
-        }
-        ColonyCommandKind::CancelShipOrder {
-            host_colony,
-            queue_index,
-        } => {
-            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
-                warn!(
-                    "CancelShipOrder: host_colony {:?} has no BuildQueue",
-                    host_colony
-                );
-                return;
-            };
-            if *queue_index < build_q.queue.len() {
-                build_q.queue.remove(*queue_index);
-            } else {
-                warn!(
-                    "CancelShipOrder: queue_index {} out of bounds (len={})",
-                    queue_index,
-                    build_q.queue.len()
-                );
-            }
         }
     }
 }

--- a/macrocosmo/src/communication/mod.rs
+++ b/macrocosmo/src/communication/mod.rs
@@ -135,6 +135,54 @@ pub struct PendingCommand {
 pub enum RemoteCommand {
     BuildShip { design_id: String },
     SetProductionFocus { minerals: f64, energy: f64, research: f64 },
+    /// #270: Colony or system build/demolish/upgrade/cancel command routed
+    /// through light-speed delay. Cost/time/refund amounts are NOT carried in
+    /// the payload — they are computed on arrival from the current
+    /// `BuildingRegistry` / `ShipDesignRegistry` at the target. This keeps the
+    /// payload small and matches the existing `BuildShip` convention.
+    Colony(ColonyCommand),
+}
+
+/// #270: A colony-scoped remote command. `target_planet = Some(planet)`
+/// addresses a planet-level `BuildingQueue`/`Buildings`; `None` addresses the
+/// system-level `SystemBuildingQueue`/`SystemBuildings` on the target system.
+#[derive(Clone, Debug)]
+pub struct ColonyCommand {
+    pub target_planet: Option<Entity>,
+    pub kind: ColonyCommandKind,
+}
+
+/// #270: Payload-free colony command variants. Arrival handler looks up the
+/// current cost/time/refund from registries when applying the command.
+#[derive(Clone, Debug)]
+pub enum ColonyCommandKind {
+    /// Enqueue construction of `building_id` into `target_slot`.
+    QueueBuilding {
+        building_id: String,
+        target_slot: usize,
+    },
+    /// Enqueue demolition of whatever occupies `target_slot`.
+    DemolishBuilding { target_slot: usize },
+    /// Enqueue an upgrade of the building in `slot_index` to `target_id`.
+    UpgradeBuilding {
+        slot_index: usize,
+        target_id: String,
+    },
+    /// Cancel the (head of the) pending build order targeting `target_slot`.
+    CancelBuildingOrder { target_slot: usize },
+    /// Enqueue a ship (or deliverable) build on `host_colony`'s `BuildQueue`.
+    QueueShipBuild {
+        host_colony: Entity,
+        design_id: String,
+        build_kind: crate::colony::BuildKind,
+    },
+    /// Cancel a ship build order on `host_colony`'s `BuildQueue` at `queue_index`.
+    /// NOTE: by-index cancel is best-effort — queues can shift between
+    /// dispatch and arrival. Stable order-ids are a follow-up (see #270 plan).
+    CancelShipOrder {
+        host_colony: Entity,
+        queue_index: usize,
+    },
 }
 
 /// Tracks command status for UI display.

--- a/macrocosmo/src/communication/mod.rs
+++ b/macrocosmo/src/communication/mod.rs
@@ -234,11 +234,31 @@ pub fn process_pending_commands(
     mut commands: Commands,
     clock: Res<GameClock>,
     pending: Query<(Entity, &PendingCommand)>,
-    mut empire_q: Query<&mut CommandLog, With<crate::player::PlayerEmpire>>,
+    mut empire_q: Query<
+        (&mut CommandLog, &crate::colony::ConstructionParams),
+        With<crate::player::PlayerEmpire>,
+    >,
+    building_registry: Res<crate::scripting::building_api::BuildingRegistry>,
+    ship_design_registry: Res<crate::ship_design::ShipDesignRegistry>,
+    mut colonies: Query<(
+        &crate::colony::Colony,
+        &crate::colony::Buildings,
+        &mut crate::colony::BuildingQueue,
+        &mut crate::colony::BuildQueue,
+    )>,
+    mut sys_buildings_q: Query<(
+        &crate::colony::SystemBuildings,
+        &mut crate::colony::SystemBuildingQueue,
+    )>,
 ) {
-    let Ok(mut command_log) = empire_q.single_mut() else {
+    let Ok((mut command_log, construction_params)) = empire_q.single_mut() else {
         return;
     };
+    let bldg_cost_mod = construction_params.building_cost_modifier.final_value();
+    let bldg_time_mod = construction_params
+        .building_build_time_modifier
+        .final_value();
+
     for (entity, cmd) in &pending {
         if clock.elapsed >= cmd.arrives_at {
             let delay = cmd.arrives_at - cmd.sent_at;
@@ -246,6 +266,23 @@ pub fn process_pending_commands(
                 "Remote command arrived at target (delay: {} sd): {:?}",
                 delay, cmd.command
             );
+
+            // #270: Dispatch colony-scoped commands on arrival.
+            if let RemoteCommand::Colony(cc) = &cmd.command {
+                apply_colony_command(
+                    cc,
+                    cmd.target_system,
+                    &building_registry,
+                    &ship_design_registry,
+                    bldg_cost_mod,
+                    bldg_time_mod,
+                    &mut colonies,
+                    &mut sys_buildings_q,
+                );
+            }
+            // NOTE: BuildShip / SetProductionFocus remain as pre-#270 "orphan
+            // API" — no UI wires them today. They'll be wired when the
+            // SetProductionFocus UI lands, tracked separately.
 
             // Mark the matching log entry as arrived.
             for entry in command_log.entries.iter_mut() {
@@ -261,6 +298,349 @@ pub fn process_pending_commands(
             commands.entity(entity).despawn();
         }
     }
+}
+
+/// #270: Apply a `ColonyCommand` to the target queues. Cost / time / refund
+/// amounts are resolved here from the current registry state — the payload
+/// only carries ids and slot indices.
+fn apply_colony_command(
+    cc: &ColonyCommand,
+    target_system: Entity,
+    br: &crate::scripting::building_api::BuildingRegistry,
+    sdr: &crate::ship_design::ShipDesignRegistry,
+    bldg_cost_mod: crate::amount::Amt,
+    bldg_time_mod: crate::amount::Amt,
+    colonies: &mut Query<(
+        &crate::colony::Colony,
+        &crate::colony::Buildings,
+        &mut crate::colony::BuildingQueue,
+        &mut crate::colony::BuildQueue,
+    )>,
+    sys_buildings_q: &mut Query<(
+        &crate::colony::SystemBuildings,
+        &mut crate::colony::SystemBuildingQueue,
+    )>,
+) {
+    use crate::amount::Amt;
+    use crate::colony::{BuildOrder, BuildingOrder, DemolitionOrder, UpgradeOrder};
+    use crate::scripting::building_api::BuildingId;
+
+    match &cc.kind {
+        ColonyCommandKind::QueueBuilding {
+            building_id,
+            target_slot,
+        } => {
+            let Some(def) = br.get(building_id) else {
+                warn!("QueueBuilding: unknown building_id '{}'", building_id);
+                return;
+            };
+            let (base_m, base_e) = def.build_cost();
+            let eff_m = base_m.mul_amt(bldg_cost_mod);
+            let eff_e = base_e.mul_amt(bldg_cost_mod);
+            let eff_time = (def.build_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
+            let order = BuildingOrder {
+                building_id: BuildingId::new(building_id),
+                target_slot: *target_slot,
+                minerals_remaining: eff_m,
+                energy_remaining: eff_e,
+                build_time_remaining: eff_time,
+            };
+            match cc.target_planet {
+                Some(planet) => {
+                    push_planet_building_order(planet, order, colonies);
+                }
+                None => {
+                    if let Ok((_, mut sbq)) = sys_buildings_q.get_mut(target_system) {
+                        sbq.queue.push(order);
+                    } else {
+                        warn!(
+                            "QueueBuilding (system): target_system {:?} has no SystemBuildingQueue",
+                            target_system
+                        );
+                    }
+                }
+            }
+        }
+        ColonyCommandKind::DemolishBuilding { target_slot } => match cc.target_planet {
+            Some(planet) => {
+                let mut found = false;
+                for (colony, buildings, mut bq, _) in colonies.iter_mut() {
+                    if colony.planet != planet {
+                        continue;
+                    }
+                    found = true;
+                    let Some(Some(bid)) = buildings.slots.get(*target_slot).cloned() else {
+                        warn!(
+                            "DemolishBuilding (planet): slot {} is empty or out of bounds",
+                            target_slot
+                        );
+                        break;
+                    };
+                    let def = br.get(bid.as_str());
+                    let (m_ref, e_ref) =
+                        def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                    let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
+                    bq.demolition_queue.push(DemolitionOrder {
+                        target_slot: *target_slot,
+                        building_id: bid,
+                        time_remaining: demo_time,
+                        minerals_refund: m_ref,
+                        energy_refund: e_ref,
+                    });
+                    break;
+                }
+                if !found {
+                    warn!(
+                        "DemolishBuilding (planet): no colony found on planet {:?}",
+                        planet
+                    );
+                }
+            }
+            None => {
+                let Ok((sys_buildings, mut sbq)) = sys_buildings_q.get_mut(target_system) else {
+                    warn!(
+                        "DemolishBuilding (system): target_system {:?} has no SystemBuildings/Queue",
+                        target_system
+                    );
+                    return;
+                };
+                let Some(Some(bid)) = sys_buildings.slots.get(*target_slot).cloned() else {
+                    warn!(
+                        "DemolishBuilding (system): slot {} is empty or out of bounds",
+                        target_slot
+                    );
+                    return;
+                };
+                let def = br.get(bid.as_str());
+                let (m_ref, e_ref) =
+                    def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
+                sbq.demolition_queue.push(DemolitionOrder {
+                    target_slot: *target_slot,
+                    building_id: bid,
+                    time_remaining: demo_time,
+                    minerals_refund: m_ref,
+                    energy_refund: e_ref,
+                });
+            }
+        },
+        ColonyCommandKind::UpgradeBuilding {
+            slot_index,
+            target_id,
+        } => {
+            let upgrade_order = |source_def: &crate::scripting::building_api::BuildingDefinition,
+                                 target_id: &str|
+             -> Option<UpgradeOrder> {
+                let up = source_def
+                    .upgrade_to
+                    .iter()
+                    .find(|u| u.target_id == target_id)?;
+                let eff_m = up.cost_minerals.mul_amt(bldg_cost_mod);
+                let eff_e = up.cost_energy.mul_amt(bldg_cost_mod);
+                let base_time = up
+                    .build_time
+                    .unwrap_or_else(|| br.get(target_id).map(|d| d.build_time / 2).unwrap_or(5));
+                let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
+                Some(UpgradeOrder {
+                    slot_index: *slot_index,
+                    target_id: BuildingId::new(target_id),
+                    minerals_remaining: eff_m,
+                    energy_remaining: eff_e,
+                    build_time_remaining: eff_time,
+                })
+            };
+            match cc.target_planet {
+                Some(planet) => {
+                    let mut handled = false;
+                    for (colony, buildings, mut bq, _) in colonies.iter_mut() {
+                        if colony.planet != planet {
+                            continue;
+                        }
+                        handled = true;
+                        let Some(Some(source_bid)) = buildings.slots.get(*slot_index).cloned()
+                        else {
+                            warn!(
+                                "UpgradeBuilding (planet): slot {} empty or OOB",
+                                slot_index
+                            );
+                            break;
+                        };
+                        let Some(source_def) = br.get(source_bid.as_str()) else {
+                            warn!(
+                                "UpgradeBuilding (planet): unknown source building '{}'",
+                                source_bid
+                            );
+                            break;
+                        };
+                        if let Some(order) = upgrade_order(source_def, target_id) {
+                            bq.upgrade_queue.push(order);
+                        } else {
+                            warn!(
+                                "UpgradeBuilding (planet): no upgrade path '{}' -> '{}'",
+                                source_bid, target_id
+                            );
+                        }
+                        break;
+                    }
+                    if !handled {
+                        warn!("UpgradeBuilding (planet): no colony on planet {:?}", planet);
+                    }
+                }
+                None => {
+                    let Ok((sys_buildings, mut sbq)) = sys_buildings_q.get_mut(target_system)
+                    else {
+                        warn!(
+                            "UpgradeBuilding (system): target_system {:?} missing components",
+                            target_system
+                        );
+                        return;
+                    };
+                    let Some(Some(source_bid)) = sys_buildings.slots.get(*slot_index).cloned()
+                    else {
+                        warn!(
+                            "UpgradeBuilding (system): slot {} empty or OOB",
+                            slot_index
+                        );
+                        return;
+                    };
+                    let Some(source_def) = br.get(source_bid.as_str()) else {
+                        warn!(
+                            "UpgradeBuilding (system): unknown source building '{}'",
+                            source_bid
+                        );
+                        return;
+                    };
+                    if let Some(order) = upgrade_order(source_def, target_id) {
+                        sbq.upgrade_queue.push(order);
+                    } else {
+                        warn!(
+                            "UpgradeBuilding (system): no upgrade path '{}' -> '{}'",
+                            source_bid, target_id
+                        );
+                    }
+                }
+            }
+        }
+        ColonyCommandKind::CancelBuildingOrder { target_slot } => match cc.target_planet {
+            Some(planet) => {
+                for (colony, _, mut bq, _) in colonies.iter_mut() {
+                    if colony.planet == planet {
+                        if let Some(pos) = bq.queue.iter().position(|o| o.target_slot == *target_slot) {
+                            bq.queue.remove(pos);
+                        } else {
+                            warn!(
+                                "CancelBuildingOrder (planet): no queued order for slot {}",
+                                target_slot
+                            );
+                        }
+                        return;
+                    }
+                }
+                warn!(
+                    "CancelBuildingOrder (planet): no colony on planet {:?}",
+                    planet
+                );
+            }
+            None => {
+                if let Ok((_, mut sbq)) = sys_buildings_q.get_mut(target_system) {
+                    if let Some(pos) = sbq.queue.iter().position(|o| o.target_slot == *target_slot) {
+                        sbq.queue.remove(pos);
+                    } else {
+                        warn!(
+                            "CancelBuildingOrder (system): no queued order for slot {}",
+                            target_slot
+                        );
+                    }
+                } else {
+                    warn!(
+                        "CancelBuildingOrder (system): target_system {:?} missing",
+                        target_system
+                    );
+                }
+            }
+        },
+        ColonyCommandKind::QueueShipBuild {
+            host_colony,
+            design_id,
+            build_kind,
+        } => {
+            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
+                warn!(
+                    "QueueShipBuild: host_colony {:?} has no BuildQueue",
+                    host_colony
+                );
+                return;
+            };
+            let Some(design) = sdr.get(design_id) else {
+                warn!("QueueShipBuild: unknown design_id '{}'", design_id);
+                return;
+            };
+            // NOTE: Ship cost/time don't yet run through an empire modifier
+            // the way buildings do (no ship_cost_modifier), so take the
+            // registry values as-is. If such a modifier lands later, apply
+            // it here at arrival time.
+            let minerals_cost = design.build_cost_minerals;
+            let energy_cost = design.build_cost_energy;
+            let build_time_total = sdr.build_time(design_id);
+            let display_name = design.name.clone();
+            build_q.queue.push(BuildOrder {
+                kind: build_kind.clone(),
+                design_id: design_id.clone(),
+                display_name,
+                minerals_cost,
+                minerals_invested: Amt::ZERO,
+                energy_cost,
+                energy_invested: Amt::ZERO,
+                build_time_total,
+                build_time_remaining: build_time_total,
+            });
+        }
+        ColonyCommandKind::CancelShipOrder {
+            host_colony,
+            queue_index,
+        } => {
+            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
+                warn!(
+                    "CancelShipOrder: host_colony {:?} has no BuildQueue",
+                    host_colony
+                );
+                return;
+            };
+            if *queue_index < build_q.queue.len() {
+                build_q.queue.remove(*queue_index);
+            } else {
+                warn!(
+                    "CancelShipOrder: queue_index {} out of bounds (len={})",
+                    queue_index,
+                    build_q.queue.len()
+                );
+            }
+        }
+    }
+}
+
+/// Helper: push a `BuildingOrder` onto the BuildingQueue of the colony whose
+/// `colony.planet == planet`. Warns if no matching colony is found.
+fn push_planet_building_order(
+    planet: Entity,
+    order: crate::colony::BuildingOrder,
+    colonies: &mut Query<(
+        &crate::colony::Colony,
+        &crate::colony::Buildings,
+        &mut crate::colony::BuildingQueue,
+        &mut crate::colony::BuildQueue,
+    )>,
+) {
+    for (colony, _, mut bq, _) in colonies.iter_mut() {
+        if colony.planet == planet {
+            bq.queue.push(order);
+            return;
+        }
+    }
+    warn!(
+        "QueueBuilding (planet): no colony found on planet {:?}",
+        planet
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -2810,7 +2810,6 @@ impl SavedPendingDiplomaticAction {
 pub enum SavedRemoteCommand {
     BuildShip { design_id: String },
     SetProductionFocus { minerals: f64, energy: f64, research: f64 },
-    /// #270: Colony/system build command routed via light-speed delay.
     Colony(SavedColonyCommand),
 }
 impl From<&RemoteCommand> for SavedRemoteCommand {
@@ -2836,7 +2835,6 @@ impl SavedRemoteCommand {
     }
 }
 
-/// #270: Saved mirror of `ColonyCommand`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedColonyCommand {
     pub target_planet_bits: Option<u64>,
@@ -2858,14 +2856,11 @@ impl SavedColonyCommand {
     }
 }
 
-/// #270: Saved mirror of `ColonyCommandKind`. `BuildKind` is mirrored via the
-/// existing `SavedBuildKind`. Entity fields go through `remap_entity` on load.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SavedColonyCommandKind {
     QueueBuilding { building_id: String, target_slot: usize },
     DemolishBuilding { target_slot: usize },
     UpgradeBuilding { slot_index: usize, target_id: String },
-    CancelBuildingOrder { target_slot: usize },
     QueueShipBuild {
         host_colony_bits: u64,
         design_id: String,
@@ -2880,7 +2875,6 @@ pub enum SavedColonyCommandKind {
         energy_cost: Amt,
         build_time: i64,
     },
-    CancelShipOrder { host_colony_bits: u64, queue_index: usize },
 }
 
 impl SavedColonyCommandKind {
@@ -2897,9 +2891,6 @@ impl SavedColonyCommandKind {
                 slot_index: *slot_index,
                 target_id: target_id.clone(),
             },
-            ColonyCommandKind::CancelBuildingOrder { target_slot } => {
-                Self::CancelBuildingOrder { target_slot: *target_slot }
-            }
             ColonyCommandKind::QueueShipBuild { host_colony, design_id, build_kind } => {
                 Self::QueueShipBuild {
                     host_colony_bits: host_colony.to_bits(),
@@ -2924,12 +2915,6 @@ impl SavedColonyCommandKind {
                 energy_cost: *energy_cost,
                 build_time: *build_time,
             },
-            ColonyCommandKind::CancelShipOrder { host_colony, queue_index } => {
-                Self::CancelShipOrder {
-                    host_colony_bits: host_colony.to_bits(),
-                    queue_index: *queue_index,
-                }
-            }
         }
     }
     pub fn into_live(self, map: &EntityMap) -> ColonyCommandKind {
@@ -2942,9 +2927,6 @@ impl SavedColonyCommandKind {
             }
             Self::UpgradeBuilding { slot_index, target_id } => {
                 ColonyCommandKind::UpgradeBuilding { slot_index, target_id }
-            }
-            Self::CancelBuildingOrder { target_slot } => {
-                ColonyCommandKind::CancelBuildingOrder { target_slot }
             }
             Self::QueueShipBuild { host_colony_bits, design_id, build_kind } => {
                 ColonyCommandKind::QueueShipBuild {
@@ -2970,12 +2952,6 @@ impl SavedColonyCommandKind {
                 energy_cost,
                 build_time,
             },
-            Self::CancelShipOrder { host_colony_bits, queue_index } => {
-                ColonyCommandKind::CancelShipOrder {
-                    host_colony: remap_entity(host_colony_bits, map),
-                    queue_index,
-                }
-            }
         }
     }
 }
@@ -3619,14 +3595,8 @@ mod tests {
     use crate::colony::BuildKind;
     use crate::communication::{ColonyCommand, ColonyCommandKind, RemoteCommand};
 
-    /// #270: `RemoteCommand::Colony` survives a save/load round-trip through
-    /// `SavedRemoteCommand`. Exercises every `ColonyCommandKind` variant and
-    /// confirms `Entity` fields are remapped (not left raw-bit-equal).
     #[test]
     fn colony_remote_command_savebag_roundtrip() {
-        // Fake-save-id -> fresh-Entity remap table, as would be built during
-        // a real load. We use two entities to represent: (a) the planet
-        // target, (b) the host colony for ship builds.
         let mut map = EntityMap::new();
         let live_planet = Entity::from_raw_u32(42).unwrap();
         let live_host = Entity::from_raw_u32(77).unwrap();
@@ -3654,10 +3624,6 @@ mod tests {
             }),
             RemoteCommand::Colony(ColonyCommand {
                 target_planet: None,
-                kind: ColonyCommandKind::CancelBuildingOrder { target_slot: 0 },
-            }),
-            RemoteCommand::Colony(ColonyCommand {
-                target_planet: None,
                 kind: ColonyCommandKind::QueueShipBuild {
                     host_colony: live_host,
                     design_id: "explorer_mk1".to_string(),
@@ -3674,13 +3640,6 @@ mod tests {
                     minerals_cost: crate::amount::Amt::units(100),
                     energy_cost: crate::amount::Amt::units(50),
                     build_time: 30,
-                },
-            }),
-            RemoteCommand::Colony(ColonyCommand {
-                target_planet: None,
-                kind: ColonyCommandKind::CancelShipOrder {
-                    host_colony: live_host,
-                    queue_index: 2,
                 },
             }),
         ];
@@ -3701,8 +3660,6 @@ mod tests {
         }
     }
 
-    /// #270: Pre-existing `BuildShip` and `SetProductionFocus` variants still
-    /// round-trip through the updated `into_live(map)` signature.
     #[test]
     fn legacy_remote_command_variants_still_roundtrip() {
         let map = EntityMap::new();

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -2871,6 +2871,15 @@ pub enum SavedColonyCommandKind {
         design_id: String,
         build_kind: SavedBuildKind,
     },
+    QueueDeliverableBuild {
+        host_colony_bits: u64,
+        def_id: String,
+        display_name: String,
+        cargo_size: u32,
+        minerals_cost: Amt,
+        energy_cost: Amt,
+        build_time: i64,
+    },
     CancelShipOrder { host_colony_bits: u64, queue_index: usize },
 }
 
@@ -2898,6 +2907,23 @@ impl SavedColonyCommandKind {
                     build_kind: build_kind.into(),
                 }
             }
+            ColonyCommandKind::QueueDeliverableBuild {
+                host_colony,
+                def_id,
+                display_name,
+                cargo_size,
+                minerals_cost,
+                energy_cost,
+                build_time,
+            } => Self::QueueDeliverableBuild {
+                host_colony_bits: host_colony.to_bits(),
+                def_id: def_id.clone(),
+                display_name: display_name.clone(),
+                cargo_size: *cargo_size,
+                minerals_cost: *minerals_cost,
+                energy_cost: *energy_cost,
+                build_time: *build_time,
+            },
             ColonyCommandKind::CancelShipOrder { host_colony, queue_index } => {
                 Self::CancelShipOrder {
                     host_colony_bits: host_colony.to_bits(),
@@ -2927,6 +2953,23 @@ impl SavedColonyCommandKind {
                     build_kind: build_kind.into(),
                 }
             }
+            Self::QueueDeliverableBuild {
+                host_colony_bits,
+                def_id,
+                display_name,
+                cargo_size,
+                minerals_cost,
+                energy_cost,
+                build_time,
+            } => ColonyCommandKind::QueueDeliverableBuild {
+                host_colony: remap_entity(host_colony_bits, map),
+                def_id,
+                display_name,
+                cargo_size,
+                minerals_cost,
+                energy_cost,
+                build_time,
+            },
             Self::CancelShipOrder { host_colony_bits, queue_index } => {
                 ColonyCommandKind::CancelShipOrder {
                     host_colony: remap_entity(host_colony_bits, map),
@@ -3619,6 +3662,18 @@ mod tests {
                     host_colony: live_host,
                     design_id: "explorer_mk1".to_string(),
                     build_kind: BuildKind::Deliverable { cargo_size: 4 },
+                },
+            }),
+            RemoteCommand::Colony(ColonyCommand {
+                target_planet: None,
+                kind: ColonyCommandKind::QueueDeliverableBuild {
+                    host_colony: live_host,
+                    def_id: "sensor_buoy".to_string(),
+                    display_name: "Sensor Buoy".to_string(),
+                    cargo_size: 2,
+                    minerals_cost: crate::amount::Amt::units(100),
+                    energy_cost: crate::amount::Amt::units(50),
+                    build_time: 30,
                 },
             }),
             RemoteCommand::Colony(ColonyCommand {

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -32,7 +32,9 @@ use crate::colony::{
     PendingColonizationOrder, Production, ProductionFocus, ResourceCapacity, ResourceStockpile,
     SystemBuildingQueue, SystemBuildings, UpgradeOrder,
 };
-use crate::communication::{CommandLog, CommandLogEntry, PendingCommand, RemoteCommand};
+use crate::communication::{
+    ColonyCommand, ColonyCommandKind, CommandLog, CommandLogEntry, PendingCommand, RemoteCommand,
+};
 use crate::components::{MovementState, Position};
 use crate::condition::ScopedFlags;
 use crate::deep_space::{
@@ -2808,6 +2810,8 @@ impl SavedPendingDiplomaticAction {
 pub enum SavedRemoteCommand {
     BuildShip { design_id: String },
     SetProductionFocus { minerals: f64, energy: f64, research: f64 },
+    /// #270: Colony/system build command routed via light-speed delay.
+    Colony(SavedColonyCommand),
 }
 impl From<&RemoteCommand> for SavedRemoteCommand {
     fn from(v: &RemoteCommand) -> Self {
@@ -2816,16 +2820,119 @@ impl From<&RemoteCommand> for SavedRemoteCommand {
             RemoteCommand::SetProductionFocus { minerals, energy, research } => Self::SetProductionFocus {
                 minerals: *minerals, energy: *energy, research: *research,
             },
+            RemoteCommand::Colony(cc) => Self::Colony(SavedColonyCommand::from_live(cc)),
         }
     }
 }
-impl From<SavedRemoteCommand> for RemoteCommand {
-    fn from(v: SavedRemoteCommand) -> Self {
+impl SavedRemoteCommand {
+    pub fn into_live(self, map: &EntityMap) -> RemoteCommand {
+        match self {
+            SavedRemoteCommand::BuildShip { design_id } => RemoteCommand::BuildShip { design_id },
+            SavedRemoteCommand::SetProductionFocus { minerals, energy, research } => {
+                RemoteCommand::SetProductionFocus { minerals, energy, research }
+            }
+            SavedRemoteCommand::Colony(sc) => RemoteCommand::Colony(sc.into_live(map)),
+        }
+    }
+}
+
+/// #270: Saved mirror of `ColonyCommand`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedColonyCommand {
+    pub target_planet_bits: Option<u64>,
+    pub kind: SavedColonyCommandKind,
+}
+
+impl SavedColonyCommand {
+    pub fn from_live(v: &ColonyCommand) -> Self {
+        Self {
+            target_planet_bits: v.target_planet.map(|e| e.to_bits()),
+            kind: SavedColonyCommandKind::from_live(&v.kind),
+        }
+    }
+    pub fn into_live(self, map: &EntityMap) -> ColonyCommand {
+        ColonyCommand {
+            target_planet: self.target_planet_bits.map(|b| remap_entity(b, map)),
+            kind: self.kind.into_live(map),
+        }
+    }
+}
+
+/// #270: Saved mirror of `ColonyCommandKind`. `BuildKind` is mirrored via the
+/// existing `SavedBuildKind`. Entity fields go through `remap_entity` on load.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SavedColonyCommandKind {
+    QueueBuilding { building_id: String, target_slot: usize },
+    DemolishBuilding { target_slot: usize },
+    UpgradeBuilding { slot_index: usize, target_id: String },
+    CancelBuildingOrder { target_slot: usize },
+    QueueShipBuild {
+        host_colony_bits: u64,
+        design_id: String,
+        build_kind: SavedBuildKind,
+    },
+    CancelShipOrder { host_colony_bits: u64, queue_index: usize },
+}
+
+impl SavedColonyCommandKind {
+    pub fn from_live(v: &ColonyCommandKind) -> Self {
         match v {
-            SavedRemoteCommand::BuildShip { design_id } => Self::BuildShip { design_id },
-            SavedRemoteCommand::SetProductionFocus { minerals, energy, research } => Self::SetProductionFocus {
-                minerals, energy, research,
+            ColonyCommandKind::QueueBuilding { building_id, target_slot } => Self::QueueBuilding {
+                building_id: building_id.clone(),
+                target_slot: *target_slot,
             },
+            ColonyCommandKind::DemolishBuilding { target_slot } => {
+                Self::DemolishBuilding { target_slot: *target_slot }
+            }
+            ColonyCommandKind::UpgradeBuilding { slot_index, target_id } => Self::UpgradeBuilding {
+                slot_index: *slot_index,
+                target_id: target_id.clone(),
+            },
+            ColonyCommandKind::CancelBuildingOrder { target_slot } => {
+                Self::CancelBuildingOrder { target_slot: *target_slot }
+            }
+            ColonyCommandKind::QueueShipBuild { host_colony, design_id, build_kind } => {
+                Self::QueueShipBuild {
+                    host_colony_bits: host_colony.to_bits(),
+                    design_id: design_id.clone(),
+                    build_kind: build_kind.into(),
+                }
+            }
+            ColonyCommandKind::CancelShipOrder { host_colony, queue_index } => {
+                Self::CancelShipOrder {
+                    host_colony_bits: host_colony.to_bits(),
+                    queue_index: *queue_index,
+                }
+            }
+        }
+    }
+    pub fn into_live(self, map: &EntityMap) -> ColonyCommandKind {
+        match self {
+            Self::QueueBuilding { building_id, target_slot } => {
+                ColonyCommandKind::QueueBuilding { building_id, target_slot }
+            }
+            Self::DemolishBuilding { target_slot } => {
+                ColonyCommandKind::DemolishBuilding { target_slot }
+            }
+            Self::UpgradeBuilding { slot_index, target_id } => {
+                ColonyCommandKind::UpgradeBuilding { slot_index, target_id }
+            }
+            Self::CancelBuildingOrder { target_slot } => {
+                ColonyCommandKind::CancelBuildingOrder { target_slot }
+            }
+            Self::QueueShipBuild { host_colony_bits, design_id, build_kind } => {
+                ColonyCommandKind::QueueShipBuild {
+                    host_colony: remap_entity(host_colony_bits, map),
+                    design_id,
+                    build_kind: build_kind.into(),
+                }
+            }
+            Self::CancelShipOrder { host_colony_bits, queue_index } => {
+                ColonyCommandKind::CancelShipOrder {
+                    host_colony: remap_entity(host_colony_bits, map),
+                    queue_index,
+                }
+            }
         }
     }
 }
@@ -2853,7 +2960,7 @@ impl SavedPendingCommand {
     pub fn into_live(self, map: &EntityMap) -> PendingCommand {
         PendingCommand {
             target_system: remap_entity(self.target_system_bits, map),
-            command: self.command.into(),
+            command: self.command.into_live(map),
             sent_at: self.sent_at,
             arrives_at: self.arrives_at,
             origin_pos: self.origin_pos,
@@ -3460,5 +3567,102 @@ impl RemapEntities for SavedComponentBag {
         // All entity references are stored as `u64` bits; remapping is done
         // when wire structs are converted back into live components via
         // their `into_live(map)` methods. No in-place rewriting needed here.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::colony::BuildKind;
+    use crate::communication::{ColonyCommand, ColonyCommandKind, RemoteCommand};
+
+    /// #270: `RemoteCommand::Colony` survives a save/load round-trip through
+    /// `SavedRemoteCommand`. Exercises every `ColonyCommandKind` variant and
+    /// confirms `Entity` fields are remapped (not left raw-bit-equal).
+    #[test]
+    fn colony_remote_command_savebag_roundtrip() {
+        // Fake-save-id -> fresh-Entity remap table, as would be built during
+        // a real load. We use two entities to represent: (a) the planet
+        // target, (b) the host colony for ship builds.
+        let mut map = EntityMap::new();
+        let live_planet = Entity::from_raw_u32(42).unwrap();
+        let live_host = Entity::from_raw_u32(77).unwrap();
+        map.insert(live_planet.to_bits(), live_planet);
+        map.insert(live_host.to_bits(), live_host);
+
+        let originals = vec![
+            RemoteCommand::Colony(ColonyCommand {
+                target_planet: Some(live_planet),
+                kind: ColonyCommandKind::QueueBuilding {
+                    building_id: "mine".to_string(),
+                    target_slot: 2,
+                },
+            }),
+            RemoteCommand::Colony(ColonyCommand {
+                target_planet: Some(live_planet),
+                kind: ColonyCommandKind::DemolishBuilding { target_slot: 1 },
+            }),
+            RemoteCommand::Colony(ColonyCommand {
+                target_planet: None,
+                kind: ColonyCommandKind::UpgradeBuilding {
+                    slot_index: 3,
+                    target_id: "advanced_shipyard".to_string(),
+                },
+            }),
+            RemoteCommand::Colony(ColonyCommand {
+                target_planet: None,
+                kind: ColonyCommandKind::CancelBuildingOrder { target_slot: 0 },
+            }),
+            RemoteCommand::Colony(ColonyCommand {
+                target_planet: None,
+                kind: ColonyCommandKind::QueueShipBuild {
+                    host_colony: live_host,
+                    design_id: "explorer_mk1".to_string(),
+                    build_kind: BuildKind::Deliverable { cargo_size: 4 },
+                },
+            }),
+            RemoteCommand::Colony(ColonyCommand {
+                target_planet: None,
+                kind: ColonyCommandKind::CancelShipOrder {
+                    host_colony: live_host,
+                    queue_index: 2,
+                },
+            }),
+        ];
+
+        for original in &originals {
+            let saved = SavedRemoteCommand::from(original);
+            let bytes = serde_json::to_vec(&saved).expect("serialize");
+            let restored: SavedRemoteCommand = serde_json::from_slice(&bytes).expect("deserialize");
+            let live = restored.into_live(&map);
+
+            // Structural equality via Debug — RemoteCommand doesn't impl Eq.
+            assert_eq!(
+                format!("{:?}", original),
+                format!("{:?}", live),
+                "round-trip mismatch for {:?}",
+                original
+            );
+        }
+    }
+
+    /// #270: Pre-existing `BuildShip` and `SetProductionFocus` variants still
+    /// round-trip through the updated `into_live(map)` signature.
+    #[test]
+    fn legacy_remote_command_variants_still_roundtrip() {
+        let map = EntityMap::new();
+        let bs = RemoteCommand::BuildShip {
+            design_id: "scout".to_string(),
+        };
+        let bs_back = SavedRemoteCommand::from(&bs).into_live(&map);
+        assert_eq!(format!("{:?}", bs), format!("{:?}", bs_back));
+
+        let focus = RemoteCommand::SetProductionFocus {
+            minerals: 0.5,
+            energy: 0.3,
+            research: 0.2,
+        };
+        let focus_back = SavedRemoteCommand::from(&focus).into_live(&map);
+        assert_eq!(format!("{:?}", focus), format!("{:?}", focus_back));
     }
 }

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -684,6 +684,7 @@ fn draw_main_panels_system(
         &deliverables_res.structure_registry,
         &deliverable_avail,
         &mut system_actions,
+        &mut deliverables_res.colony_dispatches,
     );
 
     for action in colonization_actions {

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -685,6 +685,7 @@ fn draw_main_panels_system(
         &deliverable_avail,
         &mut system_actions,
         &mut deliverables_res.colony_dispatches,
+        &world.remote_commands,
     );
 
     for action in colonization_actions {

--- a/macrocosmo/src/ui/params.rs
+++ b/macrocosmo/src/ui/params.rs
@@ -62,9 +62,6 @@ pub struct MainPanelWorldQueries<'w, 's> {
             Option<&'static ColonyJobRates>,
         ),
     >,
-    /// #270: In-flight remote commands, so the system panel can display an
-    /// "Dispatched → arrives in N hd" list for the selected system while
-    /// the light-speed delay ticks down.
     pub remote_commands: Query<'w, 's, &'static crate::communication::PendingCommand>,
 }
 
@@ -92,9 +89,6 @@ pub struct MainPanelDeliverableRes<'w, 's> {
         (&'static crate::technology::GameFlags, &'static crate::condition::ScopedFlags),
         With<crate::player::PlayerEmpire>,
     >,
-    /// #270: Write-queue for remote colony build commands. UI systems push
-    /// entries here; `dispatch_pending_colony_commands` drains them during
-    /// `Update` and turns each into a `PendingCommand` with light-speed delay.
     pub colony_dispatches: ResMut<'w, crate::communication::PendingColonyDispatches>,
 }
 

--- a/macrocosmo/src/ui/params.rs
+++ b/macrocosmo/src/ui/params.rs
@@ -62,6 +62,10 @@ pub struct MainPanelWorldQueries<'w, 's> {
             Option<&'static ColonyJobRates>,
         ),
     >,
+    /// #270: In-flight remote commands, so the system panel can display an
+    /// "Dispatched → arrives in N hd" list for the selected system while
+    /// the light-speed delay ticks down.
+    pub remote_commands: Query<'w, 's, &'static crate::communication::PendingCommand>,
 }
 
 #[derive(SystemParam)]

--- a/macrocosmo/src/ui/params.rs
+++ b/macrocosmo/src/ui/params.rs
@@ -88,6 +88,10 @@ pub struct MainPanelDeliverableRes<'w, 's> {
         (&'static crate::technology::GameFlags, &'static crate::condition::ScopedFlags),
         With<crate::player::PlayerEmpire>,
     >,
+    /// #270: Write-queue for remote colony build commands. UI systems push
+    /// entries here; `dispatch_pending_colony_commands` drains them during
+    /// `Update` and turns each into a `PendingCommand` with light-speed delay.
+    pub colony_dispatches: ResMut<'w, crate::communication::PendingColonyDispatches>,
 }
 
 #[derive(SystemParam)]

--- a/macrocosmo/src/ui/system_panel/colony_detail.rs
+++ b/macrocosmo/src/ui/system_panel/colony_detail.rs
@@ -2,6 +2,9 @@ use bevy::prelude::*;
 use bevy_egui::egui;
 
 use crate::colony::{BuildQueue, BuildingOrder, BuildingQueue, Buildings, Colony, ColonyJobRates, ConstructionParams, DemolitionOrder, FoodConsumption, MaintenanceCost, Production, ResourceStockpile, UpgradeOrder};
+use crate::communication::{
+    ColonyCommand, ColonyCommandKind, PendingColonyDispatch, PendingColonyDispatches,
+};
 use crate::scripting::building_api::{BuildingId, BuildingRegistry};
 use crate::galaxy::SystemAttributes;
 use crate::amount::{Amt, SignedAmt};
@@ -46,6 +49,11 @@ pub(super) fn draw_colony_detail(
     building_registry: &BuildingRegistry,
     job_registry: &JobRegistry,
     colony_panel_tab: &mut ColonyPanelTab,
+    // #270: Light-speed command routing. When `is_local_system` is false,
+    // build/demolish/upgrade pushes go through `dispatches` and are spawned
+    // as `PendingCommand` entities by `dispatch_pending_colony_commands`.
+    is_local_system: bool,
+    dispatches: &mut PendingColonyDispatches,
 ) {
     ui.label(
         egui::RichText::new("Colony")
@@ -83,6 +91,8 @@ pub(super) fn draw_colony_detail(
             planets,
             design_registry,
             building_registry,
+            is_local_system,
+            dispatches,
         ),
         ColonyPanelTab::PopManagement => draw_pop_management_tab(
             ui,
@@ -120,6 +130,9 @@ fn draw_overview_tab(
     planets: &Query<&crate::galaxy::Planet>,
     design_registry: &crate::ship_design::ShipDesignRegistry,
     building_registry: &BuildingRegistry,
+    // #270: Light-speed command routing.
+    is_local_system: bool,
+    dispatches: &mut PendingColonyDispatches,
 ) {
     for (_colony_entity, colony, production, _build_queue, buildings, mut building_queue, maintenance_cost, food_consumption) in
         colonies.iter_mut()
@@ -379,30 +392,59 @@ fn draw_overview_tab(
             }
 
             if let Some((slot_idx, bid)) = demolish_request {
-                if let Some(bq) = building_queue.as_mut() {
-                    let def = building_registry.get(bid.as_str());
-                    let (m_refund, e_refund) = def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                    let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
-                    bq.demolition_queue.push(DemolitionOrder {
-                        target_slot: slot_idx,
-                        building_id: bid.clone(),
-                        time_remaining: demo_time,
-                        minerals_refund: m_refund,
-                        energy_refund: e_refund,
+                if is_local_system {
+                    if let Some(bq) = building_queue.as_mut() {
+                        let def = building_registry.get(bid.as_str());
+                        let (m_refund, e_refund) = def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                        let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
+                        bq.demolition_queue.push(DemolitionOrder {
+                            target_slot: slot_idx,
+                            building_id: bid.clone(),
+                            time_remaining: demo_time,
+                            minerals_refund: m_refund,
+                            energy_refund: e_refund,
+                        });
+                        info!("Demolition order added: {} in slot {}", bid, slot_idx);
+                    }
+                } else {
+                    dispatches.queue.push(PendingColonyDispatch {
+                        target_system: system_entity,
+                        command: ColonyCommand {
+                            target_planet: Some(planet_entity),
+                            kind: ColonyCommandKind::DemolishBuilding { target_slot: slot_idx },
+                        },
                     });
-                    info!("Demolition order added: {} in slot {}", bid, slot_idx);
+                    info!("Demolition command dispatched to remote colony (slot {}, {})", slot_idx, bid);
                 }
             }
             if let Some((slot_idx, target_id, minerals, energy, time)) = upgrade_request {
-                if let Some(bq) = building_queue.as_mut() {
-                    bq.upgrade_queue.push(UpgradeOrder {
-                        slot_index: slot_idx,
-                        target_id: BuildingId::new(&target_id),
-                        minerals_remaining: minerals,
-                        energy_remaining: energy,
-                        build_time_remaining: time,
+                if is_local_system {
+                    if let Some(bq) = building_queue.as_mut() {
+                        bq.upgrade_queue.push(UpgradeOrder {
+                            slot_index: slot_idx,
+                            target_id: BuildingId::new(&target_id),
+                            minerals_remaining: minerals,
+                            energy_remaining: energy,
+                            build_time_remaining: time,
+                        });
+                        info!("Upgrade order added: {} in slot {}", target_id, slot_idx);
+                    }
+                } else {
+                    // #270: Remote path — arrival will re-resolve cost/time
+                    // from the upgrade_to path, so we discard the UI's
+                    // pre-computed values here.
+                    let _ = (minerals, energy, time);
+                    dispatches.queue.push(PendingColonyDispatch {
+                        target_system: system_entity,
+                        command: ColonyCommand {
+                            target_planet: Some(planet_entity),
+                            kind: ColonyCommandKind::UpgradeBuilding {
+                                slot_index: slot_idx,
+                                target_id: target_id.clone(),
+                            },
+                        },
                     });
-                    info!("Upgrade order added: {} in slot {}", target_id, slot_idx);
+                    info!("Upgrade command dispatched to remote colony (slot {} -> {})", slot_idx, target_id);
                 }
             }
 
@@ -429,21 +471,38 @@ fn draw_overview_tab(
                     }
                 }
                 if let Some(bid) = build_building_request {
-                    if let Some(mut bq) = building_queue {
-                        let def = building_registry.get(bid.as_str());
-                        let (base_m, base_e) = def.map(|d| d.build_cost()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                        let base_time = def.map(|d| d.build_time).unwrap_or(10);
-                        let eff_m = base_m.mul_amt(bldg_cost_mod);
-                        let eff_e = base_e.mul_amt(bldg_cost_mod);
-                        let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
-                        bq.queue.push(BuildingOrder {
-                            building_id: bid.clone(),
-                            target_slot: slot_idx,
-                            minerals_remaining: eff_m,
-                            energy_remaining: eff_e,
-                            build_time_remaining: eff_time,
+                    if is_local_system {
+                        if let Some(mut bq) = building_queue {
+                            let def = building_registry.get(bid.as_str());
+                            let (base_m, base_e) = def.map(|d| d.build_cost()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                            let base_time = def.map(|d| d.build_time).unwrap_or(10);
+                            let eff_m = base_m.mul_amt(bldg_cost_mod);
+                            let eff_e = base_e.mul_amt(bldg_cost_mod);
+                            let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
+                            bq.queue.push(BuildingOrder {
+                                building_id: bid.clone(),
+                                target_slot: slot_idx,
+                                minerals_remaining: eff_m,
+                                energy_remaining: eff_e,
+                                build_time_remaining: eff_time,
+                            });
+                            info!("Building order added: {} in slot {}", bid, slot_idx);
+                        }
+                    } else {
+                        // #270: Remote path — arrival will re-resolve
+                        // cost/time from the target's ConstructionParams
+                        // and BuildingRegistry.
+                        dispatches.queue.push(PendingColonyDispatch {
+                            target_system: system_entity,
+                            command: ColonyCommand {
+                                target_planet: Some(planet_entity),
+                                kind: ColonyCommandKind::QueueBuilding {
+                                    building_id: bid.0.clone(),
+                                    target_slot: slot_idx,
+                                },
+                            },
                         });
-                        info!("Building order added: {} in slot {}", bid, slot_idx);
+                        info!("Building command dispatched to remote colony (slot {}, {})", slot_idx, bid);
                     }
                 }
             }

--- a/macrocosmo/src/ui/system_panel/colony_detail.rs
+++ b/macrocosmo/src/ui/system_panel/colony_detail.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_egui::egui;
 
-use crate::colony::{BuildQueue, BuildingOrder, BuildingQueue, Buildings, Colony, ColonyJobRates, ConstructionParams, DemolitionOrder, FoodConsumption, MaintenanceCost, Production, ResourceStockpile, UpgradeOrder};
+use crate::colony::{BuildQueue, BuildingQueue, Buildings, Colony, ColonyJobRates, ConstructionParams, FoodConsumption, MaintenanceCost, Production, ResourceStockpile};
 use crate::communication::{
     ColonyCommand, ColonyCommandKind, PendingColonyDispatch, PendingColonyDispatches,
 };
@@ -49,10 +49,6 @@ pub(super) fn draw_colony_detail(
     building_registry: &BuildingRegistry,
     job_registry: &JobRegistry,
     colony_panel_tab: &mut ColonyPanelTab,
-    // #270: Light-speed command routing. When `is_local_system` is false,
-    // build/demolish/upgrade pushes go through `dispatches` and are spawned
-    // as `PendingCommand` entities by `dispatch_pending_colony_commands`.
-    is_local_system: bool,
     dispatches: &mut PendingColonyDispatches,
 ) {
     ui.label(
@@ -91,7 +87,6 @@ pub(super) fn draw_colony_detail(
             planets,
             design_registry,
             building_registry,
-            is_local_system,
             dispatches,
         ),
         ColonyPanelTab::PopManagement => draw_pop_management_tab(
@@ -130,11 +125,9 @@ fn draw_overview_tab(
     planets: &Query<&crate::galaxy::Planet>,
     design_registry: &crate::ship_design::ShipDesignRegistry,
     building_registry: &BuildingRegistry,
-    // #270: Light-speed command routing.
-    is_local_system: bool,
     dispatches: &mut PendingColonyDispatches,
 ) {
-    for (_colony_entity, colony, production, _build_queue, buildings, mut building_queue, maintenance_cost, food_consumption) in
+    for (_colony_entity, colony, production, _build_queue, buildings, building_queue, maintenance_cost, food_consumption) in
         colonies.iter_mut()
     {
         if colony.planet != planet_entity {
@@ -391,61 +384,26 @@ fn draw_overview_tab(
                 }
             }
 
-            if let Some((slot_idx, bid)) = demolish_request {
-                if is_local_system {
-                    if let Some(bq) = building_queue.as_mut() {
-                        let def = building_registry.get(bid.as_str());
-                        let (m_refund, e_refund) = def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                        let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
-                        bq.demolition_queue.push(DemolitionOrder {
-                            target_slot: slot_idx,
-                            building_id: bid.clone(),
-                            time_remaining: demo_time,
-                            minerals_refund: m_refund,
-                            energy_refund: e_refund,
-                        });
-                        info!("Demolition order added: {} in slot {}", bid, slot_idx);
-                    }
-                } else {
-                    dispatches.queue.push(PendingColonyDispatch {
-                        target_system: system_entity,
-                        command: ColonyCommand {
-                            target_planet: Some(planet_entity),
-                            kind: ColonyCommandKind::DemolishBuilding { target_slot: slot_idx },
-                        },
-                    });
-                    info!("Demolition command dispatched to remote colony (slot {}, {})", slot_idx, bid);
-                }
+            if let Some((slot_idx, _bid)) = demolish_request {
+                dispatches.queue.push(PendingColonyDispatch {
+                    target_system: system_entity,
+                    command: ColonyCommand {
+                        target_planet: Some(planet_entity),
+                        kind: ColonyCommandKind::DemolishBuilding { target_slot: slot_idx },
+                    },
+                });
             }
-            if let Some((slot_idx, target_id, minerals, energy, time)) = upgrade_request {
-                if is_local_system {
-                    if let Some(bq) = building_queue.as_mut() {
-                        bq.upgrade_queue.push(UpgradeOrder {
+            if let Some((slot_idx, target_id, _, _, _)) = upgrade_request {
+                dispatches.queue.push(PendingColonyDispatch {
+                    target_system: system_entity,
+                    command: ColonyCommand {
+                        target_planet: Some(planet_entity),
+                        kind: ColonyCommandKind::UpgradeBuilding {
                             slot_index: slot_idx,
-                            target_id: BuildingId::new(&target_id),
-                            minerals_remaining: minerals,
-                            energy_remaining: energy,
-                            build_time_remaining: time,
-                        });
-                        info!("Upgrade order added: {} in slot {}", target_id, slot_idx);
-                    }
-                } else {
-                    // #270: Remote path — arrival will re-resolve cost/time
-                    // from the upgrade_to path, so we discard the UI's
-                    // pre-computed values here.
-                    let _ = (minerals, energy, time);
-                    dispatches.queue.push(PendingColonyDispatch {
-                        target_system: system_entity,
-                        command: ColonyCommand {
-                            target_planet: Some(planet_entity),
-                            kind: ColonyCommandKind::UpgradeBuilding {
-                                slot_index: slot_idx,
-                                target_id: target_id.clone(),
-                            },
+                            target_id,
                         },
-                    });
-                    info!("Upgrade command dispatched to remote colony (slot {} -> {})", slot_idx, target_id);
-                }
+                    },
+                });
             }
 
             let pending_slots: Vec<usize> = pending_orders.iter().map(|(s, _, _)| *s).collect();
@@ -471,39 +429,16 @@ fn draw_overview_tab(
                     }
                 }
                 if let Some(bid) = build_building_request {
-                    if is_local_system {
-                        if let Some(mut bq) = building_queue {
-                            let def = building_registry.get(bid.as_str());
-                            let (base_m, base_e) = def.map(|d| d.build_cost()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                            let base_time = def.map(|d| d.build_time).unwrap_or(10);
-                            let eff_m = base_m.mul_amt(bldg_cost_mod);
-                            let eff_e = base_e.mul_amt(bldg_cost_mod);
-                            let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
-                            bq.queue.push(BuildingOrder {
-                                building_id: bid.clone(),
+                    dispatches.queue.push(PendingColonyDispatch {
+                        target_system: system_entity,
+                        command: ColonyCommand {
+                            target_planet: Some(planet_entity),
+                            kind: ColonyCommandKind::QueueBuilding {
+                                building_id: bid.0,
                                 target_slot: slot_idx,
-                                minerals_remaining: eff_m,
-                                energy_remaining: eff_e,
-                                build_time_remaining: eff_time,
-                            });
-                            info!("Building order added: {} in slot {}", bid, slot_idx);
-                        }
-                    } else {
-                        // #270: Remote path — arrival will re-resolve
-                        // cost/time from the target's ConstructionParams
-                        // and BuildingRegistry.
-                        dispatches.queue.push(PendingColonyDispatch {
-                            target_system: system_entity,
-                            command: ColonyCommand {
-                                target_planet: Some(planet_entity),
-                                kind: ColonyCommandKind::QueueBuilding {
-                                    building_id: bid.0.clone(),
-                                    target_slot: slot_idx,
-                                },
                             },
-                        });
-                        info!("Building command dispatched to remote colony (slot {}, {})", slot_idx, bid);
-                    }
+                        },
+                    });
                 }
             }
         }

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -369,6 +369,8 @@ pub fn draw_system_panel(
                                         structure_registry,
                                         deliverable_avail,
                                         system_actions_out,
+                                        is_local_system,
+                                        dispatches,
                                     );
                                 });
                         });
@@ -664,6 +666,9 @@ fn draw_right_panel(
     structure_registry: &StructureRegistry,
     deliverable_avail: &DeliverableAvailabilityCtx<'_>,
     system_actions_out: &mut SystemPanelActions,
+    // #270: Light-speed command routing.
+    is_local_system: bool,
+    dispatches: &mut crate::communication::PendingColonyDispatches,
 ) {
     // === Docked Ships ===
     ui.label(egui::RichText::new("Docked Ships").strong().color(egui::Color32::from_rgb(180, 180, 220)));
@@ -841,30 +846,60 @@ fn draw_right_panel(
         }
 
         if let Some((slot_idx, bid)) = sys_demolish_request {
-            if let Some(mut bq) = sys_bldg_queue {
-                let def = building_registry.get(bid.as_str());
-                let (m_refund, e_refund) = def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
-                bq.demolition_queue.push(DemolitionOrder {
-                    target_slot: slot_idx,
-                    building_id: bid.clone(),
-                    time_remaining: demo_time,
-                    minerals_refund: m_refund,
-                    energy_refund: e_refund,
+            if is_local_system {
+                if let Some(mut bq) = sys_bldg_queue {
+                    let def = building_registry.get(bid.as_str());
+                    let (m_refund, e_refund) = def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                    let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
+                    bq.demolition_queue.push(DemolitionOrder {
+                        target_slot: slot_idx,
+                        building_id: bid.clone(),
+                        time_remaining: demo_time,
+                        minerals_refund: m_refund,
+                        energy_refund: e_refund,
+                    });
+                    info!("System building demolition order added: {} in slot {}", bid, slot_idx);
+                }
+            } else {
+                dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                    target_system: sel_entity,
+                    command: crate::communication::ColonyCommand {
+                        target_planet: None,
+                        kind: crate::communication::ColonyCommandKind::DemolishBuilding {
+                            target_slot: slot_idx,
+                        },
+                    },
                 });
-                info!("System building demolition order added: {} in slot {}", bid, slot_idx);
+                info!("System building demolition dispatched to remote system (slot {}, {})", slot_idx, bid);
             }
         }
         if let Some((slot_idx, target_id, minerals, energy, time)) = sys_upgrade_request {
-            if let Ok((_, Some(mut bq))) = system_buildings_q.get_mut(sel_entity) {
-                bq.upgrade_queue.push(UpgradeOrder {
-                    slot_index: slot_idx,
-                    target_id: BuildingId::new(&target_id),
-                    minerals_remaining: minerals,
-                    energy_remaining: energy,
-                    build_time_remaining: time,
+            if is_local_system {
+                if let Ok((_, Some(mut bq))) = system_buildings_q.get_mut(sel_entity) {
+                    bq.upgrade_queue.push(UpgradeOrder {
+                        slot_index: slot_idx,
+                        target_id: BuildingId::new(&target_id),
+                        minerals_remaining: minerals,
+                        energy_remaining: energy,
+                        build_time_remaining: time,
+                    });
+                    info!("System building upgrade order added: {} in slot {}", target_id, slot_idx);
+                }
+            } else {
+                // #270: Remote path discards pre-computed cost/time; arrival
+                // re-resolves them from the UpgradePath at the target.
+                let _ = (minerals, energy, time);
+                dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                    target_system: sel_entity,
+                    command: crate::communication::ColonyCommand {
+                        target_planet: None,
+                        kind: crate::communication::ColonyCommandKind::UpgradeBuilding {
+                            slot_index: slot_idx,
+                            target_id: target_id.clone(),
+                        },
+                    },
                 });
-                info!("System building upgrade order added: {} in slot {}", target_id, slot_idx);
+                info!("System building upgrade dispatched to remote system (slot {} -> {})", slot_idx, target_id);
             }
         }
 
@@ -897,21 +932,35 @@ fn draw_right_panel(
                     }
                 }
                 if let Some(bid) = build_sys_building_request {
-                    if let Ok((_, Some(mut bq))) = system_buildings_q.get_mut(sel_entity) {
-                        let def = building_registry.get(bid.as_str());
-                        let (base_m, base_e) = def.map(|d| d.build_cost()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                        let base_time = def.map(|d| d.build_time).unwrap_or(10);
-                        let eff_m = base_m.mul_amt(bldg_cost_mod);
-                        let eff_e = base_e.mul_amt(bldg_cost_mod);
-                        let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
-                        bq.queue.push(BuildingOrder {
-                            building_id: bid.clone(),
-                            target_slot: slot_idx,
-                            minerals_remaining: eff_m,
-                            energy_remaining: eff_e,
-                            build_time_remaining: eff_time,
+                    if is_local_system {
+                        if let Ok((_, Some(mut bq))) = system_buildings_q.get_mut(sel_entity) {
+                            let def = building_registry.get(bid.as_str());
+                            let (base_m, base_e) = def.map(|d| d.build_cost()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                            let base_time = def.map(|d| d.build_time).unwrap_or(10);
+                            let eff_m = base_m.mul_amt(bldg_cost_mod);
+                            let eff_e = base_e.mul_amt(bldg_cost_mod);
+                            let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
+                            bq.queue.push(BuildingOrder {
+                                building_id: bid.clone(),
+                                target_slot: slot_idx,
+                                minerals_remaining: eff_m,
+                                energy_remaining: eff_e,
+                                build_time_remaining: eff_time,
+                            });
+                            info!("System building order added: {} in slot {}", bid, slot_idx);
+                        }
+                    } else {
+                        dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                            target_system: sel_entity,
+                            command: crate::communication::ColonyCommand {
+                                target_planet: None,
+                                kind: crate::communication::ColonyCommandKind::QueueBuilding {
+                                    building_id: bid.0.clone(),
+                                    target_slot: slot_idx,
+                                },
+                            },
                         });
-                        info!("System building order added: {} in slot {}", bid, slot_idx);
+                        info!("System building dispatched to remote system (slot {}, {})", slot_idx, bid);
                     }
                 }
             }

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -151,6 +151,8 @@ pub fn draw_system_panel(
     system_actions_out: &mut SystemPanelActions,
     // #270: Resource used by planet/system/ship UI to queue remote commands.
     dispatches: &mut crate::communication::PendingColonyDispatches,
+    // #270: Read-only view of in-flight commands, for transit feedback.
+    remote_commands: &Query<&crate::communication::PendingCommand>,
 ) {
     let Some(sel_entity) = selected_system.0 else {
         return;
@@ -371,6 +373,8 @@ pub fn draw_system_panel(
                                         system_actions_out,
                                         is_local_system,
                                         dispatches,
+                                        remote_commands,
+                                        clock.elapsed,
                                     );
                                 });
                         });
@@ -669,7 +673,15 @@ fn draw_right_panel(
     // #270: Light-speed command routing.
     is_local_system: bool,
     dispatches: &mut crate::communication::PendingColonyDispatches,
+    // #270: In-flight commands for the selected system (transit feedback).
+    remote_commands: &Query<&crate::communication::PendingCommand>,
+    clock_elapsed: i64,
 ) {
+    // #270: In-flight commands for this system (transit feedback). Listed
+    // before the rest of the panel so the player immediately sees feedback
+    // after clicking a build/demolish/upgrade button on a remote system.
+    draw_in_flight_commands_section(ui, sel_entity, remote_commands, clock_elapsed);
+
     // === Docked Ships ===
     ui.label(egui::RichText::new("Docked Ships").strong().color(egui::Color32::from_rgb(180, 180, 220)));
     ui.separator();
@@ -1610,6 +1622,72 @@ fn draw_system_map(
         egui::FontId::proportional(11.0),
         egui::Color32::from_rgb(120, 120, 140),
     );
+}
+
+/// #270: Render the in-flight remote-commands list for a system. Lists
+/// each `PendingCommand` whose `target_system == sel_entity` with the
+/// remaining hexadies until arrival. Silently collapses to a no-op when
+/// there are no in-flight commands for this system.
+fn draw_in_flight_commands_section(
+    ui: &mut egui::Ui,
+    sel_entity: Entity,
+    remote_commands: &Query<&crate::communication::PendingCommand>,
+    clock_elapsed: i64,
+) {
+    use crate::communication::{ColonyCommandKind, RemoteCommand};
+    let mut items: Vec<&crate::communication::PendingCommand> = remote_commands
+        .iter()
+        .filter(|cmd| cmd.target_system == sel_entity)
+        .collect();
+    if items.is_empty() {
+        return;
+    }
+    // Sort by arrives_at so the next-to-land entry is at the top.
+    items.sort_by_key(|c| c.arrives_at);
+
+    ui.label(
+        egui::RichText::new("In-flight Commands")
+            .strong()
+            .color(egui::Color32::from_rgb(240, 200, 120)),
+    );
+    ui.separator();
+    for cmd in items {
+        let remaining = (cmd.arrives_at - clock_elapsed).max(0);
+        let verb = match &cmd.command {
+            RemoteCommand::Colony(cc) => match &cc.kind {
+                ColonyCommandKind::QueueBuilding { building_id, target_slot } => {
+                    format!("Build {} → slot {}", building_id, target_slot)
+                }
+                ColonyCommandKind::DemolishBuilding { target_slot } => {
+                    format!("Demolish slot {}", target_slot)
+                }
+                ColonyCommandKind::UpgradeBuilding { slot_index, target_id } => {
+                    format!("Upgrade slot {} → {}", slot_index, target_id)
+                }
+                ColonyCommandKind::CancelBuildingOrder { target_slot } => {
+                    format!("Cancel order @ slot {}", target_slot)
+                }
+                ColonyCommandKind::QueueShipBuild { design_id, .. } => {
+                    format!("Build ship: {}", design_id)
+                }
+                ColonyCommandKind::CancelShipOrder { queue_index, .. } => {
+                    format!("Cancel ship order [{}]", queue_index)
+                }
+            },
+            RemoteCommand::BuildShip { design_id } => format!("Build ship: {}", design_id),
+            RemoteCommand::SetProductionFocus { .. } => "Set production focus".to_string(),
+        };
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new(format!("• {}", verb)).weak());
+            ui.label(
+                egui::RichText::new(format!("arrives in {} hd", remaining))
+                    .italics()
+                    .color(egui::Color32::from_rgb(180, 180, 180)),
+            );
+        });
+    }
+    ui.add_space(4.0);
+    ui.separator();
 }
 
 /// Format a type id into a display name (e.g. "yellow_dwarf" -> "Yellow Dwarf").

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -1132,33 +1132,24 @@ fn draw_right_panel(
                             });
                         });
 
-                    // #270: Deliverable dispatch wiring lands in Commit H
-                    // (QueueDeliverableBuild payload variant). Until then,
-                    // deliverable pushes go directly to the host BuildQueue.
                     if let Some((def_id, display_name, cargo_size, m_cost, e_cost, build_time)) =
                         deliverable_request
                     {
-                        for (colony_entity, _c, _prod, mut build_queue, _b, _bq, _m, _f) in
-                            colonies.iter_mut()
-                        {
-                            if colony_entity != host {
-                                continue;
-                            }
-                            if let Some(bq) = build_queue.as_mut() {
-                                bq.queue.push(BuildOrder {
-                                    kind: crate::colony::BuildKind::Deliverable { cargo_size },
-                                    design_id: def_id,
+                        dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                            target_system: sel_entity,
+                            command: crate::communication::ColonyCommand {
+                                target_planet: None,
+                                kind: crate::communication::ColonyCommandKind::QueueDeliverableBuild {
+                                    host_colony: host,
+                                    def_id,
                                     display_name,
+                                    cargo_size,
                                     minerals_cost: m_cost,
-                                    minerals_invested: Amt::ZERO,
                                     energy_cost: e_cost,
-                                    energy_invested: Amt::ZERO,
-                                    build_time_total: build_time,
-                                    build_time_remaining: build_time,
-                                });
-                            }
-                            break;
-                        }
+                                    build_time,
+                                },
+                            },
+                        });
                     }
                 }
             }
@@ -1552,6 +1543,9 @@ fn draw_in_flight_commands_section(
                 }
                 ColonyCommandKind::QueueShipBuild { design_id, .. } => {
                     format!("Build ship: {}", design_id)
+                }
+                ColonyCommandKind::QueueDeliverableBuild { display_name, .. } => {
+                    format!("Build deliverable: {}", display_name)
                 }
                 ColonyCommandKind::CancelShipOrder { queue_index, .. } => {
                     format!("Cancel ship order [{}]", queue_index)

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -149,6 +149,8 @@ pub fn draw_system_panel(
     structure_registry: &StructureRegistry,
     deliverable_avail: &DeliverableAvailabilityCtx<'_>,
     system_actions_out: &mut SystemPanelActions,
+    // #270: Resource used by planet/system/ship UI to queue remote commands.
+    dispatches: &mut crate::communication::PendingColonyDispatches,
 ) {
     let Some(sel_entity) = selected_system.0 else {
         return;
@@ -398,6 +400,8 @@ pub fn draw_system_panel(
         building_registry,
         job_registry,
         colony_panel_tab,
+        is_local_system,
+        dispatches,
     );
 }
 

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -1116,29 +1116,48 @@ fn draw_right_panel(
                 if let Some((design_id, display_name, minerals_cost, energy_cost, build_time)) =
                     build_request
                 {
-                    // Re-query mutably to push the order onto the host colony's BuildQueue.
-                    let display_name_log = display_name.clone();
-                    for (colony_entity, _c, _prod, mut build_queue, _b, _bq, _m, _f) in
-                        colonies.iter_mut()
-                    {
-                        if colony_entity != host {
-                            continue;
+                    if is_local_system {
+                        // Re-query mutably to push the order onto the host colony's BuildQueue.
+                        let display_name_log = display_name.clone();
+                        for (colony_entity, _c, _prod, mut build_queue, _b, _bq, _m, _f) in
+                            colonies.iter_mut()
+                        {
+                            if colony_entity != host {
+                                continue;
+                            }
+                            if let Some(bq) = build_queue.as_mut() {
+                                bq.queue.push(BuildOrder {
+                                    kind: crate::colony::BuildKind::default(),
+                                    design_id: design_id.clone(),
+                                    display_name: display_name.clone(),
+                                    minerals_cost,
+                                    minerals_invested: Amt::ZERO,
+                                    energy_cost,
+                                    energy_invested: Amt::ZERO,
+                                    build_time_total: build_time,
+                                    build_time_remaining: build_time,
+                                });
+                                info!("Build order added: {}", display_name_log);
+                            }
+                            break;
                         }
-                        if let Some(bq) = build_queue.as_mut() {
-                            bq.queue.push(BuildOrder {
-                                kind: crate::colony::BuildKind::default(),
-                                design_id: design_id.clone(),
-                                display_name: display_name.clone(),
-                                minerals_cost,
-                                minerals_invested: Amt::ZERO,
-                                energy_cost,
-                                energy_invested: Amt::ZERO,
-                                build_time_total: build_time,
-                                build_time_remaining: build_time,
-                            });
-                            info!("Build order added: {}", display_name_log);
-                        }
-                        break;
+                    } else {
+                        // #270: Remote ship build. Arrival re-resolves cost /
+                        // time from ShipDesignRegistry (modifiers not applied
+                        // — ship builds have no empire modifier yet).
+                        let _ = (minerals_cost, energy_cost, build_time, display_name);
+                        dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                            target_system: sel_entity,
+                            command: crate::communication::ColonyCommand {
+                                target_planet: None,
+                                kind: crate::communication::ColonyCommandKind::QueueShipBuild {
+                                    host_colony: host,
+                                    design_id: design_id.clone(),
+                                    build_kind: crate::colony::BuildKind::Ship,
+                                },
+                            },
+                        });
+                        info!("Ship build dispatched to remote colony: {}", design_id);
                     }
                 }
 
@@ -1198,28 +1217,52 @@ fn draw_right_panel(
                     if let Some((def_id, display_name, cargo_size, m_cost, e_cost, build_time)) =
                         deliverable_request
                     {
-                        let display_name_log = display_name.clone();
-                        for (colony_entity, _c, _prod, mut build_queue, _b, _bq, _m, _f) in
-                            colonies.iter_mut()
-                        {
-                            if colony_entity != host {
-                                continue;
+                        if is_local_system {
+                            let display_name_log = display_name.clone();
+                            for (colony_entity, _c, _prod, mut build_queue, _b, _bq, _m, _f) in
+                                colonies.iter_mut()
+                            {
+                                if colony_entity != host {
+                                    continue;
+                                }
+                                if let Some(bq) = build_queue.as_mut() {
+                                    bq.queue.push(BuildOrder {
+                                        kind: crate::colony::BuildKind::Deliverable { cargo_size },
+                                        design_id: def_id.clone(),
+                                        display_name: display_name.clone(),
+                                        minerals_cost: m_cost,
+                                        minerals_invested: Amt::ZERO,
+                                        energy_cost: e_cost,
+                                        energy_invested: Amt::ZERO,
+                                        build_time_total: build_time,
+                                        build_time_remaining: build_time,
+                                    });
+                                    info!("Deliverable order added: {}", display_name_log);
+                                }
+                                break;
                             }
-                            if let Some(bq) = build_queue.as_mut() {
-                                bq.queue.push(BuildOrder {
-                                    kind: crate::colony::BuildKind::Deliverable { cargo_size },
-                                    design_id: def_id.clone(),
-                                    display_name: display_name.clone(),
-                                    minerals_cost: m_cost,
-                                    minerals_invested: Amt::ZERO,
-                                    energy_cost: e_cost,
-                                    energy_invested: Amt::ZERO,
-                                    build_time_total: build_time,
-                                    build_time_remaining: build_time,
-                                });
-                                info!("Deliverable order added: {}", display_name_log);
-                            }
-                            break;
+                        } else {
+                            // #270: Remote deliverable build. Note: deliverable
+                            // defs live in StructureRegistry (not ShipDesignRegistry),
+                            // so the current arrival handler can't re-resolve them.
+                            // Work around by sending a minimal dispatch that will
+                            // warn; proper deliverable-registry handling is a
+                            // follow-up. TODO(#270-followup).
+                            let _ = (display_name, m_cost, e_cost, build_time);
+                            dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                                target_system: sel_entity,
+                                command: crate::communication::ColonyCommand {
+                                    target_planet: None,
+                                    kind: crate::communication::ColonyCommandKind::QueueShipBuild {
+                                        host_colony: host,
+                                        design_id: def_id.clone(),
+                                        build_kind: crate::colony::BuildKind::Deliverable {
+                                            cargo_size,
+                                        },
+                                    },
+                                },
+                            });
+                            info!("Deliverable build dispatched to remote colony: {}", def_id);
                         }
                     }
                 }

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -149,9 +149,7 @@ pub fn draw_system_panel(
     structure_registry: &StructureRegistry,
     deliverable_avail: &DeliverableAvailabilityCtx<'_>,
     system_actions_out: &mut SystemPanelActions,
-    // #270: Resource used by planet/system/ship UI to queue remote commands.
     dispatches: &mut crate::communication::PendingColonyDispatches,
-    // #270: Read-only view of in-flight commands, for transit feedback.
     remote_commands: &Query<&crate::communication::PendingCommand>,
 ) {
     let Some(sel_entity) = selected_system.0 else {
@@ -1498,17 +1496,12 @@ fn draw_system_map(
     );
 }
 
-/// #270: Render the in-flight remote-commands list for a system. Lists
-/// each `PendingCommand` whose `target_system == sel_entity` with the
-/// remaining hexadies until arrival. Silently collapses to a no-op when
-/// there are no in-flight commands for this system.
 fn draw_in_flight_commands_section(
     ui: &mut egui::Ui,
     sel_entity: Entity,
     remote_commands: &Query<&crate::communication::PendingCommand>,
     clock_elapsed: i64,
 ) {
-    use crate::communication::{ColonyCommandKind, RemoteCommand};
     let mut items: Vec<&crate::communication::PendingCommand> = remote_commands
         .iter()
         .filter(|cmd| cmd.target_system == sel_entity)
@@ -1516,7 +1509,6 @@ fn draw_in_flight_commands_section(
     if items.is_empty() {
         return;
     }
-    // Sort by arrives_at so the next-to-land entry is at the top.
     items.sort_by_key(|c| c.arrives_at);
 
     ui.label(
@@ -1527,35 +1519,8 @@ fn draw_in_flight_commands_section(
     ui.separator();
     for cmd in items {
         let remaining = (cmd.arrives_at - clock_elapsed).max(0);
-        let verb = match &cmd.command {
-            RemoteCommand::Colony(cc) => match &cc.kind {
-                ColonyCommandKind::QueueBuilding { building_id, target_slot } => {
-                    format!("Build {} → slot {}", building_id, target_slot)
-                }
-                ColonyCommandKind::DemolishBuilding { target_slot } => {
-                    format!("Demolish slot {}", target_slot)
-                }
-                ColonyCommandKind::UpgradeBuilding { slot_index, target_id } => {
-                    format!("Upgrade slot {} → {}", slot_index, target_id)
-                }
-                ColonyCommandKind::CancelBuildingOrder { target_slot } => {
-                    format!("Cancel order @ slot {}", target_slot)
-                }
-                ColonyCommandKind::QueueShipBuild { design_id, .. } => {
-                    format!("Build ship: {}", design_id)
-                }
-                ColonyCommandKind::QueueDeliverableBuild { display_name, .. } => {
-                    format!("Build deliverable: {}", display_name)
-                }
-                ColonyCommandKind::CancelShipOrder { queue_index, .. } => {
-                    format!("Cancel ship order [{}]", queue_index)
-                }
-            },
-            RemoteCommand::BuildShip { design_id } => format!("Build ship: {}", design_id),
-            RemoteCommand::SetProductionFocus { .. } => "Set production focus".to_string(),
-        };
         ui.horizontal(|ui| {
-            ui.label(egui::RichText::new(format!("• {}", verb)).weak());
+            ui.label(egui::RichText::new(format!("• {}", cmd.command.describe())).weak());
             ui.label(
                 egui::RichText::new(format!("arrives in {} hd", remaining))
                     .italics()

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -4,7 +4,7 @@ mod planet_window;
 use bevy::prelude::*;
 use bevy_egui::egui;
 
-use crate::colony::{BuildOrder, BuildQueue, BuildingOrder, BuildingQueue, Buildings, Colony, ColonizationQueue, ConstructionParams, DeliverableStockpile, DemolitionOrder, FoodConsumption, MaintenanceCost, Production, ResourceCapacity, ResourceStockpile, SystemBuildings, SystemBuildingQueue, UpgradeOrder};
+use crate::colony::{BuildOrder, BuildQueue, BuildingQueue, Buildings, Colony, ColonizationQueue, ConstructionParams, DeliverableStockpile, FoodConsumption, MaintenanceCost, Production, ResourceCapacity, ResourceStockpile, SystemBuildings, SystemBuildingQueue};
 use crate::condition::{EvalContext, ScopeData};
 use crate::deep_space::{ConstructionPlatform, DeepSpaceStructure, Scrapyard, StructureRegistry};
 use crate::scripting::building_api::{BuildingId, BuildingRegistry};
@@ -371,7 +371,6 @@ pub fn draw_system_panel(
                                         structure_registry,
                                         deliverable_avail,
                                         system_actions_out,
-                                        is_local_system,
                                         dispatches,
                                         remote_commands,
                                         clock.elapsed,
@@ -406,7 +405,6 @@ pub fn draw_system_panel(
         building_registry,
         job_registry,
         colony_panel_tab,
-        is_local_system,
         dispatches,
     );
 }
@@ -670,16 +668,10 @@ fn draw_right_panel(
     structure_registry: &StructureRegistry,
     deliverable_avail: &DeliverableAvailabilityCtx<'_>,
     system_actions_out: &mut SystemPanelActions,
-    // #270: Light-speed command routing.
-    is_local_system: bool,
     dispatches: &mut crate::communication::PendingColonyDispatches,
-    // #270: In-flight commands for the selected system (transit feedback).
     remote_commands: &Query<&crate::communication::PendingCommand>,
     clock_elapsed: i64,
 ) {
-    // #270: In-flight commands for this system (transit feedback). Listed
-    // before the rest of the panel so the player immediately sees feedback
-    // after clicking a build/demolish/upgrade button on a remote system.
     draw_in_flight_commands_section(ui, sel_entity, remote_commands, clock_elapsed);
 
     // === Docked Ships ===
@@ -857,62 +849,28 @@ fn draw_right_panel(
             }
         }
 
-        if let Some((slot_idx, bid)) = sys_demolish_request {
-            if is_local_system {
-                if let Some(mut bq) = sys_bldg_queue {
-                    let def = building_registry.get(bid.as_str());
-                    let (m_refund, e_refund) = def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                    let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
-                    bq.demolition_queue.push(DemolitionOrder {
+        if let Some((slot_idx, _bid)) = sys_demolish_request {
+            dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                target_system: sel_entity,
+                command: crate::communication::ColonyCommand {
+                    target_planet: None,
+                    kind: crate::communication::ColonyCommandKind::DemolishBuilding {
                         target_slot: slot_idx,
-                        building_id: bid.clone(),
-                        time_remaining: demo_time,
-                        minerals_refund: m_refund,
-                        energy_refund: e_refund,
-                    });
-                    info!("System building demolition order added: {} in slot {}", bid, slot_idx);
-                }
-            } else {
-                dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                    target_system: sel_entity,
-                    command: crate::communication::ColonyCommand {
-                        target_planet: None,
-                        kind: crate::communication::ColonyCommandKind::DemolishBuilding {
-                            target_slot: slot_idx,
-                        },
                     },
-                });
-                info!("System building demolition dispatched to remote system (slot {}, {})", slot_idx, bid);
-            }
+                },
+            });
         }
-        if let Some((slot_idx, target_id, minerals, energy, time)) = sys_upgrade_request {
-            if is_local_system {
-                if let Ok((_, Some(mut bq))) = system_buildings_q.get_mut(sel_entity) {
-                    bq.upgrade_queue.push(UpgradeOrder {
+        if let Some((slot_idx, target_id, _, _, _)) = sys_upgrade_request {
+            dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                target_system: sel_entity,
+                command: crate::communication::ColonyCommand {
+                    target_planet: None,
+                    kind: crate::communication::ColonyCommandKind::UpgradeBuilding {
                         slot_index: slot_idx,
-                        target_id: BuildingId::new(&target_id),
-                        minerals_remaining: minerals,
-                        energy_remaining: energy,
-                        build_time_remaining: time,
-                    });
-                    info!("System building upgrade order added: {} in slot {}", target_id, slot_idx);
-                }
-            } else {
-                // #270: Remote path discards pre-computed cost/time; arrival
-                // re-resolves them from the UpgradePath at the target.
-                let _ = (minerals, energy, time);
-                dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                    target_system: sel_entity,
-                    command: crate::communication::ColonyCommand {
-                        target_planet: None,
-                        kind: crate::communication::ColonyCommandKind::UpgradeBuilding {
-                            slot_index: slot_idx,
-                            target_id: target_id.clone(),
-                        },
+                        target_id,
                     },
-                });
-                info!("System building upgrade dispatched to remote system (slot {} -> {})", slot_idx, target_id);
-            }
+                },
+            });
         }
 
         // Build system building buttons
@@ -944,36 +902,16 @@ fn draw_right_panel(
                     }
                 }
                 if let Some(bid) = build_sys_building_request {
-                    if is_local_system {
-                        if let Ok((_, Some(mut bq))) = system_buildings_q.get_mut(sel_entity) {
-                            let def = building_registry.get(bid.as_str());
-                            let (base_m, base_e) = def.map(|d| d.build_cost()).unwrap_or((Amt::ZERO, Amt::ZERO));
-                            let base_time = def.map(|d| d.build_time).unwrap_or(10);
-                            let eff_m = base_m.mul_amt(bldg_cost_mod);
-                            let eff_e = base_e.mul_amt(bldg_cost_mod);
-                            let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
-                            bq.queue.push(BuildingOrder {
-                                building_id: bid.clone(),
+                    dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                        target_system: sel_entity,
+                        command: crate::communication::ColonyCommand {
+                            target_planet: None,
+                            kind: crate::communication::ColonyCommandKind::QueueBuilding {
+                                building_id: bid.0,
                                 target_slot: slot_idx,
-                                minerals_remaining: eff_m,
-                                energy_remaining: eff_e,
-                                build_time_remaining: eff_time,
-                            });
-                            info!("System building order added: {} in slot {}", bid, slot_idx);
-                        }
-                    } else {
-                        dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                            target_system: sel_entity,
-                            command: crate::communication::ColonyCommand {
-                                target_planet: None,
-                                kind: crate::communication::ColonyCommandKind::QueueBuilding {
-                                    building_id: bid.0.clone(),
-                                    target_slot: slot_idx,
-                                },
                             },
-                        });
-                        info!("System building dispatched to remote system (slot {}, {})", slot_idx, bid);
-                    }
+                        },
+                    });
                 }
             }
         }
@@ -1125,52 +1063,20 @@ fn draw_right_panel(
                     });
                 }
 
-                if let Some((design_id, display_name, minerals_cost, energy_cost, build_time)) =
+                if let Some((design_id, _display_name, _minerals_cost, _energy_cost, _build_time)) =
                     build_request
                 {
-                    if is_local_system {
-                        // Re-query mutably to push the order onto the host colony's BuildQueue.
-                        let display_name_log = display_name.clone();
-                        for (colony_entity, _c, _prod, mut build_queue, _b, _bq, _m, _f) in
-                            colonies.iter_mut()
-                        {
-                            if colony_entity != host {
-                                continue;
-                            }
-                            if let Some(bq) = build_queue.as_mut() {
-                                bq.queue.push(BuildOrder {
-                                    kind: crate::colony::BuildKind::default(),
-                                    design_id: design_id.clone(),
-                                    display_name: display_name.clone(),
-                                    minerals_cost,
-                                    minerals_invested: Amt::ZERO,
-                                    energy_cost,
-                                    energy_invested: Amt::ZERO,
-                                    build_time_total: build_time,
-                                    build_time_remaining: build_time,
-                                });
-                                info!("Build order added: {}", display_name_log);
-                            }
-                            break;
-                        }
-                    } else {
-                        // #270: Remote ship build. Arrival re-resolves cost /
-                        // time from ShipDesignRegistry (modifiers not applied
-                        // — ship builds have no empire modifier yet).
-                        let _ = (minerals_cost, energy_cost, build_time, display_name);
-                        dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                            target_system: sel_entity,
-                            command: crate::communication::ColonyCommand {
-                                target_planet: None,
-                                kind: crate::communication::ColonyCommandKind::QueueShipBuild {
-                                    host_colony: host,
-                                    design_id: design_id.clone(),
-                                    build_kind: crate::colony::BuildKind::Ship,
-                                },
+                    dispatches.queue.push(crate::communication::PendingColonyDispatch {
+                        target_system: sel_entity,
+                        command: crate::communication::ColonyCommand {
+                            target_planet: None,
+                            kind: crate::communication::ColonyCommandKind::QueueShipBuild {
+                                host_colony: host,
+                                design_id,
+                                build_kind: crate::colony::BuildKind::Ship,
                             },
-                        });
-                        info!("Ship build dispatched to remote colony: {}", design_id);
-                    }
+                        },
+                    });
                 }
 
                 // #229: Deliverables — shipyard-buildable deep-space structures.
@@ -1226,55 +1132,32 @@ fn draw_right_panel(
                             });
                         });
 
+                    // #270: Deliverable dispatch wiring lands in Commit H
+                    // (QueueDeliverableBuild payload variant). Until then,
+                    // deliverable pushes go directly to the host BuildQueue.
                     if let Some((def_id, display_name, cargo_size, m_cost, e_cost, build_time)) =
                         deliverable_request
                     {
-                        if is_local_system {
-                            let display_name_log = display_name.clone();
-                            for (colony_entity, _c, _prod, mut build_queue, _b, _bq, _m, _f) in
-                                colonies.iter_mut()
-                            {
-                                if colony_entity != host {
-                                    continue;
-                                }
-                                if let Some(bq) = build_queue.as_mut() {
-                                    bq.queue.push(BuildOrder {
-                                        kind: crate::colony::BuildKind::Deliverable { cargo_size },
-                                        design_id: def_id.clone(),
-                                        display_name: display_name.clone(),
-                                        minerals_cost: m_cost,
-                                        minerals_invested: Amt::ZERO,
-                                        energy_cost: e_cost,
-                                        energy_invested: Amt::ZERO,
-                                        build_time_total: build_time,
-                                        build_time_remaining: build_time,
-                                    });
-                                    info!("Deliverable order added: {}", display_name_log);
-                                }
-                                break;
+                        for (colony_entity, _c, _prod, mut build_queue, _b, _bq, _m, _f) in
+                            colonies.iter_mut()
+                        {
+                            if colony_entity != host {
+                                continue;
                             }
-                        } else {
-                            // #270: Remote deliverable build. Note: deliverable
-                            // defs live in StructureRegistry (not ShipDesignRegistry),
-                            // so the current arrival handler can't re-resolve them.
-                            // Work around by sending a minimal dispatch that will
-                            // warn; proper deliverable-registry handling is a
-                            // follow-up. TODO(#270-followup).
-                            let _ = (display_name, m_cost, e_cost, build_time);
-                            dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                                target_system: sel_entity,
-                                command: crate::communication::ColonyCommand {
-                                    target_planet: None,
-                                    kind: crate::communication::ColonyCommandKind::QueueShipBuild {
-                                        host_colony: host,
-                                        design_id: def_id.clone(),
-                                        build_kind: crate::colony::BuildKind::Deliverable {
-                                            cargo_size,
-                                        },
-                                    },
-                                },
-                            });
-                            info!("Deliverable build dispatched to remote colony: {}", def_id);
+                            if let Some(bq) = build_queue.as_mut() {
+                                bq.queue.push(BuildOrder {
+                                    kind: crate::colony::BuildKind::Deliverable { cargo_size },
+                                    design_id: def_id,
+                                    display_name,
+                                    minerals_cost: m_cost,
+                                    minerals_invested: Amt::ZERO,
+                                    energy_cost: e_cost,
+                                    energy_invested: Amt::ZERO,
+                                    build_time_total: build_time,
+                                    build_time_remaining: build_time,
+                                });
+                            }
+                            break;
                         }
                     }
                 }

--- a/macrocosmo/src/ui/system_panel/planet_window.rs
+++ b/macrocosmo/src/ui/system_panel/planet_window.rs
@@ -47,8 +47,6 @@ pub(super) fn draw_planet_window(
     building_registry: &BuildingRegistry,
     job_registry: &crate::species::JobRegistry,
     colony_panel_tab: &mut crate::ui::ColonyPanelTab,
-    // #270: Light-speed command routing propagated from draw_main_panels_system.
-    is_local_system: bool,
     dispatches: &mut PendingColonyDispatches,
 ) {
     let Some(sel_planet_entity) = selected_planet.0 else {
@@ -118,7 +116,6 @@ pub(super) fn draw_planet_window(
                             building_registry,
                             job_registry,
                             colony_panel_tab,
-                            is_local_system,
                             dispatches,
                         );
                     });

--- a/macrocosmo/src/ui/system_panel/planet_window.rs
+++ b/macrocosmo/src/ui/system_panel/planet_window.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 use bevy_egui::egui;
 
 use crate::colony::{BuildQueue, BuildingQueue, Buildings, Colony, ConstructionParams, FoodConsumption, MaintenanceCost, Production, ResourceCapacity, ResourceStockpile};
+use crate::communication::PendingColonyDispatches;
 use crate::scripting::building_api::BuildingRegistry;
 use crate::galaxy::{Planet, StarSystem, SystemAttributes};
 use crate::ship::{Cargo, Ship, ShipHitpoints, ShipState, SurveyData};
@@ -46,6 +47,9 @@ pub(super) fn draw_planet_window(
     building_registry: &BuildingRegistry,
     job_registry: &crate::species::JobRegistry,
     colony_panel_tab: &mut crate::ui::ColonyPanelTab,
+    // #270: Light-speed command routing propagated from draw_main_panels_system.
+    is_local_system: bool,
+    dispatches: &mut PendingColonyDispatches,
 ) {
     let Some(sel_planet_entity) = selected_planet.0 else {
         return;
@@ -114,6 +118,8 @@ pub(super) fn draw_planet_window(
                             building_registry,
                             job_registry,
                             colony_panel_tab,
+                            is_local_system,
+                            dispatches,
                         );
                     });
             } else {

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -562,13 +562,16 @@ pub fn full_test_app() -> App {
     );
 
     // --- Communication systems (from CommunicationPlugin) ---
+    app.init_resource::<communication::PendingColonyDispatches>();
     app.add_systems(
         Update,
         (
             communication::process_messages,
             communication::process_courier_ships,
+            communication::dispatch_pending_colony_commands,
             communication::process_pending_commands,
-        ),
+        )
+            .chain(),
     );
 
     // --- Technology resources ---

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -1,0 +1,468 @@
+//! #270: Integration tests for `RemoteCommand::Colony` arrival dispatcher.
+//!
+//! Each test spawns a `PendingCommand` directly (bypassing UI dispatch —
+//! that's covered by later commits) and verifies the arrival handler
+//! mutates the target queues correctly when the clock advances past
+//! `arrives_at`.
+
+mod common;
+
+use bevy::prelude::*;
+
+use macrocosmo::amount::Amt;
+use macrocosmo::colony::{BuildKind, BuildQueue, BuildingQueue, SystemBuildingQueue};
+use macrocosmo::communication::{
+    self, ColonyCommand, ColonyCommandKind, CommandLog, PendingCommand, RemoteCommand,
+};
+use macrocosmo::player::PlayerEmpire;
+use macrocosmo::scripting::building_api::BuildingId;
+
+use common::{
+    advance_time, empire_entity, spawn_test_colony, spawn_test_system_with_planet, test_app,
+};
+
+/// Wire `process_pending_commands` into a bare `test_app()` — only this
+/// system is needed, no need to pay the cost of `full_test_app()`.
+fn build_app() -> App {
+    let mut app = test_app();
+    app.add_systems(
+        Update,
+        communication::process_pending_commands
+            .after(macrocosmo::time_system::advance_game_time),
+    );
+    app
+}
+
+fn spawn_pending_colony_command(
+    app: &mut App,
+    target_system: Entity,
+    sent_at: i64,
+    arrives_at: i64,
+    cmd: ColonyCommand,
+) {
+    app.world_mut().spawn(PendingCommand {
+        target_system,
+        command: RemoteCommand::Colony(cmd),
+        sent_at,
+        arrives_at,
+        origin_pos: [0.0, 0.0, 0.0],
+        destination_pos: [0.0, 0.0, 0.0],
+    });
+    // Also register a matching CommandLog entry so the arrival code finds
+    // something to mark as arrived. (Not strictly required for dispatch
+    // tests — the arrival handler despawns regardless — but mirrors
+    // production where `send_remote_command` records the entry.)
+    let empire = empire_entity(app.world_mut());
+    if let Some(mut log) = app.world_mut().get_mut::<CommandLog>(empire) {
+        log.entries.push(macrocosmo::communication::CommandLogEntry {
+            description: "test".to_string(),
+            sent_at,
+            arrives_at,
+            arrived: false,
+        });
+    }
+}
+
+/// Position the clock one tick before arrival and advance by exactly 1
+/// hexadies, so the resulting `delta` seen by production/build-tick systems
+/// is 1. Without the `LastProductionTick` alignment, the tick systems would
+/// see `delta = arrives_at - 0` and complete arbitrarily cheap buildings in
+/// a single frame — this fixture focuses on the arrival dispatcher's
+/// enqueue step, not downstream build completion.
+fn run_until_arrival(app: &mut App, arrives_at: i64) {
+    let pre = arrives_at - 1;
+    app.world_mut()
+        .resource_mut::<macrocosmo::time_system::GameClock>()
+        .elapsed = pre;
+    app.world_mut()
+        .resource_mut::<macrocosmo::colony::LastProductionTick>()
+        .0 = pre;
+    advance_time(app, 1);
+}
+
+// --------------------------------------------------------------------------
+// QueueBuilding
+// --------------------------------------------------------------------------
+
+#[test]
+fn queue_building_planet_arrives_and_enqueues() {
+    let mut app = build_app();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        10,
+        ColonyCommand {
+            target_planet: Some(planet),
+            kind: ColonyCommandKind::QueueBuilding {
+                building_id: "mine".to_string(),
+                target_slot: 1,
+            },
+        },
+    );
+
+    // Before arrival the queue should be empty.
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert!(bq.queue.is_empty(), "queue should be empty before arrival");
+
+    run_until_arrival(&mut app, 10);
+
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert_eq!(bq.queue.len(), 1, "one BuildingOrder should be enqueued");
+    assert_eq!(bq.queue[0].target_slot, 1);
+    assert_eq!(bq.queue[0].building_id.as_str(), "mine");
+}
+
+#[test]
+fn queue_building_system_arrives_and_enqueues() {
+    let mut app = build_app();
+    let (sys, _planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    // spawn_test_colony also attaches SystemBuildings/SystemBuildingQueue to
+    // the system entity.
+    let _colony = spawn_test_colony(
+        app.world_mut(),
+        sys,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![],
+    );
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        10,
+        ColonyCommand {
+            target_planet: None,
+            kind: ColonyCommandKind::QueueBuilding {
+                building_id: "shipyard".to_string(),
+                target_slot: 0,
+            },
+        },
+    );
+
+    run_until_arrival(&mut app, 10);
+
+    let sbq = app.world().get::<SystemBuildingQueue>(sys).unwrap();
+    assert_eq!(sbq.queue.len(), 1);
+    assert_eq!(sbq.queue[0].target_slot, 0);
+    assert_eq!(sbq.queue[0].building_id.as_str(), "shipyard");
+}
+
+// --------------------------------------------------------------------------
+// DemolishBuilding
+// --------------------------------------------------------------------------
+
+#[test]
+fn demolish_building_planet_arrives_and_enqueues() {
+    let mut app = build_app();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![Some(BuildingId::new("mine")), None, None, None],
+    );
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        5,
+        ColonyCommand {
+            target_planet: Some(planet),
+            kind: ColonyCommandKind::DemolishBuilding { target_slot: 0 },
+        },
+    );
+
+    run_until_arrival(&mut app, 5);
+
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert_eq!(bq.demolition_queue.len(), 1);
+    assert_eq!(bq.demolition_queue[0].target_slot, 0);
+    assert_eq!(bq.demolition_queue[0].building_id.as_str(), "mine");
+    // Demolition time starts at build_time/2 = 5 (mine: build_time=10). The
+    // single tick_building_queue pass that happens within this `advance_time(1)`
+    // subtracts `delta=1`, so the observed value is 4.
+    assert_eq!(bq.demolition_queue[0].time_remaining, 4);
+}
+
+// --------------------------------------------------------------------------
+// UpgradeBuilding
+// --------------------------------------------------------------------------
+
+#[test]
+fn upgrade_building_planet_without_path_warns_and_noops() {
+    // The test building registry does not include upgrade_to paths, so a
+    // naive upgrade request should warn but not enqueue anything. This
+    // verifies the path-lookup branch.
+    let mut app = build_app();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![Some(BuildingId::new("mine")), None, None, None],
+    );
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        5,
+        ColonyCommand {
+            target_planet: Some(planet),
+            kind: ColonyCommandKind::UpgradeBuilding {
+                slot_index: 0,
+                target_id: "advanced_mine".to_string(),
+            },
+        },
+    );
+
+    run_until_arrival(&mut app, 5);
+
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert!(
+        bq.upgrade_queue.is_empty(),
+        "upgrade_queue should stay empty when no upgrade_to path matches"
+    );
+}
+
+// --------------------------------------------------------------------------
+// CancelBuildingOrder
+// --------------------------------------------------------------------------
+
+#[test]
+fn cancel_building_order_planet_removes_matching_slot() {
+    let mut app = build_app();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+
+    // Pre-populate the queue with an order for slot 2.
+    {
+        let mut bq = app.world_mut().get_mut::<BuildingQueue>(colony).unwrap();
+        bq.queue.push(macrocosmo::colony::BuildingOrder {
+            building_id: BuildingId::new("mine"),
+            target_slot: 2,
+            minerals_remaining: Amt::units(150),
+            energy_remaining: Amt::units(50),
+            build_time_remaining: 10,
+        });
+    }
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        5,
+        ColonyCommand {
+            target_planet: Some(planet),
+            kind: ColonyCommandKind::CancelBuildingOrder { target_slot: 2 },
+        },
+    );
+
+    run_until_arrival(&mut app, 5);
+
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert!(
+        bq.queue.is_empty(),
+        "queue entry matching slot 2 should be removed on arrival"
+    );
+}
+
+// --------------------------------------------------------------------------
+// QueueShipBuild
+// --------------------------------------------------------------------------
+
+#[test]
+fn queue_ship_build_arrives_and_enqueues() {
+    let mut app = build_app();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(10_000),
+        Amt::units(10_000),
+        vec![],
+    );
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        20,
+        ColonyCommand {
+            target_planet: None,
+            kind: ColonyCommandKind::QueueShipBuild {
+                host_colony: colony,
+                design_id: "explorer_mk1".to_string(),
+                build_kind: BuildKind::Ship,
+            },
+        },
+    );
+
+    run_until_arrival(&mut app, 20);
+
+    let bq = app.world().get::<BuildQueue>(colony).unwrap();
+    assert_eq!(bq.queue.len(), 1, "ship BuildOrder should be enqueued");
+    assert_eq!(bq.queue[0].design_id, "explorer_mk1");
+    assert!(matches!(bq.queue[0].kind, BuildKind::Ship));
+}
+
+// --------------------------------------------------------------------------
+// Timing: commands before arrival do NOT fire
+// --------------------------------------------------------------------------
+
+#[test]
+fn pending_colony_command_not_applied_before_arrival() {
+    let mut app = build_app();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        100,
+        ColonyCommand {
+            target_planet: Some(planet),
+            kind: ColonyCommandKind::QueueBuilding {
+                building_id: "mine".to_string(),
+                target_slot: 0,
+            },
+        },
+    );
+
+    // Advance halfway.
+    app.world_mut()
+        .resource_mut::<macrocosmo::time_system::GameClock>()
+        .elapsed = 50;
+    advance_time(&mut app, 1);
+
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert!(
+        bq.queue.is_empty(),
+        "queue must remain empty until arrives_at"
+    );
+
+    // The PendingCommand entity should still be alive.
+    let alive = app
+        .world_mut()
+        .query::<&PendingCommand>()
+        .iter(app.world())
+        .count();
+    assert_eq!(alive, 1);
+}
+
+// --------------------------------------------------------------------------
+// CommandLog arrival marking
+// --------------------------------------------------------------------------
+
+#[test]
+fn arrival_marks_command_log_entry() {
+    let mut app = build_app();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let _colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        10,
+        ColonyCommand {
+            target_planet: Some(planet),
+            kind: ColonyCommandKind::QueueBuilding {
+                building_id: "mine".to_string(),
+                target_slot: 0,
+            },
+        },
+    );
+
+    run_until_arrival(&mut app, 10);
+
+    // Locate the empire and inspect CommandLog.
+    let mut empire_q = app
+        .world_mut()
+        .query_filtered::<&CommandLog, With<PlayerEmpire>>();
+    let log = empire_q.single(app.world()).expect("empire command log");
+    assert_eq!(log.entries.len(), 1);
+    assert!(log.entries[0].arrived, "entry should be marked arrived");
+}
+

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -12,9 +12,11 @@ use bevy::prelude::*;
 use macrocosmo::amount::Amt;
 use macrocosmo::colony::{BuildKind, BuildQueue, BuildingQueue, SystemBuildingQueue};
 use macrocosmo::communication::{
-    self, ColonyCommand, ColonyCommandKind, CommandLog, PendingCommand, RemoteCommand,
+    self, ColonyCommand, ColonyCommandKind, CommandLog, PendingColonyDispatch,
+    PendingColonyDispatches, PendingCommand, RemoteCommand,
 };
-use macrocosmo::player::PlayerEmpire;
+use macrocosmo::components::Position;
+use macrocosmo::player::{Player, PlayerEmpire, StationedAt};
 use macrocosmo::scripting::building_api::BuildingId;
 
 use common::{
@@ -28,6 +30,23 @@ fn build_app() -> App {
     app.add_systems(
         Update,
         communication::process_pending_commands
+            .after(macrocosmo::time_system::advance_game_time),
+    );
+    app
+}
+
+/// Build an app with the full communication dispatch chain wired in. Used
+/// by the tests that exercise the UI-push-to-arrival pipeline (Commit C).
+fn build_app_with_dispatch() -> App {
+    let mut app = test_app();
+    app.init_resource::<PendingColonyDispatches>();
+    app.add_systems(
+        Update,
+        (
+            communication::dispatch_pending_colony_commands,
+            communication::process_pending_commands,
+        )
+            .chain()
             .after(macrocosmo::time_system::advance_game_time),
     );
     app
@@ -417,6 +436,158 @@ fn pending_colony_command_not_applied_before_arrival() {
         .iter(app.world())
         .count();
     assert_eq!(alive, 1);
+}
+
+// --------------------------------------------------------------------------
+// UI dispatch pipeline (Commit C): UI push → send_remote_command → arrival
+// --------------------------------------------------------------------------
+
+/// Local dispatch: player is at the target system, so the light-speed delay
+/// is zero and the command applies the same frame it's pushed.
+#[test]
+fn local_dispatch_applies_same_frame() {
+    let mut app = build_app_with_dispatch();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Home",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys }));
+
+    app.world_mut()
+        .resource_mut::<PendingColonyDispatches>()
+        .queue
+        .push(PendingColonyDispatch {
+            target_system: sys,
+            command: ColonyCommand {
+                target_planet: Some(planet),
+                kind: ColonyCommandKind::QueueBuilding {
+                    building_id: "mine".to_string(),
+                    target_slot: 0,
+                },
+            },
+        });
+
+    // Align LastProductionTick so the build queue tick sees delta=1.
+    app.world_mut()
+        .resource_mut::<macrocosmo::colony::LastProductionTick>()
+        .0 = 0;
+    advance_time(&mut app, 1);
+
+    let bq = app
+        .world()
+        .get::<macrocosmo::colony::BuildingQueue>(colony)
+        .unwrap();
+    // Either the order is in the queue or already in the slot if cost+time
+    // completed in the single tick. Verify progression.
+    let present_in_queue = bq.queue.iter().any(|o| o.target_slot == 0);
+    let present_in_slot = app
+        .world()
+        .get::<macrocosmo::colony::Buildings>(colony)
+        .map(|b| b.slots.get(0).and_then(|s| s.as_ref()).is_some())
+        .unwrap_or(false);
+    assert!(
+        present_in_queue || present_in_slot,
+        "local dispatch should result in queued (or completed) order by next frame"
+    );
+}
+
+/// Remote dispatch: player is 10 ly away → ~600 hd light delay. Command
+/// should NOT apply until the clock advances past `arrives_at`.
+#[test]
+fn remote_dispatch_delayed_by_light_speed() {
+    let mut app = build_app_with_dispatch();
+    let (home_sys, _home_planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Home",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let (target_sys, target_planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let target_colony = spawn_test_colony(
+        app.world_mut(),
+        target_planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+    app.world_mut()
+        .spawn((Player, StationedAt { system: home_sys }));
+
+    app.world_mut()
+        .resource_mut::<PendingColonyDispatches>()
+        .queue
+        .push(PendingColonyDispatch {
+            target_system: target_sys,
+            command: ColonyCommand {
+                target_planet: Some(target_planet),
+                kind: ColonyCommandKind::QueueBuilding {
+                    building_id: "mine".to_string(),
+                    target_slot: 0,
+                },
+            },
+        });
+
+    // Run one frame. Dispatch drains and spawns PendingCommand;
+    // process_pending_commands sees arrives_at > clock.elapsed and skips.
+    advance_time(&mut app, 1);
+
+    let bq = app
+        .world()
+        .get::<macrocosmo::colony::BuildingQueue>(target_colony)
+        .unwrap();
+    assert!(
+        bq.queue.is_empty(),
+        "remote colony queue should be empty before light delay elapses"
+    );
+
+    let pending_count = app
+        .world_mut()
+        .query::<&PendingCommand>()
+        .iter(app.world())
+        .count();
+    assert_eq!(
+        pending_count, 1,
+        "exactly one in-flight PendingCommand should exist"
+    );
+
+    // Advance past light delay (10 ly => 600 hd). Command was dispatched
+    // during the previous `advance_time(1)` so `sent_at = 1` and
+    // `arrives_at = 1 + 600 = 601`.
+    let arrives_at = 1 + macrocosmo::physics::light_delay_hexadies(10.0);
+    run_until_arrival(&mut app, arrives_at);
+
+    let bq = app
+        .world()
+        .get::<macrocosmo::colony::BuildingQueue>(target_colony)
+        .unwrap();
+    let present_in_queue = bq.queue.iter().any(|o| o.target_slot == 0);
+    let present_in_slot = app
+        .world()
+        .get::<macrocosmo::colony::Buildings>(target_colony)
+        .map(|b| b.slots.get(0).and_then(|s| s.as_ref()).is_some())
+        .unwrap_or(false);
+    assert!(
+        present_in_queue || present_in_slot,
+        "remote command should apply once clock reaches arrives_at"
+    );
 }
 
 // --------------------------------------------------------------------------

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -82,12 +82,14 @@ fn spawn_pending_colony_command(
     }
 }
 
-/// Position the clock one tick before arrival and advance by exactly 1
-/// hexadies, so the resulting `delta` seen by production/build-tick systems
-/// is 1. Without the `LastProductionTick` alignment, the tick systems would
-/// see `delta = arrives_at - 0` and complete arbitrarily cheap buildings in
-/// a single frame — this fixture focuses on the arrival dispatcher's
-/// enqueue step, not downstream build completion.
+/// Jump the clock to the frame of arrival. Tests here fast-forward from
+/// t=0 to t=arrives_at (which may be hundreds of hd for remote commands),
+/// so we also pin `LastProductionTick` to keep the build-tick `delta` at
+/// 1 — otherwise tick_building_queue would "catch up" 600 iterations in
+/// one frame and complete arbitrarily cheap orders before the assertions
+/// run. This is about delta management during fast-forward, not the
+/// arrival-vs-consumption ordering invariant (which is enforced in the
+/// production schedule via `tick_building_queue.after(process_pending_commands)`).
 fn run_until_arrival(app: &mut App, arrives_at: i64) {
     let pre = arrives_at - 1;
     app.world_mut()

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -590,6 +590,85 @@ fn remote_dispatch_delayed_by_light_speed() {
     );
 }
 
+/// Remote system-level dispatch (Commit D): `target_planet: None` targets
+/// the `SystemBuildingQueue` on the target system.
+#[test]
+fn remote_system_level_dispatch_delayed() {
+    let mut app = build_app_with_dispatch();
+    let (home_sys, _home_planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Home",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let (target_sys, _target_planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    // spawn_test_colony attaches SystemBuildings/SystemBuildingQueue to the
+    // star system entity.
+    let _target_colony = spawn_test_colony(
+        app.world_mut(),
+        target_sys,
+        Amt::units(10_000),
+        Amt::units(10_000),
+        vec![],
+    );
+    app.world_mut()
+        .spawn((Player, StationedAt { system: home_sys }));
+
+    app.world_mut()
+        .resource_mut::<PendingColonyDispatches>()
+        .queue
+        .push(PendingColonyDispatch {
+            target_system: target_sys,
+            command: ColonyCommand {
+                target_planet: None,
+                kind: ColonyCommandKind::QueueBuilding {
+                    building_id: "shipyard".to_string(),
+                    target_slot: 0,
+                },
+            },
+        });
+
+    advance_time(&mut app, 1);
+
+    let sbq = app
+        .world()
+        .get::<SystemBuildingQueue>(target_sys)
+        .unwrap();
+    assert!(
+        sbq.queue.is_empty(),
+        "remote system queue should be empty before light delay"
+    );
+
+    let arrives_at = 1 + macrocosmo::physics::light_delay_hexadies(10.0);
+    run_until_arrival(&mut app, arrives_at);
+
+    let sbq = app
+        .world()
+        .get::<SystemBuildingQueue>(target_sys)
+        .unwrap();
+    let sys_bldgs = app
+        .world()
+        .get::<macrocosmo::colony::SystemBuildings>(target_sys)
+        .unwrap();
+    let present = sbq.queue.iter().any(|o| o.target_slot == 0)
+        || sys_bldgs
+            .slots
+            .get(0)
+            .and_then(|s| s.as_ref())
+            .is_some();
+    assert!(
+        present,
+        "remote system-level command should apply once clock reaches arrives_at"
+    );
+}
+
 // --------------------------------------------------------------------------
 // CommandLog arrival marking
 // --------------------------------------------------------------------------

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -669,6 +669,70 @@ fn remote_system_level_dispatch_delayed() {
     );
 }
 
+/// Remote ship-build dispatch (Commit E): `QueueShipBuild { host_colony }`
+/// targets a specific colony's ship `BuildQueue` after light-speed delay.
+#[test]
+fn remote_ship_build_dispatch_delayed() {
+    let mut app = build_app_with_dispatch();
+    let (home_sys, _home_planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Home",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let (target_sys, target_planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let target_colony = spawn_test_colony(
+        app.world_mut(),
+        target_planet,
+        Amt::units(10_000),
+        Amt::units(10_000),
+        vec![],
+    );
+    app.world_mut()
+        .spawn((Player, StationedAt { system: home_sys }));
+
+    app.world_mut()
+        .resource_mut::<PendingColonyDispatches>()
+        .queue
+        .push(PendingColonyDispatch {
+            target_system: target_sys,
+            command: ColonyCommand {
+                target_planet: None,
+                kind: ColonyCommandKind::QueueShipBuild {
+                    host_colony: target_colony,
+                    design_id: "explorer_mk1".to_string(),
+                    build_kind: BuildKind::Ship,
+                },
+            },
+        });
+
+    advance_time(&mut app, 1);
+
+    let bq = app.world().get::<BuildQueue>(target_colony).unwrap();
+    assert!(
+        bq.queue.is_empty(),
+        "remote ship BuildQueue should be empty before light delay"
+    );
+
+    let arrives_at = 1 + macrocosmo::physics::light_delay_hexadies(10.0);
+    run_until_arrival(&mut app, arrives_at);
+
+    let bq = app.world().get::<BuildQueue>(target_colony).unwrap();
+    assert_eq!(
+        bq.queue.len(),
+        1,
+        "remote ship build should arrive and enqueue"
+    );
+    assert_eq!(bq.queue[0].design_id, "explorer_mk1");
+}
+
 // --------------------------------------------------------------------------
 // CommandLog arrival marking
 // --------------------------------------------------------------------------

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -381,6 +381,60 @@ fn queue_ship_build_arrives_and_enqueues() {
     assert!(matches!(bq.queue[0].kind, BuildKind::Ship));
 }
 
+/// #270 Commit H: Deliverable dispatch carries full payload so arrival
+/// doesn't need StructureRegistry access. Verify a
+/// `QueueDeliverableBuild` lands a `BuildOrder` with
+/// `kind: BuildKind::Deliverable { cargo_size }` on the host colony.
+#[test]
+fn queue_deliverable_build_arrives_and_enqueues() {
+    let mut app = build_app();
+    let (sys, planet) = spawn_test_system_with_planet(
+        app.world_mut(),
+        "Target",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+    );
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(10_000),
+        Amt::units(10_000),
+        vec![],
+    );
+
+    spawn_pending_colony_command(
+        &mut app,
+        sys,
+        0,
+        20,
+        ColonyCommand {
+            target_planet: None,
+            kind: ColonyCommandKind::QueueDeliverableBuild {
+                host_colony: colony,
+                def_id: "sensor_buoy".to_string(),
+                display_name: "Sensor Buoy".to_string(),
+                cargo_size: 2,
+                minerals_cost: Amt::units(100),
+                energy_cost: Amt::units(50),
+                build_time: 30,
+            },
+        },
+    );
+
+    run_until_arrival(&mut app, 20);
+
+    let bq = app.world().get::<BuildQueue>(colony).unwrap();
+    assert_eq!(bq.queue.len(), 1);
+    assert_eq!(bq.queue[0].design_id, "sensor_buoy");
+    assert!(matches!(
+        bq.queue[0].kind,
+        BuildKind::Deliverable { cargo_size: 2 }
+    ));
+    assert_eq!(bq.queue[0].minerals_cost, Amt::units(100));
+    assert_eq!(bq.queue[0].build_time_total, 30);
+}
+
 // --------------------------------------------------------------------------
 // Timing: commands before arrival do NOT fire
 // --------------------------------------------------------------------------

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -283,60 +283,6 @@ fn upgrade_building_planet_without_path_warns_and_noops() {
 }
 
 // --------------------------------------------------------------------------
-// CancelBuildingOrder
-// --------------------------------------------------------------------------
-
-#[test]
-fn cancel_building_order_planet_removes_matching_slot() {
-    let mut app = build_app();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
-    let colony = spawn_test_colony(
-        app.world_mut(),
-        planet,
-        Amt::units(1000),
-        Amt::units(1000),
-        vec![None, None, None, None],
-    );
-
-    // Pre-populate the queue with an order for slot 2.
-    {
-        let mut bq = app.world_mut().get_mut::<BuildingQueue>(colony).unwrap();
-        bq.queue.push(macrocosmo::colony::BuildingOrder {
-            building_id: BuildingId::new("mine"),
-            target_slot: 2,
-            minerals_remaining: Amt::units(150),
-            energy_remaining: Amt::units(50),
-            build_time_remaining: 10,
-        });
-    }
-
-    spawn_pending_colony_command(
-        &mut app,
-        sys,
-        0,
-        5,
-        ColonyCommand {
-            target_planet: Some(planet),
-            kind: ColonyCommandKind::CancelBuildingOrder { target_slot: 2 },
-        },
-    );
-
-    run_until_arrival(&mut app, 5);
-
-    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
-    assert!(
-        bq.queue.is_empty(),
-        "queue entry matching slot 2 should be removed on arrival"
-    );
-}
-
-// --------------------------------------------------------------------------
 // QueueShipBuild
 // --------------------------------------------------------------------------
 

--- a/macrocosmo/tests/save_load.rs
+++ b/macrocosmo/tests/save_load.rs
@@ -915,3 +915,87 @@ fn test_save_load_deterministic_continuation() {
     );
 }
 
+/// #270: In-flight `PendingCommand::Colony` entities must survive the real
+/// save/load path — the savebag-struct-only roundtrip test in
+/// `persistence::savebag::tests` doesn't exercise `EntityMap` binding
+/// coverage on live entity save-ids. This test spawns a command whose
+/// payload references a `host_colony` Entity, saves the whole world, loads
+/// into a fresh one, and verifies the remapped Entity is still valid.
+#[test]
+fn test_save_load_preserves_pending_colony_command() {
+    use macrocosmo::communication::{ColonyCommand, ColonyCommandKind, PendingCommand, RemoteCommand};
+    let mut src = build_seed_world();
+
+    // Pick two systems and a colony to reference.
+    let (sol, alpha_centauri) = {
+        let mut q = src.query::<(Entity, &StarSystem)>();
+        let mut sol = None;
+        let mut alpha = None;
+        for (e, s) in q.iter(&src) {
+            match s.name.as_str() {
+                "Sol" => sol = Some(e),
+                "Alpha Centauri" => alpha = Some(e),
+                _ => {}
+            }
+        }
+        (sol.unwrap(), alpha.unwrap())
+    };
+    let colony_entity = src
+        .query::<(Entity, &Colony)>()
+        .iter(&src)
+        .next()
+        .map(|(e, _)| e)
+        .expect("build_seed_world spawned a colony");
+
+    src.spawn(PendingCommand {
+        target_system: alpha_centauri,
+        command: RemoteCommand::Colony(ColonyCommand {
+            target_planet: None,
+            kind: ColonyCommandKind::QueueShipBuild {
+                host_colony: colony_entity,
+                design_id: "explorer_mk1".into(),
+                build_kind: macrocosmo::colony::BuildKind::Ship,
+            },
+        }),
+        sent_at: 100,
+        arrives_at: 700,
+        origin_pos: [0.0, 0.0, 0.0],
+        destination_pos: [4.3, 0.0, 0.0],
+    });
+    let _ = sol;
+
+    let bytes = round_trip_bytes(&mut src);
+    let mut dst = World::new();
+    load_game_from_reader(&mut dst, &bytes[..]).expect("load");
+
+    // Resolve the remapped Alpha Centauri + colony so we can compare.
+    let alpha_dst = dst
+        .query::<(Entity, &StarSystem)>()
+        .iter(&dst)
+        .find(|(_, s)| s.name == "Alpha Centauri")
+        .map(|(e, _)| e)
+        .unwrap();
+    let colony_dst = dst
+        .query::<(Entity, &Colony)>()
+        .iter(&dst)
+        .next()
+        .map(|(e, _)| e)
+        .expect("colony must round-trip");
+
+    let mut q = dst.query::<&PendingCommand>();
+    let cmd = q.iter(&dst).next().expect("pending command must round-trip");
+    assert_eq!(cmd.target_system, alpha_dst, "target_system Entity remap");
+    assert_eq!(cmd.sent_at, 100);
+    assert_eq!(cmd.arrives_at, 700);
+    match &cmd.command {
+        RemoteCommand::Colony(ColonyCommand {
+            target_planet: None,
+            kind: ColonyCommandKind::QueueShipBuild { host_colony, design_id, .. },
+        }) => {
+            assert_eq!(*host_colony, colony_dst, "host_colony Entity remap");
+            assert_eq!(design_id, "explorer_mk1");
+        }
+        other => panic!("unexpected command variant after load: {:?}", other),
+    }
+}
+


### PR DESCRIPTION
## Summary

Fixes the core game mechanic violation in #270: build/demolish/upgrade/ship-build commands issued to remote colonies used to apply **immediately**, bypassing the light-speed constraint that's central to Macrocosmo's design. Commands now flow through `PendingCommand` + `dispatch_pending_colony_commands` → `process_pending_commands`, taking `physics::light_delay_hexadies(distance)` to arrive.

Commits A-F implement the core fix; G-J are the adversarial-review follow-up pass (BLOCKER B1 + simplification + cleanup + tests).

## What lands

**Pipeline**
- New `RemoteCommand::Colony(ColonyCommand)` variant + `ColonyCommandKind` with 5 payload-minimal variants (`QueueBuilding`, `DemolishBuilding`, `UpgradeBuilding`, `QueueShipBuild`, `QueueDeliverableBuild`).
- New `PendingColonyDispatches` resource; UI code pushes `PendingColonyDispatch { target_system, command }` entries from egui systems; `dispatch_pending_colony_commands` drains them in `Update` and spawns `PendingCommand` entities with light-speed delay (zero for local).
- `process_pending_commands` arrival handler (`apply_colony_command`) re-resolves cost/time/refund from the target's current `BuildingRegistry` + `ConstructionParams` for buildings, `ShipDesignRegistry` for ships, and uses the pre-computed payload directly for deliverables (their defs live in `StructureRegistry`).

**UI**
- Single unified dispatch path — no `is_local_system` write-side branching. Eight UI push sites in `colony_detail.rs` + `system_panel/mod.rs` now all go through `PendingColonyDispatches`.
- New "In-flight Commands" section at the top of the system right panel showing remaining hd per in-flight `PendingCommand` targeting the selected system. Uses the shared `RemoteCommand::describe()` formatter.
- `CommandLog` entries now use `describe()` instead of `format!("{:?}", ...)`, so the bottom-bar log reads as `"Build mine → slot 1"` instead of raw Debug output.

**Persistence**
- `SavedColonyCommand` + `SavedColonyCommandKind` mirror structs; Entity fields stored as `u64` bits and remapped via `EntityMap` on load.
- `SavedRemoteCommand::into_live(map)` replaces the old `From<SavedRemoteCommand>` impl so entity remap can flow through `SavedPendingCommand::into_live`.

**Schedule ordering**
- `tick_building_queue` / `tick_system_building_queue` run `.after(process_pending_commands)` so same-frame arrivals are enqueued before the build tick consumes them.

## Acceptance criteria (#270)

- ✅ Remote system への建造物建設命令が光速遅延後に適用される
- ✅ Remote demolition / upgrade / ship build も遅延
- ✅ Remote deliverable build も同じ (Commit H で BLOCKER B1 修正)
- ✅ ローカル system は即時適用 (distance=0 で light_delay=0、同じパイプライン)
- ✅ UI に "dispatched, arrives in N hd" の transit 表示
- ✅ Save/load 対応 (savebag roundtrip + 実 save/load path のE2E test)
- ⏭ Cancel command dedup by id — deferred; CommandId は #268 で扱う想定。Cancel UI も未実装で、未使用の `Cancel*` variant は本PRで削除

## Tests

- 13 integration tests in `macrocosmo/tests/remote_colony_commands.rs` (new)
- 1 E2E save/load test in `macrocosmo/tests/save_load.rs` (new)
- 2 savebag roundtrip tests in `persistence::savebag::tests` (new)
- Full workspace suite: **all pass**, no regressions

## Adversarial review

Two review subagents ran before the cleanup commits (G-J). Summary:
- **BLOCKER B1**: Deliverable remote dispatch silently failed (ShipDesignRegistry has no deliverable defs) — fixed in Commit H with a new `QueueDeliverableBuild` variant carrying the full payload at send time.
- **BLOCKER B2**: UI's `is_local_system` disagreed with dispatcher's `AboardShip`-aware origin resolution — fixed as a side effect of Commit G (single authoritative decider).
- **Design #2**: Local/remote branches duplicated ~120 lines of UI construction code — deleted in Commit G. Net -185 lines.
- **N2**: Unknown-building demolish fell back to free + instant — now warns and drops.
- **N8**: `full_test_app` didn't register the new dispatch system — fixed in Commit J.
- **N9**: Only savebag-struct roundtrip was tested; no real save path exercise — fixed in Commit J.

Follow-ups intentionally deferred (noted in commit messages):
- Design #3 (move `apply_colony_command` from `communication/` to `colony/`) — mechanical move, out of scope
- Design #4 (split `QueueShipBuild` / `QueueDeliverableBuild` out of `ColonyCommand`) — schema polish
- N3, N5 (empire-missing hazards) — pre-existing
- N6, N7 (Cancel variant staleness) — variants deleted in Commit I

## Test plan

- [ ] Open a remote colony panel, click Build Mine — verify "Build mine → slot N arrives in X hd" appears in the In-flight Commands section
- [ ] Advance the clock past arrival — verify the order appears in the colony's BuildingQueue, and the CommandLog entry is marked arrived
- [ ] Same for local colony — should apply within the same Update pass
- [ ] Demolish/Upgrade paths on both local and remote
- [ ] Ship build + deliverable build on both local and remote shipyards
- [ ] Save a game with an in-flight command, load it, advance past arrival — command should still apply

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)