### PR TITLE
#274: Split RemoteCommand schema — Ship/Deliverable to top-level, explicit BuildingScope

### DIFF
--- a/macrocosmo/src/colony/mod.rs
+++ b/macrocosmo/src/colony/mod.rs
@@ -23,7 +23,7 @@ pub use colonization::*;
 pub use maintenance::*;
 pub use population::*;
 pub use production::*;
-pub use remote::apply_colony_command;
+pub use remote::apply_remote_command;
 pub use system_buildings::*;
 
 pub struct ColonyPlugin;

--- a/macrocosmo/src/colony/remote.rs
+++ b/macrocosmo/src/colony/remote.rs
@@ -15,7 +15,7 @@ use crate::colony::{
     BuildKind, BuildOrder, BuildQueue, BuildingOrder, BuildingQueue, Buildings, Colony,
     DemolitionOrder, SystemBuildingQueue, SystemBuildings, UpgradeOrder,
 };
-use crate::communication::{ColonyCommand, ColonyCommandKind};
+use crate::communication::{BuildingKind, BuildingScope, ColonyCommand, RemoteCommand};
 use crate::scripting::building_api::{BuildingDefinition, BuildingId, BuildingRegistry};
 use crate::ship_design::ShipDesignRegistry;
 
@@ -33,16 +33,16 @@ pub type ApplyColoniesQuery<'w, 's> = Query<
 pub type ApplySystemBuildingsQuery<'w, 's> =
     Query<'w, 's, (&'static SystemBuildings, &'static mut SystemBuildingQueue)>;
 
-/// Apply a `ColonyCommand` that has just arrived at `target_system`. Cost,
-/// time, and refund amounts are resolved here against the *current*
-/// registry + modifier state at the target (see #270 design note: "the
-/// order takes effect under the conditions at the target when it
-/// arrives"). The payload only carries ids and slot indices.
+/// Apply a `RemoteCommand` that has just arrived. Cost, time, and refund
+/// amounts are resolved here against the *current* registry + modifier
+/// state at the target for building ops and ship builds;
+/// `DeliverableBuild` carries a pre-computed payload (defs live in
+/// `StructureRegistry`, which isn't plumbed into this handler).
 ///
 /// Silently warns and drops on unknown ids / missing slots / missing
 /// target components — arrival should never panic.
