### PR TITLE
#269: Read remote colony detail from KnowledgeStore snapshot

### DIFF
--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -853,7 +853,7 @@ pub fn relay_knowledge_propagate_system(
         Option<&crate::colony::ResourceStockpile>,
         Option<&crate::colony::SystemBuildings>,
     )>,
-    colonies: Query<&crate::colony::Colony>,
+    colonies: crate::knowledge::ColonySnapshotQuery,
     planets: Query<&crate::galaxy::Planet>,
     planet_attrs: Query<(&crate::galaxy::Planet, &crate::galaxy::SystemAttributes)>,
     hostiles: Query<&crate::galaxy::HostilePresence>,

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -333,22 +333,38 @@ fn initialize_capital_knowledge(
 ///
 /// `hostile_map` is an `entity → HostilePresence` lookup the caller builds
 /// once per tick; passing it in lets both call sites share the allocation.
+/// #269: The rich colony query used when building a `SystemSnapshot`. Pulled
+/// out as a type alias so `build_system_snapshot` call sites don't repeat
+/// the whole tuple.
+pub type ColonySnapshotQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        Entity,
+        &'static crate::colony::Colony,
+        Option<&'static crate::colony::Production>,
+        Option<&'static crate::colony::Buildings>,
+        Option<&'static crate::colony::BuildingQueue>,
+        Option<&'static crate::colony::MaintenanceCost>,
+        Option<&'static crate::colony::FoodConsumption>,
+    ),
+>;
+
 pub fn build_system_snapshot(
     entity: Entity,
     star: &StarSystem,
     sys_pos: &Position,
     stockpile: Option<&ResourceStockpile>,
     sys_buildings: Option<&crate::colony::SystemBuildings>,
-    colonies: &Query<&crate::colony::Colony>,
+    colonies: &ColonySnapshotQuery,
     planets: &Query<&crate::galaxy::Planet>,
     planet_attrs: &Query<(&crate::galaxy::Planet, &crate::galaxy::SystemAttributes)>,
     hostile_map: &HashMap<Entity, &crate::galaxy::HostilePresence>,
     building_registry: &crate::colony::BuildingRegistry,
 ) -> SystemSnapshot {
-    // Derive colonized status from whether any colony has a planet in this system
     let is_colonized = colonies
         .iter()
-        .any(|c| c.system(planets) == Some(entity));
+        .any(|(_, c, _, _, _, _, _)| c.system(planets) == Some(entity));
 
     // Resource snapshot from StarSystem's stockpile (#106)
     let (minerals, energy, food, authority) = stockpile
@@ -381,6 +397,8 @@ pub fn build_system_snapshot(
             ))
             .unwrap_or((None, None, None, None, None));
 
