### PR TITLE
#266: Open context menu for Loitering ships

### DIFF
--- a/macrocosmo/src/ui/context_menu.rs
+++ b/macrocosmo/src/ui/context_menu.rs
@@ -58,7 +58,10 @@ pub fn draw_context_menu(
         } else {
             None
         };
-        // For non-docked ships, determine origin position from current state
+        // For non-docked ships, determine origin position from current state.
+        // #266: Loitering ships have no associated system but DO have a known
+        // deep-space position — carry it as a fallback so context menu can
+        // still compute light delay and open properly.
         let current_destination_system = match &*state {
             ShipState::SubLight { target_system, .. } => *target_system,
             ShipState::InFTL { destination_system, .. } => Some(*destination_system),
@@ -66,11 +69,12 @@ pub fn draw_context_menu(
             ShipState::Settling { system, .. } => Some(*system),
             ShipState::Docked { .. } => None, // handled via docked_system
             ShipState::Refitting { system, .. } => Some(*system),
-            // #185: Loitering ships have no associated system; commands will be queued
-            // and routed via MoveTo (which handles loitering->system sublight).
             ShipState::Loitering { .. } => None,
-            // #217: Scouting ships are parked at the observation target.
             ShipState::Scouting { target_system, .. } => Some(*target_system),
+        };
+        let loitering_pos: Option<[f64; 3]> = match &*state {
+            ShipState::Loitering { position } => Some(*position),
+            _ => None,
         };
         (
             ship.name.clone(),
@@ -79,28 +83,47 @@ pub fn draw_context_menu(
             ship.sublight_speed,
             docked_system,
             current_destination_system,
+            loitering_pos,
         )
     };
 
-    let (ship_name, design_id, ftl_range, sublight_speed, docked_system, current_destination_system) = ship_data;
+    let (
+        ship_name,
+        design_id,
+        ftl_range,
+        sublight_speed,
+        docked_system,
+        current_destination_system,
+        loitering_pos,
+    ) = ship_data;
 
     let is_docked = docked_system.is_some();
 
     // For docked ships, the origin is the docked system.
-    // For non-docked ships, the origin is their current destination (where they'll end up).
+    // For non-docked ships, the origin is either the current destination
+    // (in-transit / parked at target) or a loitering deep-space position
+    // (#266).
     let origin_system = if let Some(ds) = docked_system {
         Some(ds)
     } else {
         current_destination_system
     };
 
-    let Some(origin_system) = origin_system else {
-        // No origin determinable; close menu
+    // Resolve the ship's current Position — either from a system entity (the
+    // common case) or a deep-space loitering coordinate.
+    let ship_pos: Option<Position> = if let Some(sys) = origin_system {
+        positions.get(sys).ok().copied()
+    } else {
+        loitering_pos.map(Position::from)
+    };
+
+    let Some(ship_pos) = ship_pos else {
+        // No origin determinable; close menu.
         context_menu.open = false;
         return;
     };
 
-    let same_system = is_docked && target_entity == origin_system;
+    let same_system = is_docked && origin_system == Some(target_entity);
 
     // #76: Calculate light-speed delay from player to ship's location.
     // For in-transit ships, the command must also wait for the ship to arrive
@@ -111,8 +134,7 @@ pub fn draw_context_menu(
             .ok()
             .and_then(|(_, stationed, _)| {
                 let player_pos = positions.get(stationed.system).ok()?;
-                let ship_pos = positions.get(origin_system).ok()?;
-                let dist = physics::distance_ly(player_pos, ship_pos);
+                let dist = physics::distance_ly(player_pos, &ship_pos);
                 Some(physics::light_delay_hexadies(dist))
             })
             .unwrap_or(0);
@@ -143,12 +165,8 @@ pub fn draw_context_menu(
         context_menu.open = false;
         return;
     };
-    let Ok(origin_pos) = positions.get(origin_system) else {
-        context_menu.open = false;
-        return;
-    };
 
-    let dist = physics::distance_ly(origin_pos, target_pos);
+    let dist = physics::distance_ly(&ship_pos, target_pos);
     let target_name = target_star.name.clone();
     let target_surveyed = target_star.surveyed;
 

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -2703,3 +2703,86 @@ fn test_scout_report_via_return() {
         "ScoutReport must be removed after Return-mode delivery"
     );
 }
+
+/// #266: A `Loitering` ship that receives a `QueuedCommand::MoveTo` should
+/// route out of the deep-space position and eventually transition to
+/// `SubLight` or `InFTL` / `Docked` at the target. This covers the
+/// downstream pipeline regardless of how the command is produced — the UI
+/// context menu fix (which is not itself testable in headless mode) only
+/// guarantees that queueing the command is *possible*.
+#[test]
+fn test_moveto_from_loitering_routes_ship_out() {
+    let mut app = test_app();
+    let sys_home = spawn_test_system(
+        app.world_mut(),
+        "Home",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let sys_target = spawn_test_system(
+        app.world_mut(),
+        "Target",
+        [5.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+
+    let loiter_pos = [2.0, 0.0, 0.0];
+    let ship = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Loiterer".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.75,
+                ftl_range: 20.0,
+                player_aboard: false,
+                home_port: sys_home,
+                design_revision: 0,
+            },
+            ShipState::Loitering { position: loiter_pos },
+            Position::from(loiter_pos),
+            ShipHitpoints {
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            CommandQueue::default(),
+            Cargo::default(),
+            ShipModifiers::default(),
+        ))
+        .id();
+
+    // Simulate what the fixed context menu does: enqueue a MoveTo.
+    app.world_mut()
+        .get_mut::<CommandQueue>(ship)
+        .unwrap()
+        .commands
+        .push(QueuedCommand::MoveTo { system: sys_target });
+
+    // Advance until the ship leaves Loitering (should happen on the first
+    // process_command_queue pass).
+    let mut left_loitering = false;
+    for _ in 0..20 {
+        advance_time(&mut app, 1);
+        let state = app.world().get::<ShipState>(ship).unwrap();
+        if !matches!(state, ShipState::Loitering { .. }) {
+            left_loitering = true;
+            break;
+        }
+    }
+    assert!(
+        left_loitering,
+        "Loitering ship must route out of Loitering once MoveTo is queued"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the bug where selecting a `Loitering` ship and right-clicking a star system flashed the context menu for a frame and immediately closed it — Loitering ships (produced by the deliverable-deploy deep-space flow) lost the ability to accept new commands.

## Root cause

`ui/context_menu.rs:69` returned `None` for `ShipState::Loitering { .. }` from the origin-system resolution, which then hit the early-return at `:97`:
```rust
let Some(origin_system) = origin_system else {
    context_menu.open = false;
    return;
};
```
The comment next to the Loitering match arm claimed commands would be routed via MoveTo, but the menu closed before the buttons could render.

## Fix

Extract the ship's current `Position` directly from state — from the origin system for docked/in-transit ships, or from `Loitering.position` for the deep-space case. The downstream distance / light-delay / `same_system` logic then works off the resolved Position instead of an Entity round-trip. `process_command_queue` was already handling the Loitering → MoveTo transition correctly.

## Test

`test_moveto_from_loitering_routes_ship_out` (integration, in `tests/ship.rs`):
- spawns a Loitering ship with FTL range
- pushes a `QueuedCommand::MoveTo` into the CommandQueue (simulating what the fixed context menu does)
- asserts the ship leaves the Loitering state within a few ticks

Egui rendering is excluded from `full_test_app` per CLAUDE.md, so the UI-side regression test from the issue acceptance criteria (`test_context_menu_opens_for_loitering_ship`) can't be automated. This downstream test covers the "Loitering can actually accept commands" half.

## Test plan

- [ ] Deploy a Deliverable to deep-space coordinates so the carrier transitions to `Loitering`
- [ ] Select the loitering ship, right-click a star — context menu should open with Move / Survey / Colonize buttons
- [ ] Click Move — ship should leave Loitering and start transiting
- [ ] Regression: Docked / SubLight / InFTL / Surveying / Settling / Refitting / Scouting ships should still open the menu as before
- [ ] Ship panel's Cancel / Clear / queue X buttons still work for Loitering ships

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)