-pub fn apply_colony_command(
-    cc: &ColonyCommand,
+pub fn apply_remote_command(
+    cmd: &RemoteCommand,
     target_system: Entity,
     br: &BuildingRegistry,
     sdr: &ShipDesignRegistry,
@@ -51,13 +51,94 @@ pub fn apply_colony_command(
     colonies: &mut ApplyColoniesQuery,
     sys_buildings_q: &mut ApplySystemBuildingsQuery,
 ) {
+    match cmd {
+        RemoteCommand::BuildShip { .. } | RemoteCommand::SetProductionFocus { .. } => {
+            // Pre-#270 orphan API — not yet wired to any UI; intentional no-op.
+        }
+        RemoteCommand::Colony(cc) => apply_building_command(
+            cc,
+            target_system,
+            br,
+            bldg_cost_mod,
+            bldg_time_mod,
+            colonies,
+            sys_buildings_q,
+        ),
+        RemoteCommand::ShipBuild {
+            host_colony,
+            design_id,
+            build_kind,
+        } => {
+            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
+                warn!("ShipBuild: host_colony {:?} has no BuildQueue", host_colony);
+                return;
+            };
+            let Some(design) = sdr.get(design_id) else {
+                warn!("ShipBuild: unknown design_id '{}'", design_id);
+                return;
+            };
+            let build_time_total = sdr.build_time(design_id);
+            build_q.queue.push(BuildOrder {
+                kind: build_kind.clone(),
+                design_id: design_id.clone(),
+                display_name: design.name.clone(),
+                minerals_cost: design.build_cost_minerals,
+                minerals_invested: Amt::ZERO,
+                energy_cost: design.build_cost_energy,
+                energy_invested: Amt::ZERO,
+                build_time_total,
+                build_time_remaining: build_time_total,
+            });
+        }
+        RemoteCommand::DeliverableBuild {
+            host_colony,
+            def_id,
+            display_name,
+            cargo_size,
+            minerals_cost,
+            energy_cost,
+            build_time,
+        } => {
+            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
+                warn!(
+                    "DeliverableBuild: host_colony {:?} has no BuildQueue",
+                    host_colony
+                );
+                return;
+            };
+            build_q.queue.push(BuildOrder {
+                kind: BuildKind::Deliverable {
+                    cargo_size: *cargo_size,
+                },
+                design_id: def_id.clone(),
+                display_name: display_name.clone(),
+                minerals_cost: *minerals_cost,
+                minerals_invested: Amt::ZERO,
+                energy_cost: *energy_cost,
+                energy_invested: Amt::ZERO,
+                build_time_total: *build_time,
+                build_time_remaining: *build_time,
+            });
+        }
+    }
+}
+
+fn apply_building_command(
+    cc: &ColonyCommand,
+    target_system: Entity,
+    br: &BuildingRegistry,
+    bldg_cost_mod: Amt,
+    bldg_time_mod: Amt,
+    colonies: &mut ApplyColoniesQuery,
+    sys_buildings_q: &mut ApplySystemBuildingsQuery,
+) {
     match &cc.kind {
-        ColonyCommandKind::QueueBuilding {
+        BuildingKind::Queue {
             building_id,
             target_slot,
         } => {
             let Some(def) = br.get(building_id) else {
-                warn!("QueueBuilding: unknown building_id '{}'", building_id);
+                warn!("Queue: unknown building_id '{}'", building_id);
                 return;
             };
             let (base_m, base_e) = def.build_cost();
@@ -71,22 +152,24 @@ pub fn apply_colony_command(
                 energy_remaining: eff_e,
                 build_time_remaining: eff_time,
             };
-            match cc.target_planet {
-                Some(planet) => push_planet_building_order(planet, order, colonies),
-                None => {
+            match cc.scope {
+                BuildingScope::Planet(planet) => {
+                    push_planet_building_order(planet, order, colonies)
+                }
+                BuildingScope::System => {
                     if let Ok((_, mut sbq)) = sys_buildings_q.get_mut(target_system) {
                         sbq.queue.push(order);
                     } else {
                         warn!(
-                            "QueueBuilding (system): target_system {:?} has no SystemBuildingQueue",
+                            "Queue (system): target_system {:?} has no SystemBuildingQueue",
                             target_system
                         );
                     }
                 }
             }
         }
-        ColonyCommandKind::DemolishBuilding { target_slot } => match cc.target_planet {
-            Some(planet) => {
+        BuildingKind::Demolish { target_slot } => match cc.scope {
+            BuildingScope::Planet(planet) => {
                 let mut found = false;
                 for (colony, buildings, mut bq, _) in colonies.iter_mut() {
                     if colony.planet != planet {
@@ -95,14 +178,14 @@ pub fn apply_colony_command(
                     found = true;
                     let Some(Some(bid)) = buildings.slots.get(*target_slot).cloned() else {
                         warn!(
-                            "DemolishBuilding (planet): slot {} is empty or out of bounds",
+                            "Demolish (planet): slot {} is empty or out of bounds",
                             target_slot
                         );
                         break;
                     };
                     let Some(def) = br.get(bid.as_str()) else {
                         warn!(
-                            "DemolishBuilding (planet): unknown building '{}' in slot {}; dropping order to avoid silent free demolition",
+                            "Demolish (planet): unknown building '{}' in slot {}; dropping order to avoid silent free demolition",
                             bid, target_slot
                         );
                         break;
@@ -118,30 +201,27 @@ pub fn apply_colony_command(
                     break;
                 }
                 if !found {
-                    warn!(
-                        "DemolishBuilding (planet): no colony found on planet {:?}",
-                        planet
-                    );
+                    warn!("Demolish (planet): no colony found on planet {:?}", planet);
                 }
             }
-            None => {
+            BuildingScope::System => {
                 let Ok((sys_buildings, mut sbq)) = sys_buildings_q.get_mut(target_system) else {
                     warn!(
-                        "DemolishBuilding (system): target_system {:?} has no SystemBuildings/Queue",
+                        "Demolish (system): target_system {:?} has no SystemBuildings/Queue",
                         target_system
                     );
                     return;
                 };
                 let Some(Some(bid)) = sys_buildings.slots.get(*target_slot).cloned() else {
                     warn!(
-                        "DemolishBuilding (system): slot {} is empty or out of bounds",
+                        "Demolish (system): slot {} is empty or out of bounds",
                         target_slot
                     );
                     return;
                 };
                 let Some(def) = br.get(bid.as_str()) else {
                     warn!(
-                        "DemolishBuilding (system): unknown building '{}' in slot {}; dropping order",
+                        "Demolish (system): unknown building '{}' in slot {}; dropping order",
                         bid, target_slot
                     );
                     return;
@@ -156,7 +236,7 @@ pub fn apply_colony_command(
                 });
             }
         },
-        ColonyCommandKind::UpgradeBuilding {
+        BuildingKind::Upgrade {
             slot_index,
             target_id,
         } => {
@@ -181,8 +261,8 @@ pub fn apply_colony_command(
                     build_time_remaining: eff_time,
                 })
             };
-            match cc.target_planet {
-                Some(planet) => {
+            match cc.scope {
+                BuildingScope::Planet(planet) => {
                     let mut handled = false;
                     for (colony, buildings, mut bq, _) in colonies.iter_mut() {
                         if colony.planet != planet {
@@ -191,12 +271,12 @@ pub fn apply_colony_command(
                         handled = true;
                         let Some(Some(source_bid)) = buildings.slots.get(*slot_index).cloned()
                         else {
-                            warn!("UpgradeBuilding (planet): slot {} empty or OOB", slot_index);
+                            warn!("Upgrade (planet): slot {} empty or OOB", slot_index);
                             break;
                         };
                         let Some(source_def) = br.get(source_bid.as_str()) else {
                             warn!(
-                                "UpgradeBuilding (planet): unknown source building '{}'",
+                                "Upgrade (planet): unknown source building '{}'",
                                 source_bid
                             );
                             break;
@@ -205,33 +285,33 @@ pub fn apply_colony_command(
                             bq.upgrade_queue.push(order);
                         } else {
                             warn!(
-                                "UpgradeBuilding (planet): no upgrade path '{}' -> '{}'",
+                                "Upgrade (planet): no upgrade path '{}' -> '{}'",
                                 source_bid, target_id
                             );
                         }
                         break;
                     }
                     if !handled {
-                        warn!("UpgradeBuilding (planet): no colony on planet {:?}", planet);
+                        warn!("Upgrade (planet): no colony on planet {:?}", planet);
                     }
                 }
-                None => {
+                BuildingScope::System => {
                     let Ok((sys_buildings, mut sbq)) = sys_buildings_q.get_mut(target_system)
                     else {
                         warn!(
-                            "UpgradeBuilding (system): target_system {:?} missing components",
+                            "Upgrade (system): target_system {:?} missing components",
                             target_system
                         );
                         return;
                     };
                     let Some(Some(source_bid)) = sys_buildings.slots.get(*slot_index).cloned()
                     else {
-                        warn!("UpgradeBuilding (system): slot {} empty or OOB", slot_index);
+                        warn!("Upgrade (system): slot {} empty or OOB", slot_index);
                         return;
                     };
                     let Some(source_def) = br.get(source_bid.as_str()) else {
                         warn!(
-                            "UpgradeBuilding (system): unknown source building '{}'",
+                            "Upgrade (system): unknown source building '{}'",
                             source_bid
                         );
                         return;
@@ -240,74 +320,12 @@ pub fn apply_colony_command(
                         sbq.upgrade_queue.push(order);
                     } else {
                         warn!(
-                            "UpgradeBuilding (system): no upgrade path '{}' -> '{}'",
+                            "Upgrade (system): no upgrade path '{}' -> '{}'",
                             source_bid, target_id
                         );
                     }
                 }
             }
-        }
-        ColonyCommandKind::QueueShipBuild {
-            host_colony,
-            design_id,
-            build_kind,
-        } => {
-            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
-                warn!(
-                    "QueueShipBuild: host_colony {:?} has no BuildQueue",
-                    host_colony
-                );
-                return;
-            };
-            let Some(design) = sdr.get(design_id) else {
-                warn!("QueueShipBuild: unknown design_id '{}'", design_id);
-                return;
-            };
-            let minerals_cost = design.build_cost_minerals;
-            let energy_cost = design.build_cost_energy;
-            let build_time_total = sdr.build_time(design_id);
-            let display_name = design.name.clone();
-            build_q.queue.push(BuildOrder {
-                kind: build_kind.clone(),
-                design_id: design_id.clone(),
-                display_name,
-                minerals_cost,
-                minerals_invested: Amt::ZERO,
-                energy_cost,
-                energy_invested: Amt::ZERO,
-                build_time_total,
-                build_time_remaining: build_time_total,
-            });
-        }
-        ColonyCommandKind::QueueDeliverableBuild {
-            host_colony,
-            def_id,
-            display_name,
-            cargo_size,
-            minerals_cost,
-            energy_cost,
-            build_time,
-        } => {
-            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
-                warn!(
-                    "QueueDeliverableBuild: host_colony {:?} has no BuildQueue",
-                    host_colony
-                );
-                return;
-            };
-            build_q.queue.push(BuildOrder {
-                kind: BuildKind::Deliverable {
-                    cargo_size: *cargo_size,
-                },
-                design_id: def_id.clone(),
-                display_name: display_name.clone(),
-                minerals_cost: *minerals_cost,
-                minerals_invested: Amt::ZERO,
-                energy_cost: *energy_cost,
-                energy_invested: Amt::ZERO,
-                build_time_total: *build_time,
-                build_time_remaining: *build_time,
-            });
         }
     }
 }

--- a/macrocosmo/src/communication/mod.rs
+++ b/macrocosmo/src/communication/mod.rs
@@ -33,7 +33,7 @@ pub struct PendingColonyDispatches {
 
 pub struct PendingColonyDispatch {
     pub target_system: Entity,
-    pub command: ColonyCommand,
+    pub command: RemoteCommand,
 }
 
 /// A message in transit (light-speed or via courier)
@@ -154,26 +154,62 @@ pub struct PendingCommand {
 
 /// The kinds of remote commands a player can issue.
 ///
-/// Build-related payloads (`Colony(ColonyCommand)`) are deliberately minimal —
+/// Building slot ops (`Colony(ColonyCommand)`) are deliberately minimal —
 /// cost/time/refund amounts are re-resolved on arrival from the target's
-/// current `BuildingRegistry` + `ConstructionParams`. `QueueDeliverableBuild`
-/// is the exception (defs live in a separate registry; see variant doc).
+/// current `BuildingRegistry` + `ConstructionParams`. Ship / deliverable
+/// builds carry their own `host_colony` entity; `ShipBuild` re-resolves
+/// from `ShipDesignRegistry` at arrival while `DeliverableBuild` freezes
+/// the full payload at send time (defs live in `StructureRegistry`).
 #[derive(Clone, Debug)]
 pub enum RemoteCommand {
     BuildShip { design_id: String },
     SetProductionFocus { minerals: f64, energy: f64, research: f64 },
     Colony(ColonyCommand),
+    ShipBuild {
+        host_colony: Entity,
+        design_id: String,
+        build_kind: crate::colony::BuildKind,
+    },
+    DeliverableBuild {
+        host_colony: Entity,
+        def_id: String,
+        display_name: String,
+        cargo_size: u32,
+        minerals_cost: crate::amount::Amt,
+        energy_cost: crate::amount::Amt,
+        build_time: i64,
+    },
 }
 
-/// A colony-scoped remote command. `target_planet = Some(p)` addresses a
-/// planet-level `BuildingQueue`/`Buildings`; `None` addresses the
-/// system-level `SystemBuildingQueue`/`SystemBuildings` on `target_system`.
-/// Some variants (`QueueShipBuild`, `QueueDeliverableBuild`) carry their
-/// own `host_colony` and ignore `target_planet`.
+/// Building-slot op against the target system. `scope` picks planet-level
+/// vs system-level; `kind` is the action.
 #[derive(Clone, Debug)]
 pub struct ColonyCommand {
-    pub target_planet: Option<Entity>,
-    pub kind: ColonyCommandKind,
+    pub scope: BuildingScope,
+    pub kind: BuildingKind,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum BuildingScope {
+    /// Acts on the planet-level `BuildingQueue` of the colony on this planet.
+    Planet(Entity),
+    /// Acts on the system-level `SystemBuildingQueue` of the target system.
+    System,
+}
+
+#[derive(Clone, Debug)]
+pub enum BuildingKind {
+    Queue {
+        building_id: String,
+        target_slot: usize,
+    },
+    Demolish {
+        target_slot: usize,
+    },
+    Upgrade {
+        slot_index: usize,
+        target_id: String,
+    },
 }
 
 impl RemoteCommand {
@@ -185,60 +221,22 @@ impl RemoteCommand {
             RemoteCommand::BuildShip { design_id } => format!("Build ship: {}", design_id),
             RemoteCommand::SetProductionFocus { .. } => "Set production focus".to_string(),
             RemoteCommand::Colony(cc) => match &cc.kind {
-                ColonyCommandKind::QueueBuilding { building_id, target_slot } => {
+                BuildingKind::Queue { building_id, target_slot } => {
                     format!("Build {} → slot {}", building_id, target_slot)
                 }
-                ColonyCommandKind::DemolishBuilding { target_slot } => {
+                BuildingKind::Demolish { target_slot } => {
                     format!("Demolish slot {}", target_slot)
                 }
-                ColonyCommandKind::UpgradeBuilding { slot_index, target_id } => {
+                BuildingKind::Upgrade { slot_index, target_id } => {
                     format!("Upgrade slot {} → {}", slot_index, target_id)
                 }
-                ColonyCommandKind::QueueShipBuild { design_id, .. } => {
-                    format!("Build ship: {}", design_id)
-                }
-                ColonyCommandKind::QueueDeliverableBuild { display_name, .. } => {
-                    format!("Build deliverable: {}", display_name)
-                }
             },
+            RemoteCommand::ShipBuild { design_id, .. } => format!("Build ship: {}", design_id),
+            RemoteCommand::DeliverableBuild { display_name, .. } => {
+                format!("Build deliverable: {}", display_name)
+            }
         }
     }
-}
-
-#[derive(Clone, Debug)]
-pub enum ColonyCommandKind {
-    /// Enqueue construction of `building_id` into `target_slot`.
-    QueueBuilding {
-        building_id: String,
-        target_slot: usize,
-    },
-    /// Enqueue demolition of whatever occupies `target_slot`.
-    DemolishBuilding { target_slot: usize },
-    /// Enqueue an upgrade of the building in `slot_index` to `target_id`.
-    UpgradeBuilding {
-        slot_index: usize,
-        target_id: String,
-    },
-    /// Enqueue a ship (or deliverable) build on `host_colony`'s `BuildQueue`.
-    QueueShipBuild {
-        host_colony: Entity,
-        design_id: String,
-        build_kind: crate::colony::BuildKind,
-    },
-    /// Enqueue a deliverable build on `host_colony`'s `BuildQueue`. Full
-    /// payload (def_id/display_name/cargo_size/cost/time) is frozen at
-    /// send time because deliverable defs live in `StructureRegistry`,
-    /// not `ShipDesignRegistry`, so arrival-time re-resolution would
-    /// require a second registry lookup path.
-    QueueDeliverableBuild {
-        host_colony: Entity,
-        def_id: String,
-        display_name: String,
-        cargo_size: u32,
-        minerals_cost: crate::amount::Amt,
-        energy_cost: crate::amount::Amt,
-        build_time: i64,
-    },
 }
 
 /// Tracks command status for UI display.
@@ -302,7 +300,7 @@ pub fn dispatch_pending_colony_commands(
             origin,
             destination,
             clock.elapsed,
-            RemoteCommand::Colony(dispatch.command),
+            dispatch.command,
             dispatch.target_system,
             &mut command_log,
         );
@@ -371,18 +369,16 @@ pub fn process_pending_commands(
                 cmd.command.describe()
             );
 
-            if let RemoteCommand::Colony(cc) = &cmd.command {
-                crate::colony::apply_colony_command(
-                    cc,
-                    cmd.target_system,
-                    &building_registry,
-                    &ship_design_registry,
-                    bldg_cost_mod,
-                    bldg_time_mod,
-                    &mut colonies,
-                    &mut sys_buildings_q,
-                );
-            }
+            crate::colony::apply_remote_command(
+                &cmd.command,
+                cmd.target_system,
+                &building_registry,
+                &ship_design_registry,
+                bldg_cost_mod,
+                bldg_time_mod,
+                &mut colonies,
+                &mut sys_buildings_q,
+            );
 
             for entry in command_log.entries.iter_mut() {
                 if entry.sent_at == cmd.sent_at

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -33,7 +33,8 @@ use crate::colony::{
     SystemBuildingQueue, SystemBuildings, UpgradeOrder,
 };
 use crate::communication::{
-    ColonyCommand, ColonyCommandKind, CommandLog, CommandLogEntry, PendingCommand, RemoteCommand,
+    BuildingKind, BuildingScope, ColonyCommand, CommandLog, CommandLogEntry, PendingCommand,
+    RemoteCommand,
 };
 use crate::components::{MovementState, Position};
 use crate::condition::ScopedFlags;
@@ -2921,18 +2922,66 @@ impl SavedPendingDiplomaticAction {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SavedRemoteCommand {
-    BuildShip { design_id: String },
-    SetProductionFocus { minerals: f64, energy: f64, research: f64 },
+    BuildShip {
+        design_id: String,
+    },
+    SetProductionFocus {
+        minerals: f64,
+        energy: f64,
+        research: f64,
+    },
     Colony(SavedColonyCommand),
+    ShipBuild {
+        host_colony_bits: u64,
+        design_id: String,
+        build_kind: SavedBuildKind,
+    },
+    DeliverableBuild {
+        host_colony_bits: u64,
+        def_id: String,
+        display_name: String,
+        cargo_size: u32,
+        minerals_cost: Amt,
+        energy_cost: Amt,
+        build_time: i64,
+    },
 }
 impl From<&RemoteCommand> for SavedRemoteCommand {
     fn from(v: &RemoteCommand) -> Self {
         match v {
-            RemoteCommand::BuildShip { design_id } => Self::BuildShip { design_id: design_id.clone() },
-            RemoteCommand::SetProductionFocus { minerals, energy, research } => Self::SetProductionFocus {
-                minerals: *minerals, energy: *energy, research: *research,
+            RemoteCommand::BuildShip { design_id } => Self::BuildShip {
+                design_id: design_id.clone(),
             },
+            RemoteCommand::SetProductionFocus { minerals, energy, research } => {
+                Self::SetProductionFocus {
+                    minerals: *minerals,
+                    energy: *energy,
+                    research: *research,
+                }
+            }
             RemoteCommand::Colony(cc) => Self::Colony(SavedColonyCommand::from_live(cc)),
+            RemoteCommand::ShipBuild { host_colony, design_id, build_kind } => Self::ShipBuild {
+                host_colony_bits: host_colony.to_bits(),
+                design_id: design_id.clone(),
+                build_kind: build_kind.into(),
+            },
+            RemoteCommand::DeliverableBuild {
+                host_colony,
+                def_id,
+                display_name,
+                cargo_size,
+                minerals_cost,
+                energy_cost,
+                build_time,
+            } => Self::DeliverableBuild {
+                host_colony_bits: host_colony.to_bits(),
+                def_id: def_id.clone(),
+                display_name: display_name.clone(),
+                cargo_size: *cargo_size,
+                minerals_cost: *minerals_cost,
+                energy_cost: *energy_cost,
+                build_time: *build_time,
+            },
         }
     }
 }
@@ -2944,111 +2993,14 @@ impl SavedRemoteCommand {
                 RemoteCommand::SetProductionFocus { minerals, energy, research }
             }
             SavedRemoteCommand::Colony(sc) => RemoteCommand::Colony(sc.into_live(map)),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SavedColonyCommand {
-    pub target_planet_bits: Option<u64>,
-    pub kind: SavedColonyCommandKind,
-}
-
-impl SavedColonyCommand {
-    pub fn from_live(v: &ColonyCommand) -> Self {
-        Self {
-            target_planet_bits: v.target_planet.map(|e| e.to_bits()),
-            kind: SavedColonyCommandKind::from_live(&v.kind),
-        }
-    }
-    pub fn into_live(self, map: &EntityMap) -> ColonyCommand {
-        ColonyCommand {
-            target_planet: self.target_planet_bits.map(|b| remap_entity(b, map)),
-            kind: self.kind.into_live(map),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum SavedColonyCommandKind {
-    QueueBuilding { building_id: String, target_slot: usize },
-    DemolishBuilding { target_slot: usize },
-    UpgradeBuilding { slot_index: usize, target_id: String },
-    QueueShipBuild {
-        host_colony_bits: u64,
-        design_id: String,
-        build_kind: SavedBuildKind,
-    },
-    QueueDeliverableBuild {
-        host_colony_bits: u64,
-        def_id: String,
-        display_name: String,
-        cargo_size: u32,
-        minerals_cost: Amt,
-        energy_cost: Amt,
-        build_time: i64,
-    },
-}
-
-impl SavedColonyCommandKind {
-    pub fn from_live(v: &ColonyCommandKind) -> Self {
-        match v {
-            ColonyCommandKind::QueueBuilding { building_id, target_slot } => Self::QueueBuilding {
-                building_id: building_id.clone(),
-                target_slot: *target_slot,
-            },
-            ColonyCommandKind::DemolishBuilding { target_slot } => {
-                Self::DemolishBuilding { target_slot: *target_slot }
-            }
-            ColonyCommandKind::UpgradeBuilding { slot_index, target_id } => Self::UpgradeBuilding {
-                slot_index: *slot_index,
-                target_id: target_id.clone(),
-            },
-            ColonyCommandKind::QueueShipBuild { host_colony, design_id, build_kind } => {
-                Self::QueueShipBuild {
-                    host_colony_bits: host_colony.to_bits(),
-                    design_id: design_id.clone(),
-                    build_kind: build_kind.into(),
-                }
-            }
-            ColonyCommandKind::QueueDeliverableBuild {
-                host_colony,
-                def_id,
-                display_name,
-                cargo_size,
-                minerals_cost,
-                energy_cost,
-                build_time,
-            } => Self::QueueDeliverableBuild {
-                host_colony_bits: host_colony.to_bits(),
-                def_id: def_id.clone(),
-                display_name: display_name.clone(),
-                cargo_size: *cargo_size,
-                minerals_cost: *minerals_cost,
-                energy_cost: *energy_cost,
-                build_time: *build_time,
-            },
-        }
-    }
-    pub fn into_live(self, map: &EntityMap) -> ColonyCommandKind {
-        match self {
-            Self::QueueBuilding { building_id, target_slot } => {
-                ColonyCommandKind::QueueBuilding { building_id, target_slot }
-            }
-            Self::DemolishBuilding { target_slot } => {
-                ColonyCommandKind::DemolishBuilding { target_slot }
-            }
-            Self::UpgradeBuilding { slot_index, target_id } => {
-                ColonyCommandKind::UpgradeBuilding { slot_index, target_id }
-            }
-            Self::QueueShipBuild { host_colony_bits, design_id, build_kind } => {
-                ColonyCommandKind::QueueShipBuild {
+            SavedRemoteCommand::ShipBuild { host_colony_bits, design_id, build_kind } => {
+                RemoteCommand::ShipBuild {
                     host_colony: remap_entity(host_colony_bits, map),
                     design_id,
                     build_kind: build_kind.into(),
                 }
             }
-            Self::QueueDeliverableBuild {
+            SavedRemoteCommand::DeliverableBuild {
                 host_colony_bits,
                 def_id,
                 display_name,
@@ -3056,7 +3008,7 @@ impl SavedColonyCommandKind {
                 minerals_cost,
                 energy_cost,
                 build_time,
-            } => ColonyCommandKind::QueueDeliverableBuild {
+            } => RemoteCommand::DeliverableBuild {
                 host_colony: remap_entity(host_colony_bits, map),
                 def_id,
                 display_name,
@@ -3065,6 +3017,94 @@ impl SavedColonyCommandKind {
                 energy_cost,
                 build_time,
             },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedColonyCommand {
+    pub scope: SavedBuildingScope,
+    pub kind: SavedBuildingKind,
+}
+
+impl SavedColonyCommand {
+    pub fn from_live(v: &ColonyCommand) -> Self {
+        Self {
+            scope: SavedBuildingScope::from_live(&v.scope),
+            kind: SavedBuildingKind::from_live(&v.kind),
+        }
+    }
+    pub fn into_live(self, map: &EntityMap) -> ColonyCommand {
+        ColonyCommand {
+            scope: self.scope.into_live(map),
+            kind: self.kind.into_live(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SavedBuildingScope {
+    Planet { planet_bits: u64 },
+    System,
+}
+
+impl SavedBuildingScope {
+    pub fn from_live(v: &BuildingScope) -> Self {
+        match v {
+            BuildingScope::Planet(e) => Self::Planet {
+                planet_bits: e.to_bits(),
+            },
+            BuildingScope::System => Self::System,
+        }
+    }
+    pub fn into_live(self, map: &EntityMap) -> BuildingScope {
+        match self {
+            Self::Planet { planet_bits } => BuildingScope::Planet(remap_entity(planet_bits, map)),
+            Self::System => BuildingScope::System,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SavedBuildingKind {
+    Queue {
+        building_id: String,
+        target_slot: usize,
+    },
+    Demolish {
+        target_slot: usize,
+    },
+    Upgrade {
+        slot_index: usize,
+        target_id: String,
+    },
+}
+
+impl SavedBuildingKind {
+    pub fn from_live(v: &BuildingKind) -> Self {
+        match v {
+            BuildingKind::Queue { building_id, target_slot } => Self::Queue {
+                building_id: building_id.clone(),
+                target_slot: *target_slot,
+            },
+            BuildingKind::Demolish { target_slot } => Self::Demolish {
+                target_slot: *target_slot,
+            },
+            BuildingKind::Upgrade { slot_index, target_id } => Self::Upgrade {
+                slot_index: *slot_index,
+                target_id: target_id.clone(),
+            },
+        }
+    }
+    pub fn into_live(self) -> BuildingKind {
+        match self {
+            Self::Queue { building_id, target_slot } => {
+                BuildingKind::Queue { building_id, target_slot }
+            }
+            Self::Demolish { target_slot } => BuildingKind::Demolish { target_slot },
+            Self::Upgrade { slot_index, target_id } => {
+                BuildingKind::Upgrade { slot_index, target_id }
+            }
         }
     }
 }
@@ -3706,7 +3746,7 @@ impl RemapEntities for SavedComponentBag {
 mod tests {
     use super::*;
     use crate::colony::BuildKind;
-    use crate::communication::{ColonyCommand, ColonyCommandKind, RemoteCommand};
+    use crate::communication::{BuildingKind, BuildingScope, ColonyCommand, RemoteCommand};
 
     #[test]
     fn colony_remote_command_savebag_roundtrip() {
@@ -3718,43 +3758,37 @@ mod tests {
 
         let originals = vec![
             RemoteCommand::Colony(ColonyCommand {
-                target_planet: Some(live_planet),
-                kind: ColonyCommandKind::QueueBuilding {
+                scope: BuildingScope::Planet(live_planet),
+                kind: BuildingKind::Queue {
                     building_id: "mine".to_string(),
                     target_slot: 2,
                 },
             }),
             RemoteCommand::Colony(ColonyCommand {
-                target_planet: Some(live_planet),
-                kind: ColonyCommandKind::DemolishBuilding { target_slot: 1 },
+                scope: BuildingScope::Planet(live_planet),
+                kind: BuildingKind::Demolish { target_slot: 1 },
             }),
             RemoteCommand::Colony(ColonyCommand {
-                target_planet: None,
-                kind: ColonyCommandKind::UpgradeBuilding {
+                scope: BuildingScope::System,
+                kind: BuildingKind::Upgrade {
                     slot_index: 3,
                     target_id: "advanced_shipyard".to_string(),
                 },
             }),
-            RemoteCommand::Colony(ColonyCommand {
-                target_planet: None,
-                kind: ColonyCommandKind::QueueShipBuild {
-                    host_colony: live_host,
-                    design_id: "explorer_mk1".to_string(),
-                    build_kind: BuildKind::Deliverable { cargo_size: 4 },
-                },
-            }),
-            RemoteCommand::Colony(ColonyCommand {
-                target_planet: None,
-                kind: ColonyCommandKind::QueueDeliverableBuild {
-                    host_colony: live_host,
-                    def_id: "sensor_buoy".to_string(),
-                    display_name: "Sensor Buoy".to_string(),
-                    cargo_size: 2,
-                    minerals_cost: crate::amount::Amt::units(100),
-                    energy_cost: crate::amount::Amt::units(50),
-                    build_time: 30,
-                },
-            }),
+            RemoteCommand::ShipBuild {
+                host_colony: live_host,
+                design_id: "explorer_mk1".to_string(),
+                build_kind: BuildKind::Deliverable { cargo_size: 4 },
+            },
+            RemoteCommand::DeliverableBuild {
+                host_colony: live_host,
+                def_id: "sensor_buoy".to_string(),
+                display_name: "Sensor Buoy".to_string(),
+                cargo_size: 2,
+                minerals_cost: crate::amount::Amt::units(100),
+                energy_cost: crate::amount::Amt::units(50),
+                build_time: 30,
+            },
         ];
 
         for original in &originals {

--- a/macrocosmo/src/ui/system_panel/colony_detail.rs
+++ b/macrocosmo/src/ui/system_panel/colony_detail.rs
@@ -3,7 +3,7 @@ use bevy_egui::egui;
 
 use crate::colony::{BuildQueue, BuildingQueue, Buildings, Colony, ColonyJobRates, ConstructionParams, FoodConsumption, MaintenanceCost, Production, ResourceStockpile};
 use crate::communication::{
-    ColonyCommand, ColonyCommandKind, PendingColonyDispatch, PendingColonyDispatches,
+    BuildingKind, BuildingScope, ColonyCommand, PendingColonyDispatch, PendingColonyDispatches,
 };
 use crate::knowledge::{ColonySnapshot, ObservationSource, SystemKnowledge};
 use crate::scripting::building_api::{BuildingId, BuildingRegistry};
@@ -510,22 +510,22 @@ fn draw_overview_tab(
             if let Some((slot_idx, _bid)) = demolish_request {
                 dispatches.queue.push(PendingColonyDispatch {
                     target_system: system_entity,
-                    command: ColonyCommand {
-                        target_planet: Some(planet_entity),
-                        kind: ColonyCommandKind::DemolishBuilding { target_slot: slot_idx },
-                    },
+                    command: crate::communication::RemoteCommand::Colony(ColonyCommand {
+                        scope: BuildingScope::Planet(planet_entity),
+                        kind: BuildingKind::Demolish { target_slot: slot_idx },
+                    }),
                 });
             }
             if let Some((slot_idx, target_id, _, _, _)) = upgrade_request {
                 dispatches.queue.push(PendingColonyDispatch {
                     target_system: system_entity,
-                    command: ColonyCommand {
-                        target_planet: Some(planet_entity),
-                        kind: ColonyCommandKind::UpgradeBuilding {
+                    command: crate::communication::RemoteCommand::Colony(ColonyCommand {
+                        scope: BuildingScope::Planet(planet_entity),
+                        kind: BuildingKind::Upgrade {
                             slot_index: slot_idx,
                             target_id,
                         },
-                    },
+                    }),
                 });
             }
 
@@ -554,13 +554,13 @@ fn draw_overview_tab(
                 if let Some(bid) = build_building_request {
                     dispatches.queue.push(PendingColonyDispatch {
                         target_system: system_entity,
-                        command: ColonyCommand {
-                            target_planet: Some(planet_entity),
-                            kind: ColonyCommandKind::QueueBuilding {
+                        command: crate::communication::RemoteCommand::Colony(ColonyCommand {
+                            scope: BuildingScope::Planet(planet_entity),
+                            kind: BuildingKind::Queue {
                                 building_id: bid.0,
                                 target_slot: slot_idx,
                             },
-                        },
+                        }),
                     });
                 }
             }

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -853,24 +853,28 @@ fn draw_right_panel(
         if let Some((slot_idx, _bid)) = sys_demolish_request {
             dispatches.queue.push(crate::communication::PendingColonyDispatch {
                 target_system: sel_entity,
-                command: crate::communication::ColonyCommand {
-                    target_planet: None,
-                    kind: crate::communication::ColonyCommandKind::DemolishBuilding {
-                        target_slot: slot_idx,
+                command: crate::communication::RemoteCommand::Colony(
+                    crate::communication::ColonyCommand {
+                        scope: crate::communication::BuildingScope::System,
+                        kind: crate::communication::BuildingKind::Demolish {
+                            target_slot: slot_idx,
+                        },
                     },
-                },
+                ),
             });
         }
         if let Some((slot_idx, target_id, _, _, _)) = sys_upgrade_request {
             dispatches.queue.push(crate::communication::PendingColonyDispatch {
                 target_system: sel_entity,
-                command: crate::communication::ColonyCommand {
-                    target_planet: None,
-                    kind: crate::communication::ColonyCommandKind::UpgradeBuilding {
-                        slot_index: slot_idx,
-                        target_id,
+                command: crate::communication::RemoteCommand::Colony(
+                    crate::communication::ColonyCommand {
+                        scope: crate::communication::BuildingScope::System,
+                        kind: crate::communication::BuildingKind::Upgrade {
+                            slot_index: slot_idx,
+                            target_id,
+                        },
                     },
-                },
+                ),
             });
         }
 
@@ -905,13 +909,15 @@ fn draw_right_panel(
                 if let Some(bid) = build_sys_building_request {
                     dispatches.queue.push(crate::communication::PendingColonyDispatch {
                         target_system: sel_entity,
-                        command: crate::communication::ColonyCommand {
-                            target_planet: None,
-                            kind: crate::communication::ColonyCommandKind::QueueBuilding {
-                                building_id: bid.0,
-                                target_slot: slot_idx,
+                        command: crate::communication::RemoteCommand::Colony(
+                            crate::communication::ColonyCommand {
+                                scope: crate::communication::BuildingScope::System,
+                                kind: crate::communication::BuildingKind::Queue {
+                                    building_id: bid.0,
+                                    target_slot: slot_idx,
+                                },
                             },
-                        },
+                        ),
                     });
                 }
             }
@@ -1069,13 +1075,10 @@ fn draw_right_panel(
                 {
                     dispatches.queue.push(crate::communication::PendingColonyDispatch {
                         target_system: sel_entity,
-                        command: crate::communication::ColonyCommand {
-                            target_planet: None,
-                            kind: crate::communication::ColonyCommandKind::QueueShipBuild {
-                                host_colony: host,
-                                design_id,
-                                build_kind: crate::colony::BuildKind::Ship,
-                            },
+                        command: crate::communication::RemoteCommand::ShipBuild {
+                            host_colony: host,
+                            design_id,
+                            build_kind: crate::colony::BuildKind::Ship,
                         },
                     });
                 }
@@ -1138,17 +1141,14 @@ fn draw_right_panel(
                     {
                         dispatches.queue.push(crate::communication::PendingColonyDispatch {
                             target_system: sel_entity,
-                            command: crate::communication::ColonyCommand {
-                                target_planet: None,
-                                kind: crate::communication::ColonyCommandKind::QueueDeliverableBuild {
-                                    host_colony: host,
-                                    def_id,
-                                    display_name,
-                                    cargo_size,
-                                    minerals_cost: m_cost,
-                                    energy_cost: e_cost,
-                                    build_time,
-                                },
+                            command: crate::communication::RemoteCommand::DeliverableBuild {
+                                host_colony: host,
+                                def_id,
+                                display_name,
+                                cargo_size,
+                                minerals_cost: m_cost,
+                                energy_cost: e_cost,
+                                build_time,
                             },
                         });
                     }

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -12,7 +12,7 @@ use bevy::prelude::*;
 use macrocosmo::amount::Amt;
 use macrocosmo::colony::{BuildKind, BuildQueue, BuildingQueue, SystemBuildingQueue};
 use macrocosmo::communication::{
-    self, ColonyCommand, ColonyCommandKind, CommandLog, PendingColonyDispatch,
+    self, BuildingKind, BuildingScope, ColonyCommand, CommandLog, PendingColonyDispatch,
     PendingColonyDispatches, PendingCommand, RemoteCommand,
 };
 use macrocosmo::components::Position;
@@ -52,16 +52,16 @@ fn build_app_with_dispatch() -> App {
     app
 }
 
-fn spawn_pending_colony_command(
+fn spawn_pending_remote_command(
     app: &mut App,
     target_system: Entity,
     sent_at: i64,
     arrives_at: i64,
-    cmd: ColonyCommand,
+    cmd: RemoteCommand,
 ) {
     app.world_mut().spawn(PendingCommand {
         target_system,
-        command: RemoteCommand::Colony(cmd),
+        command: cmd,
         sent_at,
         arrives_at,
         origin_pos: [0.0, 0.0, 0.0],
@@ -123,18 +123,15 @@ fn queue_building_planet_arrives_and_enqueues() {
         vec![None, None, None, None],
     );
 
-    spawn_pending_colony_command(
+    spawn_pending_remote_command(
         &mut app,
         sys,
         0,
         10,
-        ColonyCommand {
-            target_planet: Some(planet),
-            kind: ColonyCommandKind::QueueBuilding {
+        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Queue {
                 building_id: "mine".to_string(),
                 target_slot: 1,
-            },
-        },
+            } }),
     );
 
     // Before arrival the queue should be empty.
@@ -169,18 +166,15 @@ fn queue_building_system_arrives_and_enqueues() {
         vec![],
     );
 
-    spawn_pending_colony_command(
+    spawn_pending_remote_command(
         &mut app,
         sys,
         0,
         10,
-        ColonyCommand {
-            target_planet: None,
-            kind: ColonyCommandKind::QueueBuilding {
+        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::System, kind: BuildingKind::Queue {
                 building_id: "shipyard".to_string(),
                 target_slot: 0,
-            },
-        },
+            } }),
     );
 
     run_until_arrival(&mut app, 10);
@@ -213,15 +207,12 @@ fn demolish_building_planet_arrives_and_enqueues() {
         vec![Some(BuildingId::new("mine")), None, None, None],
     );
 
-    spawn_pending_colony_command(
+    spawn_pending_remote_command(
         &mut app,
         sys,
         0,
         5,
-        ColonyCommand {
-            target_planet: Some(planet),
-            kind: ColonyCommandKind::DemolishBuilding { target_slot: 0 },
-        },
+        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Demolish { target_slot: 0 } }),
     );
 
     run_until_arrival(&mut app, 5);
@@ -261,18 +252,15 @@ fn upgrade_building_planet_without_path_warns_and_noops() {
         vec![Some(BuildingId::new("mine")), None, None, None],
     );
 
-    spawn_pending_colony_command(
+    spawn_pending_remote_command(
         &mut app,
         sys,
         0,
         5,
-        ColonyCommand {
-            target_planet: Some(planet),
-            kind: ColonyCommandKind::UpgradeBuilding {
+        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Upgrade {
                 slot_index: 0,
                 target_id: "advanced_mine".to_string(),
-            },
-        },
+            } }),
     );
 
     run_until_arrival(&mut app, 5);
@@ -306,19 +294,12 @@ fn queue_ship_build_arrives_and_enqueues() {
         vec![],
     );
 
-    spawn_pending_colony_command(
+    spawn_pending_remote_command(
         &mut app,
         sys,
         0,
         20,
-        ColonyCommand {
-            target_planet: None,
-            kind: ColonyCommandKind::QueueShipBuild {
-                host_colony: colony,
-                design_id: "explorer_mk1".to_string(),
-                build_kind: BuildKind::Ship,
-            },
-        },
+        RemoteCommand::ShipBuild { host_colony: colony, design_id: "explorer_mk1".to_string(), build_kind: BuildKind::Ship },
     );
 
     run_until_arrival(&mut app, 20);
@@ -351,14 +332,12 @@ fn queue_deliverable_build_arrives_and_enqueues() {
         vec![],
     );
 
-    spawn_pending_colony_command(
+    spawn_pending_remote_command(
         &mut app,
         sys,
         0,
         20,
-        ColonyCommand {
-            target_planet: None,
-            kind: ColonyCommandKind::QueueDeliverableBuild {
+        RemoteCommand::DeliverableBuild {
                 host_colony: colony,
                 def_id: "sensor_buoy".to_string(),
                 display_name: "Sensor Buoy".to_string(),
@@ -367,7 +346,6 @@ fn queue_deliverable_build_arrives_and_enqueues() {
                 energy_cost: Amt::units(50),
                 build_time: 30,
             },
-        },
     );
 
     run_until_arrival(&mut app, 20);
@@ -405,18 +383,15 @@ fn pending_colony_command_not_applied_before_arrival() {
         vec![None, None, None, None],
     );
 
-    spawn_pending_colony_command(
+    spawn_pending_remote_command(
         &mut app,
         sys,
         0,
         100,
-        ColonyCommand {
-            target_planet: Some(planet),
-            kind: ColonyCommandKind::QueueBuilding {
+        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Queue {
                 building_id: "mine".to_string(),
                 target_slot: 0,
-            },
-        },
+            } }),
     );
 
     // Advance halfway.
@@ -471,13 +446,10 @@ fn local_dispatch_applies_same_frame() {
         .queue
         .push(PendingColonyDispatch {
             target_system: sys,
-            command: ColonyCommand {
-                target_planet: Some(planet),
-                kind: ColonyCommandKind::QueueBuilding {
+            command: RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Queue {
                     building_id: "mine".to_string(),
                     target_slot: 0,
-                },
-            },
+                } }),
         });
 
     // Align LastProductionTick so the build queue tick sees delta=1.
@@ -538,13 +510,10 @@ fn remote_dispatch_delayed_by_light_speed() {
         .queue
         .push(PendingColonyDispatch {
             target_system: target_sys,
-            command: ColonyCommand {
-                target_planet: Some(target_planet),
-                kind: ColonyCommandKind::QueueBuilding {
+            command: RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(target_planet), kind: BuildingKind::Queue {
                     building_id: "mine".to_string(),
                     target_slot: 0,
-                },
-            },
+                } }),
         });
 
     // Run one frame. Dispatch drains and spawns PendingCommand;
@@ -592,7 +561,7 @@ fn remote_dispatch_delayed_by_light_speed() {
     );
 }
 
-/// Remote system-level dispatch (Commit D): `target_planet: None` targets
+/// Remote system-level dispatch (Commit D): `scope: BuildingScope::System` targets
 /// the `SystemBuildingQueue` on the target system.
 #[test]
 fn remote_system_level_dispatch_delayed() {
@@ -628,13 +597,10 @@ fn remote_system_level_dispatch_delayed() {
         .queue
         .push(PendingColonyDispatch {
             target_system: target_sys,
-            command: ColonyCommand {
-                target_planet: None,
-                kind: ColonyCommandKind::QueueBuilding {
+            command: RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::System, kind: BuildingKind::Queue {
                     building_id: "shipyard".to_string(),
                     target_slot: 0,
-                },
-            },
+                } }),
         });
 
     advance_time(&mut app, 1);
@@ -705,14 +671,7 @@ fn remote_ship_build_dispatch_delayed() {
         .queue
         .push(PendingColonyDispatch {
             target_system: target_sys,
-            command: ColonyCommand {
-                target_planet: None,
-                kind: ColonyCommandKind::QueueShipBuild {
-                    host_colony: target_colony,
-                    design_id: "explorer_mk1".to_string(),
-                    build_kind: BuildKind::Ship,
-                },
-            },
+            command: RemoteCommand::ShipBuild { host_colony: target_colony, design_id: "explorer_mk1".to_string(), build_kind: BuildKind::Ship },
         });
 
     advance_time(&mut app, 1);
@@ -757,18 +716,15 @@ fn arrival_marks_command_log_entry() {
         vec![None, None, None, None],
     );
 
-    spawn_pending_colony_command(
+    spawn_pending_remote_command(
         &mut app,
         sys,
         0,
         10,
-        ColonyCommand {
-            target_planet: Some(planet),
-            kind: ColonyCommandKind::QueueBuilding {
+        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Queue {
                 building_id: "mine".to_string(),
                 target_slot: 0,
-            },
-        },
+            } }),
     );
 
     run_until_arrival(&mut app, 10);

--- a/macrocosmo/tests/save_load.rs
+++ b/macrocosmo/tests/save_load.rs
@@ -923,7 +923,7 @@ fn test_save_load_deterministic_continuation() {
 /// into a fresh one, and verifies the remapped Entity is still valid.
 #[test]
 fn test_save_load_preserves_pending_colony_command() {
-    use macrocosmo::communication::{ColonyCommand, ColonyCommandKind, PendingCommand, RemoteCommand};
+    use macrocosmo::communication::{PendingCommand, RemoteCommand};
     let mut src = build_seed_world();
 
     // Pick two systems and a colony to reference.
@@ -949,14 +949,11 @@ fn test_save_load_preserves_pending_colony_command() {
 
     src.spawn(PendingCommand {
         target_system: alpha_centauri,
-        command: RemoteCommand::Colony(ColonyCommand {
-            target_planet: None,
-            kind: ColonyCommandKind::QueueShipBuild {
-                host_colony: colony_entity,
-                design_id: "explorer_mk1".into(),
-                build_kind: macrocosmo::colony::BuildKind::Ship,
-            },
-        }),
+        command: RemoteCommand::ShipBuild {
+            host_colony: colony_entity,
+            design_id: "explorer_mk1".into(),
+            build_kind: macrocosmo::colony::BuildKind::Ship,
+        },
         sent_at: 100,
         arrives_at: 700,
         origin_pos: [0.0, 0.0, 0.0],
@@ -988,10 +985,7 @@ fn test_save_load_preserves_pending_colony_command() {
     assert_eq!(cmd.sent_at, 100);
     assert_eq!(cmd.arrives_at, 700);
     match &cmd.command {
-        RemoteCommand::Colony(ColonyCommand {
-            target_planet: None,
-            kind: ColonyCommandKind::QueueShipBuild { host_colony, design_id, .. },
-        }) => {
+        RemoteCommand::ShipBuild { host_colony, design_id, .. } => {
             assert_eq!(*host_colony, colony_dst, "host_colony Entity remap");
             assert_eq!(design_id, "explorer_mk1");
         }


### PR DESCRIPTION
## Summary

#270 design review (Design #4) flagged that `ColonyCommand.target_planet: Option<Entity>` lied — `QueueShipBuild` / `QueueDeliverableBuild` carried their own `host_colony` and ignored `target_planet` entirely. This PR splits the schema so each variant only carries the fields it uses.

## Schema change

**Before**
```rust
RemoteCommand::Colony(ColonyCommand {
    target_planet: Option<Entity>,
    kind: ColonyCommandKind {
        QueueBuilding / DemolishBuilding / UpgradeBuilding / QueueShipBuild / QueueDeliverableBuild
    }
})
```

**After**
```rust
RemoteCommand {
    Colony(ColonyCommand { scope: BuildingScope, kind: BuildingKind }),
    ShipBuild { host_colony, design_id, build_kind },
    DeliverableBuild { host_colony, def_id, display_name, cargo_size, minerals_cost, energy_cost, build_time },
}

BuildingScope = Planet(Entity) | System       // explicit, no more Option<Entity>
BuildingKind  = Queue | Demolish | Upgrade    // building-slot ops only
```

## Changes

- `communication/mod.rs` — new `BuildingScope` / `BuildingKind` types; `ColonyCommand` is building-only; `PendingColonyDispatch.command` changes from `ColonyCommand` to `RemoteCommand` (UI already dispatches arbitrary RemoteCommand shapes)
- `colony/remote.rs` — `apply_colony_command` → `apply_remote_command`; dispatches at the top level, delegates to a private `apply_building_command` helper for building slot ops
- `persistence/savebag.rs` — `SavedRemoteCommand` grows `ShipBuild` / `DeliverableBuild` variants; `SavedColonyCommand` carries `SavedBuildingScope` enum instead of `Option<u64>` bits
- `ui/system_panel/*` — callsites updated
- `tests/remote_colony_commands.rs` + `tests/save_load.rs` — test constructors updated

## Breaking change

Old save files with in-flight `PendingCommand` entities will fail to deserialize (enum variant name changes). Pre-alpha, acceptable — no migration layer added.

## Tests

All 12 integration tests in `tests/remote_colony_commands.rs` + save/load tests + full workspace suite pass after the refactor.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)