+    let colony_snapshots = build_colony_snapshots(entity, colonies, planets, planet_attrs);
+
     SystemSnapshot {
         name: star.name.clone(),
         position: sys_pos.as_array(),
@@ -399,8 +417,100 @@ pub fn build_system_snapshot(
         energy_potential,
         research_potential,
         max_building_slots,
+        colonies: colony_snapshots,
         ..SystemSnapshot::default()
     }
+}
+
+/// #269: Build per-colony snapshots for the colonies living in `system`.
+/// Population, production, maintenance, buildings, and queue contents are
+/// frozen at the current world state — the returned vec becomes the
+/// snapshot the remote colony detail panel reads from.
+fn build_colony_snapshots(
+    system: Entity,
+    colonies: &ColonySnapshotQuery,
+    planets: &Query<&crate::galaxy::Planet>,
+    planet_attrs: &Query<(&crate::galaxy::Planet, &crate::galaxy::SystemAttributes)>,
+) -> Vec<ColonySnapshot> {
+    use crate::galaxy::{BASE_CARRYING_CAPACITY, FOOD_PER_POP_PER_HEXADIES};
+    let mut out = Vec::new();
+    for (colony_entity, colony, production, buildings, bq, maintenance, food) in colonies.iter() {
+        if colony.system(planets) != Some(system) {
+            continue;
+        }
+        let planet_name = planets
+            .get(colony.planet)
+            .ok()
+            .map(|p| p.name.clone())
+            .unwrap_or_default();
+        let habitability = planet_attrs
+            .get(colony.planet)
+            .ok()
+            .map(|(_, a)| a.habitability)
+            .unwrap_or(0.5);
+        let food_prod = production.map(|p| p.food_per_hexadies.final_value()).unwrap_or(Amt::ZERO);
+        let k_habitat = BASE_CARRYING_CAPACITY * habitability;
+        let k_food = if FOOD_PER_POP_PER_HEXADIES.raw() > 0 {
+            food_prod.div_amt(FOOD_PER_POP_PER_HEXADIES).to_f64()
+        } else {
+            k_habitat
+        };
+        let carrying_cap_hint = k_habitat.min(k_food).max(1.0);
+        let build_queue = bq
+            .map(|b| {
+                b.queue
+                    .iter()
+                    .map(|o| BuildQueueEntrySnapshot {
+                        building_id: o.building_id.clone(),
+                        target_slot: o.target_slot,
+                        build_time_remaining: o.build_time_remaining,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let demolition_queue = bq
+            .map(|b| {
+                b.demolition_queue
+                    .iter()
+                    .map(|d| DemolitionSnapshot {
+                        target_slot: d.target_slot,
+                        building_id: d.building_id.clone(),
+                        time_remaining: d.time_remaining,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let upgrade_queue = bq
+            .map(|b| {
+                b.upgrade_queue
+                    .iter()
+                    .map(|u| UpgradeSnapshot {
+                        slot_index: u.slot_index,
+                        target_id: u.target_id.clone(),
+                        build_time_remaining: u.build_time_remaining,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        out.push(ColonySnapshot {
+            colony_entity,
+            planet_entity: colony.planet,
+            planet_name,
+            population: colony.population,
+            carrying_cap_hint,
+            production_minerals: production.map(|p| p.minerals_per_hexadies.final_value()).unwrap_or(Amt::ZERO),
+            production_energy: production.map(|p| p.energy_per_hexadies.final_value()).unwrap_or(Amt::ZERO),
+            production_food: food_prod,
+            production_research: production.map(|p| p.research_per_hexadies.final_value()).unwrap_or(Amt::ZERO),
+            food_consumption: food.map(|f| f.food_per_hexadies.final_value()).unwrap_or(Amt::ZERO),
+            maintenance_energy: maintenance.map(|m| m.energy_per_hexadies.final_value()).unwrap_or(Amt::ZERO),
+            buildings: buildings.map(|b| b.slots.clone()).unwrap_or_default(),
+            build_queue,
+            demolition_queue,
+            upgrade_queue,
+        });
+    }
+    out
 }
 
 pub fn propagate_knowledge(
@@ -415,7 +525,7 @@ pub fn propagate_knowledge(
     )>,
     positions: Query<&Position>,
     mut empire_q: Query<&mut KnowledgeStore, With<crate::player::PlayerEmpire>>,
-    colonies: Query<&crate::colony::Colony>,
+    colonies: ColonySnapshotQuery,
     planets: Query<&crate::galaxy::Planet>,
     planet_attrs: Query<(&crate::galaxy::Planet, &crate::galaxy::SystemAttributes)>,
     hostiles: Query<&crate::galaxy::HostilePresence>,

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -126,6 +126,53 @@ pub struct SystemSnapshot {
     pub production_food: Amt,
     pub production_research: Amt,
     pub maintenance_energy: Amt,
+    /// #269: Per-colony snapshot. Populated by the snapshot build path so
+    /// remote colony detail UI reads from this instead of the live world.
+    /// Empty vec means "system is known but no colonies observed yet".
+    pub colonies: Vec<ColonySnapshot>,
+}
+
+/// #269: Snapshot of a single colony's observable state at the moment of
+/// last observation. Carries enough data for the remote colony detail
+/// panel to render without reading live components.
+#[derive(Clone, Debug)]
+pub struct ColonySnapshot {
+    pub colony_entity: Entity,
+    pub planet_entity: Entity,
+    pub planet_name: String,
+    pub population: f64,
+    pub carrying_cap_hint: f64,
+    pub production_minerals: Amt,
+    pub production_energy: Amt,
+    pub production_food: Amt,
+    pub production_research: Amt,
+    pub food_consumption: Amt,
+    pub maintenance_energy: Amt,
+    pub buildings: Vec<Option<crate::scripting::building_api::BuildingId>>,
+    pub build_queue: Vec<BuildQueueEntrySnapshot>,
+    pub demolition_queue: Vec<DemolitionSnapshot>,
+    pub upgrade_queue: Vec<UpgradeSnapshot>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BuildQueueEntrySnapshot {
+    pub building_id: crate::scripting::building_api::BuildingId,
+    pub target_slot: usize,
+    pub build_time_remaining: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct DemolitionSnapshot {
+    pub target_slot: usize,
+    pub building_id: crate::scripting::building_api::BuildingId,
+    pub time_remaining: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct UpgradeSnapshot {
+    pub slot_index: usize,
+    pub target_id: crate::scripting::building_api::BuildingId,
+    pub build_time_remaining: i64,
 }
 
 /// #175: Snapshot of a ship's last known state for light-speed delayed visibility.

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -1315,7 +1315,7 @@ impl SavedScoutReport {
             origin_system: remap_entity(self.origin_system_bits, map),
             observed_at: self.observed_at,
             report_mode: self.report_mode.into(),
-            system_snapshot: self.system_snapshot.into_live(),
+            system_snapshot: self.system_snapshot.into_live(map),
             ship_snapshots: self.ship_snapshots.into_iter().map(|s| s.into_live(map)).collect(),
             return_queued: self.return_queued,
         }
@@ -2256,6 +2256,117 @@ pub struct SavedSystemSnapshot {
     pub production_food: Amt,
     pub production_research: Amt,
     pub maintenance_energy: Amt,
+    /// #269: Per-colony snapshots. `#[serde(default)]` so older saves that
+    /// predate this field still deserialize with an empty vec.
+    #[serde(default)]
+    pub colonies: Vec<SavedColonySnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedColonySnapshot {
+    pub colony_entity_bits: u64,
+    pub planet_entity_bits: u64,
+    pub planet_name: String,
+    pub population: f64,
+    pub carrying_cap_hint: f64,
+    pub production_minerals: Amt,
+    pub production_energy: Amt,
+    pub production_food: Amt,
+    pub production_research: Amt,
+    pub food_consumption: Amt,
+    pub maintenance_energy: Amt,
+    pub buildings: Vec<Option<String>>,
+    pub build_queue: Vec<SavedBuildQueueEntrySnapshot>,
+    pub demolition_queue: Vec<SavedDemolitionSnapshot>,
+    pub upgrade_queue: Vec<SavedUpgradeSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedBuildQueueEntrySnapshot {
+    pub building_id: String,
+    pub target_slot: usize,
+    pub build_time_remaining: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedDemolitionSnapshot {
+    pub target_slot: usize,
+    pub building_id: String,
+    pub time_remaining: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedUpgradeSnapshot {
+    pub slot_index: usize,
+    pub target_id: String,
+    pub build_time_remaining: i64,
+}
+
+impl SavedColonySnapshot {
+    pub fn from_live(v: &crate::knowledge::ColonySnapshot) -> Self {
+        Self {
+            colony_entity_bits: v.colony_entity.to_bits(),
+            planet_entity_bits: v.planet_entity.to_bits(),
+            planet_name: v.planet_name.clone(),
+            population: v.population,
+            carrying_cap_hint: v.carrying_cap_hint,
+            production_minerals: v.production_minerals,
+            production_energy: v.production_energy,
+            production_food: v.production_food,
+            production_research: v.production_research,
+            food_consumption: v.food_consumption,
+            maintenance_energy: v.maintenance_energy,
+            buildings: v.buildings.iter().map(|s| s.as_ref().map(|b| b.0.clone())).collect(),
+            build_queue: v.build_queue.iter().map(|e| SavedBuildQueueEntrySnapshot {
+                building_id: e.building_id.0.clone(),
+                target_slot: e.target_slot,
+                build_time_remaining: e.build_time_remaining,
+            }).collect(),
+            demolition_queue: v.demolition_queue.iter().map(|d| SavedDemolitionSnapshot {
+                target_slot: d.target_slot,
+                building_id: d.building_id.0.clone(),
+                time_remaining: d.time_remaining,
+            }).collect(),
+            upgrade_queue: v.upgrade_queue.iter().map(|u| SavedUpgradeSnapshot {
+                slot_index: u.slot_index,
+                target_id: u.target_id.0.clone(),
+                build_time_remaining: u.build_time_remaining,
+            }).collect(),
+        }
+    }
+    pub fn into_live(self, map: &EntityMap) -> crate::knowledge::ColonySnapshot {
+        use crate::knowledge::{BuildQueueEntrySnapshot, ColonySnapshot, DemolitionSnapshot, UpgradeSnapshot};
+        use crate::scripting::building_api::BuildingId;
+        ColonySnapshot {
+            colony_entity: remap_entity(self.colony_entity_bits, map),
+            planet_entity: remap_entity(self.planet_entity_bits, map),
+            planet_name: self.planet_name,
+            population: self.population,
+            carrying_cap_hint: self.carrying_cap_hint,
+            production_minerals: self.production_minerals,
+            production_energy: self.production_energy,
+            production_food: self.production_food,
+            production_research: self.production_research,
+            food_consumption: self.food_consumption,
+            maintenance_energy: self.maintenance_energy,
+            buildings: self.buildings.into_iter().map(|s| s.map(BuildingId::new)).collect(),
+            build_queue: self.build_queue.into_iter().map(|e| BuildQueueEntrySnapshot {
+                building_id: BuildingId::new(e.building_id),
+                target_slot: e.target_slot,
+                build_time_remaining: e.build_time_remaining,
+            }).collect(),
+            demolition_queue: self.demolition_queue.into_iter().map(|d| DemolitionSnapshot {
+                target_slot: d.target_slot,
+                building_id: BuildingId::new(d.building_id),
+                time_remaining: d.time_remaining,
+            }).collect(),
+            upgrade_queue: self.upgrade_queue.into_iter().map(|u| UpgradeSnapshot {
+                slot_index: u.slot_index,
+                target_id: BuildingId::new(u.target_id),
+                build_time_remaining: u.build_time_remaining,
+            }).collect(),
+        }
+    }
 }
 
 impl SavedSystemSnapshot {
@@ -2285,9 +2396,10 @@ impl SavedSystemSnapshot {
             production_food: v.production_food,
             production_research: v.production_research,
             maintenance_energy: v.maintenance_energy,
+            colonies: v.colonies.iter().map(SavedColonySnapshot::from_live).collect(),
         }
     }
-    pub fn into_live(self) -> SystemSnapshot {
+    pub fn into_live(self, map: &EntityMap) -> SystemSnapshot {
         SystemSnapshot {
             name: self.name,
             position: self.position,
@@ -2313,6 +2425,7 @@ impl SavedSystemSnapshot {
             production_food: self.production_food,
             production_research: self.production_research,
             maintenance_energy: self.maintenance_energy,
+            colonies: self.colonies.into_iter().map(|c| c.into_live(map)).collect(),
         }
     }
 }
@@ -2340,7 +2453,7 @@ impl SavedSystemKnowledge {
             system: remap_entity(self.system_bits, map),
             observed_at: self.observed_at,
             received_at: self.received_at,
-            data: self.data.into_live(),
+            data: self.data.into_live(map),
             source: self.source.into(),
         }
     }

--- a/macrocosmo/src/ui/system_panel/colony_detail.rs
+++ b/macrocosmo/src/ui/system_panel/colony_detail.rs
@@ -5,6 +5,7 @@ use crate::colony::{BuildQueue, BuildingQueue, Buildings, Colony, ColonyJobRates
 use crate::communication::{
     ColonyCommand, ColonyCommandKind, PendingColonyDispatch, PendingColonyDispatches,
 };
+use crate::knowledge::{ColonySnapshot, ObservationSource, SystemKnowledge};
 use crate::scripting::building_api::{BuildingId, BuildingRegistry};
 use crate::galaxy::SystemAttributes;
 use crate::amount::{Amt, SignedAmt};
@@ -50,6 +51,11 @@ pub(super) fn draw_colony_detail(
     job_registry: &JobRegistry,
     colony_panel_tab: &mut ColonyPanelTab,
     dispatches: &mut PendingColonyDispatches,
+    // #269: When the selected system is not the player's local, read from
+    // the empire's KnowledgeStore snapshot instead of live components.
+    is_local_system: bool,
+    k_data: Option<&SystemKnowledge>,
+    clock_elapsed: i64,
 ) {
     ui.label(
         egui::RichText::new("Colony")
@@ -57,7 +63,34 @@ pub(super) fn draw_colony_detail(
             .color(egui::Color32::from_rgb(100, 200, 100)),
     );
 
-    // #252: Tab selector.
+    if !is_local_system {
+        let snapshot = k_data
+            .and_then(|k| k.data.colonies.iter().find(|c| c.planet_entity == planet_entity));
+        match snapshot {
+            None => {
+                ui.label(
+                    egui::RichText::new("No intelligence available for this colony.")
+                        .italics()
+                        .color(egui::Color32::from_rgb(180, 180, 180)),
+                );
+                // Dispatch buttons are still useful on remote — they fire
+                // PendingColonyDispatch regardless. Fall through to the
+                // Overview tab which renders them even without snapshot data.
+                // (Intentional: observation can land between clicks.)
+            }
+            Some(cs) => {
+                let age = k_data.map(|k| clock_elapsed - k.observed_at).unwrap_or(0);
+                let source = k_data.map(|k| k.source).unwrap_or(ObservationSource::Direct);
+                draw_colony_detail_snapshot(ui, cs, age, source);
+                // Build/Demolish/Upgrade buttons for remote colonies are
+                // rendered via the dispatcher pipeline — the snapshot view
+                // above is read-only.
+                return;
+            }
+        }
+    }
+
+    // #252: Tab selector (local view or remote-without-snapshot fallback).
     ui.horizontal(|ui| {
         if ui
             .selectable_label(*colony_panel_tab == ColonyPanelTab::Overview, "Overview")
@@ -96,6 +129,96 @@ pub(super) fn draw_colony_detail(
             colony_pop_view,
             job_registry,
         ),
+    }
+}
+
+/// #269: Render colony detail from a `ColonySnapshot` only. No live
+/// component access — reads the freshness banner (source + age), then
+/// population, production, buildings, and queue progress as they were at
+/// `observed_at`.
+fn draw_colony_detail_snapshot(
+    ui: &mut egui::Ui,
+    cs: &ColonySnapshot,
+    age: i64,
+    source: ObservationSource,
+) {
+    let source_tag = match source {
+        ObservationSource::Direct => "Direct",
+        ObservationSource::Relay => "Relay",
+        ObservationSource::Scout => "Scout",
+        ObservationSource::Stale => "Stale",
+    };
+    let banner_color = if age >= crate::knowledge::STALE_THRESHOLD_HEXADIES {
+        egui::Color32::from_rgb(200, 140, 140)
+    } else if age >= 60 {
+        egui::Color32::from_rgb(220, 200, 140)
+    } else {
+        egui::Color32::from_rgb(180, 220, 180)
+    };
+    ui.label(
+        egui::RichText::new(format!(
+            "Remote colony intelligence [{}] — {} hd old",
+            source_tag, age
+        ))
+        .italics()
+        .color(banner_color),
+    );
+    ui.separator();
+
+    ui.label(format!(
+        "Population: {:.0} / {:.0} (at observation)",
+        cs.population, cs.carrying_cap_hint
+    ));
+    ui.label(egui::RichText::new("Income/hd (snapshot):").strong());
+    ui.label(format!("  Food:     {}", cs.production_food.display_compact()));
+    if cs.food_consumption > Amt::ZERO {
+        ui.label(format!("  (consume {})", cs.food_consumption.display_compact()));
+    }
+    ui.label(format!("  Energy:   {}", cs.production_energy.display_compact()));
+    if cs.maintenance_energy > Amt::ZERO {
+        ui.label(format!("  (maintain {})", cs.maintenance_energy.display_compact()));
+    }
+    ui.label(format!("  Minerals: {}", cs.production_minerals.display_compact()));
+    ui.label(format!("  Research: {}", cs.production_research.display_compact()));
+
+    ui.separator();
+    ui.label(egui::RichText::new("Buildings (snapshot)").strong());
+    for (i, slot) in cs.buildings.iter().enumerate() {
+        match slot {
+            Some(bid) => {
+                ui.label(format!("[{}] {}", i, bid));
+            }
+            None => {
+                if let Some(order) = cs.build_queue.iter().find(|o| o.target_slot == i) {
+                    ui.label(format!(
+                        "[{}] (Building: {}) ~{} hd remaining (as of {} hd ago)",
+                        i, order.building_id, order.build_time_remaining, age
+                    ));
+                } else {
+                    ui.label(format!("[{}] (empty)", i));
+                }
+            }
+        }
+    }
+    if !cs.demolition_queue.is_empty() {
+        ui.separator();
+        ui.label(egui::RichText::new("Demolition (snapshot)").strong());
+        for d in &cs.demolition_queue {
+            ui.label(format!(
+                "[{}] {} — {} hd remaining (as of {} hd ago)",
+                d.target_slot, d.building_id, d.time_remaining, age
+            ));
+        }
+    }
+    if !cs.upgrade_queue.is_empty() {
+        ui.separator();
+        ui.label(egui::RichText::new("Upgrades (snapshot)").strong());
+        for u in &cs.upgrade_queue {
+            ui.label(format!(
+                "[{}] -> {} — {} hd remaining (as of {} hd ago)",
+                u.slot_index, u.target_id, u.build_time_remaining, age
+            ));
+        }
     }
 }
 

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -404,6 +404,9 @@ pub fn draw_system_panel(
         job_registry,
         colony_panel_tab,
         dispatches,
+        is_local_system,
+        k_data,
+        clock.elapsed,
     );
 }
 

--- a/macrocosmo/src/ui/system_panel/planet_window.rs
+++ b/macrocosmo/src/ui/system_panel/planet_window.rs
@@ -48,6 +48,9 @@ pub(super) fn draw_planet_window(
     job_registry: &crate::species::JobRegistry,
     colony_panel_tab: &mut crate::ui::ColonyPanelTab,
     dispatches: &mut PendingColonyDispatches,
+    is_local_system: bool,
+    k_data: Option<&crate::knowledge::SystemKnowledge>,
+    clock_elapsed: i64,
 ) {
     let Some(sel_planet_entity) = selected_planet.0 else {
         return;
@@ -117,6 +120,9 @@ pub(super) fn draw_planet_window(
                             job_registry,
                             colony_panel_tab,
                             dispatches,
+                            is_local_system,
+                            k_data,
+                            clock_elapsed,
                         );
                     });
             } else {

--- a/macrocosmo/tests/knowledge.rs
+++ b/macrocosmo/tests/knowledge.rs
@@ -2312,3 +2312,101 @@ fn test_relay_chain_aggregates_system_resources() {
     assert_eq!(entry.data.authority, Amt::units(10));
 }
 
+// #269: ColonySnapshot population tests.
+
+#[test]
+fn test_system_snapshot_includes_colonies_after_propagation() {
+    let mut app = test_app();
+    let capital = spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
+    let remote = spawn_test_system(app.world_mut(), "Remote", [10.0, 0.0, 0.0], 0.8, true, false);
+    app.world_mut().spawn((Player, StationedAt { system: capital }));
+
+    let remote_planet = find_planet(app.world_mut(), remote);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        remote_planet,
+        Amt::units(500),
+        Amt::units(500),
+        vec![Some(BuildingId::new("mine")), None, None, None],
+    );
+
+    advance_time(&mut app, light_delay_hexadies(10.0));
+
+    let empire = empire_entity(app.world_mut());
+    let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+    let entry = store.get(remote).expect("remote system knowledge must exist");
+    assert_eq!(entry.data.colonies.len(), 1, "one colony snapshot expected");
+    let cs = &entry.data.colonies[0];
+    assert_eq!(cs.colony_entity, colony);
+    assert_eq!(cs.planet_entity, remote_planet);
+    assert!((cs.population - 100.0).abs() < 1e-9, "population preserved");
+    assert_eq!(cs.buildings.len(), 4, "slot count preserved");
+    assert_eq!(cs.buildings[0].as_ref().map(|b| b.0.as_str()), Some("mine"));
+}
+
+#[test]
+fn test_colony_snapshot_preserves_build_queue_entries() {
+    let mut app = test_app();
+    let capital = spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
+    let remote = spawn_test_system(app.world_mut(), "Remote", [10.0, 0.0, 0.0], 0.8, true, false);
+    app.world_mut().spawn((Player, StationedAt { system: capital }));
+
+    let remote_planet = find_planet(app.world_mut(), remote);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        remote_planet,
+        Amt::units(500),
+        Amt::units(500),
+        vec![None, None, None, None],
+    );
+    {
+        let mut bq = app.world_mut().get_mut::<BuildingQueue>(colony).unwrap();
+        bq.queue.push(BuildingOrder {
+            building_id: BuildingId::new("mine"),
+            target_slot: 1,
+            minerals_remaining: Amt::units(150),
+            energy_remaining: Amt::units(50),
+            build_time_remaining: 10,
+        });
+    }
+
+    advance_time(&mut app, light_delay_hexadies(10.0));
+
+    let empire = empire_entity(app.world_mut());
+    let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+    let entry = store.get(remote).unwrap();
+    let cs = entry.data.colonies.iter().find(|c| c.colony_entity == colony).unwrap();
+    assert_eq!(cs.build_queue.len(), 1);
+    assert_eq!(cs.build_queue[0].target_slot, 1);
+    assert_eq!(cs.build_queue[0].building_id.0, "mine");
+}
+
+#[test]
+fn test_local_colony_snapshot_also_populated() {
+    // Even when the player is local, propagate_knowledge writes snapshots for
+    // local systems (observed_at = clock.elapsed). This is relied on by the
+    // UI's fallback path when a system panel is opened before the first
+    // observation tick.
+    let mut app = test_app();
+    let capital = spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
+    app.world_mut().spawn((Player, StationedAt { system: capital }));
+
+    let capital_planet = find_planet(app.world_mut(), capital);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        capital_planet,
+        Amt::units(500),
+        Amt::units(500),
+        vec![None, None, None, None],
+    );
+
+    advance_time(&mut app, 1);
+
+    let empire = empire_entity(app.world_mut());
+    let store = app.world().get::<KnowledgeStore>(empire).unwrap();
+    let entry = store.get(capital).expect("local system has knowledge");
+    assert_eq!(entry.data.colonies.len(), 1);
+    assert_eq!(entry.data.colonies[0].colony_entity, colony);
+}
+
+

--- a/macrocosmo/tests/save_load.rs
+++ b/macrocosmo/tests/save_load.rs
@@ -999,3 +999,111 @@ fn test_save_load_preserves_pending_colony_command() {
     }
 }
 
+/// #269: `SystemKnowledge::data.colonies` must round-trip through the real
+/// save/load path, including the `colony_entity` / `planet_entity` remap via
+/// `EntityMap` and nested `BuildQueueEntrySnapshot` contents.
+#[test]
+fn test_save_load_preserves_colony_snapshot() {
+    use macrocosmo::knowledge::{
+        BuildQueueEntrySnapshot, ColonySnapshot, KnowledgeStore, ObservationSource,
+        SystemKnowledge, SystemSnapshot,
+    };
+    use macrocosmo::scripting::building_api::BuildingId;
+    let mut src = build_seed_world();
+
+    let (sol, alpha) = {
+        let mut q = src.query::<(Entity, &StarSystem)>();
+        let mut sol = None;
+        let mut alpha = None;
+        for (e, s) in q.iter(&src) {
+            match s.name.as_str() {
+                "Sol" => sol = Some(e),
+                "Alpha Centauri" => alpha = Some(e),
+                _ => {}
+            }
+        }
+        (sol.unwrap(), alpha.unwrap())
+    };
+    let (colony_entity, planet_entity) = src
+        .query::<(Entity, &Colony)>()
+        .iter(&src)
+        .next()
+        .map(|(e, c)| (e, c.planet))
+        .unwrap();
+    let empire = src
+        .query_filtered::<Entity, With<PlayerEmpire>>()
+        .iter(&src)
+        .next()
+        .unwrap();
+
+    let colony_snap = ColonySnapshot {
+        colony_entity,
+        planet_entity,
+        planet_name: "Earth".into(),
+        population: 1234.0,
+        carrying_cap_hint: 2000.0,
+        production_minerals: Amt::units(5),
+        production_energy: Amt::units(3),
+        production_food: Amt::units(2),
+        production_research: Amt::units(1),
+        food_consumption: Amt::units(4),
+        maintenance_energy: Amt::units(1),
+        buildings: vec![Some(BuildingId::new("mine")), None, None, None],
+        build_queue: vec![BuildQueueEntrySnapshot {
+            building_id: BuildingId::new("farm"),
+            target_slot: 1,
+            build_time_remaining: 7,
+        }],
+        demolition_queue: vec![],
+        upgrade_queue: vec![],
+    };
+    let mut store = KnowledgeStore::default();
+    store.update(SystemKnowledge {
+        system: alpha,
+        observed_at: 50,
+        received_at: 50,
+        data: SystemSnapshot {
+            name: "Alpha Centauri".into(),
+            position: [4.3, 0.0, 0.0],
+            surveyed: true,
+            colonized: true,
+            colonies: vec![colony_snap],
+            ..SystemSnapshot::default()
+        },
+        source: ObservationSource::Direct,
+    });
+    src.entity_mut(empire).insert(store);
+    let _ = sol;
+
+    let bytes = round_trip_bytes(&mut src);
+    let mut dst = World::new();
+    load_game_from_reader(&mut dst, &bytes[..]).expect("load");
+
+    let alpha_dst = dst
+        .query::<(Entity, &StarSystem)>()
+        .iter(&dst)
+        .find(|(_, s)| s.name == "Alpha Centauri")
+        .map(|(e, _)| e)
+        .unwrap();
+    let (colony_dst, planet_dst) = dst
+        .query::<(Entity, &Colony)>()
+        .iter(&dst)
+        .next()
+        .map(|(e, c)| (e, c.planet))
+        .unwrap();
+    let mut eq = dst.query_filtered::<&KnowledgeStore, With<PlayerEmpire>>();
+    let store = eq.single(&dst).expect("loaded KnowledgeStore");
+    let entry = store.get(alpha_dst).expect("alpha knowledge");
+    assert_eq!(entry.data.colonies.len(), 1);
+    let cs = &entry.data.colonies[0];
+    assert_eq!(cs.colony_entity, colony_dst, "colony_entity Entity remap");
+    assert_eq!(cs.planet_entity, planet_dst, "planet_entity Entity remap");
+    assert_eq!(cs.planet_name, "Earth");
+    assert!((cs.population - 1234.0).abs() < 1e-9);
+    assert_eq!(cs.buildings.len(), 4);
+    assert_eq!(cs.buildings[0].as_ref().map(|b| b.0.as_str()), Some("mine"));
+    assert_eq!(cs.build_queue.len(), 1);
+    assert_eq!(cs.build_queue[0].building_id.0, "farm");
+    assert_eq!(cs.build_queue[0].build_time_remaining, 7);
+}
+


### PR DESCRIPTION
## Summary

Closes the read-side counterpart to #270. Remote colony detail panels used to display real-time ground truth (population, production, buildings, build queue) regardless of whether the player could actually observe that system. Now they render from the empire's `KnowledgeStore` snapshot instead of live components, respecting the light-speed constraint.

## Commits

1. **Add `ColonySnapshot` types + savebag mirror** — extends `SystemSnapshot` with `colonies: Vec<ColonySnapshot>` carrying population, production per resource, food consumption, maintenance energy, slot layout, and build/demolition/upgrade queue snapshots. Saved mirror uses `#[serde(default)]` for backward compat with older Phase B saves. `SavedSystemSnapshot::into_live` gains `&EntityMap` for colony/planet entity remap.

2. **Populate via `build_system_snapshot`** — new `ColonySnapshotQuery` type alias + `build_colony_snapshots` helper writes per-colony snapshots from `build_system_snapshot`. Both `propagate_knowledge` and the FTL relay propagation in `deep_space/` swap their plain `Query<&Colony>` for the richer query. Per plan's atomicity preference, writes happen only from `build_system_snapshot` — `snapshot_production_knowledge` continues to update system-level aggregates only.

3. **UI split in `draw_colony_detail`** — 3-way dispatcher:
   - Local: current `draw_overview_tab` unchanged
   - Remote + snapshot: new `draw_colony_detail_snapshot` renders from `ColonySnapshot`, with a freshness banner (source tag + age, color-ramped green/yellow/red)
   - Remote + no snapshot: "No intelligence available" + fallback to Overview so buttons still dispatch via `PendingColonyDispatches`

Queue progress is rendered as "N hd remaining (as of M hd ago)" with no current-time projection — snapshot is frozen at `observed_at`.

## Tests

**New integration tests in `tests/knowledge.rs`:**
- `test_system_snapshot_includes_colonies_after_propagation` — remote colony appears in `k.data.colonies` with correct slot layout after light delay
- `test_colony_snapshot_preserves_build_queue_entries` — pushed `BuildingOrder` survives into snapshot
- `test_local_colony_snapshot_also_populated` — local colonies also get snapshots (UI fallback path)

**New integration test in `tests/save_load.rs`:**
- `test_save_load_preserves_colony_snapshot` — real save/load path round-trips `SystemKnowledge.data.colonies` including `colony_entity`/`planet_entity` EntityMap remap and nested queue contents

All workspace tests pass.

## Acceptance criteria (#269)

- ✅ 遠隔 planet の colony detail が `ColonySnapshot` ベースで表示される
- ✅ Freshness (age + source) が表示される (Direct / Relay / Scout / Stale + color ramp)
- ✅ Snapshot のない (未観測) 遠隔 colony は "No intelligence" 表示
- ✅ ローカル colony は現行通り live 表示
- ✅ Build queue 進捗は snapshot 時点の残時間を "~N hd remaining (as of M hd ago)" で表示
- ⏭ Pop management tab on remote: shows the Overview-fallback labels from ColonySnapshot (no per-pop breakdown yet — that's a natural #269 follow-up since ColonyJobs/ColonyPopulation aren't in the snapshot)

## Test plan

- [ ] Open a remote colony panel — verify the "Remote colony intelligence [Direct] — N hd old" banner appears
- [ ] Let the clock advance past 600 hd — banner should turn red with `[Stale]` tag
- [ ] Click build/demolish on the remote colony — dispatched command should appear in the In-flight list (unchanged from #270)
- [ ] Open an unobserved remote colony (player just saw a new system) — should show "No intelligence available"
- [ ] Save mid-flight with a populated snapshot, load, verify detail still renders
- [ ] Local colony detail should be unchanged in all cases

Closes #269

Related: #270 (write side, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)