### PR TITLE
#275: BuildOrder stable order_id + Cancel Ship/Building UI

### DIFF
--- a/macrocosmo/src/colony/building_queue.rs
+++ b/macrocosmo/src/colony/building_queue.rs
@@ -1,24 +1,49 @@
 use bevy::prelude::*;
 
 use crate::amount::Amt;
+use crate::components::Position;
 use crate::events::{GameEvent, GameEventKind};
 use crate::galaxy::{Planet, StarSystem};
-use crate::components::Position;
-use crate::knowledge::{
- FactSysParam, KnowledgeFact, PlayerVantage,
-};
+use crate::knowledge::{FactSysParam, KnowledgeFact, PlayerVantage};
 use crate::player::{AboardShip, Player, StationedAt};
 use crate::scripting::building_api::BuildingId;
-use crate::ship::{spawn_ship, CargoItem, Owner, Ship};
+use crate::ship::{CargoItem, Owner, Ship, spawn_ship};
 use crate::time_system::GameClock;
 
-use super::{
-    Colony, DeliverableStockpile, LastProductionTick, ResourceStockpile, SystemBuildings,
-};
+use super::{Colony, DeliverableStockpile, LastProductionTick, ResourceStockpile, SystemBuildings};
 
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct BuildQueue {
     pub queue: Vec<BuildOrder>,
+    /// #275: Monotonic counter used to stamp stable `BuildOrder::order_id`
+    /// values. Starts at 1 so that 0 is reserved as a "manufactured / never
+    /// pushed via helper" sentinel for test scaffolding. Wraps on overflow
+    /// — practically unreachable.
+    pub next_order_id: u64,
+}
+
+impl BuildQueue {
+    /// #275: Push a new order, auto-assigning a unique `order_id`. Returns
+    /// the assigned id so the caller can correlate (e.g. dispatch a cancel
+    /// later). Ignores any id pre-set on `order`.
+    pub fn push_order(&mut self, mut order: BuildOrder) -> u64 {
+        if self.next_order_id == 0 {
+            self.next_order_id = 1;
+        }
+        let id = self.next_order_id;
+        self.next_order_id = self.next_order_id.wrapping_add(1);
+        order.order_id = id;
+        self.queue.push(order);
+        id
+    }
+
+    /// #275: Remove the first order matching `order_id`. Returns the
+    /// removed `BuildOrder` if found, or `None` if no match (e.g. the
+    /// order already completed / was cancelled by a racing arrival).
+    pub fn remove_order(&mut self, order_id: u64) -> Option<BuildOrder> {
+        let pos = self.queue.iter().position(|o| o.order_id == order_id)?;
+        Some(self.queue.remove(pos))
+    }
 }
 
 /// #223: What kind of thing a `BuildOrder` builds.
@@ -37,6 +62,12 @@ pub enum BuildKind {
 }
 
 pub struct BuildOrder {
+    /// #275: Stable id assigned at push time. Used by cancel commands to
+    /// survive queue shifts under light-speed delay (the index at
+    /// send-time may not match the index at arrival). Pushing via
+    /// `BuildQueue::push_order` auto-assigns; manually constructed orders
+    /// (test scaffolding, save-game restores) carry the caller's value.
+    pub order_id: u64,
     /// #223: What this order builds (Ship or Deliverable). Defaults to Ship
     /// for back-compat with existing construction sites.
     pub kind: BuildKind,
@@ -60,13 +91,26 @@ impl BuildOrder {
     }
 
     /// Returns the build time in hexadies for a given design_id.
-    pub fn build_time_for(design_id: &str, design_registry: &crate::ship_design::ShipDesignRegistry) -> i64 {
+    pub fn build_time_for(
+        design_id: &str,
+        design_registry: &crate::ship_design::ShipDesignRegistry,
+    ) -> i64 {
         design_registry.build_time(design_id)
     }
 }
 
 // BuildingType enum has been removed. Use BuildingId + BuildingRegistry instead.
 // BuildingId is defined in scripting::building_api.
+
+/// #275: Tag returned by `BuildingQueue::cancel_order` / `SystemBuildingQueue::cancel_order`
+/// identifying which sub-queue the cancelled order lived in. Primarily for log
+/// context; callers rarely branch on it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CancelledOrderKind {
+    Construction,
+    Demolition,
+    Upgrade,
+}
 
 #[derive(Component)]
 pub struct Buildings {
@@ -76,14 +120,22 @@ pub struct Buildings {
 impl Buildings {
     /// Check if any slot contains a building with the given id.
     pub fn has_building(&self, id: &str) -> bool {
-        self.slots.iter().any(|s| s.as_ref().is_some_and(|b| b.0 == id))
+        self.slots
+            .iter()
+            .any(|s| s.as_ref().is_some_and(|b| b.0 == id))
     }
 
     /// Check if any building in slots has the given capability (looked up via BuildingRegistry).
-    pub fn has_capability(&self, capability: &str, registry: &crate::scripting::building_api::BuildingRegistry) -> bool {
+    pub fn has_capability(
+        &self,
+        capability: &str,
+        registry: &crate::scripting::building_api::BuildingRegistry,
+    ) -> bool {
         self.slots.iter().any(|slot| {
             slot.as_ref().is_some_and(|id| {
-                registry.get(id.as_str()).is_some_and(|def| def.capabilities.contains_key(capability))
+                registry
+                    .get(id.as_str())
+                    .is_some_and(|def| def.capabilities.contains_key(capability))
             })
         })
     }
@@ -104,9 +156,16 @@ pub struct BuildingQueue {
     pub queue: Vec<BuildingOrder>,
     pub demolition_queue: Vec<DemolitionOrder>,
     pub upgrade_queue: Vec<UpgradeOrder>,
+    /// #275: Shared monotonic counter for `order_id` across all three
+    /// sub-queues (construction / demolition / upgrade). A single counter
+    /// lets the cancel command carry a single opaque `order_id` without
+    /// the caller having to remember which sub-queue holds it.
+    pub next_order_id: u64,
 }
 
 pub struct BuildingOrder {
+    /// #275: Stable id (see `BuildOrder::order_id`).
+    pub order_id: u64,
     pub building_id: BuildingId,
     pub target_slot: usize,
     pub minerals_remaining: Amt,
@@ -115,6 +174,8 @@ pub struct BuildingOrder {
 }
 
 pub struct DemolitionOrder {
+    /// #275: Stable id (see `BuildOrder::order_id`).
+    pub order_id: u64,
     pub target_slot: usize,
     pub building_id: BuildingId,
     pub time_remaining: i64,
@@ -126,6 +187,8 @@ pub struct DemolitionOrder {
 /// During the upgrade, the original building remains active. On completion,
 /// the slot's building ID is replaced with the target.
 pub struct UpgradeOrder {
+    /// #275: Stable id (see `BuildOrder::order_id`).
+    pub order_id: u64,
     pub slot_index: usize,
     pub target_id: BuildingId,
     pub minerals_remaining: Amt,
@@ -134,6 +197,69 @@ pub struct UpgradeOrder {
 }
 
 impl BuildingQueue {
+    fn allocate_order_id(&mut self) -> u64 {
+        if self.next_order_id == 0 {
+            self.next_order_id = 1;
+        }
+        let id = self.next_order_id;
+        self.next_order_id = self.next_order_id.wrapping_add(1);
+        id
+    }
+
+    /// #275: Push a construction order, auto-assigning `order_id`. Returns
+    /// the assigned id.
+    pub fn push_build_order(&mut self, mut order: BuildingOrder) -> u64 {
+        let id = self.allocate_order_id();
+        order.order_id = id;
+        self.queue.push(order);
+        id
+    }
+
+    /// #275: Push a demolition order, auto-assigning `order_id`.
+    pub fn push_demolition_order(&mut self, mut order: DemolitionOrder) -> u64 {
+        let id = self.allocate_order_id();
+        order.order_id = id;
+        self.demolition_queue.push(order);
+        id
+    }
+
+    /// #275: Push an upgrade order, auto-assigning `order_id`.
+    pub fn push_upgrade_order(&mut self, mut order: UpgradeOrder) -> u64 {
+        let id = self.allocate_order_id();
+        order.order_id = id;
+        self.upgrade_queue.push(order);
+        id
+    }
+
+    /// #275: Find and remove an order across all three sub-queues by
+    /// `order_id`. Returns the sub-queue the order lived in (for caller
+    /// logging) or `None` if no match. Invested resources are NOT
+    /// refunded on construction cancel; demolitions are cancelled before
+    /// they refund (no double-refund risk).
+    pub fn cancel_order(&mut self, order_id: u64) -> Option<CancelledOrderKind> {
+        if let Some(pos) = self.queue.iter().position(|o| o.order_id == order_id) {
+            self.queue.remove(pos);
+            return Some(CancelledOrderKind::Construction);
+        }
+        if let Some(pos) = self
+            .demolition_queue
+            .iter()
+            .position(|o| o.order_id == order_id)
+        {
+            self.demolition_queue.remove(pos);
+            return Some(CancelledOrderKind::Demolition);
+        }
+        if let Some(pos) = self
+            .upgrade_queue
+            .iter()
+            .position(|o| o.order_id == order_id)
+        {
+            self.upgrade_queue.remove(pos);
+            return Some(CancelledOrderKind::Upgrade);
+        }
+        None
+    }
+
     /// Check if a given slot is currently being demolished.
     pub fn is_demolishing(&self, slot: usize) -> bool {
         self.demolition_queue.iter().any(|d| d.target_slot == slot)
@@ -141,7 +267,8 @@ impl BuildingQueue {
 
     /// Get the remaining demolition time for a slot, if any.
     pub fn demolition_time_remaining(&self, slot: usize) -> Option<i64> {
-        self.demolition_queue.iter()
+        self.demolition_queue
+            .iter()
             .find(|d| d.target_slot == slot)
             .map(|d| d.time_remaining)
     }
@@ -202,8 +329,14 @@ pub fn tick_build_queue(
 
     // Per-order completion info (#223).
     enum Completion {
-        Ship { design_id: String, display_name: String },
-        Deliverable { definition_id: String, display_name: String },
+        Ship {
+            design_id: String,
+            display_name: String,
+        },
+        Deliverable {
+            definition_id: String,
+            display_name: String,
+        },
     }
 
     // Collect build queue processing results
@@ -217,18 +350,24 @@ pub fn tick_build_queue(
     let mut results: Vec<BuildResult> = Vec::new();
 
     for (colony, mut build_queue) in &mut colonies {
-        let Some(sys) = colony.system(&planets) else { continue };
+        let Some(sys) = colony.system(&planets) else {
+            continue;
+        };
 
         // #35: Skip ship construction if system has no shipyard capability.
         // Deliverables also require a shipyard.
-        let has_shipyard = system_buildings.get(sys).is_ok_and(|sb| sb.has_shipyard(&building_registry));
+        let has_shipyard = system_buildings
+            .get(sys)
+            .is_ok_and(|sb| sb.has_shipyard(&building_registry));
         if !build_queue.queue.is_empty() && !has_shipyard {
             warn!("System lacks a Shipyard; skipping construction");
             continue;
         }
 
         // Get current stockpile amounts for this system
-        let Ok(stockpile) = stockpiles.get(sys) else { continue };
+        let Ok(stockpile) = stockpiles.get(sys) else {
+            continue;
+        };
         let mut available_minerals = stockpile.minerals;
         let mut available_energy = stockpile.energy;
         let mut total_minerals_consumed = Amt::ZERO;
@@ -288,9 +427,15 @@ pub fn tick_build_queue(
             stockpile.energy = stockpile.energy.sub(result.energy_consumed);
         }
         for c in result.completed {
-            let sys_name = stars.get(result.system).map(|s| s.name.clone()).unwrap_or_default();
+            let sys_name = stars
+                .get(result.system)
+                .map(|s| s.name.clone())
+                .unwrap_or_default();
             match c {
-                Completion::Ship { design_id, display_name } => {
+                Completion::Ship {
+                    design_id,
+                    display_name,
+                } => {
                     if let Ok(pos) = positions.get(result.system) {
                         spawn_ship(
                             &mut commands,
@@ -311,10 +456,8 @@ pub fn tick_build_queue(
                             description: desc.clone(),
                             related_system: Some(result.system),
                         });
-                        let origin_pos: Option<[f64; 3]> = positions
-                            .get(result.system)
-                            .ok()
-                            .map(|p| p.as_array());
+                        let origin_pos: Option<[f64; 3]> =
+                            positions.get(result.system).ok().map(|p| p.as_array());
                         if let (Some(v), Some(op)) = (vantage, origin_pos) {
                             let fact = KnowledgeFact::StructureBuilt {
                                 event_id: Some(event_id),
@@ -329,16 +472,21 @@ pub fn tick_build_queue(
                         info!("Ship built and launched: {}", display_name);
                     }
                 }
-                Completion::Deliverable { definition_id, display_name } => {
+                Completion::Deliverable {
+                    definition_id,
+                    display_name,
+                } => {
                     // #223: Push the new CargoItem into the system's DeliverableStockpile.
                     // If the component doesn't yet exist, add one via commands.
-                    let item = CargoItem::Deliverable { definition_id: definition_id.clone() };
+                    let item = CargoItem::Deliverable {
+                        definition_id: definition_id.clone(),
+                    };
                     if let Ok(mut dstock) = deliverable_stockpiles.get_mut(result.system) {
                         dstock.push(item);
                     } else {
-                        commands.entity(result.system).insert(DeliverableStockpile {
-                            items: vec![item],
-                        });
+                        commands
+                            .entity(result.system)
+                            .insert(DeliverableStockpile { items: vec![item] });
                     }
                     let event_id = fact_sys.allocate_event_id();
                     let desc = format!("Deliverable '{}' produced at {}", display_name, sys_name);
@@ -389,13 +537,18 @@ pub fn tick_building_queue(
         minerals_refunded: Amt,
         energy_refunded: Amt,
     }
-    let mut system_deltas: std::collections::HashMap<Entity, SystemDelta> = std::collections::HashMap::new();
+    let mut system_deltas: std::collections::HashMap<Entity, SystemDelta> =
+        std::collections::HashMap::new();
 
     for (colony_entity, colony, mut bq, mut buildings) in &mut query {
-        let Some(sys) = colony.system(&planets) else { continue };
+        let Some(sys) = colony.system(&planets) else {
+            continue;
+        };
 
         // Get available resources from system stockpile
-        let Ok(stockpile) = stockpiles.get(sys) else { continue };
+        let Ok(stockpile) = stockpiles.get(sys) else {
+            continue;
+        };
         let mut available_minerals = stockpile.minerals;
         let mut available_energy = stockpile.energy;
 
@@ -407,8 +560,12 @@ pub fn tick_building_queue(
 
         // Also account for deltas already accumulated for this system by previous colonies
         if let Some(existing) = system_deltas.get(&sys) {
-            available_minerals = available_minerals.sub(existing.minerals_consumed).add(existing.minerals_refunded);
-            available_energy = available_energy.sub(existing.energy_consumed).add(existing.energy_refunded);
+            available_minerals = available_minerals
+                .sub(existing.minerals_consumed)
+                .add(existing.minerals_refunded);
+            available_energy = available_energy
+                .sub(existing.energy_consumed)
+                .add(existing.energy_refunded);
         }
 
         // --- Process construction queue ---
@@ -434,8 +591,8 @@ pub fn tick_building_queue(
             // the completion check (which also requires 0 remaining cost)
             // keeps blocking completion.
             let transferred = minerals_transfer > Amt::ZERO || energy_transfer > Amt::ZERO;
-            let no_more_needed = order.minerals_remaining == Amt::ZERO
-                && order.energy_remaining == Amt::ZERO;
+            let no_more_needed =
+                order.minerals_remaining == Amt::ZERO && order.energy_remaining == Amt::ZERO;
             super::build_tick::maybe_tick_build_time(
                 &mut order.build_time_remaining,
                 transferred,
@@ -473,7 +630,11 @@ pub fn tick_building_queue(
             }
         }
         for slot_idx in completed_demolitions {
-            if let Some(pos) = bq.demolition_queue.iter().position(|d| d.target_slot == slot_idx) {
+            if let Some(pos) = bq
+                .demolition_queue
+                .iter()
+                .position(|d| d.target_slot == slot_idx)
+            {
                 let completed = bq.demolition_queue.remove(pos);
                 if slot_idx < buildings.slots.len() {
                     let building_name = buildings.slots[slot_idx]
@@ -553,11 +714,7 @@ pub fn tick_building_queue(
                     "Building upgrade completed: {} -> {} in slot {}",
                     old_name, completed.target_id, completed.slot_index
                 );
-                event_system.fire_event(
-                    "building_upgraded",
-                    Some(colony_entity),
-                    clock.elapsed,
-                );
+                event_system.fire_event("building_upgraded", Some(colony_entity), clock.elapsed);
             }
         }
 
@@ -576,8 +733,14 @@ pub fn tick_building_queue(
     // Apply all stockpile changes
     for (sys, delta) in system_deltas {
         if let Ok(mut stockpile) = stockpiles.get_mut(sys) {
-            stockpile.minerals = stockpile.minerals.sub(delta.minerals_consumed).add(delta.minerals_refunded);
-            stockpile.energy = stockpile.energy.sub(delta.energy_consumed).add(delta.energy_refunded);
+            stockpile.minerals = stockpile
+                .minerals
+                .sub(delta.minerals_consumed)
+                .add(delta.minerals_refunded);
+            stockpile.energy = stockpile
+                .energy
+                .sub(delta.energy_consumed)
+                .add(delta.energy_refunded);
         }
     }
 }
@@ -643,9 +806,15 @@ mod tests {
         registry
     }
 
-    fn make_order(minerals_cost: Amt, minerals_invested: Amt, energy_cost: Amt, energy_invested: Amt) -> BuildOrder {
+    fn make_order(
+        minerals_cost: Amt,
+        minerals_invested: Amt,
+        energy_cost: Amt,
+        energy_invested: Amt,
+    ) -> BuildOrder {
         let build_time = 60;
         BuildOrder {
+            order_id: 0,
             kind: BuildKind::default(),
             design_id: "explorer_mk1".to_string(),
             display_name: "Explorer".to_string(),
@@ -660,25 +829,45 @@ mod tests {
 
     #[test]
     fn build_order_complete_when_both_met() {
-        let order = make_order(Amt::units(100), Amt::units(100), Amt::units(50), Amt::units(50));
+        let order = make_order(
+            Amt::units(100),
+            Amt::units(100),
+            Amt::units(50),
+            Amt::units(50),
+        );
         assert!(order.is_complete());
     }
 
     #[test]
     fn build_order_incomplete_minerals_short() {
-        let order = make_order(Amt::units(100), Amt::units(80), Amt::units(50), Amt::units(50));
+        let order = make_order(
+            Amt::units(100),
+            Amt::units(80),
+            Amt::units(50),
+            Amt::units(50),
+        );
         assert!(!order.is_complete());
     }
 
     #[test]
     fn build_order_incomplete_energy_short() {
-        let order = make_order(Amt::units(100), Amt::units(100), Amt::units(50), Amt::units(30));
+        let order = make_order(
+            Amt::units(100),
+            Amt::units(100),
+            Amt::units(50),
+            Amt::units(30),
+        );
         assert!(!order.is_complete());
     }
 
     #[test]
     fn build_order_incomplete_time_remaining() {
-        let mut order = make_order(Amt::units(100), Amt::units(100), Amt::units(50), Amt::units(50));
+        let mut order = make_order(
+            Amt::units(100),
+            Amt::units(100),
+            Amt::units(50),
+            Amt::units(50),
+        );
         order.build_time_remaining = 5;
         assert!(!order.is_complete());
     }
@@ -712,7 +901,11 @@ mod tests {
     #[test]
     fn has_shipyard_true() {
         let buildings = Buildings {
-            slots: vec![Some(BuildingId::new("mine")), Some(BuildingId::new("shipyard")), None],
+            slots: vec![
+                Some(BuildingId::new("mine")),
+                Some(BuildingId::new("shipyard")),
+                None,
+            ],
         };
         assert!(buildings.has_shipyard());
     }
@@ -720,24 +913,40 @@ mod tests {
     #[test]
     fn has_shipyard_false() {
         let buildings = Buildings {
-            slots: vec![Some(BuildingId::new("mine")), Some(BuildingId::new("power_plant")), None],
+            slots: vec![
+                Some(BuildingId::new("mine")),
+                Some(BuildingId::new("power_plant")),
+                None,
+            ],
         };
         assert!(!buildings.has_shipyard());
     }
 
     #[test]
     fn production_focus_labels() {
-        assert_eq!(super::super::ProductionFocus::balanced().label(), "Balanced");
-        assert_eq!(super::super::ProductionFocus::minerals().label(), "Minerals");
+        assert_eq!(
+            super::super::ProductionFocus::balanced().label(),
+            "Balanced"
+        );
+        assert_eq!(
+            super::super::ProductionFocus::minerals().label(),
+            "Minerals"
+        );
         assert_eq!(super::super::ProductionFocus::energy().label(), "Energy");
-        assert_eq!(super::super::ProductionFocus::research().label(), "Research");
+        assert_eq!(
+            super::super::ProductionFocus::research().label(),
+            "Research"
+        );
     }
 
     #[test]
     fn build_order_build_time_for() {
         let registry = test_design_registry();
         assert_eq!(BuildOrder::build_time_for("explorer_mk1", &registry), 60);
-        assert_eq!(BuildOrder::build_time_for("colony_ship_mk1", &registry), 120);
+        assert_eq!(
+            BuildOrder::build_time_for("colony_ship_mk1", &registry),
+            120
+        );
         assert_eq!(BuildOrder::build_time_for("courier_mk1", &registry), 30);
         assert_eq!(BuildOrder::build_time_for("unknown", &registry), 60);
     }
@@ -747,7 +956,11 @@ mod tests {
     #[test]
     fn has_port_true() {
         let buildings = Buildings {
-            slots: vec![Some(BuildingId::new("mine")), Some(BuildingId::new("port")), None],
+            slots: vec![
+                Some(BuildingId::new("mine")),
+                Some(BuildingId::new("port")),
+                None,
+            ],
         };
         assert!(buildings.has_port());
     }
@@ -755,7 +968,11 @@ mod tests {
     #[test]
     fn has_port_false() {
         let buildings = Buildings {
-            slots: vec![Some(BuildingId::new("mine")), Some(BuildingId::new("shipyard")), None],
+            slots: vec![
+                Some(BuildingId::new("mine")),
+                Some(BuildingId::new("shipyard")),
+                None,
+            ],
         };
         assert!(!buildings.has_port());
     }
@@ -765,6 +982,7 @@ mod tests {
         let bq = BuildingQueue {
             queue: Vec::new(),
             demolition_queue: vec![DemolitionOrder {
+                order_id: 0,
                 target_slot: 2,
                 building_id: BuildingId::new("mine"),
                 time_remaining: 5,
@@ -772,6 +990,7 @@ mod tests {
                 energy_refund: Amt::ZERO,
             }],
             upgrade_queue: Vec::new(),
+            next_order_id: 0,
         };
         assert!(bq.is_demolishing(2));
         assert!(!bq.is_demolishing(0));

--- a/macrocosmo/src/colony/colonization.rs
+++ b/macrocosmo/src/colony/colonization.rs
@@ -1,22 +1,20 @@
 use bevy::prelude::*;
 
 use crate::amount::Amt;
-use crate::galaxy::{Planet, StarSystem, SystemAttributes};
-use crate::modifier::ModifiedValue;
-use crate::events::GameEvent;
 use crate::colony::ColonyJobRates;
 use crate::components::Position;
-use crate::knowledge::{
- FactSysParam, KnowledgeFact, PlayerVantage,
-};
+use crate::events::GameEvent;
+use crate::galaxy::{Planet, StarSystem, SystemAttributes};
+use crate::knowledge::{FactSysParam, KnowledgeFact, PlayerVantage};
+use crate::modifier::ModifiedValue;
 use crate::player::{AboardShip, Player, StationedAt};
 use crate::species::{ColonyJobs, ColonyPopulation, ColonySpecies};
 use crate::time_system::GameClock;
 
 use super::{
-    Buildings, BuildQueue, BuildingQueue, Colony, FoodConsumption, LastProductionTick,
-    MaintenanceCost, Production, ProductionFocus, ResourceCapacity, ResourceStockpile,
-    SystemBuildings, SystemBuildingQueue, DEFAULT_SYSTEM_BUILDING_SLOTS,
+    BuildQueue, BuildingQueue, Buildings, Colony, DEFAULT_SYSTEM_BUILDING_SLOTS, FoodConsumption,
+    LastProductionTick, MaintenanceCost, Production, ProductionFocus, ResourceCapacity,
+    ResourceStockpile, SystemBuildingQueue, SystemBuildings,
 };
 
 /// #114: Default cost/time to colonize a new planet from an existing colony in the same system.
@@ -97,9 +95,7 @@ pub fn spawn_capital_colony(
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue {
-            queue: Vec::new(),
-        },
+        BuildQueue::default(),
         Buildings { slots },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -124,7 +120,9 @@ pub fn spawn_capital_colony(
             authority: Amt::ZERO,
         },
         ResourceCapacity::default(),
-        SystemBuildings { slots: system_slots },
+        SystemBuildings {
+            slots: system_slots,
+        },
         SystemBuildingQueue::default(),
     ));
     info!("Capital colony scaffold created on {}", capital_star.name);
@@ -220,8 +218,10 @@ pub fn tick_colonization_queue(
                     research_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
                     food_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
                 },
-                BuildQueue { queue: Vec::new() },
-                Buildings { slots: vec![None; num_slots] },
+                BuildQueue::default(),
+                Buildings {
+                    slots: vec![None; num_slots],
+                },
                 BuildingQueue::default(),
                 ProductionFocus::default(),
                 MaintenanceCost::default(),
@@ -259,7 +259,10 @@ pub fn tick_colonization_queue(
                 fact_sys.record(fact, op, clock.elapsed, &v);
             }
 
-            info!("Colony established on {} via build queue colonization", planet_name);
+            info!(
+                "Colony established on {} via build queue colonization",
+                planet_name
+            );
         }
     }
 }
@@ -288,16 +291,18 @@ pub fn apply_pending_colonization_orders(
                 initial_population: COLONIZATION_POPULATION_TRANSFER,
             });
         } else {
-            commands.entity(order.system_entity).insert(ColonizationQueue {
-                orders: vec![ColonizationOrder {
-                    target_planet: order.target_planet,
-                    source_colony: order.source_colony,
-                    minerals_remaining: mineral_cost,
-                    energy_remaining: energy_cost,
-                    build_time_remaining: build_time,
-                    initial_population: COLONIZATION_POPULATION_TRANSFER,
-                }],
-            });
+            commands
+                .entity(order.system_entity)
+                .insert(ColonizationQueue {
+                    orders: vec![ColonizationOrder {
+                        target_planet: order.target_planet,
+                        source_colony: order.source_colony,
+                        minerals_remaining: mineral_cost,
+                        energy_remaining: energy_cost,
+                        build_time_remaining: build_time,
+                        initial_population: COLONIZATION_POPULATION_TRANSFER,
+                    }],
+                });
         }
         commands.entity(entity).despawn();
     }

--- a/macrocosmo/src/colony/remote.rs
+++ b/macrocosmo/src/colony/remote.rs
@@ -33,6 +33,10 @@ pub type ApplyColoniesQuery<'w, 's> = Query<
 pub type ApplySystemBuildingsQuery<'w, 's> =
     Query<'w, 's, (&'static SystemBuildings, &'static mut SystemBuildingQueue)>;
 
+/// #275: Read-only `Planet` lookup used by `CancelBuildingOrder` to scope
+/// the order-id search to colonies in the target system.
+pub type ApplyPlanetsQuery<'w, 's> = Query<'w, 's, &'static crate::galaxy::Planet>;
+
 /// Apply a `RemoteCommand` that has just arrived. Cost, time, and refund
 /// amounts are resolved here against the *current* registry + modifier
 /// state at the target for building ops and ship builds;
@@ -41,6 +45,7 @@ pub type ApplySystemBuildingsQuery<'w, 's> =
 ///
 /// Silently warns and drops on unknown ids / missing slots / missing
 /// target components — arrival should never panic.
+#[allow(clippy::too_many_arguments)]
 pub fn apply_remote_command(
     cmd: &RemoteCommand,
     target_system: Entity,
@@ -50,6 +55,7 @@ pub fn apply_remote_command(
     bldg_time_mod: Amt,
     colonies: &mut ApplyColoniesQuery,
     sys_buildings_q: &mut ApplySystemBuildingsQuery,
+    planets: &ApplyPlanetsQuery,
 ) {
     match cmd {
         RemoteCommand::BuildShip { .. } | RemoteCommand::SetProductionFocus { .. } => {
@@ -78,7 +84,8 @@ pub fn apply_remote_command(
                 return;
             };
             let build_time_total = sdr.build_time(design_id);
-            build_q.queue.push(BuildOrder {
+            build_q.push_order(BuildOrder {
+                order_id: 0,
                 kind: build_kind.clone(),
                 design_id: design_id.clone(),
                 display_name: design.name.clone(),
@@ -106,7 +113,8 @@ pub fn apply_remote_command(
                 );
                 return;
             };
-            build_q.queue.push(BuildOrder {
+            build_q.push_order(BuildOrder {
+                order_id: 0,
                 kind: BuildKind::Deliverable {
                     cargo_size: *cargo_size,
                 },
@@ -120,7 +128,98 @@ pub fn apply_remote_command(
                 build_time_remaining: *build_time,
             });
         }
+        RemoteCommand::CancelBuildingOrder { order_id } => apply_cancel_building_order(
+            *order_id,
+            target_system,
+            colonies,
+            sys_buildings_q,
+            planets,
+        ),
+        RemoteCommand::CancelShipOrder {
+            host_colony,
+            order_id,
+        } => {
+            let Ok((_, _, _, mut build_q)) = colonies.get_mut(*host_colony) else {
+                warn!(
+                    "CancelShipOrder: host_colony {:?} has no BuildQueue (race with colony despawn?)",
+                    host_colony
+                );
+                return;
+            };
+            match build_q.remove_order(*order_id) {
+                Some(o) => {
+                    info!(
+                        "Cancelled ship order id={} design={} on host_colony {:?}",
+                        order_id, o.design_id, host_colony
+                    );
+                }
+                None => {
+                    warn!(
+                        "CancelShipOrder: order_id={} not found on host_colony {:?} \
+                         (likely raced with completion or another cancel)",
+                        order_id, host_colony
+                    );
+                }
+            }
+        }
     }
+}
+
+/// #275: Cancel a building / demolition / upgrade order by `order_id`.
+/// The dispatch does not carry scope. The handler first scopes to the
+/// target system (via the Planet lookup): iterate colonies whose planet
+/// lives in `target_system` and ask each BuildingQueue to cancel the id.
+/// If none match, fall back to the system-level SystemBuildingQueue.
+/// First hit wins; the matching order is removed.
+///
+/// Why scope to `target_system`: `order_id` counters are per-queue, so
+/// the same numeric id can occur independently on different colonies.
+/// Without scoping, a cancel dispatched for system A could accidentally
+/// cancel an unrelated order on system B. Restricting the search to
+/// `target_system` reuses the information the player (and the command)
+/// already carried.
+///
+/// Race semantics: if no queue in `target_system` holds the id (order
+/// already completed, or was cancelled by a racing dispatch), we warn
+/// and drop. Never panics. No resource refund on construction cancel
+/// (invested resources are forfeit); demolition cancel just revokes
+/// the pending refund.
+fn apply_cancel_building_order(
+    order_id: u64,
+    target_system: Entity,
+    colonies: &mut ApplyColoniesQuery,
+    sys_buildings_q: &mut ApplySystemBuildingsQuery,
+    planets: &ApplyPlanetsQuery,
+) {
+    for (colony, _b, mut bq, _) in colonies.iter_mut() {
+        let Ok(planet) = planets.get(colony.planet) else {
+            continue;
+        };
+        if planet.system != target_system {
+            continue;
+        }
+        if let Some(kind) = bq.cancel_order(order_id) {
+            info!(
+                "Cancelled planet building order id={} ({:?}) on system {:?}",
+                order_id, kind, target_system
+            );
+            return;
+        }
+    }
+    if let Ok((_, mut sbq)) = sys_buildings_q.get_mut(target_system) {
+        if let Some(kind) = sbq.cancel_order(order_id) {
+            info!(
+                "Cancelled system building order id={} ({:?}) on system {:?}",
+                order_id, kind, target_system
+            );
+            return;
+        }
+    }
+    warn!(
+        "CancelBuildingOrder: order_id={} not found on system {:?} \
+         (likely raced with completion or another cancel)",
+        order_id, target_system
+    );
 }
 
 fn apply_building_command(
@@ -146,6 +245,7 @@ fn apply_building_command(
             let eff_e = base_e.mul_amt(bldg_cost_mod);
             let eff_time = (def.build_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
             let order = BuildingOrder {
+                order_id: 0,
                 building_id: BuildingId::new(building_id),
                 target_slot: *target_slot,
                 minerals_remaining: eff_m,
@@ -158,7 +258,7 @@ fn apply_building_command(
                 }
                 BuildingScope::System => {
                     if let Ok((_, mut sbq)) = sys_buildings_q.get_mut(target_system) {
-                        sbq.queue.push(order);
+                        sbq.push_build_order(order);
                     } else {
                         warn!(
                             "Queue (system): target_system {:?} has no SystemBuildingQueue",
@@ -191,7 +291,8 @@ fn apply_building_command(
                         break;
                     };
                     let (m_ref, e_ref) = def.demolition_refund();
-                    bq.demolition_queue.push(DemolitionOrder {
+                    bq.push_demolition_order(DemolitionOrder {
+                        order_id: 0,
                         target_slot: *target_slot,
                         building_id: bid,
                         time_remaining: def.demolition_time(),
@@ -227,7 +328,8 @@ fn apply_building_command(
                     return;
                 };
                 let (m_ref, e_ref) = def.demolition_refund();
-                sbq.demolition_queue.push(DemolitionOrder {
+                sbq.push_demolition_order(DemolitionOrder {
+                    order_id: 0,
                     target_slot: *target_slot,
                     building_id: bid,
                     time_remaining: def.demolition_time(),
@@ -240,27 +342,27 @@ fn apply_building_command(
             slot_index,
             target_id,
         } => {
-            let upgrade_order = |source_def: &BuildingDefinition,
-                                 target_id: &str|
-             -> Option<UpgradeOrder> {
-                let up = source_def
-                    .upgrade_to
-                    .iter()
-                    .find(|u| u.target_id == target_id)?;
-                let eff_m = up.cost_minerals.mul_amt(bldg_cost_mod);
-                let eff_e = up.cost_energy.mul_amt(bldg_cost_mod);
-                let base_time = up
-                    .build_time
-                    .unwrap_or_else(|| br.get(target_id).map(|d| d.build_time / 2).unwrap_or(5));
-                let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
-                Some(UpgradeOrder {
-                    slot_index: *slot_index,
-                    target_id: BuildingId::new(target_id),
-                    minerals_remaining: eff_m,
-                    energy_remaining: eff_e,
-                    build_time_remaining: eff_time,
-                })
-            };
+            let upgrade_order =
+                |source_def: &BuildingDefinition, target_id: &str| -> Option<UpgradeOrder> {
+                    let up = source_def
+                        .upgrade_to
+                        .iter()
+                        .find(|u| u.target_id == target_id)?;
+                    let eff_m = up.cost_minerals.mul_amt(bldg_cost_mod);
+                    let eff_e = up.cost_energy.mul_amt(bldg_cost_mod);
+                    let base_time = up.build_time.unwrap_or_else(|| {
+                        br.get(target_id).map(|d| d.build_time / 2).unwrap_or(5)
+                    });
+                    let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
+                    Some(UpgradeOrder {
+                        order_id: 0,
+                        slot_index: *slot_index,
+                        target_id: BuildingId::new(target_id),
+                        minerals_remaining: eff_m,
+                        energy_remaining: eff_e,
+                        build_time_remaining: eff_time,
+                    })
+                };
             match cc.scope {
                 BuildingScope::Planet(planet) => {
                     let mut handled = false;
@@ -275,14 +377,11 @@ fn apply_building_command(
                             break;
                         };
                         let Some(source_def) = br.get(source_bid.as_str()) else {
-                            warn!(
-                                "Upgrade (planet): unknown source building '{}'",
-                                source_bid
-                            );
+                            warn!("Upgrade (planet): unknown source building '{}'", source_bid);
                             break;
                         };
                         if let Some(order) = upgrade_order(source_def, target_id) {
-                            bq.upgrade_queue.push(order);
+                            bq.push_upgrade_order(order);
                         } else {
                             warn!(
                                 "Upgrade (planet): no upgrade path '{}' -> '{}'",
@@ -310,14 +409,11 @@ fn apply_building_command(
                         return;
                     };
                     let Some(source_def) = br.get(source_bid.as_str()) else {
-                        warn!(
-                            "Upgrade (system): unknown source building '{}'",
-                            source_bid
-                        );
+                        warn!("Upgrade (system): unknown source building '{}'", source_bid);
                         return;
                     };
                     if let Some(order) = upgrade_order(source_def, target_id) {
-                        sbq.upgrade_queue.push(order);
+                        sbq.push_upgrade_order(order);
                     } else {
                         warn!(
                             "Upgrade (system): no upgrade path '{}' -> '{}'",
@@ -337,7 +433,7 @@ fn push_planet_building_order(
 ) {
     for (colony, _, mut bq, _) in colonies.iter_mut() {
         if colony.planet == planet {
-            bq.queue.push(order);
+            bq.push_build_order(order);
             return;
         }
     }

--- a/macrocosmo/src/colony/system_buildings.rs
+++ b/macrocosmo/src/colony/system_buildings.rs
@@ -7,8 +7,8 @@ use crate::scripting::building_api::{BuildingId, BuildingRegistry};
 use crate::time_system::GameClock;
 
 use super::{
-    BuildingOrder, Colony, DemolitionOrder, LastProductionTick, MaintenanceCost,
-    ResourceStockpile, UpgradeOrder,
+    BuildingOrder, CancelledOrderKind, Colony, DemolitionOrder, LastProductionTick,
+    MaintenanceCost, ResourceStockpile, UpgradeOrder,
 };
 
 /// Default number of system building slots for any star system.
@@ -23,21 +23,30 @@ pub struct SystemBuildings {
 impl SystemBuildings {
     /// Check if any slot contains a building with the given id.
     pub fn has_building(&self, id: &str) -> bool {
-        self.slots.iter().any(|s| s.as_ref().is_some_and(|b| b.0 == id))
+        self.slots
+            .iter()
+            .any(|s| s.as_ref().is_some_and(|b| b.0 == id))
     }
 
     /// Check if any building in slots has the given capability (looked up via BuildingRegistry).
     pub fn has_capability(&self, capability: &str, registry: &BuildingRegistry) -> bool {
         self.slots.iter().any(|slot| {
             slot.as_ref().is_some_and(|id| {
-                registry.get(id.as_str()).is_some_and(|def| def.capabilities.contains_key(capability))
+                registry
+                    .get(id.as_str())
+                    .is_some_and(|def| def.capabilities.contains_key(capability))
             })
         })
     }
 
     /// Get a named parameter from the first building with the given capability.
     /// Returns None if no building has the capability or the param is not defined.
-    pub fn get_capability_param(&self, capability: &str, param: &str, registry: &BuildingRegistry) -> Option<f64> {
+    pub fn get_capability_param(
+        &self,
+        capability: &str,
+        param: &str,
+        registry: &BuildingRegistry,
+    ) -> Option<f64> {
         for slot in &self.slots {
             if let Some(id) = slot {
                 if let Some(def) = registry.get(id.as_str()) {
@@ -83,9 +92,70 @@ pub struct SystemBuildingQueue {
     pub queue: Vec<BuildingOrder>,
     pub demolition_queue: Vec<DemolitionOrder>,
     pub upgrade_queue: Vec<UpgradeOrder>,
+    /// #275: Shared monotonic counter for `order_id`. See
+    /// `BuildingQueue::next_order_id` for rationale.
+    pub next_order_id: u64,
 }
 
 impl SystemBuildingQueue {
+    fn allocate_order_id(&mut self) -> u64 {
+        if self.next_order_id == 0 {
+            self.next_order_id = 1;
+        }
+        let id = self.next_order_id;
+        self.next_order_id = self.next_order_id.wrapping_add(1);
+        id
+    }
+
+    /// #275: Push a construction order, auto-assigning `order_id`.
+    pub fn push_build_order(&mut self, mut order: BuildingOrder) -> u64 {
+        let id = self.allocate_order_id();
+        order.order_id = id;
+        self.queue.push(order);
+        id
+    }
+
+    /// #275: Push a demolition order, auto-assigning `order_id`.
+    pub fn push_demolition_order(&mut self, mut order: DemolitionOrder) -> u64 {
+        let id = self.allocate_order_id();
+        order.order_id = id;
+        self.demolition_queue.push(order);
+        id
+    }
+
+    /// #275: Push an upgrade order, auto-assigning `order_id`.
+    pub fn push_upgrade_order(&mut self, mut order: UpgradeOrder) -> u64 {
+        let id = self.allocate_order_id();
+        order.order_id = id;
+        self.upgrade_queue.push(order);
+        id
+    }
+
+    /// #275: See `BuildingQueue::cancel_order`.
+    pub fn cancel_order(&mut self, order_id: u64) -> Option<CancelledOrderKind> {
+        if let Some(pos) = self.queue.iter().position(|o| o.order_id == order_id) {
+            self.queue.remove(pos);
+            return Some(CancelledOrderKind::Construction);
+        }
+        if let Some(pos) = self
+            .demolition_queue
+            .iter()
+            .position(|o| o.order_id == order_id)
+        {
+            self.demolition_queue.remove(pos);
+            return Some(CancelledOrderKind::Demolition);
+        }
+        if let Some(pos) = self
+            .upgrade_queue
+            .iter()
+            .position(|o| o.order_id == order_id)
+        {
+            self.upgrade_queue.remove(pos);
+            return Some(CancelledOrderKind::Upgrade);
+        }
+        None
+    }
+
     /// Check if a given slot is currently being demolished.
     pub fn is_demolishing(&self, slot: usize) -> bool {
         self.demolition_queue.iter().any(|d| d.target_slot == slot)
@@ -93,7 +163,8 @@ impl SystemBuildingQueue {
 
     /// Get the remaining demolition time for a slot, if any.
     pub fn demolition_time_remaining(&self, slot: usize) -> Option<i64> {
-        self.demolition_queue.iter()
+        self.demolition_queue
+            .iter()
             .find(|d| d.target_slot == slot)
             .map(|d| d.time_remaining)
     }
@@ -166,7 +237,12 @@ pub fn sync_system_building_maintenance(
 pub fn tick_system_building_queue(
     clock: Res<GameClock>,
     last_tick: Res<LastProductionTick>,
-    mut query: Query<(Entity, &mut SystemBuildingQueue, &mut SystemBuildings, &mut ResourceStockpile)>,
+    mut query: Query<(
+        Entity,
+        &mut SystemBuildingQueue,
+        &mut SystemBuildings,
+        &mut ResourceStockpile,
+    )>,
     mut event_system: ResMut<crate::event_system::EventSystem>,
 ) {
     let delta = clock.elapsed - last_tick.0;
@@ -204,8 +280,8 @@ pub fn tick_system_building_queue(
             // planet-level building queue so starved system builds don't
             // sink into negative-time limbo.
             let transferred = minerals_transfer > Amt::ZERO || energy_transfer > Amt::ZERO;
-            let no_more_needed = order.minerals_remaining == Amt::ZERO
-                && order.energy_remaining == Amt::ZERO;
+            let no_more_needed =
+                order.minerals_remaining == Amt::ZERO && order.energy_remaining == Amt::ZERO;
             super::build_tick::maybe_tick_build_time(
                 &mut order.build_time_remaining,
                 transferred,
@@ -236,7 +312,11 @@ pub fn tick_system_building_queue(
             }
         }
         for slot_idx in completed_demolitions {
-            if let Some(pos) = bq.demolition_queue.iter().position(|d| d.target_slot == slot_idx) {
+            if let Some(pos) = bq
+                .demolition_queue
+                .iter()
+                .position(|d| d.target_slot == slot_idx)
+            {
                 let completed = bq.demolition_queue.remove(pos);
                 if slot_idx < buildings.slots.len() {
                     let building_name = buildings.slots[slot_idx]
@@ -304,15 +384,14 @@ pub fn tick_system_building_queue(
                     "System building upgrade completed: {} -> {} in slot {}",
                     old_name, completed.target_id, completed.slot_index
                 );
-                event_system.fire_event(
-                    "building_upgraded",
-                    Some(system_entity),
-                    clock.elapsed,
-                );
+                event_system.fire_event("building_upgraded", Some(system_entity), clock.elapsed);
             }
         }
 
-        stockpile.minerals = stockpile.minerals.sub(minerals_consumed).add(minerals_refunded);
+        stockpile.minerals = stockpile
+            .minerals
+            .sub(minerals_consumed)
+            .add(minerals_refunded);
         stockpile.energy = stockpile.energy.sub(energy_consumed).add(energy_refunded);
     }
 }
@@ -326,13 +405,16 @@ mod tests {
     fn test_building_registry() -> BuildingRegistry {
         let mut registry = BuildingRegistry::default();
         let mut shipyard_caps = HashMap::new();
-        shipyard_caps.insert("shipyard".to_string(), CapabilityParams {
-            params: {
-                let mut m = HashMap::new();
-                m.insert("concurrent_builds".to_string(), 1.0);
-                m
+        shipyard_caps.insert(
+            "shipyard".to_string(),
+            CapabilityParams {
+                params: {
+                    let mut m = HashMap::new();
+                    m.insert("concurrent_builds".to_string(), 1.0);
+                    m
+                },
             },
-        });
+        );
         registry.insert(BuildingDefinition {
             id: "shipyard".to_string(),
             name: "Shipyard".to_string(),
@@ -354,14 +436,17 @@ mod tests {
         });
 
         let mut port_caps = HashMap::new();
-        port_caps.insert("port".to_string(), CapabilityParams {
-            params: {
-                let mut m = HashMap::new();
-                m.insert("ftl_range_bonus".to_string(), 10.0);
-                m.insert("travel_time_factor".to_string(), 0.8);
-                m
+        port_caps.insert(
+            "port".to_string(),
+            CapabilityParams {
+                params: {
+                    let mut m = HashMap::new();
+                    m.insert("ftl_range_bonus".to_string(), 10.0);
+                    m.insert("travel_time_factor".to_string(), 0.8);
+                    m
+                },
             },
-        });
+        );
         registry.insert(BuildingDefinition {
             id: "port".to_string(),
             name: "Port".to_string(),
@@ -420,7 +505,11 @@ mod tests {
     fn system_buildings_has_capability() {
         let registry = test_building_registry();
         let sb = SystemBuildings {
-            slots: vec![Some(BuildingId::new("shipyard")), Some(BuildingId::new("port")), None],
+            slots: vec![
+                Some(BuildingId::new("shipyard")),
+                Some(BuildingId::new("port")),
+                None,
+            ],
         };
         assert!(sb.has_capability("shipyard", &registry));
         assert!(sb.has_capability("port", &registry));
@@ -449,6 +538,7 @@ mod tests {
         let bq = SystemBuildingQueue {
             queue: Vec::new(),
             demolition_queue: vec![DemolitionOrder {
+                order_id: 0,
                 target_slot: 1,
                 building_id: BuildingId::new("shipyard"),
                 time_remaining: 15,
@@ -456,6 +546,7 @@ mod tests {
                 energy_refund: Amt::ZERO,
             }],
             upgrade_queue: Vec::new(),
+            next_order_id: 0,
         };
         assert!(bq.is_demolishing(1));
         assert!(!bq.is_demolishing(0));

--- a/macrocosmo/src/communication/mod.rs
+++ b/macrocosmo/src/communication/mod.rs
@@ -108,10 +108,7 @@ pub fn process_messages(
                 }
                 MessageContent::Report(report) => {
                     let age = clock.elapsed - report.info_timestamp;
-                    info!(
-                        "Report received (information age: {} sd)",
-                        age
-                    );
+                    info!("Report received (information age: {} sd)", age);
                 }
             }
             commands.entity(entity).despawn();
@@ -162,8 +159,14 @@ pub struct PendingCommand {
 /// the full payload at send time (defs live in `StructureRegistry`).
 #[derive(Clone, Debug)]
 pub enum RemoteCommand {
-    BuildShip { design_id: String },
-    SetProductionFocus { minerals: f64, energy: f64, research: f64 },
+    BuildShip {
+        design_id: String,
+    },
+    SetProductionFocus {
+        minerals: f64,
+        energy: f64,
+        research: f64,
+    },
     Colony(ColonyCommand),
     ShipBuild {
         host_colony: Entity,
@@ -178,6 +181,22 @@ pub enum RemoteCommand {
         minerals_cost: crate::amount::Amt,
         energy_cost: crate::amount::Amt,
         build_time: i64,
+    },
+    /// #275: Cancel a planet- or system-level building order (construction,
+    /// demolition, or upgrade) by stable `order_id`. Scope is derived at
+    /// arrival by which queue holds the id — the cancel command itself
+    /// doesn't carry scope, which keeps the send-side UI simple and
+    /// robust against queue shifts during light-speed transit.
+    CancelBuildingOrder {
+        order_id: u64,
+    },
+    /// #275: Cancel a ship / deliverable `BuildOrder` by stable
+    /// `order_id`. Ship orders live on a specific `host_colony`'s
+    /// `BuildQueue`, so we carry that entity explicitly — the id alone
+    /// isn't scoped across colonies.
+    CancelShipOrder {
+        host_colony: Entity,
+        order_id: u64,
     },
 }
 
@@ -221,19 +240,31 @@ impl RemoteCommand {
             RemoteCommand::BuildShip { design_id } => format!("Build ship: {}", design_id),
             RemoteCommand::SetProductionFocus { .. } => "Set production focus".to_string(),
             RemoteCommand::Colony(cc) => match &cc.kind {
-                BuildingKind::Queue { building_id, target_slot } => {
+                BuildingKind::Queue {
+                    building_id,
+                    target_slot,
+                } => {
                     format!("Build {} → slot {}", building_id, target_slot)
                 }
                 BuildingKind::Demolish { target_slot } => {
                     format!("Demolish slot {}", target_slot)
                 }
-                BuildingKind::Upgrade { slot_index, target_id } => {
+                BuildingKind::Upgrade {
+                    slot_index,
+                    target_id,
+                } => {
                     format!("Upgrade slot {} → {}", slot_index, target_id)
                 }
             },
             RemoteCommand::ShipBuild { design_id, .. } => format!("Build ship: {}", design_id),
             RemoteCommand::DeliverableBuild { display_name, .. } => {
                 format!("Build deliverable: {}", display_name)
+            }
+            RemoteCommand::CancelBuildingOrder { order_id } => {
+                format!("Cancel building order #{}", order_id)
+            }
+            RemoteCommand::CancelShipOrder { order_id, .. } => {
+                format!("Cancel ship order #{}", order_id)
             }
         }
     }
@@ -259,7 +290,10 @@ pub fn dispatch_pending_colony_commands(
     stars: Query<&crate::components::Position, With<crate::galaxy::StarSystem>>,
     ship_positions: Query<&crate::components::Position, With<crate::ship::Ship>>,
     player_q: Query<
-        (&crate::player::StationedAt, Option<&crate::player::AboardShip>),
+        (
+            &crate::player::StationedAt,
+            Option<&crate::player::AboardShip>,
+        ),
         With<crate::player::Player>,
     >,
     mut empire_q: Query<&mut CommandLog, With<crate::player::PlayerEmpire>>,
@@ -351,6 +385,7 @@ pub fn process_pending_commands(
     ship_design_registry: Res<crate::ship_design::ShipDesignRegistry>,
     mut colonies: crate::colony::remote::ApplyColoniesQuery,
     mut sys_buildings_q: crate::colony::remote::ApplySystemBuildingsQuery,
+    planets: crate::colony::remote::ApplyPlanetsQuery,
 ) {
     let Ok((mut command_log, construction_params)) = empire_q.single_mut() else {
         return;
@@ -378,6 +413,7 @@ pub fn process_pending_commands(
                 bldg_time_mod,
                 &mut colonies,
                 &mut sys_buildings_q,
+                &planets,
             );
 
             for entry in command_log.entries.iter_mut() {
@@ -394,7 +430,6 @@ pub fn process_pending_commands(
         }
     }
 }
-
 
 // ---------------------------------------------------------------------------
 // Existing helpers

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -26,8 +26,8 @@ use std::collections::HashMap;
 
 use crate::amount::Amt;
 use crate::colony::{
-    AlertCooldowns, AuthorityParams, BuildKind, BuildOrder, BuildQueue, Buildings, BuildingOrder,
-    BuildingQueue, Colony, ColonizationOrder, ColonizationQueue, ColonyJobRates,
+    AlertCooldowns, AuthorityParams, BuildKind, BuildOrder, BuildQueue, BuildingOrder,
+    BuildingQueue, Buildings, ColonizationOrder, ColonizationQueue, Colony, ColonyJobRates,
     ConstructionParams, DeliverableStockpile, DemolitionOrder, FoodConsumption, MaintenanceCost,
     PendingColonizationOrder, Production, ProductionFocus, ResourceCapacity, ResourceStockpile,
     SystemBuildingQueue, SystemBuildings, UpgradeOrder,
@@ -51,11 +51,11 @@ use crate::galaxy::{
     Anomalies, Anomaly, ForbiddenRegion, HostilePresence, HostileType, Planet, PortFacility,
     Sovereignty, StarSystem, SystemAttributes,
 };
-use crate::knowledge::{
-    KnowledgeFact, KnowledgeStore, ObservationSource, PendingFactQueue, PerceivedFact, ShipSnapshot,
-    ShipSnapshotState, SystemKnowledge, SystemSnapshot,
-};
 use crate::knowledge::facts::CombatVictor;
+use crate::knowledge::{
+    KnowledgeFact, KnowledgeStore, ObservationSource, PendingFactQueue, PerceivedFact,
+    ShipSnapshot, ShipSnapshotState, SystemKnowledge, SystemSnapshot,
+};
 use crate::modifier::{ModifiedValue, ScopedModifiers};
 use crate::notifications::{Notification, NotificationPriority, NotificationQueue};
 use crate::player::{AboardShip, Empire, Faction, Player, StationedAt};
@@ -63,8 +63,8 @@ use crate::scripting::building_api::BuildingId;
 use crate::ship::scout::ScoutReport;
 use crate::ship::{
     Cargo, CargoItem, CommandQueue, CourierMode, CourierRoute, DetectedHostiles, Fleet,
-    FleetMembership, Owner, PendingShipCommand, QueuedCommand, ReportMode, RulesOfEngagement,
-    Ship, ShipCommand, ShipHitpoints, ShipModifiers, ShipState, SurveyData,
+    FleetMembership, Owner, PendingShipCommand, QueuedCommand, ReportMode, RulesOfEngagement, Ship,
+    ShipCommand, ShipHitpoints, ShipModifiers, ShipState, SurveyData,
 };
 use crate::species::{ColonyJobs, ColonyPopulation, ColonySpecies, JobSlot};
 use crate::technology::{
@@ -92,7 +92,9 @@ fn remap_entity(bits: u64, map: &EntityMap) -> Entity {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SavedMovementState {
-    Docked { system_bits: u64 },
+    Docked {
+        system_bits: u64,
+    },
     SubLight {
         origin: Position,
         destination: Position,
@@ -981,7 +983,9 @@ pub struct SavedEmpire {
 
 impl SavedEmpire {
     pub fn from_live(v: &Empire) -> Self {
-        Self { name: v.name.clone() }
+        Self {
+            name: v.name.clone(),
+        }
     }
     pub fn into_live(self) -> Empire {
         Empire { name: self.name }
@@ -1057,41 +1061,86 @@ impl From<SavedRulesOfEngagement> for RulesOfEngagement {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SavedQueuedCommand {
-    MoveTo { system_bits: u64 },
-    Survey { system_bits: u64 },
-    Colonize { system_bits: u64, planet_bits: Option<u64> },
-    MoveToCoordinates { target: [f64; 3] },
-    Scout { target_system_bits: u64, observation_duration: i64, report_mode: SavedReportMode },
-    LoadDeliverable { system_bits: u64, stockpile_index: usize },
-    DeployDeliverable { position: [f64; 3], item_index: usize },
-    TransferToStructure { structure_bits: u64, minerals: Amt, energy: Amt },
-    LoadFromScrapyard { structure_bits: u64 },
+    MoveTo {
+        system_bits: u64,
+    },
+    Survey {
+        system_bits: u64,
+    },
+    Colonize {
+        system_bits: u64,
+        planet_bits: Option<u64>,
+    },
+    MoveToCoordinates {
+        target: [f64; 3],
+    },
+    Scout {
+        target_system_bits: u64,
+        observation_duration: i64,
+        report_mode: SavedReportMode,
+    },
+    LoadDeliverable {
+        system_bits: u64,
+        stockpile_index: usize,
+    },
+    DeployDeliverable {
+        position: [f64; 3],
+        item_index: usize,
+    },
+    TransferToStructure {
+        structure_bits: u64,
+        minerals: Amt,
+        energy: Amt,
+    },
+    LoadFromScrapyard {
+        structure_bits: u64,
+    },
 }
 
 impl SavedQueuedCommand {
     pub fn from_live(v: &QueuedCommand) -> Self {
         match v {
-            QueuedCommand::MoveTo { system } => Self::MoveTo { system_bits: system.to_bits() },
-            QueuedCommand::Survey { system } => Self::Survey { system_bits: system.to_bits() },
+            QueuedCommand::MoveTo { system } => Self::MoveTo {
+                system_bits: system.to_bits(),
+            },
+            QueuedCommand::Survey { system } => Self::Survey {
+                system_bits: system.to_bits(),
+            },
             QueuedCommand::Colonize { system, planet } => Self::Colonize {
                 system_bits: system.to_bits(),
                 planet_bits: planet.map(|e| e.to_bits()),
             },
-            QueuedCommand::MoveToCoordinates { target } => Self::MoveToCoordinates { target: *target },
-            QueuedCommand::Scout { target_system, observation_duration, report_mode } => Self::Scout {
+            QueuedCommand::MoveToCoordinates { target } => {
+                Self::MoveToCoordinates { target: *target }
+            }
+            QueuedCommand::Scout {
+                target_system,
+                observation_duration,
+                report_mode,
+            } => Self::Scout {
                 target_system_bits: target_system.to_bits(),
                 observation_duration: *observation_duration,
                 report_mode: report_mode.into(),
             },
-            QueuedCommand::LoadDeliverable { system, stockpile_index } => Self::LoadDeliverable {
+            QueuedCommand::LoadDeliverable {
+                system,
+                stockpile_index,
+            } => Self::LoadDeliverable {
                 system_bits: system.to_bits(),
                 stockpile_index: *stockpile_index,
             },
-            QueuedCommand::DeployDeliverable { position, item_index } => Self::DeployDeliverable {
+            QueuedCommand::DeployDeliverable {
+                position,
+                item_index,
+            } => Self::DeployDeliverable {
                 position: *position,
                 item_index: *item_index,
             },
-            QueuedCommand::TransferToStructure { structure, minerals, energy } => Self::TransferToStructure {
+            QueuedCommand::TransferToStructure {
+                structure,
+                minerals,
+                energy,
+            } => Self::TransferToStructure {
                 structure_bits: structure.to_bits(),
                 minerals: *minerals,
                 energy: *energy,
@@ -1104,24 +1153,48 @@ impl SavedQueuedCommand {
 
     pub fn into_live(self, map: &EntityMap) -> QueuedCommand {
         match self {
-            Self::MoveTo { system_bits } => QueuedCommand::MoveTo { system: remap_entity(system_bits, map) },
-            Self::Survey { system_bits } => QueuedCommand::Survey { system: remap_entity(system_bits, map) },
-            Self::Colonize { system_bits, planet_bits } => QueuedCommand::Colonize {
+            Self::MoveTo { system_bits } => QueuedCommand::MoveTo {
+                system: remap_entity(system_bits, map),
+            },
+            Self::Survey { system_bits } => QueuedCommand::Survey {
+                system: remap_entity(system_bits, map),
+            },
+            Self::Colonize {
+                system_bits,
+                planet_bits,
+            } => QueuedCommand::Colonize {
                 system: remap_entity(system_bits, map),
                 planet: planet_bits.map(|b| remap_entity(b, map)),
             },
             Self::MoveToCoordinates { target } => QueuedCommand::MoveToCoordinates { target },
-            Self::Scout { target_system_bits, observation_duration, report_mode } => QueuedCommand::Scout {
+            Self::Scout {
+                target_system_bits,
+                observation_duration,
+                report_mode,
+            } => QueuedCommand::Scout {
                 target_system: remap_entity(target_system_bits, map),
                 observation_duration,
                 report_mode: report_mode.into(),
             },
-            Self::LoadDeliverable { system_bits, stockpile_index } => QueuedCommand::LoadDeliverable {
+            Self::LoadDeliverable {
+                system_bits,
+                stockpile_index,
+            } => QueuedCommand::LoadDeliverable {
                 system: remap_entity(system_bits, map),
                 stockpile_index,
             },
-            Self::DeployDeliverable { position, item_index } => QueuedCommand::DeployDeliverable { position, item_index },
-            Self::TransferToStructure { structure_bits, minerals, energy } => QueuedCommand::TransferToStructure {
+            Self::DeployDeliverable {
+                position,
+                item_index,
+            } => QueuedCommand::DeployDeliverable {
+                position,
+                item_index,
+            },
+            Self::TransferToStructure {
+                structure_bits,
+                minerals,
+                energy,
+            } => QueuedCommand::TransferToStructure {
                 structure: remap_entity(structure_bits, map),
                 minerals,
                 energy,
@@ -1143,14 +1216,22 @@ pub struct SavedCommandQueue {
 impl SavedCommandQueue {
     pub fn from_live(v: &CommandQueue) -> Self {
         Self {
-            commands: v.commands.iter().map(SavedQueuedCommand::from_live).collect(),
+            commands: v
+                .commands
+                .iter()
+                .map(SavedQueuedCommand::from_live)
+                .collect(),
             predicted_position: v.predicted_position,
             predicted_system_bits: v.predicted_system.map(|e| e.to_bits()),
         }
     }
     pub fn into_live(self, map: &EntityMap) -> CommandQueue {
         CommandQueue {
-            commands: self.commands.into_iter().map(|c| c.into_live(map)).collect(),
+            commands: self
+                .commands
+                .into_iter()
+                .map(|c| c.into_live(map))
+                .collect(),
             predicted_position: self.predicted_position,
             predicted_system: self.predicted_system_bits.map(|b| remap_entity(b, map)),
         }
@@ -1251,7 +1332,11 @@ impl SavedCourierRoute {
     }
     pub fn into_live(self, map: &EntityMap) -> CourierRoute {
         CourierRoute {
-            waypoints: self.waypoints_bits.into_iter().map(|b| remap_entity(b, map)).collect(),
+            waypoints: self
+                .waypoints_bits
+                .into_iter()
+                .map(|b| remap_entity(b, map))
+                .collect(),
             current_index: self.current_index,
             mode: self.mode.into(),
             repeat: self.repeat,
@@ -1306,7 +1391,11 @@ impl SavedScoutReport {
             observed_at: v.observed_at,
             report_mode: (&v.report_mode).into(),
             system_snapshot: SavedSystemSnapshot::from_live(&v.system_snapshot),
-            ship_snapshots: v.ship_snapshots.iter().map(SavedShipSnapshot::from_live).collect(),
+            ship_snapshots: v
+                .ship_snapshots
+                .iter()
+                .map(SavedShipSnapshot::from_live)
+                .collect(),
             return_queued: v.return_queued,
         }
     }
@@ -1317,7 +1406,11 @@ impl SavedScoutReport {
             observed_at: self.observed_at,
             report_mode: self.report_mode.into(),
             system_snapshot: self.system_snapshot.into_live(map),
-            ship_snapshots: self.ship_snapshots.into_iter().map(|s| s.into_live(map)).collect(),
+            ship_snapshots: self
+                .ship_snapshots
+                .into_iter()
+                .map(|s| s.into_live(map))
+                .collect(),
             return_queued: self.return_queued,
         }
     }
@@ -1341,7 +1434,11 @@ impl SavedFleet {
     pub fn into_live(self, map: &EntityMap) -> Fleet {
         Fleet {
             name: self.name,
-            members: self.members_bits.into_iter().map(|b| remap_entity(b, map)).collect(),
+            members: self
+                .members_bits
+                .into_iter()
+                .map(|b| remap_entity(b, map))
+                .collect(),
             flagship: remap_entity(self.flagship_bits, map),
         }
     }
@@ -1354,10 +1451,14 @@ pub struct SavedFleetMembership {
 
 impl SavedFleetMembership {
     pub fn from_live(v: &FleetMembership) -> Self {
-        Self { fleet_bits: v.fleet.to_bits() }
+        Self {
+            fleet_bits: v.fleet.to_bits(),
+        }
     }
     pub fn into_live(self, map: &EntityMap) -> FleetMembership {
-        FleetMembership { fleet: remap_entity(self.fleet_bits, map) }
+        FleetMembership {
+            fleet: remap_entity(self.fleet_bits, map),
+        }
     }
 }
 
@@ -1401,17 +1502,27 @@ pub enum SavedShipCommand {
 impl SavedShipCommand {
     pub fn from_live(v: &ShipCommand) -> Self {
         match v {
-            ShipCommand::MoveTo { destination } => Self::MoveTo { destination_bits: destination.to_bits() },
-            ShipCommand::Survey { target } => Self::Survey { target_bits: target.to_bits() },
+            ShipCommand::MoveTo { destination } => Self::MoveTo {
+                destination_bits: destination.to_bits(),
+            },
+            ShipCommand::Survey { target } => Self::Survey {
+                target_bits: target.to_bits(),
+            },
             ShipCommand::Colonize => Self::Colonize,
             ShipCommand::SetROE { roe } => Self::SetROE { roe: roe.into() },
-            ShipCommand::EnqueueCommand(c) => Self::EnqueueCommand(SavedQueuedCommand::from_live(c)),
+            ShipCommand::EnqueueCommand(c) => {
+                Self::EnqueueCommand(SavedQueuedCommand::from_live(c))
+            }
         }
     }
     pub fn into_live(self, map: &EntityMap) -> ShipCommand {
         match self {
-            Self::MoveTo { destination_bits } => ShipCommand::MoveTo { destination: remap_entity(destination_bits, map) },
-            Self::Survey { target_bits } => ShipCommand::Survey { target: remap_entity(target_bits, map) },
+            Self::MoveTo { destination_bits } => ShipCommand::MoveTo {
+                destination: remap_entity(destination_bits, map),
+            },
+            Self::Survey { target_bits } => ShipCommand::Survey {
+                target: remap_entity(target_bits, map),
+            },
             Self::Colonize => ShipCommand::Colonize,
             Self::SetROE { roe } => ShipCommand::SetROE { roe: roe.into() },
             Self::EnqueueCommand(c) => ShipCommand::EnqueueCommand(c.into_live(map)),
@@ -1450,7 +1561,9 @@ impl From<&BuildKind> for SavedBuildKind {
     fn from(v: &BuildKind) -> Self {
         match v {
             BuildKind::Ship => Self::Ship,
-            BuildKind::Deliverable { cargo_size } => Self::Deliverable { cargo_size: *cargo_size },
+            BuildKind::Deliverable { cargo_size } => Self::Deliverable {
+                cargo_size: *cargo_size,
+            },
         }
     }
 }
@@ -1465,6 +1578,9 @@ impl From<SavedBuildKind> for BuildKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedBuildOrder {
+    /// #275: Stable order id for cancel commands. Preserved across saves.
+    #[serde(default)]
+    pub order_id: u64,
     pub kind: SavedBuildKind,
     pub design_id: String,
     pub display_name: String,
@@ -1479,6 +1595,7 @@ pub struct SavedBuildOrder {
 impl SavedBuildOrder {
     pub fn from_live(v: &BuildOrder) -> Self {
         Self {
+            order_id: v.order_id,
             kind: (&v.kind).into(),
             design_id: v.design_id.clone(),
             display_name: v.display_name.clone(),
@@ -1492,6 +1609,7 @@ impl SavedBuildOrder {
     }
     pub fn into_live(self) -> BuildOrder {
         BuildOrder {
+            order_id: self.order_id,
             kind: self.kind.into(),
             design_id: self.design_id,
             display_name: self.display_name,
@@ -1508,19 +1626,36 @@ impl SavedBuildOrder {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SavedBuildQueue {
     pub queue: Vec<SavedBuildOrder>,
+    /// #275: `BuildQueue::next_order_id` counter. Preserved so ids stay
+    /// unique across save/load.
+    #[serde(default)]
+    pub next_order_id: u64,
 }
 
 impl SavedBuildQueue {
     pub fn from_live(v: &BuildQueue) -> Self {
-        Self { queue: v.queue.iter().map(SavedBuildOrder::from_live).collect() }
+        Self {
+            queue: v.queue.iter().map(SavedBuildOrder::from_live).collect(),
+            next_order_id: v.next_order_id,
+        }
     }
     pub fn into_live(self) -> BuildQueue {
-        BuildQueue { queue: self.queue.into_iter().map(SavedBuildOrder::into_live).collect() }
+        BuildQueue {
+            queue: self
+                .queue
+                .into_iter()
+                .map(SavedBuildOrder::into_live)
+                .collect(),
+            next_order_id: self.next_order_id,
+        }
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedBuildingOrder {
+    /// #275: Stable order id for cancel commands.
+    #[serde(default)]
+    pub order_id: u64,
     pub building_id: String,
     pub target_slot: usize,
     pub minerals_remaining: Amt,
@@ -1531,6 +1666,7 @@ pub struct SavedBuildingOrder {
 impl SavedBuildingOrder {
     pub fn from_live(v: &BuildingOrder) -> Self {
         Self {
+            order_id: v.order_id,
             building_id: v.building_id.0.clone(),
             target_slot: v.target_slot,
             minerals_remaining: v.minerals_remaining,
@@ -1540,6 +1676,7 @@ impl SavedBuildingOrder {
     }
     pub fn into_live(self) -> BuildingOrder {
         BuildingOrder {
+            order_id: self.order_id,
             building_id: BuildingId::new(self.building_id),
             target_slot: self.target_slot,
             minerals_remaining: self.minerals_remaining,
@@ -1551,6 +1688,9 @@ impl SavedBuildingOrder {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedDemolitionOrder {
+    /// #275: Stable order id for cancel commands.
+    #[serde(default)]
+    pub order_id: u64,
     pub target_slot: usize,
     pub building_id: String,
     pub time_remaining: i64,
@@ -1561,6 +1701,7 @@ pub struct SavedDemolitionOrder {
 impl SavedDemolitionOrder {
     pub fn from_live(v: &DemolitionOrder) -> Self {
         Self {
+            order_id: v.order_id,
             target_slot: v.target_slot,
             building_id: v.building_id.0.clone(),
             time_remaining: v.time_remaining,
@@ -1570,6 +1711,7 @@ impl SavedDemolitionOrder {
     }
     pub fn into_live(self) -> DemolitionOrder {
         DemolitionOrder {
+            order_id: self.order_id,
             target_slot: self.target_slot,
             building_id: BuildingId::new(self.building_id),
             time_remaining: self.time_remaining,
@@ -1581,6 +1723,9 @@ impl SavedDemolitionOrder {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedUpgradeOrder {
+    /// #275: Stable order id for cancel commands.
+    #[serde(default)]
+    pub order_id: u64,
     pub slot_index: usize,
     pub target_id: String,
     pub minerals_remaining: Amt,
@@ -1591,6 +1736,7 @@ pub struct SavedUpgradeOrder {
 impl SavedUpgradeOrder {
     pub fn from_live(v: &UpgradeOrder) -> Self {
         Self {
+            order_id: v.order_id,
             slot_index: v.slot_index,
             target_id: v.target_id.0.clone(),
             minerals_remaining: v.minerals_remaining,
@@ -1600,6 +1746,7 @@ impl SavedUpgradeOrder {
     }
     pub fn into_live(self) -> UpgradeOrder {
         UpgradeOrder {
+            order_id: self.order_id,
             slot_index: self.slot_index,
             target_id: BuildingId::new(self.target_id),
             minerals_remaining: self.minerals_remaining,
@@ -1614,21 +1761,47 @@ pub struct SavedBuildingQueue {
     pub queue: Vec<SavedBuildingOrder>,
     pub demolition_queue: Vec<SavedDemolitionOrder>,
     pub upgrade_queue: Vec<SavedUpgradeOrder>,
+    /// #275: `BuildingQueue::next_order_id` counter, preserved across
+    /// save/load so ids stay unique.
+    #[serde(default)]
+    pub next_order_id: u64,
 }
 
 impl SavedBuildingQueue {
     pub fn from_live(v: &BuildingQueue) -> Self {
         Self {
             queue: v.queue.iter().map(SavedBuildingOrder::from_live).collect(),
-            demolition_queue: v.demolition_queue.iter().map(SavedDemolitionOrder::from_live).collect(),
-            upgrade_queue: v.upgrade_queue.iter().map(SavedUpgradeOrder::from_live).collect(),
+            demolition_queue: v
+                .demolition_queue
+                .iter()
+                .map(SavedDemolitionOrder::from_live)
+                .collect(),
+            upgrade_queue: v
+                .upgrade_queue
+                .iter()
+                .map(SavedUpgradeOrder::from_live)
+                .collect(),
+            next_order_id: v.next_order_id,
         }
     }
     pub fn into_live(self) -> BuildingQueue {
         BuildingQueue {
-            queue: self.queue.into_iter().map(SavedBuildingOrder::into_live).collect(),
-            demolition_queue: self.demolition_queue.into_iter().map(SavedDemolitionOrder::into_live).collect(),
-            upgrade_queue: self.upgrade_queue.into_iter().map(SavedUpgradeOrder::into_live).collect(),
+            queue: self
+                .queue
+                .into_iter()
+                .map(SavedBuildingOrder::into_live)
+                .collect(),
+            demolition_queue: self
+                .demolition_queue
+                .into_iter()
+                .map(SavedDemolitionOrder::into_live)
+                .collect(),
+            upgrade_queue: self
+                .upgrade_queue
+                .into_iter()
+                .map(SavedUpgradeOrder::into_live)
+                .collect(),
+            next_order_id: self.next_order_id,
         }
     }
 }
@@ -1640,10 +1813,22 @@ pub struct SavedBuildings {
 
 impl SavedBuildings {
     pub fn from_live(v: &Buildings) -> Self {
-        Self { slots: v.slots.iter().map(|s| s.as_ref().map(|b| b.0.clone())).collect() }
+        Self {
+            slots: v
+                .slots
+                .iter()
+                .map(|s| s.as_ref().map(|b| b.0.clone()))
+                .collect(),
+        }
     }
     pub fn into_live(self) -> Buildings {
-        Buildings { slots: self.slots.into_iter().map(|s| s.map(BuildingId::new)).collect() }
+        Buildings {
+            slots: self
+                .slots
+                .into_iter()
+                .map(|s| s.map(BuildingId::new))
+                .collect(),
+        }
     }
 }
 
@@ -1654,10 +1839,22 @@ pub struct SavedSystemBuildings {
 
 impl SavedSystemBuildings {
     pub fn from_live(v: &SystemBuildings) -> Self {
-        Self { slots: v.slots.iter().map(|s| s.as_ref().map(|b| b.0.clone())).collect() }
+        Self {
+            slots: v
+                .slots
+                .iter()
+                .map(|s| s.as_ref().map(|b| b.0.clone()))
+                .collect(),
+        }
     }
     pub fn into_live(self) -> SystemBuildings {
-        SystemBuildings { slots: self.slots.into_iter().map(|s| s.map(BuildingId::new)).collect() }
+        SystemBuildings {
+            slots: self
+                .slots
+                .into_iter()
+                .map(|s| s.map(BuildingId::new))
+                .collect(),
+        }
     }
 }
 
@@ -1666,21 +1863,46 @@ pub struct SavedSystemBuildingQueue {
     pub queue: Vec<SavedBuildingOrder>,
     pub demolition_queue: Vec<SavedDemolitionOrder>,
     pub upgrade_queue: Vec<SavedUpgradeOrder>,
+    /// #275: `SystemBuildingQueue::next_order_id` counter.
+    #[serde(default)]
+    pub next_order_id: u64,
 }
 
 impl SavedSystemBuildingQueue {
     pub fn from_live(v: &SystemBuildingQueue) -> Self {
         Self {
             queue: v.queue.iter().map(SavedBuildingOrder::from_live).collect(),
-            demolition_queue: v.demolition_queue.iter().map(SavedDemolitionOrder::from_live).collect(),
-            upgrade_queue: v.upgrade_queue.iter().map(SavedUpgradeOrder::from_live).collect(),
+            demolition_queue: v
+                .demolition_queue
+                .iter()
+                .map(SavedDemolitionOrder::from_live)
+                .collect(),
+            upgrade_queue: v
+                .upgrade_queue
+                .iter()
+                .map(SavedUpgradeOrder::from_live)
+                .collect(),
+            next_order_id: v.next_order_id,
         }
     }
     pub fn into_live(self) -> SystemBuildingQueue {
         SystemBuildingQueue {
-            queue: self.queue.into_iter().map(SavedBuildingOrder::into_live).collect(),
-            demolition_queue: self.demolition_queue.into_iter().map(SavedDemolitionOrder::into_live).collect(),
-            upgrade_queue: self.upgrade_queue.into_iter().map(SavedUpgradeOrder::into_live).collect(),
+            queue: self
+                .queue
+                .into_iter()
+                .map(SavedBuildingOrder::into_live)
+                .collect(),
+            demolition_queue: self
+                .demolition_queue
+                .into_iter()
+                .map(SavedDemolitionOrder::into_live)
+                .collect(),
+            upgrade_queue: self
+                .upgrade_queue
+                .into_iter()
+                .map(SavedUpgradeOrder::into_live)
+                .collect(),
+            next_order_id: self.next_order_id,
         }
     }
 }
@@ -1768,10 +1990,18 @@ pub struct SavedColonyJobs {
 
 impl SavedColonyJobs {
     pub fn from_live(v: &ColonyJobs) -> Self {
-        Self { slots: v.slots.iter().map(SavedJobSlot::from_live).collect() }
+        Self {
+            slots: v.slots.iter().map(SavedJobSlot::from_live).collect(),
+        }
     }
     pub fn into_live(self) -> ColonyJobs {
-        ColonyJobs { slots: self.slots.into_iter().map(SavedJobSlot::into_live).collect() }
+        ColonyJobs {
+            slots: self
+                .slots
+                .into_iter()
+                .map(SavedJobSlot::into_live)
+                .collect(),
+        }
     }
 }
 
@@ -1784,7 +2014,10 @@ pub struct SavedColonyJobRates {
 impl SavedColonyJobRates {
     pub fn from_live(v: &ColonyJobRates) -> Self {
         Self {
-            buckets: v.iter().map(|(j, t, mv)| (j.clone(), t.clone(), mv.clone())).collect(),
+            buckets: v
+                .iter()
+                .map(|(j, t, mv)| (j.clone(), t.clone(), mv.clone()))
+                .collect(),
         }
     }
     pub fn into_live(self) -> ColonyJobRates {
@@ -1803,10 +2036,16 @@ pub struct SavedColonySpecies {
 }
 impl SavedColonySpecies {
     pub fn from_live(v: &ColonySpecies) -> Self {
-        Self { species_id: v.species_id.clone(), population: v.population }
+        Self {
+            species_id: v.species_id.clone(),
+            population: v.population,
+        }
     }
     pub fn into_live(self) -> ColonySpecies {
-        ColonySpecies { species_id: self.species_id, population: self.population }
+        ColonySpecies {
+            species_id: self.species_id,
+            population: self.population,
+        }
     }
 }
 
@@ -1816,10 +2055,22 @@ pub struct SavedColonyPopulation {
 }
 impl SavedColonyPopulation {
     pub fn from_live(v: &ColonyPopulation) -> Self {
-        Self { species: v.species.iter().map(SavedColonySpecies::from_live).collect() }
+        Self {
+            species: v
+                .species
+                .iter()
+                .map(SavedColonySpecies::from_live)
+                .collect(),
+        }
     }
     pub fn into_live(self) -> ColonyPopulation {
-        ColonyPopulation { species: self.species.into_iter().map(SavedColonySpecies::into_live).collect() }
+        ColonyPopulation {
+            species: self
+                .species
+                .into_iter()
+                .map(SavedColonySpecies::into_live)
+                .collect(),
+        }
     }
 }
 
@@ -1856,10 +2107,16 @@ pub struct SavedAuthorityParams {
 }
 impl SavedAuthorityParams {
     pub fn from_live(v: &AuthorityParams) -> Self {
-        Self { production: v.production.clone(), cost_per_colony: v.cost_per_colony.clone() }
+        Self {
+            production: v.production.clone(),
+            cost_per_colony: v.cost_per_colony.clone(),
+        }
     }
     pub fn into_live(self) -> AuthorityParams {
-        AuthorityParams { production: self.production, cost_per_colony: self.cost_per_colony }
+        AuthorityParams {
+            production: self.production,
+            cost_per_colony: self.cost_per_colony,
+        }
     }
 }
 
@@ -1869,10 +2126,14 @@ pub struct SavedMaintenanceCost {
 }
 impl SavedMaintenanceCost {
     pub fn from_live(v: &MaintenanceCost) -> Self {
-        Self { energy_per_hexadies: v.energy_per_hexadies.clone() }
+        Self {
+            energy_per_hexadies: v.energy_per_hexadies.clone(),
+        }
     }
     pub fn into_live(self) -> MaintenanceCost {
-        MaintenanceCost { energy_per_hexadies: self.energy_per_hexadies }
+        MaintenanceCost {
+            energy_per_hexadies: self.energy_per_hexadies,
+        }
     }
 }
 
@@ -1882,10 +2143,14 @@ pub struct SavedFoodConsumption {
 }
 impl SavedFoodConsumption {
     pub fn from_live(v: &FoodConsumption) -> Self {
-        Self { food_per_hexadies: v.food_per_hexadies.clone() }
+        Self {
+            food_per_hexadies: v.food_per_hexadies.clone(),
+        }
     }
     pub fn into_live(self) -> FoodConsumption {
-        FoodConsumption { food_per_hexadies: self.food_per_hexadies }
+        FoodConsumption {
+            food_per_hexadies: self.food_per_hexadies,
+        }
     }
 }
 
@@ -1895,10 +2160,14 @@ pub struct SavedDeliverableStockpile {
 }
 impl SavedDeliverableStockpile {
     pub fn from_live(v: &DeliverableStockpile) -> Self {
-        Self { items: v.items.iter().map(Into::into).collect() }
+        Self {
+            items: v.items.iter().map(Into::into).collect(),
+        }
     }
     pub fn into_live(self) -> DeliverableStockpile {
-        DeliverableStockpile { items: self.items.into_iter().map(Into::into).collect() }
+        DeliverableStockpile {
+            items: self.items.into_iter().map(Into::into).collect(),
+        }
     }
 }
 
@@ -1942,7 +2211,13 @@ pub struct SavedColonizationQueue {
 
 impl SavedColonizationQueue {
     pub fn from_live(v: &ColonizationQueue) -> Self {
-        Self { orders: v.orders.iter().map(SavedColonizationOrder::from_live).collect() }
+        Self {
+            orders: v
+                .orders
+                .iter()
+                .map(SavedColonizationOrder::from_live)
+                .collect(),
+        }
     }
     pub fn into_live(self, map: &EntityMap) -> ColonizationQueue {
         ColonizationQueue {
@@ -2007,10 +2282,18 @@ pub struct SavedAnomalies {
 }
 impl SavedAnomalies {
     pub fn from_live(v: &Anomalies) -> Self {
-        Self { discoveries: v.discoveries.iter().map(SavedAnomaly::from_live).collect() }
+        Self {
+            discoveries: v.discoveries.iter().map(SavedAnomaly::from_live).collect(),
+        }
     }
     pub fn into_live(self) -> Anomalies {
-        Anomalies { discoveries: self.discoveries.into_iter().map(SavedAnomaly::into_live).collect() }
+        Anomalies {
+            discoveries: self
+                .discoveries
+                .into_iter()
+                .map(SavedAnomaly::into_live)
+                .collect(),
+        }
     }
 }
 
@@ -2025,10 +2308,16 @@ pub struct SavedResourceCost {
 }
 impl SavedResourceCost {
     pub fn from_live(v: &ResourceCost) -> Self {
-        Self { minerals: v.minerals, energy: v.energy }
+        Self {
+            minerals: v.minerals,
+            energy: v.energy,
+        }
     }
     pub fn into_live(self) -> ResourceCost {
-        ResourceCost { minerals: self.minerals, energy: self.energy }
+        ResourceCost {
+            minerals: self.minerals,
+            energy: self.energy,
+        }
     }
 }
 
@@ -2104,10 +2393,16 @@ pub struct SavedStructureHitpoints {
 }
 impl SavedStructureHitpoints {
     pub fn from_live(v: &StructureHitpoints) -> Self {
-        Self { current: v.current, max: v.max }
+        Self {
+            current: v.current,
+            max: v.max,
+        }
     }
     pub fn into_live(self) -> StructureHitpoints {
-        StructureHitpoints { current: self.current, max: self.max }
+        StructureHitpoints {
+            current: self.current,
+            max: self.max,
+        }
     }
 }
 
@@ -2157,7 +2452,9 @@ pub struct SavedLifetimeCost {
 }
 impl SavedLifetimeCost {
     pub fn from_live(v: &LifetimeCost) -> Self {
-        Self { cost: SavedResourceCost::from_live(&v.0) }
+        Self {
+            cost: SavedResourceCost::from_live(&v.0),
+        }
     }
     pub fn into_live(self) -> LifetimeCost {
         LifetimeCost(self.cost.into_live())
@@ -2317,26 +2614,44 @@ impl SavedColonySnapshot {
             production_research: v.production_research,
             food_consumption: v.food_consumption,
             maintenance_energy: v.maintenance_energy,
-            buildings: v.buildings.iter().map(|s| s.as_ref().map(|b| b.0.clone())).collect(),
-            build_queue: v.build_queue.iter().map(|e| SavedBuildQueueEntrySnapshot {
-                building_id: e.building_id.0.clone(),
-                target_slot: e.target_slot,
-                build_time_remaining: e.build_time_remaining,
-            }).collect(),
-            demolition_queue: v.demolition_queue.iter().map(|d| SavedDemolitionSnapshot {
-                target_slot: d.target_slot,
-                building_id: d.building_id.0.clone(),
-                time_remaining: d.time_remaining,
-            }).collect(),
-            upgrade_queue: v.upgrade_queue.iter().map(|u| SavedUpgradeSnapshot {
-                slot_index: u.slot_index,
-                target_id: u.target_id.0.clone(),
-                build_time_remaining: u.build_time_remaining,
-            }).collect(),
+            buildings: v
+                .buildings
+                .iter()
+                .map(|s| s.as_ref().map(|b| b.0.clone()))
+                .collect(),
+            build_queue: v
+                .build_queue
+                .iter()
+                .map(|e| SavedBuildQueueEntrySnapshot {
+                    building_id: e.building_id.0.clone(),
+                    target_slot: e.target_slot,
+                    build_time_remaining: e.build_time_remaining,
+                })
+                .collect(),
+            demolition_queue: v
+                .demolition_queue
+                .iter()
+                .map(|d| SavedDemolitionSnapshot {
+                    target_slot: d.target_slot,
+                    building_id: d.building_id.0.clone(),
+                    time_remaining: d.time_remaining,
+                })
+                .collect(),
+            upgrade_queue: v
+                .upgrade_queue
+                .iter()
+                .map(|u| SavedUpgradeSnapshot {
+                    slot_index: u.slot_index,
+                    target_id: u.target_id.0.clone(),
+                    build_time_remaining: u.build_time_remaining,
+                })
+                .collect(),
         }
     }
     pub fn into_live(self, map: &EntityMap) -> crate::knowledge::ColonySnapshot {
-        use crate::knowledge::{BuildQueueEntrySnapshot, ColonySnapshot, DemolitionSnapshot, UpgradeSnapshot};
+        use crate::knowledge::{
+            BuildQueueEntrySnapshot, ColonySnapshot, DemolitionSnapshot, UpgradeSnapshot,
+        };
         use crate::scripting::building_api::BuildingId;
         ColonySnapshot {
             colony_entity: remap_entity(self.colony_entity_bits, map),
@@ -2350,22 +2665,38 @@ impl SavedColonySnapshot {
             production_research: self.production_research,
             food_consumption: self.food_consumption,
             maintenance_energy: self.maintenance_energy,
-            buildings: self.buildings.into_iter().map(|s| s.map(BuildingId::new)).collect(),
-            build_queue: self.build_queue.into_iter().map(|e| BuildQueueEntrySnapshot {
-                building_id: BuildingId::new(e.building_id),
-                target_slot: e.target_slot,
-                build_time_remaining: e.build_time_remaining,
-            }).collect(),
-            demolition_queue: self.demolition_queue.into_iter().map(|d| DemolitionSnapshot {
-                target_slot: d.target_slot,
-                building_id: BuildingId::new(d.building_id),
-                time_remaining: d.time_remaining,
-            }).collect(),
-            upgrade_queue: self.upgrade_queue.into_iter().map(|u| UpgradeSnapshot {
-                slot_index: u.slot_index,
-                target_id: BuildingId::new(u.target_id),
-                build_time_remaining: u.build_time_remaining,
-            }).collect(),
+            buildings: self
+                .buildings
+                .into_iter()
+                .map(|s| s.map(BuildingId::new))
+                .collect(),
+            build_queue: self
+                .build_queue
+                .into_iter()
+                .map(|e| BuildQueueEntrySnapshot {
+                    building_id: BuildingId::new(e.building_id),
+                    target_slot: e.target_slot,
+                    build_time_remaining: e.build_time_remaining,
+                })
+                .collect(),
+            demolition_queue: self
+                .demolition_queue
+                .into_iter()
+                .map(|d| DemolitionSnapshot {
+                    target_slot: d.target_slot,
+                    building_id: BuildingId::new(d.building_id),
+                    time_remaining: d.time_remaining,
+                })
+                .collect(),
+            upgrade_queue: self
+                .upgrade_queue
+                .into_iter()
+                .map(|u| UpgradeSnapshot {
+                    slot_index: u.slot_index,
+                    target_id: BuildingId::new(u.target_id),
+                    build_time_remaining: u.build_time_remaining,
+                })
+                .collect(),
         }
     }
 }
@@ -2397,7 +2728,11 @@ impl SavedSystemSnapshot {
             production_food: v.production_food,
             production_research: v.production_research,
             maintenance_energy: v.maintenance_energy,
-            colonies: v.colonies.iter().map(SavedColonySnapshot::from_live).collect(),
+            colonies: v
+                .colonies
+                .iter()
+                .map(SavedColonySnapshot::from_live)
+                .collect(),
         }
     }
     pub fn into_live(self, map: &EntityMap) -> SystemSnapshot {
@@ -2426,7 +2761,11 @@ impl SavedSystemSnapshot {
             production_food: self.production_food,
             production_research: self.production_research,
             maintenance_energy: self.maintenance_energy,
-            colonies: self.colonies.into_iter().map(|c| c.into_live(map)).collect(),
+            colonies: self
+                .colonies
+                .into_iter()
+                .map(|c| c.into_live(map))
+                .collect(),
         }
     }
 }
@@ -2479,7 +2818,9 @@ impl From<&ShipSnapshotState> for SavedShipSnapshotState {
             ShipSnapshotState::Settling => Self::Settling,
             ShipSnapshotState::Refitting => Self::Refitting,
             ShipSnapshotState::Destroyed => Self::Destroyed,
-            ShipSnapshotState::Loitering { position } => Self::Loitering { position: *position },
+            ShipSnapshotState::Loitering { position } => Self::Loitering {
+                position: *position,
+            },
         }
     }
 }
@@ -2547,8 +2888,14 @@ pub struct SavedKnowledgeStore {
 impl SavedKnowledgeStore {
     pub fn from_live(v: &KnowledgeStore) -> Self {
         Self {
-            entries: v.iter().map(|(_, k)| SavedSystemKnowledge::from_live(k)).collect(),
-            ship_snapshots: v.iter_ships().map(|(_, s)| SavedShipSnapshot::from_live(s)).collect(),
+            entries: v
+                .iter()
+                .map(|(_, k)| SavedSystemKnowledge::from_live(k))
+                .collect(),
+            ship_snapshots: v
+                .iter_ships()
+                .map(|(_, s)| SavedShipSnapshot::from_live(s))
+                .collect(),
         }
     }
     pub fn into_live(self, map: &EntityMap) -> KnowledgeStore {
@@ -2658,37 +3005,69 @@ pub enum SavedKnowledgeFact {
 impl SavedKnowledgeFact {
     pub fn from_live(v: &KnowledgeFact) -> Self {
         match v {
-            KnowledgeFact::HostileDetected { event_id, target, detector, target_pos, description } => Self::HostileDetected {
+            KnowledgeFact::HostileDetected {
+                event_id,
+                target,
+                detector,
+                target_pos,
+                description,
+            } => Self::HostileDetected {
                 target_bits: target.to_bits(),
                 detector_bits: detector.to_bits(),
                 target_pos: *target_pos,
                 description: description.clone(),
                 event_id: event_id.map(|e| e.0),
             },
-            KnowledgeFact::CombatOutcome { event_id, system, victor, detail } => Self::CombatOutcome {
+            KnowledgeFact::CombatOutcome {
+                event_id,
+                system,
+                victor,
+                detail,
+            } => Self::CombatOutcome {
                 system_bits: system.to_bits(),
                 victor: victor.into(),
                 detail: detail.clone(),
                 event_id: event_id.map(|e| e.0),
             },
-            KnowledgeFact::SurveyComplete { event_id, system, system_name, detail } => Self::SurveyComplete {
+            KnowledgeFact::SurveyComplete {
+                event_id,
+                system,
+                system_name,
+                detail,
+            } => Self::SurveyComplete {
                 system_bits: system.to_bits(),
                 system_name: system_name.clone(),
                 detail: detail.clone(),
                 event_id: event_id.map(|e| e.0),
             },
-            KnowledgeFact::AnomalyDiscovered { event_id, system, anomaly_id, detail } => Self::AnomalyDiscovered {
+            KnowledgeFact::AnomalyDiscovered {
+                event_id,
+                system,
+                anomaly_id,
+                detail,
+            } => Self::AnomalyDiscovered {
                 system_bits: system.to_bits(),
                 anomaly_id: anomaly_id.clone(),
                 detail: detail.clone(),
                 event_id: event_id.map(|e| e.0),
             },
-            KnowledgeFact::SurveyDiscovery { event_id, system, detail } => Self::SurveyDiscovery {
+            KnowledgeFact::SurveyDiscovery {
+                event_id,
+                system,
+                detail,
+            } => Self::SurveyDiscovery {
                 system_bits: system.to_bits(),
                 detail: detail.clone(),
                 event_id: event_id.map(|e| e.0),
             },
-            KnowledgeFact::StructureBuilt { event_id, system, kind, name, destroyed, detail } => Self::StructureBuilt {
+            KnowledgeFact::StructureBuilt {
+                event_id,
+                system,
+                kind,
+                name,
+                destroyed,
+                detail,
+            } => Self::StructureBuilt {
                 system_bits: system.map(|e| e.to_bits()),
                 kind: kind.clone(),
                 name: name.clone(),
@@ -2696,20 +3075,36 @@ impl SavedKnowledgeFact {
                 detail: detail.clone(),
                 event_id: event_id.map(|e| e.0),
             },
-            KnowledgeFact::ColonyEstablished { event_id, system, planet, name, detail } => Self::ColonyEstablished {
+            KnowledgeFact::ColonyEstablished {
+                event_id,
+                system,
+                planet,
+                name,
+                detail,
+            } => Self::ColonyEstablished {
                 system_bits: system.to_bits(),
                 planet_bits: planet.to_bits(),
                 name: name.clone(),
                 detail: detail.clone(),
                 event_id: event_id.map(|e| e.0),
             },
-            KnowledgeFact::ColonyFailed { event_id, system, name, reason } => Self::ColonyFailed {
+            KnowledgeFact::ColonyFailed {
+                event_id,
+                system,
+                name,
+                reason,
+            } => Self::ColonyFailed {
                 system_bits: system.to_bits(),
                 name: name.clone(),
                 reason: reason.clone(),
                 event_id: event_id.map(|e| e.0),
             },
-            KnowledgeFact::ShipArrived { event_id, system, name, detail } => Self::ShipArrived {
+            KnowledgeFact::ShipArrived {
+                event_id,
+                system,
+                name,
+                detail,
+            } => Self::ShipArrived {
                 system_bits: system.map(|e| e.to_bits()),
                 name: name.clone(),
                 detail: detail.clone(),
@@ -2720,56 +3115,110 @@ impl SavedKnowledgeFact {
     pub fn into_live(self, map: &EntityMap) -> KnowledgeFact {
         use crate::knowledge::EventId;
         match self {
-            Self::HostileDetected { target_bits, detector_bits, target_pos, description, event_id } => KnowledgeFact::HostileDetected {
+            Self::HostileDetected {
+                target_bits,
+                detector_bits,
+                target_pos,
+                description,
+                event_id,
+            } => KnowledgeFact::HostileDetected {
                 event_id: event_id.map(EventId),
                 target: remap_entity(target_bits, map),
                 detector: remap_entity(detector_bits, map),
                 target_pos,
                 description,
             },
-            Self::CombatOutcome { system_bits, victor, detail, event_id } => KnowledgeFact::CombatOutcome {
+            Self::CombatOutcome {
+                system_bits,
+                victor,
+                detail,
+                event_id,
+            } => KnowledgeFact::CombatOutcome {
                 event_id: event_id.map(EventId),
                 system: remap_entity(system_bits, map),
                 victor: victor.into(),
                 detail,
             },
-            Self::SurveyComplete { system_bits, system_name, detail, event_id } => KnowledgeFact::SurveyComplete {
+            Self::SurveyComplete {
+                system_bits,
+                system_name,
+                detail,
+                event_id,
+            } => KnowledgeFact::SurveyComplete {
                 event_id: event_id.map(EventId),
                 system: remap_entity(system_bits, map),
                 system_name,
                 detail,
             },
-            Self::AnomalyDiscovered { system_bits, anomaly_id, detail, event_id } => KnowledgeFact::AnomalyDiscovered {
+            Self::AnomalyDiscovered {
+                system_bits,
+                anomaly_id,
+                detail,
+                event_id,
+            } => KnowledgeFact::AnomalyDiscovered {
                 event_id: event_id.map(EventId),
                 system: remap_entity(system_bits, map),
                 anomaly_id,
                 detail,
             },
-            Self::SurveyDiscovery { system_bits, detail, event_id } => KnowledgeFact::SurveyDiscovery {
+            Self::SurveyDiscovery {
+                system_bits,
+                detail,
+                event_id,
+            } => KnowledgeFact::SurveyDiscovery {
                 event_id: event_id.map(EventId),
                 system: remap_entity(system_bits, map),
                 detail,
             },
-            Self::StructureBuilt { system_bits, kind, name, destroyed, detail, event_id } => KnowledgeFact::StructureBuilt {
+            Self::StructureBuilt {
+                system_bits,
+                kind,
+                name,
+                destroyed,
+                detail,
+                event_id,
+            } => KnowledgeFact::StructureBuilt {
                 event_id: event_id.map(EventId),
                 system: system_bits.map(|b| remap_entity(b, map)),
-                kind, name, destroyed, detail,
+                kind,
+                name,
+                destroyed,
+                detail,
             },
-            Self::ColonyEstablished { system_bits, planet_bits, name, detail, event_id } => KnowledgeFact::ColonyEstablished {
+            Self::ColonyEstablished {
+                system_bits,
+                planet_bits,
+                name,
+                detail,
+                event_id,
+            } => KnowledgeFact::ColonyEstablished {
                 event_id: event_id.map(EventId),
                 system: remap_entity(system_bits, map),
                 planet: remap_entity(planet_bits, map),
-                name, detail,
+                name,
+                detail,
             },
-            Self::ColonyFailed { system_bits, name, reason, event_id } => KnowledgeFact::ColonyFailed {
+            Self::ColonyFailed {
+                system_bits,
+                name,
+                reason,
+                event_id,
+            } => KnowledgeFact::ColonyFailed {
                 event_id: event_id.map(EventId),
                 system: remap_entity(system_bits, map),
-                name, reason,
+                name,
+                reason,
             },
-            Self::ShipArrived { system_bits, name, detail, event_id } => KnowledgeFact::ShipArrived {
+            Self::ShipArrived {
+                system_bits,
+                name,
+                detail,
+                event_id,
+            } => KnowledgeFact::ShipArrived {
                 event_id: event_id.map(EventId),
                 system: system_bits.map(|b| remap_entity(b, map)),
-                name, detail,
+                name,
+                detail,
             },
         }
     }
@@ -2815,7 +3264,9 @@ pub struct SavedPendingFactQueue {
 
 impl SavedPendingFactQueue {
     pub fn from_live(v: &PendingFactQueue) -> Self {
-        Self { facts: v.facts.iter().map(SavedPerceivedFact::from_live).collect() }
+        Self {
+            facts: v.facts.iter().map(SavedPerceivedFact::from_live).collect(),
+        }
     }
     pub fn into_live(self, map: &EntityMap) -> PendingFactQueue {
         PendingFactQueue {
@@ -2945,6 +3396,15 @@ pub enum SavedRemoteCommand {
         energy_cost: Amt,
         build_time: i64,
     },
+    /// #275: `RemoteCommand::CancelBuildingOrder`.
+    CancelBuildingOrder {
+        order_id: u64,
+    },
+    /// #275: `RemoteCommand::CancelShipOrder`.
+    CancelShipOrder {
+        host_colony_bits: u64,
+        order_id: u64,
+    },
 }
 impl From<&RemoteCommand> for SavedRemoteCommand {
     fn from(v: &RemoteCommand) -> Self {
@@ -2952,15 +3412,21 @@ impl From<&RemoteCommand> for SavedRemoteCommand {
             RemoteCommand::BuildShip { design_id } => Self::BuildShip {
                 design_id: design_id.clone(),
             },
-            RemoteCommand::SetProductionFocus { minerals, energy, research } => {
-                Self::SetProductionFocus {
-                    minerals: *minerals,
-                    energy: *energy,
-                    research: *research,
-                }
-            }
+            RemoteCommand::SetProductionFocus {
+                minerals,
+                energy,
+                research,
+            } => Self::SetProductionFocus {
+                minerals: *minerals,
+                energy: *energy,
+                research: *research,
+            },
             RemoteCommand::Colony(cc) => Self::Colony(SavedColonyCommand::from_live(cc)),
-            RemoteCommand::ShipBuild { host_colony, design_id, build_kind } => Self::ShipBuild {
+            RemoteCommand::ShipBuild {
+                host_colony,
+                design_id,
+                build_kind,
+            } => Self::ShipBuild {
                 host_colony_bits: host_colony.to_bits(),
                 design_id: design_id.clone(),
                 build_kind: build_kind.into(),
@@ -2982,6 +3448,16 @@ impl From<&RemoteCommand> for SavedRemoteCommand {
                 energy_cost: *energy_cost,
                 build_time: *build_time,
             },
+            RemoteCommand::CancelBuildingOrder { order_id } => Self::CancelBuildingOrder {
+                order_id: *order_id,
+            },
+            RemoteCommand::CancelShipOrder {
+                host_colony,
+                order_id,
+            } => Self::CancelShipOrder {
+                host_colony_bits: host_colony.to_bits(),
+                order_id: *order_id,
+            },
         }
     }
 }
@@ -2989,17 +3465,25 @@ impl SavedRemoteCommand {
     pub fn into_live(self, map: &EntityMap) -> RemoteCommand {
         match self {
             SavedRemoteCommand::BuildShip { design_id } => RemoteCommand::BuildShip { design_id },
-            SavedRemoteCommand::SetProductionFocus { minerals, energy, research } => {
-                RemoteCommand::SetProductionFocus { minerals, energy, research }
-            }
+            SavedRemoteCommand::SetProductionFocus {
+                minerals,
+                energy,
+                research,
+            } => RemoteCommand::SetProductionFocus {
+                minerals,
+                energy,
+                research,
+            },
             SavedRemoteCommand::Colony(sc) => RemoteCommand::Colony(sc.into_live(map)),
-            SavedRemoteCommand::ShipBuild { host_colony_bits, design_id, build_kind } => {
-                RemoteCommand::ShipBuild {
-                    host_colony: remap_entity(host_colony_bits, map),
-                    design_id,
-                    build_kind: build_kind.into(),
-                }
-            }
+            SavedRemoteCommand::ShipBuild {
+                host_colony_bits,
+                design_id,
+                build_kind,
+            } => RemoteCommand::ShipBuild {
+                host_colony: remap_entity(host_colony_bits, map),
+                design_id,
+                build_kind: build_kind.into(),
+            },
             SavedRemoteCommand::DeliverableBuild {
                 host_colony_bits,
                 def_id,
@@ -3016,6 +3500,16 @@ impl SavedRemoteCommand {
                 minerals_cost,
                 energy_cost,
                 build_time,
+            },
+            SavedRemoteCommand::CancelBuildingOrder { order_id } => {
+                RemoteCommand::CancelBuildingOrder { order_id }
+            }
+            SavedRemoteCommand::CancelShipOrder {
+                host_colony_bits,
+                order_id,
+            } => RemoteCommand::CancelShipOrder {
+                host_colony: remap_entity(host_colony_bits, map),
+                order_id,
             },
         }
     }
@@ -3083,14 +3577,20 @@ pub enum SavedBuildingKind {
 impl SavedBuildingKind {
     pub fn from_live(v: &BuildingKind) -> Self {
         match v {
-            BuildingKind::Queue { building_id, target_slot } => Self::Queue {
+            BuildingKind::Queue {
+                building_id,
+                target_slot,
+            } => Self::Queue {
                 building_id: building_id.clone(),
                 target_slot: *target_slot,
             },
             BuildingKind::Demolish { target_slot } => Self::Demolish {
                 target_slot: *target_slot,
             },
-            BuildingKind::Upgrade { slot_index, target_id } => Self::Upgrade {
+            BuildingKind::Upgrade {
+                slot_index,
+                target_id,
+            } => Self::Upgrade {
                 slot_index: *slot_index,
                 target_id: target_id.clone(),
             },
@@ -3098,13 +3598,21 @@ impl SavedBuildingKind {
     }
     pub fn into_live(self) -> BuildingKind {
         match self {
-            Self::Queue { building_id, target_slot } => {
-                BuildingKind::Queue { building_id, target_slot }
-            }
+            Self::Queue {
+                building_id,
+                target_slot,
+            } => BuildingKind::Queue {
+                building_id,
+                target_slot,
+            },
             Self::Demolish { target_slot } => BuildingKind::Demolish { target_slot },
-            Self::Upgrade { slot_index, target_id } => {
-                BuildingKind::Upgrade { slot_index, target_id }
-            }
+            Self::Upgrade {
+                slot_index,
+                target_id,
+            } => BuildingKind::Upgrade {
+                slot_index,
+                target_id,
+            },
         }
     }
 }
@@ -3173,10 +3681,22 @@ pub struct SavedCommandLog {
 }
 impl SavedCommandLog {
     pub fn from_live(v: &CommandLog) -> Self {
-        Self { entries: v.entries.iter().map(SavedCommandLogEntry::from_live).collect() }
+        Self {
+            entries: v
+                .entries
+                .iter()
+                .map(SavedCommandLogEntry::from_live)
+                .collect(),
+        }
     }
     pub fn into_live(self) -> CommandLog {
-        CommandLog { entries: self.entries.into_iter().map(SavedCommandLogEntry::into_live).collect() }
+        CommandLog {
+            entries: self
+                .entries
+                .into_iter()
+                .map(SavedCommandLogEntry::into_live)
+                .collect(),
+        }
     }
 }
 
@@ -3191,7 +3711,9 @@ pub struct SavedTechTree {
 }
 impl SavedTechTree {
     pub fn from_live(v: &TechTree) -> Self {
-        Self { researched: v.researched.iter().map(|t| t.0.clone()).collect() }
+        Self {
+            researched: v.researched.iter().map(|t| t.0.clone()).collect(),
+        }
     }
     /// Merge into an existing TechTree (preserves the tree's `technologies`
     /// field which was populated from Lua scripts at startup).
@@ -3242,7 +3764,9 @@ impl SavedResearchPool {
         Self { points: v.points }
     }
     pub fn into_live(self) -> ResearchPool {
-        ResearchPool { points: self.points }
+        ResearchPool {
+            points: self.points,
+        }
     }
 }
 
@@ -3252,10 +3776,14 @@ pub struct SavedRecentlyResearched {
 }
 impl SavedRecentlyResearched {
     pub fn from_live(v: &RecentlyResearched) -> Self {
-        Self { techs: v.techs.iter().map(|t| t.0.clone()).collect() }
+        Self {
+            techs: v.techs.iter().map(|t| t.0.clone()).collect(),
+        }
     }
     pub fn into_live(self) -> RecentlyResearched {
-        RecentlyResearched { techs: self.techs.into_iter().map(TechId).collect() }
+        RecentlyResearched {
+            techs: self.techs.into_iter().map(TechId).collect(),
+        }
     }
 }
 
@@ -3266,10 +3794,16 @@ pub struct SavedPendingResearch {
 }
 impl SavedPendingResearch {
     pub fn from_live(v: &PendingResearch) -> Self {
-        Self { amount: v.amount, arrives_at: v.arrives_at }
+        Self {
+            amount: v.amount,
+            arrives_at: v.arrives_at,
+        }
     }
     pub fn into_live(self) -> PendingResearch {
-        PendingResearch { amount: self.amount, arrives_at: self.arrives_at }
+        PendingResearch {
+            amount: self.amount,
+            arrives_at: self.arrives_at,
+        }
     }
 }
 
@@ -3279,7 +3813,9 @@ pub struct SavedTechKnowledge {
 }
 impl SavedTechKnowledge {
     pub fn from_live(v: &TechKnowledge) -> Self {
-        Self { known_techs: v.known_techs.iter().map(|t| t.0.clone()).collect() }
+        Self {
+            known_techs: v.known_techs.iter().map(|t| t.0.clone()).collect(),
+        }
     }
     pub fn into_live(self) -> TechKnowledge {
         TechKnowledge {
@@ -3344,12 +3880,20 @@ pub struct SavedPendingColonyTechModifiers {
 impl SavedPendingColonyTechModifiers {
     pub fn from_live(v: &PendingColonyTechModifiers) -> Self {
         Self {
-            entries: v.entries.iter().map(|(t, pm)| (t.0.clone(), SavedParsedModifier::from_live(pm))).collect(),
+            entries: v
+                .entries
+                .iter()
+                .map(|(t, pm)| (t.0.clone(), SavedParsedModifier::from_live(pm)))
+                .collect(),
         }
     }
     pub fn into_live(self) -> PendingColonyTechModifiers {
         PendingColonyTechModifiers {
-            entries: self.entries.into_iter().map(|(t, pm)| (TechId(t), pm.into_live())).collect(),
+            entries: self
+                .entries
+                .into_iter()
+                .map(|(t, pm)| (TechId(t), pm.into_live()))
+                .collect(),
         }
     }
 }
@@ -3360,10 +3904,14 @@ pub struct SavedEmpireModifiers {
 }
 impl SavedEmpireModifiers {
     pub fn from_live(v: &EmpireModifiers) -> Self {
-        Self { population_growth: v.population_growth.clone() }
+        Self {
+            population_growth: v.population_growth.clone(),
+        }
     }
     pub fn into_live(self) -> EmpireModifiers {
-        EmpireModifiers { population_growth: self.population_growth }
+        EmpireModifiers {
+            population_growth: self.population_growth,
+        }
     }
 }
 
@@ -3373,10 +3921,14 @@ pub struct SavedGameFlags {
 }
 impl SavedGameFlags {
     pub fn from_live(v: &GameFlags) -> Self {
-        Self { flags: v.flags.iter().cloned().collect() }
+        Self {
+            flags: v.flags.iter().cloned().collect(),
+        }
     }
     pub fn into_live(self) -> GameFlags {
-        GameFlags { flags: self.flags.into_iter().collect() }
+        GameFlags {
+            flags: self.flags.into_iter().collect(),
+        }
     }
 }
 
@@ -3386,10 +3938,14 @@ pub struct SavedScopedFlags {
 }
 impl SavedScopedFlags {
     pub fn from_live(v: &ScopedFlags) -> Self {
-        Self { flags: v.flags.iter().cloned().collect() }
+        Self {
+            flags: v.flags.iter().cloned().collect(),
+        }
     }
     pub fn into_live(self) -> ScopedFlags {
-        ScopedFlags { flags: self.flags.into_iter().collect() }
+        ScopedFlags {
+            flags: self.flags.into_iter().collect(),
+        }
     }
 }
 
@@ -3531,7 +4087,11 @@ impl SavedEventLog {
     pub fn into_live(self, map: &EntityMap) -> EventLog {
         EventLog {
             entries: self.entries.into_iter().map(|e| e.into_live(map)).collect(),
-            max_entries: if self.max_entries == 0 { 50 } else { self.max_entries },
+            max_entries: if self.max_entries == 0 {
+                50
+            } else {
+                self.max_entries
+            },
         }
     }
 }

--- a/macrocosmo/src/setup/mod.rs
+++ b/macrocosmo/src/setup/mod.rs
@@ -2,9 +2,9 @@ use bevy::prelude::*;
 
 use crate::amount::Amt;
 use crate::colony::{
-    BuildQueue, BuildingQueue, Buildings, Colony, FoodConsumption, MaintenanceCost, Production,
-    ProductionFocus, ResourceCapacity, ResourceStockpile, SystemBuildingQueue, SystemBuildings,
-    DEFAULT_SYSTEM_BUILDING_SLOTS,
+    BuildQueue, BuildingQueue, Buildings, Colony, DEFAULT_SYSTEM_BUILDING_SLOTS, FoodConsumption,
+    MaintenanceCost, Production, ProductionFocus, ResourceCapacity, ResourceStockpile,
+    SystemBuildingQueue, SystemBuildings,
 };
 use crate::communication::CommandLog;
 use crate::components::Position;
@@ -14,13 +14,13 @@ use crate::knowledge::KnowledgeStore;
 use crate::modifier::ModifiedValue;
 use crate::observer::{in_observer_mode, not_in_observer_mode};
 use crate::player::{Empire, Faction, PlayerEmpire};
+use crate::scripting::ScriptEngine;
 use crate::scripting::building_api::BuildingId;
-use crate::scripting::faction_api::{lookup_on_game_start, FactionRegistry};
+use crate::scripting::faction_api::{FactionRegistry, lookup_on_game_start};
 use crate::scripting::game_start_ctx::{
     GameStartActions, GameStartCtx, PlanetAttributesSpec, PlanetRef, SpawnedPlanetSpec,
 };
-use crate::scripting::ScriptEngine;
-use crate::ship::{spawn_ship, Owner};
+use crate::ship::{Owner, spawn_ship};
 use crate::ship_design::ShipDesignRegistry;
 use crate::species::{ColonyJobs, ColonyPopulation, ColonySpecies};
 use crate::technology::{
@@ -70,10 +70,8 @@ pub fn init_observer_view(
     if view.viewing.is_some() {
         return;
     }
-    let mut items: Vec<(Entity, String)> = empires
-        .iter()
-        .map(|(e, f)| (e, f.name.clone()))
-        .collect();
+    let mut items: Vec<(Entity, String)> =
+        empires.iter().map(|(e, f)| (e, f.name.clone())).collect();
     items.sort_by(|a, b| a.1.cmp(&b.1));
     if let Some((e, name)) = items.into_iter().next() {
         view.viewing = Some(e);
@@ -92,11 +90,7 @@ fn player_faction_id(world: &mut World) -> Option<String> {
 /// mirrors `crate::player::spawn_player_empire` so observer-mode empires are
 /// indistinguishable from the player empire (aside from the `PlayerEmpire`
 /// marker).
-fn empire_bundle(
-    name: String,
-    faction_id: String,
-    faction_name: String,
-) -> impl Bundle {
+fn empire_bundle(name: String, faction_id: String, faction_name: String) -> impl Bundle {
     (
         Empire { name },
         Faction {
@@ -144,9 +138,7 @@ pub fn run_all_factions_on_game_start(world: &mut World) {
     // so we don't double-spawn.
     let existing_by_id: std::collections::HashMap<String, Entity> = {
         let mut q = world.query_filtered::<(Entity, &Faction), Without<Empire>>();
-        q.iter(world)
-            .map(|(e, f)| (f.id.clone(), e))
-            .collect()
+        q.iter(world).map(|(e, f)| (f.id.clone(), e)).collect()
     };
 
     for (faction_id, faction_name, has_callback) in &registry_ids {
@@ -156,8 +148,8 @@ pub fn run_all_factions_on_game_start(world: &mut World) {
             // Leave passive factions (space_creature, ancient_defense) alone
             // — they're added by FactionRelationsPlugin and shouldn't be
             // promoted to full empires.
-            let is_passive = faction_id == "space_creature_faction"
-                || faction_id == "ancient_defense_faction";
+            let is_passive =
+                faction_id == "space_creature_faction" || faction_id == "ancient_defense_faction";
             if is_passive {
                 continue;
             }
@@ -178,7 +170,10 @@ pub fn run_all_factions_on_game_start(world: &mut World) {
                 faction_id.clone(),
                 faction_name.clone(),
             ));
-            info!("Observer mode: spawned NPC Empire for faction '{}'", faction_id);
+            info!(
+                "Observer mode: spawned NPC Empire for faction '{}'",
+                faction_id
+            );
         }
 
         if *has_callback {
@@ -282,11 +277,7 @@ pub fn run_faction_on_game_start(world: &mut World) {
 
 /// Resolve a `PlanetRef` to a planet `Entity` using the existing-planets list and the
 /// freshly spawned-planets list. Returns `None` if the index is out of range.
-fn resolve_planet_ref(
-    pref: PlanetRef,
-    existing: &[Entity],
-    spawned: &[Entity],
-) -> Option<Entity> {
+fn resolve_planet_ref(pref: PlanetRef, existing: &[Entity], spawned: &[Entity]) -> Option<Entity> {
     match pref {
         PlanetRef::Existing(idx) => {
             if idx == 0 || idx > existing.len() {
@@ -356,7 +347,7 @@ fn spawn_colony_on_planet(world: &mut World, planet_entity: Entity, num_slots: u
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
+            BuildQueue::default(),
             Buildings {
                 slots: vec![None; num_slots],
             },
@@ -632,10 +623,8 @@ pub fn apply_game_start_actions(world: &mut World, faction_id: &str, actions: Ga
             }
         };
         // Use SystemState to obtain a Commands queue from the world.
-        let mut state: bevy::ecs::system::SystemState<(
-            Commands,
-            Res<ShipDesignRegistry>,
-        )> = bevy::ecs::system::SystemState::new(world);
+        let mut state: bevy::ecs::system::SystemState<(Commands, Res<ShipDesignRegistry>)> =
+            bevy::ecs::system::SystemState::new(world);
         {
             let (mut commands, registry) = state.get_mut(world);
             for (design_id, name) in &actions.ships {
@@ -670,9 +659,9 @@ mod tests {
     use super::*;
     use crate::amount::Amt;
     use crate::colony::{
-        BuildQueue, BuildingQueue, Colony, FoodConsumption, MaintenanceCost, Production,
-        ProductionFocus, ResourceCapacity, ResourceStockpile, SystemBuildingQueue,
-        DEFAULT_SYSTEM_BUILDING_SLOTS,
+        BuildQueue, BuildingQueue, Colony, DEFAULT_SYSTEM_BUILDING_SLOTS, FoodConsumption,
+        MaintenanceCost, Production, ProductionFocus, ResourceCapacity, ResourceStockpile,
+        SystemBuildingQueue,
     };
     use crate::components::Position;
     use crate::condition::ScopedFlags;
@@ -751,7 +740,7 @@ mod tests {
                 research_per_hexadies: ModifiedValue::new(Amt::units(1)),
                 food_per_hexadies: ModifiedValue::new(Amt::units(5)),
             },
-            BuildQueue { queue: Vec::new() },
+            BuildQueue::default(),
             crate::colony::Buildings {
                 slots: vec![None; 5],
             },
@@ -871,8 +860,12 @@ mod tests {
         let (mut world, capital, _planet) = setup_world();
 
         let mut actions = GameStartActions::default();
-        actions.ships.push(("explorer_mk1".into(), "Explorer-1".into()));
-        actions.ships.push(("explorer_mk1".into(), "Explorer-2".into()));
+        actions
+            .ships
+            .push(("explorer_mk1".into(), "Explorer-1".into()));
+        actions
+            .ships
+            .push(("explorer_mk1".into(), "Explorer-2".into()));
 
         apply_game_start_actions(&mut world, "test_faction", actions);
 
@@ -1125,4 +1118,3 @@ mod tests {
         assert_eq!(sq.iter(&world).count(), 1);
     }
 }
-

--- a/macrocosmo/src/ship/settlement.rs
+++ b/macrocosmo/src/ship/settlement.rs
@@ -2,18 +2,16 @@ use bevy::prelude::*;
 
 use crate::amount::Amt;
 use crate::colony::{
-    BuildQueue, Buildings, BuildingQueue, Colony, ColonyJobRates, FoodConsumption,
-    MaintenanceCost, Production, ProductionFocus, ResourceCapacity, ResourceStockpile,
-    SystemBuildings, SystemBuildingQueue,
+    BuildQueue, BuildingQueue, Buildings, Colony, ColonyJobRates, FoodConsumption, MaintenanceCost,
+    Production, ProductionFocus, ResourceCapacity, ResourceStockpile, SystemBuildingQueue,
+    SystemBuildings,
 };
 use crate::components::Position;
-use crate::knowledge::{
- FactSysParam, KnowledgeFact, PlayerVantage,
-};
-use crate::player::{AboardShip, Player, StationedAt};
-use crate::species::{ColonyJobs, ColonyPopulation, ColonySpecies};
 use crate::events::{GameEvent, GameEventKind};
 use crate::galaxy::{HostilePresence, StarSystem, SystemAttributes};
+use crate::knowledge::{FactSysParam, KnowledgeFact, PlayerVantage};
+use crate::player::{AboardShip, Player, StationedAt};
+use crate::species::{ColonyJobs, ColonyPopulation, ColonySpecies};
 use crate::time_system::GameClock;
 
 use super::{Ship, ShipState};
@@ -75,7 +73,9 @@ pub fn process_settling(
                     "Colony Ship {} cannot settle at {} — hostile presence!",
                     ship.name, star_system.name
                 );
-                *state = ShipState::Docked { system: system_entity };
+                *state = ShipState::Docked {
+                    system: system_entity,
+                };
                 // #249: Dual-write ColonyFailed.
                 let event_id = fact_sys.allocate_event_id();
                 let desc = format!(
@@ -103,15 +103,17 @@ pub fn process_settling(
             }
 
             // Collect planets that already have a colony
-            let colonized_planets: Vec<Entity> = existing_colonies.iter()
-                .map(|c| c.planet)
-                .collect();
+            let colonized_planets: Vec<Entity> =
+                existing_colonies.iter().map(|c| c.planet).collect();
 
             // If a specific planet was targeted, try to use it
             let target_planet = if let Some(target_pe) = target_planet_entity {
                 // Verify target planet is valid and not already colonized
                 if colonized_planets.contains(&target_pe) {
-                    info!("Target planet in {} is already colonized, settling aborted", star_system.name);
+                    info!(
+                        "Target planet in {} is already colonized, settling aborted",
+                        star_system.name
+                    );
                     commands.entity(ship_entity).despawn();
                     continue;
                 }
@@ -126,7 +128,10 @@ pub fn process_settling(
             };
 
             let Some((planet_entity, _, attrs)) = target_planet else {
-                info!("Colony Ship {} found no habitable planet at {}", ship.name, star_system.name);
+                info!(
+                    "Colony Ship {} found no habitable planet at {}",
+                    ship.name, star_system.name
+                );
                 commands.entity(ship_entity).despawn();
                 continue;
             };
@@ -149,9 +154,7 @@ pub fn process_settling(
                     research_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
                     food_per_hexadies: crate::modifier::ModifiedValue::new(Amt::ZERO),
                 },
-                BuildQueue {
-                    queue: Vec::new(),
-                },
+                BuildQueue::default(),
                 Buildings {
                     slots: vec![None; num_slots],
                 },
@@ -245,9 +248,18 @@ pub fn process_refitting(
 
     for (_entity, mut ship, mut state) in &mut ships {
         let (system, completes_at, new_modules, target_revision) = match &*state {
-            ShipState::Refitting { system, completes_at, new_modules, target_revision, .. } => {
-                (*system, *completes_at, new_modules.clone(), *target_revision)
-            }
+            ShipState::Refitting {
+                system,
+                completes_at,
+                new_modules,
+                target_revision,
+                ..
+            } => (
+                *system,
+                *completes_at,
+                new_modules.clone(),
+                *target_revision,
+            ),
             _ => continue,
         };
 

--- a/macrocosmo/src/ui/system_panel/colony_detail.rs
+++ b/macrocosmo/src/ui/system_panel/colony_detail.rs
@@ -1,14 +1,17 @@
 use bevy::prelude::*;
 use bevy_egui::egui;
 
-use crate::colony::{BuildQueue, BuildingQueue, Buildings, Colony, ColonyJobRates, ConstructionParams, FoodConsumption, MaintenanceCost, Production, ResourceStockpile};
+use crate::amount::{Amt, SignedAmt};
+use crate::colony::{
+    BuildQueue, BuildingQueue, Buildings, Colony, ColonyJobRates, ConstructionParams,
+    FoodConsumption, MaintenanceCost, Production, ResourceStockpile,
+};
 use crate::communication::{
     BuildingKind, BuildingScope, ColonyCommand, PendingColonyDispatch, PendingColonyDispatches,
 };
+use crate::galaxy::SystemAttributes;
 use crate::knowledge::{ColonySnapshot, ObservationSource, SystemKnowledge};
 use crate::scripting::building_api::{BuildingId, BuildingRegistry};
-use crate::galaxy::SystemAttributes;
-use crate::amount::{Amt, SignedAmt};
 use crate::ship::{Cargo, Ship, ShipHitpoints, ShipState, SurveyData};
 use crate::species::{ColonyJobs, ColonyPopulation, JobRegistry, JobSlot};
 use crate::ui::ColonyPanelTab;
@@ -40,8 +43,21 @@ pub(super) fn draw_colony_detail(
         Option<&ColonyJobs>,
         Option<&ColonyJobRates>,
     )>,
-    system_stockpiles: &mut Query<(&mut ResourceStockpile, Option<&crate::colony::ResourceCapacity>), With<crate::galaxy::StarSystem>>,
-    ships_query: &mut Query<(Entity, &mut Ship, &mut ShipState, Option<&mut Cargo>, &ShipHitpoints, Option<&SurveyData>)>,
+    system_stockpiles: &mut Query<
+        (
+            &mut ResourceStockpile,
+            Option<&crate::colony::ResourceCapacity>,
+        ),
+        With<crate::galaxy::StarSystem>,
+    >,
+    ships_query: &mut Query<(
+        Entity,
+        &mut Ship,
+        &mut ShipState,
+        Option<&mut Cargo>,
+        &ShipHitpoints,
+        Option<&SurveyData>,
+    )>,
     construction_params: &ConstructionParams,
     planets: &Query<&crate::galaxy::Planet>,
     _hull_registry: &crate::ship_design::HullRegistry,
@@ -64,8 +80,12 @@ pub(super) fn draw_colony_detail(
     );
 
     if !is_local_system {
-        let snapshot = k_data
-            .and_then(|k| k.data.colonies.iter().find(|c| c.planet_entity == planet_entity));
+        let snapshot = k_data.and_then(|k| {
+            k.data
+                .colonies
+                .iter()
+                .find(|c| c.planet_entity == planet_entity)
+        });
         match snapshot {
             None => {
                 ui.label(
@@ -80,7 +100,9 @@ pub(super) fn draw_colony_detail(
             }
             Some(cs) => {
                 let age = k_data.map(|k| clock_elapsed - k.observed_at).unwrap_or(0);
-                let source = k_data.map(|k| k.source).unwrap_or(ObservationSource::Direct);
+                let source = k_data
+                    .map(|k| k.source)
+                    .unwrap_or(ObservationSource::Direct);
                 draw_colony_detail_snapshot(ui, cs, age, source);
                 // Build/Demolish/Upgrade buttons for remote colonies are
                 // rendered via the dispatcher pipeline — the snapshot view
@@ -99,7 +121,10 @@ pub(super) fn draw_colony_detail(
             *colony_panel_tab = ColonyPanelTab::Overview;
         }
         if ui
-            .selectable_label(*colony_panel_tab == ColonyPanelTab::PopManagement, "Pop & Job Management")
+            .selectable_label(
+                *colony_panel_tab == ColonyPanelTab::PopManagement,
+                "Pop & Job Management",
+            )
             .clicked()
         {
             *colony_panel_tab = ColonyPanelTab::PopManagement;
@@ -122,13 +147,9 @@ pub(super) fn draw_colony_detail(
             building_registry,
             dispatches,
         ),
-        ColonyPanelTab::PopManagement => draw_pop_management_tab(
-            ui,
-            planet_entity,
-            colonies,
-            colony_pop_view,
-            job_registry,
-        ),
+        ColonyPanelTab::PopManagement => {
+            draw_pop_management_tab(ui, planet_entity, colonies, colony_pop_view, job_registry)
+        }
     }
 }
 
@@ -170,16 +191,34 @@ fn draw_colony_detail_snapshot(
         cs.population, cs.carrying_cap_hint
     ));
     ui.label(egui::RichText::new("Income/hd (snapshot):").strong());
-    ui.label(format!("  Food:     {}", cs.production_food.display_compact()));
+    ui.label(format!(
+        "  Food:     {}",
+        cs.production_food.display_compact()
+    ));
     if cs.food_consumption > Amt::ZERO {
-        ui.label(format!("  (consume {})", cs.food_consumption.display_compact()));
+        ui.label(format!(
+            "  (consume {})",
+            cs.food_consumption.display_compact()
+        ));
     }
-    ui.label(format!("  Energy:   {}", cs.production_energy.display_compact()));
+    ui.label(format!(
+        "  Energy:   {}",
+        cs.production_energy.display_compact()
+    ));
     if cs.maintenance_energy > Amt::ZERO {
-        ui.label(format!("  (maintain {})", cs.maintenance_energy.display_compact()));
+        ui.label(format!(
+            "  (maintain {})",
+            cs.maintenance_energy.display_compact()
+        ));
     }
-    ui.label(format!("  Minerals: {}", cs.production_minerals.display_compact()));
-    ui.label(format!("  Research: {}", cs.production_research.display_compact()));
+    ui.label(format!(
+        "  Minerals: {}",
+        cs.production_minerals.display_compact()
+    ));
+    ui.label(format!(
+        "  Research: {}",
+        cs.production_research.display_compact()
+    ));
 
     ui.separator();
     ui.label(egui::RichText::new("Buildings (snapshot)").strong());
@@ -242,16 +281,37 @@ fn draw_overview_tab(
         Option<&MaintenanceCost>,
         Option<&FoodConsumption>,
     )>,
-    system_stockpiles: &mut Query<(&mut ResourceStockpile, Option<&crate::colony::ResourceCapacity>), With<crate::galaxy::StarSystem>>,
-    ships_query: &mut Query<(Entity, &mut Ship, &mut ShipState, Option<&mut Cargo>, &ShipHitpoints, Option<&SurveyData>)>,
+    system_stockpiles: &mut Query<
+        (
+            &mut ResourceStockpile,
+            Option<&crate::colony::ResourceCapacity>,
+        ),
+        With<crate::galaxy::StarSystem>,
+    >,
+    ships_query: &mut Query<(
+        Entity,
+        &mut Ship,
+        &mut ShipState,
+        Option<&mut Cargo>,
+        &ShipHitpoints,
+        Option<&SurveyData>,
+    )>,
     construction_params: &ConstructionParams,
     planets: &Query<&crate::galaxy::Planet>,
     design_registry: &crate::ship_design::ShipDesignRegistry,
     building_registry: &BuildingRegistry,
     dispatches: &mut PendingColonyDispatches,
 ) {
-    for (_colony_entity, colony, production, _build_queue, buildings, building_queue, maintenance_cost, food_consumption) in
-        colonies.iter_mut()
+    for (
+        _colony_entity,
+        colony,
+        production,
+        _build_queue,
+        buildings,
+        building_queue,
+        maintenance_cost,
+        food_consumption,
+    ) in colonies.iter_mut()
     {
         if colony.planet != planet_entity {
             continue;
@@ -262,7 +322,9 @@ fn draw_overview_tab(
             use crate::galaxy::{BASE_CARRYING_CAPACITY, FOOD_PER_POP_PER_HEXADIES};
             let hab_score = planet_attrs.map(|a| a.habitability).unwrap_or(0.5);
             let k_habitat = BASE_CARRYING_CAPACITY * hab_score;
-            let food_prod = production.map(|p| p.food_per_hexadies.final_value()).unwrap_or(Amt::ZERO);
+            let food_prod = production
+                .map(|p| p.food_per_hexadies.final_value())
+                .unwrap_or(Amt::ZERO);
             let k_food = if FOOD_PER_POP_PER_HEXADIES.raw() > 0 {
                 food_prod.div_amt(FOOD_PER_POP_PER_HEXADIES).to_f64()
             } else {
@@ -270,7 +332,10 @@ fn draw_overview_tab(
             };
             k_habitat.min(k_food).max(1.0)
         };
-        ui.label(format!("Population: {:.0} / {:.0}", colony.population, carrying_cap));
+        ui.label(format!(
+            "Population: {:.0} / {:.0}",
+            colony.population, carrying_cap
+        ));
 
         if let Some(prod) = production {
             let green = egui::Color32::from_rgb(100, 200, 100);
@@ -280,34 +345,64 @@ fn draw_overview_tab(
 
             // Food: production - consumption
             let food_prod = prod.food_per_hexadies.final_value();
-            let food_cons = food_consumption.map(|fc| fc.food_per_hexadies.final_value()).unwrap_or(Amt::ZERO);
-            let food_net = SignedAmt::from_amt(food_prod).add(SignedAmt(0 - SignedAmt::from_amt(food_cons).raw()));
-            let food_color = if food_net.raw() > 0 { green } else if food_net.raw() < 0 { red } else { egui::Color32::GRAY };
+            let food_cons = food_consumption
+                .map(|fc| fc.food_per_hexadies.final_value())
+                .unwrap_or(Amt::ZERO);
+            let food_net = SignedAmt::from_amt(food_prod)
+                .add(SignedAmt(0 - SignedAmt::from_amt(food_cons).raw()));
+            let food_color = if food_net.raw() > 0 {
+                green
+            } else if food_net.raw() < 0 {
+                red
+            } else {
+                egui::Color32::GRAY
+            };
             ui.horizontal(|ui| {
                 ui.label("  Food:    ");
                 ui.label(egui::RichText::new(food_net.display_compact()).color(food_color));
                 if food_cons > Amt::ZERO {
-                    ui.label(format!("(produce {}, consume {})", food_prod.display_compact(), food_cons.display_compact()));
+                    ui.label(format!(
+                        "(produce {}, consume {})",
+                        food_prod.display_compact(),
+                        food_cons.display_compact()
+                    ));
                 }
             });
 
             // Energy: production - maintenance
             let energy_prod = prod.energy_per_hexadies.final_value();
-            let maint = maintenance_cost.map(|mc| mc.energy_per_hexadies.final_value()).unwrap_or(Amt::ZERO);
-            let energy_net = SignedAmt::from_amt(energy_prod).add(SignedAmt(0 - SignedAmt::from_amt(maint).raw()));
-            let energy_color = if energy_net.raw() > 0 { green } else if energy_net.raw() < 0 { red } else { egui::Color32::GRAY };
+            let maint = maintenance_cost
+                .map(|mc| mc.energy_per_hexadies.final_value())
+                .unwrap_or(Amt::ZERO);
+            let energy_net = SignedAmt::from_amt(energy_prod)
+                .add(SignedAmt(0 - SignedAmt::from_amt(maint).raw()));
+            let energy_color = if energy_net.raw() > 0 {
+                green
+            } else if energy_net.raw() < 0 {
+                red
+            } else {
+                egui::Color32::GRAY
+            };
             ui.horizontal(|ui| {
                 ui.label("  Energy:  ");
                 ui.label(egui::RichText::new(energy_net.display_compact()).color(energy_color));
                 if maint > Amt::ZERO {
-                    ui.label(format!("(produce {}, maintain {})", energy_prod.display_compact(), maint.display_compact()));
+                    ui.label(format!(
+                        "(produce {}, maintain {})",
+                        energy_prod.display_compact(),
+                        maint.display_compact()
+                    ));
                 }
             });
 
             // Minerals: just production
             let minerals_prod = prod.minerals_per_hexadies.final_value();
             let minerals_net = SignedAmt::from_amt(minerals_prod);
-            let minerals_color = if minerals_net.raw() > 0 { green } else { egui::Color32::GRAY };
+            let minerals_color = if minerals_net.raw() > 0 {
+                green
+            } else {
+                egui::Color32::GRAY
+            };
             ui.horizontal(|ui| {
                 ui.label("  Minerals:");
                 ui.label(egui::RichText::new(minerals_net.display_compact()).color(minerals_color));
@@ -338,7 +433,10 @@ fn draw_overview_tab(
                 for slot in &b.slots {
                     if let Some(bid) = slot {
                         building_maintenance = building_maintenance.add(
-                            building_registry.get(bid.as_str()).map(|d| d.maintenance).unwrap_or(Amt::ZERO)
+                            building_registry
+                                .get(bid.as_str())
+                                .map(|d| d.maintenance)
+                                .unwrap_or(Amt::ZERO),
                         );
                     }
                 }
@@ -347,19 +445,27 @@ fn draw_overview_tab(
             let mut ships_based_here = 0u32;
             for (_, ship, _, _, _, _) in ships_query.iter() {
                 if colony.system(planets) == Some(ship.home_port) {
-                    ship_maintenance = ship_maintenance.add(design_registry.maintenance(&ship.design_id));
+                    ship_maintenance =
+                        ship_maintenance.add(design_registry.maintenance(&ship.design_id));
                     ships_based_here += 1;
                 }
             }
             let total_maintenance = building_maintenance.add(ship_maintenance);
             if total_maintenance > Amt::ZERO {
-                ui.label(format!("Maintenance: {} E/hd", total_maintenance.display_compact()));
-                ui.label(format!("  Buildings: {} E/hd", building_maintenance.display_compact()));
+                ui.label(format!(
+                    "Maintenance: {} E/hd",
+                    total_maintenance.display_compact()
+                ));
+                ui.label(format!(
+                    "  Buildings: {} E/hd",
+                    building_maintenance.display_compact()
+                ));
             }
             if ships_based_here > 0 {
                 ui.label(format!(
                     "Ships based here: {} (maintenance: {} E/hd)",
-                    ships_based_here, ship_maintenance.display_compact()
+                    ships_based_here,
+                    ship_maintenance.display_compact()
                 ));
             }
         }
@@ -374,16 +480,22 @@ fn draw_overview_tab(
 
             let mut demolish_request: Option<(usize, BuildingId)> = None;
             let mut upgrade_request: Option<(usize, String, Amt, Amt, i64)> = None;
+            // #275: Any of the three queues can produce a cancel.
+            let mut cancel_request: Option<u64> = None;
 
-            // Collect pending building slots so we can show in-progress orders
-            let pending_orders: Vec<(usize, String, f32)> = building_queue
+            // Collect pending building slots so we can show in-progress orders.
+            // #275: `order_id` is carried through so the cancel button on the
+            // in-progress row can dispatch `CancelBuildingOrder`.
+            let pending_orders: Vec<(usize, String, f32, u64)> = building_queue
                 .as_ref()
                 .map(|bq| {
                     bq.queue
                         .iter()
                         .map(|order| {
                             let def = building_registry.get(order.building_id.as_str());
-                            let (total_m, total_e) = def.map(|d| d.build_cost()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                            let (total_m, total_e) = def
+                                .map(|d| d.build_cost())
+                                .unwrap_or((Amt::ZERO, Amt::ZERO));
                             let m_pct = if total_m.raw() > 0 {
                                 1.0 - (order.minerals_remaining.raw() as f32 / total_m.raw() as f32)
                             } else {
@@ -401,15 +513,19 @@ fn draw_overview_tab(
                                 1.0
                             };
                             let pct = m_pct.min(e_pct).min(time_pct).max(0.0);
-                            let name = def.map(|d| d.name.clone()).unwrap_or_else(|| order.building_id.0.clone());
-                            (order.target_slot, name, pct)
+                            let name = def
+                                .map(|d| d.name.clone())
+                                .unwrap_or_else(|| order.building_id.0.clone());
+                            (order.target_slot, name, pct, order.order_id)
                         })
                         .collect()
                 })
                 .unwrap_or_default();
 
             let bldg_cost_mod = construction_params.building_cost_modifier.final_value();
-            let bldg_time_mod = construction_params.building_build_time_modifier.final_value();
+            let bldg_time_mod = construction_params
+                .building_build_time_modifier
+                .final_value();
 
             for (i, slot) in buildings.slots.iter().enumerate() {
                 let is_demolishing = building_queue
@@ -423,82 +539,127 @@ fn draw_overview_tab(
 
                 match slot {
                     Some(bid) if is_demolishing => {
-                        let remaining = building_queue
+                        let (remaining, demo_order_id) = building_queue
                             .as_ref()
-                            .and_then(|bq| bq.demolition_time_remaining(i))
-                            .unwrap_or(0);
-                        let name = building_registry.get(bid.as_str()).map(|d| d.name.as_str()).unwrap_or(bid.as_str());
-                        ui.label(format!(
-                            "  [{}] {} — Demolishing... ({} hd remaining)",
-                            i, name, remaining
-                        ));
+                            .and_then(|bq| {
+                                bq.demolition_queue
+                                    .iter()
+                                    .find(|d| d.target_slot == i)
+                                    .map(|d| (d.time_remaining, d.order_id))
+                            })
+                            .unwrap_or((0, 0));
+                        let name = building_registry
+                            .get(bid.as_str())
+                            .map(|d| d.name.as_str())
+                            .unwrap_or(bid.as_str());
+                        ui.horizontal(|ui| {
+                            ui.label(format!(
+                                "  [{}] {} — Demolishing... ({} hd remaining)",
+                                i, name, remaining
+                            ));
+                            // #275: Cancel the demolition mid-flight.
+                            if ui
+                                .small_button("×")
+                                .on_hover_text("Cancel demolition")
+                                .clicked()
+                            {
+                                cancel_request = Some(demo_order_id);
+                            }
+                        });
                     }
                     Some(bid) if is_upgrading => {
-                        let upgrade_info = building_queue
-                            .as_ref()
-                            .and_then(|bq| bq.upgrade_info(i));
-                        let name = building_registry.get(bid.as_str()).map(|d| d.name.as_str()).unwrap_or(bid.as_str());
+                        let upgrade_info =
+                            building_queue.as_ref().and_then(|bq| bq.upgrade_info(i));
+                        let name = building_registry
+                            .get(bid.as_str())
+                            .map(|d| d.name.as_str())
+                            .unwrap_or(bid.as_str());
                         let target_name = upgrade_info
                             .and_then(|u| building_registry.get(u.target_id.as_str()))
                             .map(|d| d.name.as_str())
                             .unwrap_or("?");
                         let remaining = upgrade_info.map(|u| u.build_time_remaining).unwrap_or(0);
-                        ui.label(format!(
-                            "  [{}] {} — Upgrading to {} ({} hd remaining)",
-                            i, name, target_name, remaining
-                        ));
+                        let upgrade_order_id = upgrade_info.map(|u| u.order_id).unwrap_or(0);
+                        ui.horizontal(|ui| {
+                            ui.label(format!(
+                                "  [{}] {} — Upgrading to {} ({} hd remaining)",
+                                i, name, target_name, remaining
+                            ));
+                            // #275: Cancel the in-progress upgrade.
+                            if ui
+                                .small_button("×")
+                                .on_hover_text("Cancel upgrade")
+                                .clicked()
+                            {
+                                cancel_request = Some(upgrade_order_id);
+                            }
+                        });
                     }
                     Some(bid) => {
                         let def = building_registry.get(bid.as_str());
                         let name = def.map(|d| d.name.as_str()).unwrap_or(bid.as_str());
-                        let (m_refund, e_refund) = def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                        let (m_refund, e_refund) = def
+                            .map(|d| d.demolition_refund())
+                            .unwrap_or((Amt::ZERO, Amt::ZERO));
                         let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
                         ui.horizontal(|ui| {
                             ui.label(format!("  [{}] {}", i, name));
                             let tooltip = format!(
                                 "Demolish: {} hd | Refund M:{} E:{}",
-                                demo_time, m_refund.display_compact(), e_refund.display_compact()
+                                demo_time,
+                                m_refund.display_compact(),
+                                e_refund.display_compact()
                             );
-                            if ui
-                                .small_button("Demolish")
-                                .on_hover_text(tooltip)
-                                .clicked()
-                            {
+                            if ui.small_button("Demolish").on_hover_text(tooltip).clicked() {
                                 demolish_request = Some((i, bid.clone()));
                             }
                             // Show upgrade buttons if upgrade paths exist
                             if let Some(src_def) = def {
                                 for up in &src_def.upgrade_to {
                                     let target_def = building_registry.get(&up.target_id);
-                                    let target_name = target_def.map(|d| d.name.as_str()).unwrap_or(&up.target_id);
+                                    let target_name = target_def
+                                        .map(|d| d.name.as_str())
+                                        .unwrap_or(&up.target_id);
                                     let eff_m = up.cost_minerals.mul_amt(bldg_cost_mod);
                                     let eff_e = up.cost_energy.mul_amt(bldg_cost_mod);
                                     let base_time = up.build_time.unwrap_or_else(|| {
                                         target_def.map(|d| d.build_time / 2).unwrap_or(5)
                                     });
-                                    let eff_time = (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
+                                    let eff_time =
+                                        (base_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
                                     let tooltip = format!(
                                         "Upgrade to {} (M:{} E:{} | {} hd)",
-                                        target_name, eff_m.display_compact(), eff_e.display_compact(), eff_time
+                                        target_name,
+                                        eff_m.display_compact(),
+                                        eff_e.display_compact(),
+                                        eff_time
                                     );
                                     let btn_label = format!("-> {}", target_name);
-                                    if ui
-                                        .small_button(&btn_label)
-                                        .on_hover_text(tooltip)
-                                        .clicked()
+                                    if ui.small_button(&btn_label).on_hover_text(tooltip).clicked()
                                     {
-                                        upgrade_request = Some((i, up.target_id.clone(), eff_m, eff_e, eff_time));
+                                        upgrade_request =
+                                            Some((i, up.target_id.clone(), eff_m, eff_e, eff_time));
                                     }
                                 }
                             }
                         });
                     }
                     None => {
-                        if let Some((_, name, pct)) = pending_orders.iter().find(|(s, _, _)| *s == i) {
+                        if let Some((_, name, pct, order_id)) =
+                            pending_orders.iter().find(|(s, _, _, _)| *s == i)
+                        {
                             ui.horizontal(|ui| {
                                 ui.label(format!("  [{}] (Building: {})", i, name));
                                 let bar = egui::ProgressBar::new(*pct).desired_width(80.0);
                                 ui.add(bar);
+                                // #275: Cancel an in-progress construction.
+                                if ui
+                                    .small_button("×")
+                                    .on_hover_text("Cancel construction")
+                                    .clicked()
+                                {
+                                    cancel_request = Some(*order_id);
+                                }
                             });
                         } else {
                             ui.label(format!("  [{}] (empty)", i));
@@ -512,7 +673,9 @@ fn draw_overview_tab(
                     target_system: system_entity,
                     command: crate::communication::RemoteCommand::Colony(ColonyCommand {
                         scope: BuildingScope::Planet(planet_entity),
-                        kind: BuildingKind::Demolish { target_slot: slot_idx },
+                        kind: BuildingKind::Demolish {
+                            target_slot: slot_idx,
+                        },
                     }),
                 });
             }
@@ -528,8 +691,17 @@ fn draw_overview_tab(
                     }),
                 });
             }
+            // #275: Dispatch a cancel by stable order_id. Cancels travel
+            // through the same light-speed pipeline — local (zero-delay)
+            // cancel applies the same frame it's pushed.
+            if let Some(order_id) = cancel_request {
+                dispatches.queue.push(PendingColonyDispatch {
+                    target_system: system_entity,
+                    command: crate::communication::RemoteCommand::CancelBuildingOrder { order_id },
+                });
+            }
 
-            let pending_slots: Vec<usize> = pending_orders.iter().map(|(s, _, _)| *s).collect();
+            let pending_slots: Vec<usize> = pending_orders.iter().map(|(s, _, _, _)| *s).collect();
             let empty_slot = buildings
                 .slots
                 .iter()
@@ -546,7 +718,12 @@ fn draw_overview_tab(
                     let eff_m = base_m.mul_amt(bldg_cost_mod);
                     let eff_e = base_e.mul_amt(bldg_cost_mod);
                     let eff_time = (def.build_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
-                    let tooltip = format!("M:{} E:{} | {} hexadies", eff_m.display_compact(), eff_e.display_compact(), eff_time);
+                    let tooltip = format!(
+                        "M:{} E:{} | {} hexadies",
+                        eff_m.display_compact(),
+                        eff_e.display_compact(),
+                        eff_time
+                    );
                     if ui.button(&def.name).on_hover_text(tooltip).clicked() {
                         build_building_request = Some(BuildingId::new(&def.id));
                     }
@@ -749,8 +926,8 @@ fn draw_pop_management_tab(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::modifier::{Modifier, ModifiedValue};
     use crate::amount::SignedAmt;
+    use crate::modifier::{ModifiedValue, Modifier};
     use crate::species::{JobDefinition, JobSlot};
 
     fn make_bucket(base_add_f64: f64) -> ModifiedValue {
@@ -883,7 +1060,10 @@ mod tests {
 
     #[test]
     fn short_target_label_strips_common_prefix_and_suffix() {
-        assert_eq!(short_target_label("colony.minerals_per_hexadies"), "minerals");
+        assert_eq!(
+            short_target_label("colony.minerals_per_hexadies"),
+            "minerals"
+        );
         assert_eq!(short_target_label("colony.food_per_hexadies"), "food");
         assert_eq!(short_target_label("custom_target"), "custom_target");
     }

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -4,16 +4,20 @@ mod planet_window;
 use bevy::prelude::*;
 use bevy_egui::egui;
 
-use crate::colony::{BuildOrder, BuildQueue, BuildingQueue, Buildings, Colony, ColonizationQueue, ConstructionParams, DeliverableStockpile, FoodConsumption, MaintenanceCost, Production, ResourceCapacity, ResourceStockpile, SystemBuildings, SystemBuildingQueue};
+use crate::amount::Amt;
+use crate::colony::{
+    BuildOrder, BuildQueue, BuildingQueue, Buildings, ColonizationQueue, Colony,
+    ConstructionParams, DeliverableStockpile, FoodConsumption, MaintenanceCost, Production,
+    ResourceCapacity, ResourceStockpile, SystemBuildingQueue, SystemBuildings,
+};
+use crate::components::Position;
 use crate::condition::{EvalContext, ScopeData};
 use crate::deep_space::{ConstructionPlatform, DeepSpaceStructure, Scrapyard, StructureRegistry};
-use crate::scripting::building_api::{BuildingId, BuildingRegistry};
-use crate::components::Position;
 use crate::galaxy::{Planet, StarSystem, SystemAttributes, habitability_label, is_colonizable};
 use crate::knowledge::KnowledgeStore;
 use crate::physics;
 use crate::player::{AboardShip, Player, StationedAt};
-use crate::amount::Amt;
+use crate::scripting::building_api::{BuildingId, BuildingRegistry};
 use crate::ship::{Cargo, Ship, ShipHitpoints, ShipState, SurveyData};
 use crate::time_system::{GameClock, HEXADIES_PER_YEAR};
 use crate::visualization::{SelectedPlanet, SelectedShip, SelectedSystem};
@@ -120,15 +124,28 @@ pub fn draw_system_panel(
         Option<&crate::species::ColonyJobs>,
         Option<&crate::colony::ColonyJobRates>,
     )>,
-    system_stockpiles: &mut Query<(&mut ResourceStockpile, Option<&ResourceCapacity>), With<StarSystem>>,
-    ships_query: &mut Query<(Entity, &mut Ship, &mut ShipState, Option<&mut Cargo>, &ShipHitpoints, Option<&SurveyData>)>,
+    system_stockpiles: &mut Query<
+        (&mut ResourceStockpile, Option<&ResourceCapacity>),
+        With<StarSystem>,
+    >,
+    ships_query: &mut Query<(
+        Entity,
+        &mut Ship,
+        &mut ShipState,
+        Option<&mut Cargo>,
+        &ShipHitpoints,
+        Option<&SurveyData>,
+    )>,
     positions: &Query<&Position>,
     knowledge: &KnowledgeStore,
     clock: &GameClock,
     construction_params: &ConstructionParams,
     planets: &Query<&Planet>,
     planet_entities: &Query<(Entity, &Planet, Option<&SystemAttributes>)>,
-    system_buildings_q: &mut Query<(Option<&mut SystemBuildings>, Option<&mut SystemBuildingQueue>)>,
+    system_buildings_q: &mut Query<(
+        Option<&mut SystemBuildings>,
+        Option<&mut SystemBuildingQueue>,
+    )>,
     hull_registry: &crate::ship_design::HullRegistry,
     module_registry: &crate::ship_design::ModuleRegistry,
     design_registry: &crate::ship_design::ShipDesignRegistry,
@@ -163,7 +180,11 @@ pub fn draw_system_panel(
     // #176: Determine if this is the player's local system
     let player_system = player_q.iter().next().map(|(_, s, _)| s.system);
     let is_local_system = player_system == Some(sel_entity);
-    let k_data = if is_local_system { None } else { knowledge.get(sel_entity) };
+    let k_data = if is_local_system {
+        None
+    } else {
+        knowledge.get(sel_entity)
+    };
 
     // Collect planets in this system with attributes for map rendering
     let colonized_planets: std::collections::HashSet<Entity> = colonies
@@ -178,18 +199,26 @@ pub fn draw_system_panel(
         if planet.system == sel_entity {
             let is_colonized = colonized_planets.contains(&planet_entity);
             let hab = attrs.map(|a| a.habitability);
-            system_planets.push((planet_entity, planet.name.clone(), planet.planet_type.clone(), is_colonized, hab));
+            system_planets.push((
+                planet_entity,
+                planet.name.clone(),
+                planet.planet_type.clone(),
+                is_colonized,
+                hab,
+            ));
         }
     }
     system_planets.sort_by(|a, b| a.1.cmp(&b.1));
 
     // Auto-select planet: if no planet selected or selected planet not in this system,
     // pick first colonized planet, or first planet
-    let current_planet_valid = selected_planet.0
+    let current_planet_valid = selected_planet
+        .0
         .map(|pe| system_planets.iter().any(|(e, _, _, _, _)| *e == pe))
         .unwrap_or(false);
     if !current_planet_valid {
-        selected_planet.0 = system_planets.iter()
+        selected_planet.0 = system_planets
+            .iter()
             .find(|(_, _, _, colonized, _)| *colonized)
             .or(system_planets.first())
             .map(|(e, _, _, _, _)| *e);
@@ -206,79 +235,84 @@ pub fn draw_system_panel(
     let docked_ships = ships_docked_at(sel_entity, ships_query);
     // #229: Is the currently-selected ship docked at this system? Enables
     // the "Load" button on DeliverableStockpile rows.
-    let selected_ship_docked_here: Option<Entity> =
-        selected_ship.0.filter(|e| docked_ships.iter().any(|(se, _, _)| se == e));
+    let selected_ship_docked_here: Option<Entity> = selected_ship
+        .0
+        .filter(|e| docked_ships.iter().any(|(se, _, _)| se == e));
 
     // Collect system stockpile info for display
-    let stockpile_info: Option<(Amt, Amt, Amt, Amt)> = system_stockpiles.get(sel_entity).ok()
+    let stockpile_info: Option<(Amt, Amt, Amt, Amt)> = system_stockpiles
+        .get(sel_entity)
+        .ok()
         .map(|(s, _)| (s.minerals, s.energy, s.food, s.authority));
 
     let screen = ctx.screen_rect();
     let mut close_system_view = false;
 
     // Full-screen window with three-column layout
-    egui::Window::new(format!("{} ({})", star.name, format_star_type(&star.star_type)))
-        .id(egui::Id::new("system_detail_view"))
-        .fixed_pos(egui::pos2(0.0, 28.0))
-        .fixed_size(egui::vec2(screen.width(), screen.height() - 28.0))
-        .title_bar(false)
-        .frame(egui::Frame::NONE.fill(egui::Color32::from_rgb(10, 10, 20)))
-        .show(ctx, |ui| {
-            // === Top bar with system name and close button ===
-            ui.horizontal(|ui| {
-                if ui.button("\u{2190} Back to Galaxy").clicked() {
-                    close_system_view = true;
+    egui::Window::new(format!(
+        "{} ({})",
+        star.name,
+        format_star_type(&star.star_type)
+    ))
+    .id(egui::Id::new("system_detail_view"))
+    .fixed_pos(egui::pos2(0.0, 28.0))
+    .fixed_size(egui::vec2(screen.width(), screen.height() - 28.0))
+    .title_bar(false)
+    .frame(egui::Frame::NONE.fill(egui::Color32::from_rgb(10, 10, 20)))
+    .show(ctx, |ui| {
+        // === Top bar with system name and close button ===
+        ui.horizontal(|ui| {
+            if ui.button("\u{2190} Back to Galaxy").clicked() {
+                close_system_view = true;
+            }
+            ui.separator();
+            ui.label(
+                egui::RichText::new(&star.name)
+                    .heading()
+                    .strong()
+                    .color(egui::Color32::from_rgb(220, 220, 255)),
+            );
+            ui.label(
+                egui::RichText::new(format!("({})", format_star_type(&star.star_type)))
+                    .color(egui::Color32::from_rgb(160, 160, 200)),
+            );
+
+            if let Ok((_, stationed, _)) = player_q.single() {
+                if let Ok(player_pos) = positions.get(stationed.system) {
+                    let dist = physics::distance_ly(player_pos, star_pos);
+                    let delay_sd = physics::light_delay_hexadies(dist);
+                    ui.separator();
+                    ui.label(format!("{:.1} ly | {} hd delay", dist, delay_sd));
                 }
+            }
+
+            if effective_surveyed {
                 ui.separator();
                 ui.label(
-                    egui::RichText::new(&star.name)
-                        .heading()
-                        .strong()
-                        .color(egui::Color32::from_rgb(220, 220, 255)),
+                    egui::RichText::new("Surveyed").color(egui::Color32::from_rgb(100, 200, 100)),
                 );
+            } else {
+                ui.separator();
                 ui.label(
-                    egui::RichText::new(format!("({})", format_star_type(&star.star_type)))
-                        .color(egui::Color32::from_rgb(160, 160, 200)),
+                    egui::RichText::new("Unsurveyed").color(egui::Color32::from_rgb(200, 150, 100)),
                 );
+            }
+        });
+        ui.separator();
 
-                if let Ok((_, stationed, _)) = player_q.single() {
-                    if let Ok(player_pos) = positions.get(stationed.system) {
-                        let dist = physics::distance_ly(player_pos, star_pos);
-                        let delay_sd = physics::light_delay_hexadies(dist);
-                        ui.separator();
-                        ui.label(format!("{:.1} ly | {} hd delay", dist, delay_sd));
-                    }
-                }
+        // === Three-column layout ===
+        let available_width = ui.available_width();
+        let available_height = ui.available_height();
+        let left_width = (available_width * 0.22).clamp(180.0, 320.0);
+        let right_width = (available_width * 0.25).clamp(200.0, 380.0);
+        let center_width = (available_width - left_width - right_width - 16.0).max(200.0);
 
-                if effective_surveyed {
-                    ui.separator();
-                    ui.label(
-                        egui::RichText::new("Surveyed")
-                            .color(egui::Color32::from_rgb(100, 200, 100)),
-                    );
-                } else {
-                    ui.separator();
-                    ui.label(
-                        egui::RichText::new("Unsurveyed")
-                            .color(egui::Color32::from_rgb(200, 150, 100)),
-                    );
-                }
-            });
-            ui.separator();
-
-            // === Three-column layout ===
-            let available_width = ui.available_width();
-            let available_height = ui.available_height();
-            let left_width = (available_width * 0.22).clamp(180.0, 320.0);
-            let right_width = (available_width * 0.25).clamp(200.0, 380.0);
-            let center_width = (available_width - left_width - right_width - 16.0).max(200.0);
-
-            ui.horizontal_top(|ui| {
-                // === LEFT PANEL: System info ===
-                ui.allocate_ui_with_layout(
-                    egui::vec2(left_width, available_height),
-                    egui::Layout::top_down(egui::Align::Min),
-                    |ui| {
+        ui.horizontal_top(|ui| {
+            // === LEFT PANEL: System info ===
+            ui.allocate_ui_with_layout(
+                egui::vec2(left_width, available_height),
+                egui::Layout::top_down(egui::Align::Min),
+                |ui| {
                     egui::Frame::NONE
                         .fill(egui::Color32::from_rgb(15, 15, 28))
                         .inner_margin(6.0)
@@ -310,13 +344,14 @@ pub fn draw_system_panel(
                                     );
                                 });
                         });
-                });
+                },
+            );
 
-                // === CENTER: System map ===
-                ui.allocate_ui_with_layout(
-                    egui::vec2(center_width, available_height),
-                    egui::Layout::top_down(egui::Align::Min),
-                    |ui| {
+            // === CENTER: System map ===
+            ui.allocate_ui_with_layout(
+                egui::vec2(center_width, available_height),
+                egui::Layout::top_down(egui::Align::Min),
+                |ui| {
                     egui::Frame::NONE
                         .fill(egui::Color32::from_rgb(6, 6, 14))
                         .inner_margin(4.0)
@@ -331,13 +366,14 @@ pub fn draw_system_panel(
                                 design_registry,
                             );
                         });
-                });
+                },
+            );
 
-                // === RIGHT PANEL: Actions ===
-                ui.allocate_ui_with_layout(
-                    egui::vec2(right_width, available_height),
-                    egui::Layout::top_down(egui::Align::Min),
-                    |ui| {
+            // === RIGHT PANEL: Actions ===
+            ui.allocate_ui_with_layout(
+                egui::vec2(right_width, available_height),
+                egui::Layout::top_down(egui::Align::Min),
+                |ui| {
                     egui::Frame::NONE
                         .fill(egui::Color32::from_rgb(15, 15, 28))
                         .inner_margin(6.0)
@@ -375,9 +411,10 @@ pub fn draw_system_panel(
                                     );
                                 });
                         });
-                });
-            });
+                },
+            );
         });
+    });
 
     if close_system_view {
         selected_system.0 = None;
@@ -436,7 +473,11 @@ fn draw_left_panel(
     system_actions_out: &mut SystemPanelActions,
 ) {
     // --- Survey & Distance ---
-    ui.label(egui::RichText::new("System Info").strong().color(egui::Color32::from_rgb(180, 180, 220)));
+    ui.label(
+        egui::RichText::new("System Info")
+            .strong()
+            .color(egui::Color32::from_rgb(180, 180, 220)),
+    );
     ui.separator();
 
     if let Ok((_, stationed, _)) = player_q.single() {
@@ -453,7 +494,9 @@ fn draw_left_panel(
         ui.label("Approximate position only. Survey required.");
     }
 
-    if let Some(perceived) = crate::knowledge::perceived_system(knowledge, sel_entity, clock.elapsed) {
+    if let Some(perceived) =
+        crate::knowledge::perceived_system(knowledge, sel_entity, clock.elapsed)
+    {
         let age = perceived.age(clock.elapsed);
         let years = age as f64 / HEXADIES_PER_YEAR as f64;
         let freshness = if age < 60 {
@@ -479,7 +522,11 @@ fn draw_left_panel(
     // --- Resource stockpile ---
     if let Some((minerals, energy, food, authority)) = stockpile_info {
         ui.separator();
-        ui.label(egui::RichText::new("System Stockpile").strong().color(egui::Color32::from_rgb(180, 180, 220)));
+        ui.label(
+            egui::RichText::new("System Stockpile")
+                .strong()
+                .color(egui::Color32::from_rgb(180, 180, 220)),
+        );
         ui.label(format!("Minerals: {}", minerals.display_compact()));
         ui.label(format!("Energy:   {}", energy.display_compact()));
         ui.label(format!("Food:     {}", food.display_compact()));
@@ -503,20 +550,17 @@ fn draw_left_panel(
                     ui.label(format!("  #{}: {}", i, item.definition_id()));
                     if let Some(ship_e) = selected_ship_docked_here {
                         if ui.small_button("Load").clicked() {
-                            system_actions_out.load_deliverable =
-                                Some((ship_e, sel_entity, i));
+                            system_actions_out.load_deliverable = Some((ship_e, sel_entity, i));
                         }
                     }
                 });
             }
             if selected_ship_docked_here.is_none() {
                 ui.label(
-                    egui::RichText::new(
-                        "(Select a ship docked here to Load a deliverable.)",
-                    )
-                    .small()
-                    .italics()
-                    .weak(),
+                    egui::RichText::new("(Select a ship docked here to Load a deliverable.)")
+                        .small()
+                        .italics()
+                        .weak(),
                 );
             }
         }
@@ -527,23 +571,39 @@ fn draw_left_panel(
         if let Some(k) = k_data {
             let snap = &k.data;
             ui.separator();
-            ui.label(egui::RichText::new("Remote Intelligence").strong()
-                .color(egui::Color32::from_rgb(200, 180, 100)));
+            ui.label(
+                egui::RichText::new("Remote Intelligence")
+                    .strong()
+                    .color(egui::Color32::from_rgb(200, 180, 100)),
+            );
             ui.label(egui::RichText::new("(light-speed delayed)").weak().small());
             if snap.colonized {
-                ui.label(format!("M {} | E {} | F {} | A {}",
-                    snap.minerals.display_compact(), snap.energy.display_compact(),
-                    snap.food.display_compact(), snap.authority.display_compact()));
-                if snap.production_minerals > Amt::ZERO || snap.production_energy > Amt::ZERO
-                    || snap.production_food > Amt::ZERO || snap.production_research > Amt::ZERO
+                ui.label(format!(
+                    "M {} | E {} | F {} | A {}",
+                    snap.minerals.display_compact(),
+                    snap.energy.display_compact(),
+                    snap.food.display_compact(),
+                    snap.authority.display_compact()
+                ));
+                if snap.production_minerals > Amt::ZERO
+                    || snap.production_energy > Amt::ZERO
+                    || snap.production_food > Amt::ZERO
+                    || snap.production_research > Amt::ZERO
                 {
                     ui.label(egui::RichText::new("Production/hd:").strong());
-                    ui.label(format!("M {} | E {} | F {} | R {}",
-                        snap.production_minerals.display_compact(), snap.production_energy.display_compact(),
-                        snap.production_food.display_compact(), snap.production_research.display_compact()));
+                    ui.label(format!(
+                        "M {} | E {} | F {} | R {}",
+                        snap.production_minerals.display_compact(),
+                        snap.production_energy.display_compact(),
+                        snap.production_food.display_compact(),
+                        snap.production_research.display_compact()
+                    ));
                 }
                 if snap.maintenance_energy > Amt::ZERO {
-                    ui.label(format!("Maintenance: E {}/hd", snap.maintenance_energy.display_compact()));
+                    ui.label(format!(
+                        "Maintenance: E {}/hd",
+                        snap.maintenance_energy.display_compact()
+                    ));
                 }
             }
             if snap.has_hostile {
@@ -583,8 +643,11 @@ fn draw_left_panel(
             }
         } else if !star.is_capital {
             ui.separator();
-            ui.label(egui::RichText::new("No intelligence available for this system.")
-                .weak().italics());
+            ui.label(
+                egui::RichText::new("No intelligence available for this system.")
+                    .weak()
+                    .italics(),
+            );
         }
     }
 
@@ -592,12 +655,23 @@ fn draw_left_panel(
     if let Ok(anomalies) = anomalies_q.get(sel_entity) {
         if !anomalies.discoveries.is_empty() {
             ui.separator();
-            ui.label(egui::RichText::new(format!("Anomalies ({})", anomalies.discoveries.len())).strong());
+            ui.label(
+                egui::RichText::new(format!("Anomalies ({})", anomalies.discoveries.len()))
+                    .strong(),
+            );
             for anomaly in &anomalies.discoveries {
-                let discovered_yr = anomaly.discovered_at as f64 / crate::time_system::HEXADIES_PER_YEAR as f64;
+                let discovered_yr =
+                    anomaly.discovered_at as f64 / crate::time_system::HEXADIES_PER_YEAR as f64;
                 ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new(&anomaly.name).color(egui::Color32::from_rgb(200, 180, 100)));
-                    ui.label(egui::RichText::new(format!("(t={:.1}yr)", discovered_yr)).weak().small());
+                    ui.label(
+                        egui::RichText::new(&anomaly.name)
+                            .color(egui::Color32::from_rgb(200, 180, 100)),
+                    );
+                    ui.label(
+                        egui::RichText::new(format!("(t={:.1}yr)", discovered_yr))
+                            .weak()
+                            .small(),
+                    );
                 });
                 ui.label(egui::RichText::new(&anomaly.description).weak().small());
             }
@@ -607,7 +681,11 @@ fn draw_left_panel(
     // --- Planet list ---
     if !system_planets.is_empty() {
         ui.separator();
-        ui.label(egui::RichText::new("Planets").strong().color(egui::Color32::from_rgb(180, 180, 220)));
+        ui.label(
+            egui::RichText::new("Planets")
+                .strong()
+                .color(egui::Color32::from_rgb(180, 180, 220)),
+        );
         for (planet_entity, name, planet_type, is_colonized, hab) in system_planets {
             let is_selected = selected_planet.0 == Some(*planet_entity);
             let label_text = format!(
@@ -641,7 +719,10 @@ fn draw_right_panel(
     hull_registry: &crate::ship_design::HullRegistry,
     module_registry: &crate::ship_design::ModuleRegistry,
     design_registry: &crate::ship_design::ShipDesignRegistry,
-    system_buildings_q: &mut Query<(Option<&mut SystemBuildings>, Option<&mut SystemBuildingQueue>)>,
+    system_buildings_q: &mut Query<(
+        Option<&mut SystemBuildings>,
+        Option<&mut SystemBuildingQueue>,
+    )>,
     construction_params: &ConstructionParams,
     building_registry: &BuildingRegistry,
     colonized_planets: &std::collections::HashSet<Entity>,
@@ -676,14 +757,21 @@ fn draw_right_panel(
     draw_in_flight_commands_section(ui, sel_entity, remote_commands, clock_elapsed);
 
     // === Docked Ships ===
-    ui.label(egui::RichText::new("Docked Ships").strong().color(egui::Color32::from_rgb(180, 180, 220)));
+    ui.label(
+        egui::RichText::new("Docked Ships")
+            .strong()
+            .color(egui::Color32::from_rgb(180, 180, 220)),
+    );
     ui.separator();
     if docked_ships.is_empty() {
         ui.label(egui::RichText::new("No ships docked").weak().italics());
     } else {
         for (entity, name, design_id) in docked_ships {
             let is_selected = selected_ship.0 == Some(*entity);
-            let design_name = design_registry.get(design_id).map(|d| d.name.as_str()).unwrap_or(design_id);
+            let design_name = design_registry
+                .get(design_id)
+                .map(|d| d.name.as_str())
+                .unwrap_or(design_id);
             let label = format!(
                 "{} ({}){}",
                 name,
@@ -699,28 +787,38 @@ fn draw_right_panel(
     // === System Buildings ===
     if let Ok((Some(sys_bldgs), sys_bldg_queue)) = system_buildings_q.get_mut(sel_entity) {
         ui.add_space(8.0);
-        ui.label(egui::RichText::new("System Buildings").strong().color(egui::Color32::from_rgb(180, 180, 220)));
+        ui.label(
+            egui::RichText::new("System Buildings")
+                .strong()
+                .color(egui::Color32::from_rgb(180, 180, 220)),
+        );
         ui.separator();
 
         let mut sys_demolish_request: Option<(usize, BuildingId)> = None;
         let mut sys_upgrade_request: Option<(usize, String, Amt, Amt, i64)> = None;
+        // #275: Cancel requests for system-level build / demo / upgrade orders.
+        let mut sys_cancel_request: Option<u64> = None;
         let sys_bldg_cost_mod = construction_params.building_cost_modifier.final_value();
-        let sys_bldg_time_mod = construction_params.building_build_time_modifier.final_value();
+        let sys_bldg_time_mod = construction_params
+            .building_build_time_modifier
+            .final_value();
 
         // #260: Collect pending system-building construction orders so empty
         // slots can show their in-progress target + progress bar. Mirrors the
         // planet-side logic in `colony_detail::draw_colony_detail`. Kept inline
         // (no shared helper yet) to minimise churn — see issue for the
         // follow-up on extracting a common row renderer.
-        let sys_pending_orders: Vec<(usize, String, f32)> = sys_bldg_queue
+        // #275: `order_id` tagged along so the cancel button can dispatch.
+        let sys_pending_orders: Vec<(usize, String, f32, u64)> = sys_bldg_queue
             .as_ref()
             .map(|bq| {
                 bq.queue
                     .iter()
                     .map(|order| {
                         let def = building_registry.get(order.building_id.as_str());
-                        let (total_m, total_e) =
-                            def.map(|d| d.build_cost()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                        let (total_m, total_e) = def
+                            .map(|d| d.build_cost())
+                            .unwrap_or((Amt::ZERO, Amt::ZERO));
                         let m_pct = if total_m.raw() > 0 {
                             1.0 - (order.minerals_remaining.raw() as f32 / total_m.raw() as f32)
                         } else {
@@ -741,7 +839,7 @@ fn draw_right_panel(
                         let name = def
                             .map(|d| d.name.clone())
                             .unwrap_or_else(|| order.building_id.0.clone());
-                        (order.target_slot, name, pct)
+                        (order.target_slot, name, pct, order.order_id)
                     })
                     .collect()
             })
@@ -759,72 +857,105 @@ fn draw_right_panel(
 
             match slot {
                 Some(bid) if is_demolishing => {
-                    let remaining = sys_bldg_queue
+                    let (remaining, demo_order_id) = sys_bldg_queue
                         .as_ref()
-                        .and_then(|bq| bq.demolition_time_remaining(i))
-                        .unwrap_or(0);
-                    let name = building_registry.get(bid.as_str()).map(|d| d.name.as_str()).unwrap_or(bid.as_str());
-                    ui.label(format!(
-                        "[{}] {} — Demolishing ({} hd)",
-                        i, name, remaining
-                    ));
+                        .and_then(|bq| {
+                            bq.demolition_queue
+                                .iter()
+                                .find(|d| d.target_slot == i)
+                                .map(|d| (d.time_remaining, d.order_id))
+                        })
+                        .unwrap_or((0, 0));
+                    let name = building_registry
+                        .get(bid.as_str())
+                        .map(|d| d.name.as_str())
+                        .unwrap_or(bid.as_str());
+                    ui.horizontal(|ui| {
+                        ui.label(format!("[{}] {} — Demolishing ({} hd)", i, name, remaining));
+                        // #275: Cancel the in-progress demolition.
+                        if ui
+                            .small_button("×")
+                            .on_hover_text("Cancel demolition")
+                            .clicked()
+                        {
+                            sys_cancel_request = Some(demo_order_id);
+                        }
+                    });
                 }
                 Some(bid) if is_upgrading => {
-                    let upgrade_info = sys_bldg_queue
-                        .as_ref()
-                        .and_then(|bq| bq.upgrade_info(i));
-                    let name = building_registry.get(bid.as_str()).map(|d| d.name.as_str()).unwrap_or(bid.as_str());
+                    let upgrade_info = sys_bldg_queue.as_ref().and_then(|bq| bq.upgrade_info(i));
+                    let name = building_registry
+                        .get(bid.as_str())
+                        .map(|d| d.name.as_str())
+                        .unwrap_or(bid.as_str());
                     let target_name = upgrade_info
                         .and_then(|u| building_registry.get(u.target_id.as_str()))
                         .map(|d| d.name.as_str())
                         .unwrap_or("?");
                     let remaining = upgrade_info.map(|u| u.build_time_remaining).unwrap_or(0);
-                    ui.label(format!(
-                        "[{}] {} -> {} ({} hd)",
-                        i, name, target_name, remaining
-                    ));
+                    let upgrade_order_id = upgrade_info.map(|u| u.order_id).unwrap_or(0);
+                    ui.horizontal(|ui| {
+                        ui.label(format!(
+                            "[{}] {} -> {} ({} hd)",
+                            i, name, target_name, remaining
+                        ));
+                        // #275: Cancel the in-progress upgrade.
+                        if ui
+                            .small_button("×")
+                            .on_hover_text("Cancel upgrade")
+                            .clicked()
+                        {
+                            sys_cancel_request = Some(upgrade_order_id);
+                        }
+                    });
                 }
                 Some(bid) => {
                     let def = building_registry.get(bid.as_str());
                     let name = def.map(|d| d.name.as_str()).unwrap_or(bid.as_str());
-                    let (m_refund, e_refund) = def.map(|d| d.demolition_refund()).unwrap_or((Amt::ZERO, Amt::ZERO));
+                    let (m_refund, e_refund) = def
+                        .map(|d| d.demolition_refund())
+                        .unwrap_or((Amt::ZERO, Amt::ZERO));
                     let demo_time = def.map(|d| d.demolition_time()).unwrap_or(0);
                     ui.horizontal(|ui| {
                         ui.label(format!("[{}] {}", i, name));
                         let tooltip = format!(
                             "Demolish: {} hd | Refund M:{} E:{}",
-                            demo_time, m_refund.display_compact(), e_refund.display_compact()
+                            demo_time,
+                            m_refund.display_compact(),
+                            e_refund.display_compact()
                         );
                         // #260: `"Demolish"` matches the planet-side label so
                         // the button is discoverable. The previous `"X"` was
                         // effectively hidden.
-                        if ui
-                            .small_button("Demolish")
-                            .on_hover_text(tooltip)
-                            .clicked()
-                        {
+                        if ui.small_button("Demolish").on_hover_text(tooltip).clicked() {
                             sys_demolish_request = Some((i, bid.clone()));
                         }
                         if let Some(src_def) = def {
                             for up in &src_def.upgrade_to {
                                 let target_def = building_registry.get(&up.target_id);
-                                let target_name = target_def.map(|d| d.name.as_str()).unwrap_or(&up.target_id);
+                                let target_name =
+                                    target_def.map(|d| d.name.as_str()).unwrap_or(&up.target_id);
                                 let eff_m = up.cost_minerals.mul_amt(sys_bldg_cost_mod);
                                 let eff_e = up.cost_energy.mul_amt(sys_bldg_cost_mod);
                                 let base_time = up.build_time.unwrap_or_else(|| {
                                     target_def.map(|d| d.build_time / 2).unwrap_or(5)
                                 });
-                                let eff_time = (base_time as f64 * sys_bldg_time_mod.to_f64()).ceil() as i64;
+                                let eff_time =
+                                    (base_time as f64 * sys_bldg_time_mod.to_f64()).ceil() as i64;
                                 let tooltip = format!(
                                     "Upgrade to {} (M:{} E:{} | {} hd)",
-                                    target_name, eff_m.display_compact(), eff_e.display_compact(), eff_time
+                                    target_name,
+                                    eff_m.display_compact(),
+                                    eff_e.display_compact(),
+                                    eff_time
                                 );
                                 if ui
                                     .small_button(format!("-> {}", target_name))
                                     .on_hover_text(tooltip)
                                     .clicked()
                                 {
-                                    sys_upgrade_request = Some((i, up.target_id.clone(), eff_m, eff_e, eff_time));
+                                    sys_upgrade_request =
+                                        Some((i, up.target_id.clone(), eff_m, eff_e, eff_time));
                                 }
                             }
                         }
@@ -835,13 +966,21 @@ fn draw_right_panel(
                     // way `colony_detail` does for planet buildings. Without
                     // this the player has no feedback after queueing a
                     // shipyard/port — the slot stays blank until completion.
-                    if let Some((_, name, pct)) =
-                        sys_pending_orders.iter().find(|(s, _, _)| *s == i)
+                    if let Some((_, name, pct, order_id)) =
+                        sys_pending_orders.iter().find(|(s, _, _, _)| *s == i)
                     {
                         ui.horizontal(|ui| {
                             ui.label(format!("[{}] (Building: {})", i, name));
                             let bar = egui::ProgressBar::new(*pct).desired_width(80.0);
                             ui.add(bar);
+                            // #275: Cancel an in-progress system construction.
+                            if ui
+                                .small_button("×")
+                                .on_hover_text("Cancel construction")
+                                .clicked()
+                            {
+                                sys_cancel_request = Some(*order_id);
+                            }
                         });
                     } else {
                         ui.label(format!("[{}] (empty)", i));
@@ -851,31 +990,46 @@ fn draw_right_panel(
         }
 
         if let Some((slot_idx, _bid)) = sys_demolish_request {
-            dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                target_system: sel_entity,
-                command: crate::communication::RemoteCommand::Colony(
-                    crate::communication::ColonyCommand {
-                        scope: crate::communication::BuildingScope::System,
-                        kind: crate::communication::BuildingKind::Demolish {
-                            target_slot: slot_idx,
+            dispatches
+                .queue
+                .push(crate::communication::PendingColonyDispatch {
+                    target_system: sel_entity,
+                    command: crate::communication::RemoteCommand::Colony(
+                        crate::communication::ColonyCommand {
+                            scope: crate::communication::BuildingScope::System,
+                            kind: crate::communication::BuildingKind::Demolish {
+                                target_slot: slot_idx,
+                            },
                         },
-                    },
-                ),
-            });
+                    ),
+                });
         }
         if let Some((slot_idx, target_id, _, _, _)) = sys_upgrade_request {
-            dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                target_system: sel_entity,
-                command: crate::communication::RemoteCommand::Colony(
-                    crate::communication::ColonyCommand {
-                        scope: crate::communication::BuildingScope::System,
-                        kind: crate::communication::BuildingKind::Upgrade {
-                            slot_index: slot_idx,
-                            target_id,
+            dispatches
+                .queue
+                .push(crate::communication::PendingColonyDispatch {
+                    target_system: sel_entity,
+                    command: crate::communication::RemoteCommand::Colony(
+                        crate::communication::ColonyCommand {
+                            scope: crate::communication::BuildingScope::System,
+                            kind: crate::communication::BuildingKind::Upgrade {
+                                slot_index: slot_idx,
+                                target_id,
+                            },
                         },
-                    },
-                ),
-            });
+                    ),
+                });
+        }
+        // #275: Dispatch a system-level cancel. `CancelBuildingOrder`
+        // does not need explicit scope — the arrival handler searches
+        // both planet and system queues by id.
+        if let Some(order_id) = sys_cancel_request {
+            dispatches
+                .queue
+                .push(crate::communication::PendingColonyDispatch {
+                    target_system: sel_entity,
+                    command: crate::communication::RemoteCommand::CancelBuildingOrder { order_id },
+                });
         }
 
         // Build system building buttons
@@ -894,31 +1048,40 @@ fn draw_right_panel(
                 ui.label(egui::RichText::new("Build System Building").strong());
                 let system_building_defs = building_registry.system_buildings();
                 let bldg_cost_mod = construction_params.building_cost_modifier.final_value();
-                let bldg_time_mod = construction_params.building_build_time_modifier.final_value();
+                let bldg_time_mod = construction_params
+                    .building_build_time_modifier
+                    .final_value();
                 let mut build_sys_building_request: Option<BuildingId> = None;
                 for def in &system_building_defs {
                     let (base_m, base_e) = def.build_cost();
                     let eff_m = base_m.mul_amt(bldg_cost_mod);
                     let eff_e = base_e.mul_amt(bldg_cost_mod);
                     let eff_time = (def.build_time as f64 * bldg_time_mod.to_f64()).ceil() as i64;
-                    let tooltip = format!("M:{} E:{} | {} hexadies", eff_m.display_compact(), eff_e.display_compact(), eff_time);
+                    let tooltip = format!(
+                        "M:{} E:{} | {} hexadies",
+                        eff_m.display_compact(),
+                        eff_e.display_compact(),
+                        eff_time
+                    );
                     if ui.button(&def.name).on_hover_text(tooltip).clicked() {
                         build_sys_building_request = Some(BuildingId::new(&def.id));
                     }
                 }
                 if let Some(bid) = build_sys_building_request {
-                    dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                        target_system: sel_entity,
-                        command: crate::communication::RemoteCommand::Colony(
-                            crate::communication::ColonyCommand {
-                                scope: crate::communication::BuildingScope::System,
-                                kind: crate::communication::BuildingKind::Queue {
-                                    building_id: bid.0,
-                                    target_slot: slot_idx,
+                    dispatches
+                        .queue
+                        .push(crate::communication::PendingColonyDispatch {
+                            target_system: sel_entity,
+                            command: crate::communication::RemoteCommand::Colony(
+                                crate::communication::ColonyCommand {
+                                    scope: crate::communication::BuildingScope::System,
+                                    kind: crate::communication::BuildingKind::Queue {
+                                        building_id: bid.0,
+                                        target_slot: slot_idx,
+                                    },
                                 },
-                            },
-                        ),
-                    });
+                            ),
+                        });
                 }
             }
         }
@@ -937,8 +1100,11 @@ fn draw_right_panel(
         // Also remember the first colony entity, which we will use as the host for
         // newly enqueued ship orders (BuildQueue is per-colony but ship construction
         // is gated by system-level shipyard).
+        // #275: Each snapshot carries (host_colony_entity, order_id) so the
+        // cancel button can dispatch `CancelShipOrder { host_colony, order_id }`.
         let mut host_colony: Option<Entity> = None;
-        let mut queue_snapshots: Vec<(String, Amt, Amt, Amt, Amt, i64, i64)> = Vec::new();
+        let mut queue_snapshots: Vec<(String, Amt, Amt, Amt, Amt, i64, i64, Entity, u64)> =
+            Vec::new();
         for (colony_entity, colony, _prod, build_queue, _b, _bq, _m, _f) in colonies.iter() {
             if colony.system(planets) != Some(sel_entity) {
                 continue;
@@ -956,6 +1122,8 @@ fn draw_right_panel(
                         order.energy_cost,
                         order.build_time_remaining,
                         order.build_time_total,
+                        colony_entity,
+                        order.order_id,
                     ));
                 }
             }
@@ -984,10 +1152,14 @@ fn draw_right_panel(
 
         // --- Build Queue (combined across colonies in this system) ---
         ui.label(egui::RichText::new("Build Queue").strong());
+        // #275: Cancel request for a ship / deliverable build order.
+        let mut ship_cancel_request: Option<(Entity, u64)> = None;
         if queue_snapshots.is_empty() {
             ui.label("[empty]");
         } else {
-            for (name, m_inv, m_cost, e_inv, e_cost, time_rem, time_total) in &queue_snapshots {
+            for (name, m_inv, m_cost, e_inv, e_cost, time_rem, time_total, host, order_id) in
+                &queue_snapshots
+            {
                 let m_pct = if m_cost.raw() > 0 {
                     (m_inv.raw() as f32 / m_cost.raw() as f32).min(1.0)
                 } else {
@@ -1011,10 +1183,33 @@ fn draw_right_panel(
                     if m_pct < 1.0 || e_pct < 1.0 {
                         ui.label(egui::RichText::new("(awaiting resources)").weak().small());
                     } else if time_pct < 1.0 {
-                        ui.label(egui::RichText::new(format!("{} hd", time_rem)).weak().small());
+                        ui.label(
+                            egui::RichText::new(format!("{} hd", time_rem))
+                                .weak()
+                                .small(),
+                        );
+                    }
+                    // #275: Cancel this ship / deliverable build order.
+                    if ui
+                        .small_button("×")
+                        .on_hover_text("Cancel build order")
+                        .clicked()
+                    {
+                        ship_cancel_request = Some((*host, *order_id));
                     }
                 });
             }
+        }
+        if let Some((host, order_id)) = ship_cancel_request {
+            dispatches
+                .queue
+                .push(crate::communication::PendingColonyDispatch {
+                    target_system: sel_entity,
+                    command: crate::communication::RemoteCommand::CancelShipOrder {
+                        host_colony: host,
+                        order_id,
+                    },
+                });
         }
 
         // --- Build buttons (only if a shipyard is present and a host colony exists) ---
@@ -1030,57 +1225,63 @@ fn draw_right_panel(
                     egui::ScrollArea::horizontal()
                         .id_salt("system_panel_build_ship")
                         .show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            for design_id in &design_ids {
-                                let design = &design_registry.designs[design_id];
-                                let hull = hull_registry.get(&design.hull_id);
-                                let (base_m, base_e, base_time) = if let Some(hull) = hull {
-                                    let mods: Vec<_> = design
-                                        .modules
-                                        .iter()
-                                        .filter_map(|a| module_registry.get(&a.module_id))
-                                        .collect();
-                                    let (m, e, t, _maint) =
-                                        crate::ship_design::design_cost(hull, &mods);
-                                    (m, e, t)
-                                } else {
-                                    (
-                                        design.build_cost_minerals,
-                                        design.build_cost_energy,
-                                        design.build_time,
-                                    )
-                                };
-                                let eff_m = base_m.mul_amt(ship_mod);
-                                let eff_e = base_e.mul_amt(ship_mod);
-                                let eff_time =
-                                    (base_time as f64 * ship_time_mod.to_f64()).ceil() as i64;
-                                let tooltip =
-                                    format!("M:{} E:{} | {} hd", eff_m.display_compact(), eff_e.display_compact(), eff_time);
-                                if ui.button(&design.name).on_hover_text(tooltip).clicked() {
-                                    build_request = Some((
-                                        design_id.clone(),
-                                        design.name.clone(),
-                                        eff_m,
-                                        eff_e,
-                                        eff_time,
-                                    ));
+                            ui.horizontal(|ui| {
+                                for design_id in &design_ids {
+                                    let design = &design_registry.designs[design_id];
+                                    let hull = hull_registry.get(&design.hull_id);
+                                    let (base_m, base_e, base_time) = if let Some(hull) = hull {
+                                        let mods: Vec<_> = design
+                                            .modules
+                                            .iter()
+                                            .filter_map(|a| module_registry.get(&a.module_id))
+                                            .collect();
+                                        let (m, e, t, _maint) =
+                                            crate::ship_design::design_cost(hull, &mods);
+                                        (m, e, t)
+                                    } else {
+                                        (
+                                            design.build_cost_minerals,
+                                            design.build_cost_energy,
+                                            design.build_time,
+                                        )
+                                    };
+                                    let eff_m = base_m.mul_amt(ship_mod);
+                                    let eff_e = base_e.mul_amt(ship_mod);
+                                    let eff_time =
+                                        (base_time as f64 * ship_time_mod.to_f64()).ceil() as i64;
+                                    let tooltip = format!(
+                                        "M:{} E:{} | {} hd",
+                                        eff_m.display_compact(),
+                                        eff_e.display_compact(),
+                                        eff_time
+                                    );
+                                    if ui.button(&design.name).on_hover_text(tooltip).clicked() {
+                                        build_request = Some((
+                                            design_id.clone(),
+                                            design.name.clone(),
+                                            eff_m,
+                                            eff_e,
+                                            eff_time,
+                                        ));
+                                    }
                                 }
-                            }
+                            });
                         });
-                    });
                 }
 
                 if let Some((design_id, _display_name, _minerals_cost, _energy_cost, _build_time)) =
                     build_request
                 {
-                    dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                        target_system: sel_entity,
-                        command: crate::communication::RemoteCommand::ShipBuild {
-                            host_colony: host,
-                            design_id,
-                            build_kind: crate::colony::BuildKind::Ship,
-                        },
-                    });
+                    dispatches
+                        .queue
+                        .push(crate::communication::PendingColonyDispatch {
+                            target_system: sel_entity,
+                            command: crate::communication::RemoteCommand::ShipBuild {
+                                host_colony: host,
+                                design_id,
+                                build_kind: crate::colony::BuildKind::Ship,
+                            },
+                        });
                 }
 
                 // #229: Deliverables — shipyard-buildable deep-space structures.
@@ -1090,10 +1291,8 @@ fn draw_right_panel(
                 // with `kind = BuildKind::Deliverable { cargo_size }` so the
                 // building_queue tick routes the completed item to the
                 // DeliverableStockpile instead of spawning a Ship entity.
-                let available = available_shipyard_deliverables(
-                    structure_registry,
-                    deliverable_avail,
-                );
+                let available =
+                    available_shipyard_deliverables(structure_registry, deliverable_avail);
                 if !available.is_empty() {
                     ui.separator();
                     ui.label(egui::RichText::new("Deliverables").strong());
@@ -1112,9 +1311,9 @@ fn draw_right_panel(
                                     };
                                     let eff_m = meta.cost.minerals.mul_amt(ship_mod);
                                     let eff_e = meta.cost.energy.mul_amt(ship_mod);
-                                    let eff_time = (meta.build_time as f64
-                                        * ship_time_mod.to_f64())
-                                    .ceil() as i64;
+                                    let eff_time = (meta.build_time as f64 * ship_time_mod.to_f64())
+                                        .ceil()
+                                        as i64;
                                     let tooltip = format!(
                                         "M:{} E:{} | {} hd | cargo {}",
                                         eff_m.display_compact(),
@@ -1139,18 +1338,20 @@ fn draw_right_panel(
                     if let Some((def_id, display_name, cargo_size, m_cost, e_cost, build_time)) =
                         deliverable_request
                     {
-                        dispatches.queue.push(crate::communication::PendingColonyDispatch {
-                            target_system: sel_entity,
-                            command: crate::communication::RemoteCommand::DeliverableBuild {
-                                host_colony: host,
-                                def_id,
-                                display_name,
-                                cargo_size,
-                                minerals_cost: m_cost,
-                                energy_cost: e_cost,
-                                build_time,
-                            },
-                        });
+                        dispatches
+                            .queue
+                            .push(crate::communication::PendingColonyDispatch {
+                                target_system: sel_entity,
+                                command: crate::communication::RemoteCommand::DeliverableBuild {
+                                    host_colony: host,
+                                    def_id,
+                                    display_name,
+                                    cargo_size,
+                                    minerals_cost: m_cost,
+                                    energy_cost: e_cost,
+                                    build_time,
+                                },
+                            });
                     }
                 }
             }
@@ -1171,12 +1372,7 @@ fn draw_right_panel(
             if pos.distance_to(star_pos) > STRUCTURE_SYSTEM_RADIUS_LY {
                 continue;
             }
-            in_system.push((
-                entity,
-                ds.name.clone(),
-                platform.is_some(),
-                scrap.is_some(),
-            ));
+            in_system.push((entity, ds.name.clone(), platform.is_some(), scrap.is_some()));
         }
         if !in_system.is_empty() {
             ui.add_space(8.0);
@@ -1218,15 +1414,20 @@ fn draw_right_panel(
         for (pe, planet, attrs) in planet_entities.iter() {
             if planet.system == sel_entity
                 && !colonized_planets.contains(&pe)
-                && attrs.map(|a| {
-                    is_colonizable(a.habitability)
-                }).unwrap_or(false)
+                && attrs
+                    .map(|a| is_colonizable(a.habitability))
+                    .unwrap_or(false)
             {
-                let in_queue = colonization_queues.get(sel_entity)
+                let in_queue = colonization_queues
+                    .get(sel_entity)
                     .map(|cq| cq.orders.iter().any(|o| o.target_planet == pe))
                     .unwrap_or(false);
                 if !in_queue {
-                    colonizable.push((pe, planet.name.clone(), format_planet_type(&planet.planet_type)));
+                    colonizable.push((
+                        pe,
+                        planet.name.clone(),
+                        format_planet_type(&planet.planet_type),
+                    ));
                 }
             }
         }
@@ -1234,16 +1435,24 @@ fn draw_right_panel(
 
         if !colonizable.is_empty() {
             ui.add_space(8.0);
-            ui.label(egui::RichText::new("Colonize Planet").strong().color(egui::Color32::from_rgb(180, 180, 220)));
+            ui.label(
+                egui::RichText::new("Colonize Planet")
+                    .strong()
+                    .color(egui::Color32::from_rgb(180, 180, 220)),
+            );
             ui.separator();
-            ui.label(egui::RichText::new(format!(
-                "Cost: {} M, {} E, {} hd",
-                crate::colony::COLONIZATION_MINERAL_COST,
-                crate::colony::COLONIZATION_ENERGY_COST,
-                crate::colony::COLONIZATION_BUILD_TIME,
-            )).small());
+            ui.label(
+                egui::RichText::new(format!(
+                    "Cost: {} M, {} E, {} hd",
+                    crate::colony::COLONIZATION_MINERAL_COST,
+                    crate::colony::COLONIZATION_ENERGY_COST,
+                    crate::colony::COLONIZATION_BUILD_TIME,
+                ))
+                .small(),
+            );
 
-            let source_colony: Option<Entity> = colonies.iter()
+            let source_colony: Option<Entity> = colonies
+                .iter()
                 .find(|(_, c, _, _, _, _, _, _)| {
                     c.system(planets) == Some(sel_entity)
                         && c.population > crate::colony::COLONIZATION_MIN_POPULATION
@@ -1253,7 +1462,10 @@ fn draw_right_panel(
             for (pe, name, ptype) in &colonizable {
                 let label = format!("{} ({})", name, ptype);
                 let enabled = source_colony.is_some();
-                if ui.add_enabled(enabled, egui::Button::new(format!("Colonize {}", label))).clicked() {
+                if ui
+                    .add_enabled(enabled, egui::Button::new(format!("Colonize {}", label)))
+                    .clicked()
+                {
                     if let Some(source) = source_colony {
                         colonization_actions_out.push(ColonizationAction {
                             system_entity: sel_entity,
@@ -1282,13 +1494,24 @@ fn draw_right_panel(
                 ui.separator();
                 ui.label(egui::RichText::new("Colonization In Progress").strong());
                 for order in &cq.orders {
-                    let planet_name = planets.get(order.target_planet)
+                    let planet_name = planets
+                        .get(order.target_planet)
                         .map(|p| p.name.as_str())
                         .unwrap_or("Unknown");
                     let total_time = crate::colony::COLONIZATION_BUILD_TIME;
                     let elapsed = total_time - order.build_time_remaining;
-                    let pct = if total_time > 0 { elapsed as f32 / total_time as f32 } else { 1.0 };
-                    ui.label(format!("{}: {}/{} hd ({:.0}%)", planet_name, elapsed, total_time, pct * 100.0));
+                    let pct = if total_time > 0 {
+                        elapsed as f32 / total_time as f32
+                    } else {
+                        1.0
+                    };
+                    ui.label(format!(
+                        "{}: {}/{} hd ({:.0}%)",
+                        planet_name,
+                        elapsed,
+                        total_time,
+                        pct * 100.0
+                    ));
                     let bar = egui::ProgressBar::new(pct);
                     ui.add(bar);
                 }
@@ -1311,10 +1534,8 @@ fn draw_system_map(
 ) {
     // Use the entire available area for the map
     let available = ui.available_size();
-    let (response, painter) = ui.allocate_painter(
-        egui::vec2(available.x, available.y),
-        egui::Sense::click(),
-    );
+    let (response, painter) =
+        ui.allocate_painter(egui::vec2(available.x, available.y), egui::Sense::click());
     let rect = response.rect;
     let center = rect.center();
 
@@ -1328,24 +1549,37 @@ fn draw_system_map(
         t if t.contains("white") => egui::Color32::from_rgb(240, 240, 255),
         t if t.contains("orange") => egui::Color32::from_rgb(255, 180, 80),
         t if t.contains("brown") || t.contains("dwarf") => egui::Color32::from_rgb(180, 120, 80),
-        t if t.contains("neutron") || t.contains("pulsar") => egui::Color32::from_rgb(200, 200, 255),
+        t if t.contains("neutron") || t.contains("pulsar") => {
+            egui::Color32::from_rgb(200, 200, 255)
+        }
         _ => egui::Color32::from_rgb(255, 220, 80), // Yellow default
     };
 
     // Draw star glow
     let star_radius = 20.0;
-    painter.circle_filled(center, star_radius + 8.0, egui::Color32::from_rgba_premultiplied(
-        star_color.r(), star_color.g(), star_color.b(), 30,
-    ));
-    painter.circle_filled(center, star_radius + 4.0, egui::Color32::from_rgba_premultiplied(
-        star_color.r(), star_color.g(), star_color.b(), 60,
-    ));
+    painter.circle_filled(
+        center,
+        star_radius + 8.0,
+        egui::Color32::from_rgba_premultiplied(star_color.r(), star_color.g(), star_color.b(), 30),
+    );
+    painter.circle_filled(
+        center,
+        star_radius + 4.0,
+        egui::Color32::from_rgba_premultiplied(star_color.r(), star_color.g(), star_color.b(), 60),
+    );
     painter.circle_filled(center, star_radius, star_color);
-    painter.circle_stroke(center, star_radius, egui::Stroke::new(1.0, egui::Color32::from_rgb(
-        (star_color.r() as u16 * 3 / 4) as u8,
-        (star_color.g() as u16 * 3 / 4) as u8,
-        (star_color.b() as u16 * 3 / 4) as u8,
-    )));
+    painter.circle_stroke(
+        center,
+        star_radius,
+        egui::Stroke::new(
+            1.0,
+            egui::Color32::from_rgb(
+                (star_color.r() as u16 * 3 / 4) as u8,
+                (star_color.g() as u16 * 3 / 4) as u8,
+                (star_color.b() as u16 * 3 / 4) as u8,
+            ),
+        ),
+    );
 
     // Star label
     painter.text(
@@ -1366,7 +1600,9 @@ fn draw_system_map(
     };
 
     // Draw planets on orbital rings
-    for (i, (planet_entity, name, _planet_type, is_colonized, hab)) in system_planets.iter().enumerate() {
+    for (i, (planet_entity, name, _planet_type, is_colonized, hab)) in
+        system_planets.iter().enumerate()
+    {
         let orbit_r = 50.0 + (i as f32) * orbit_spacing;
 
         // Orbit ring
@@ -1400,8 +1636,16 @@ fn draw_system_map(
         // Selected planet highlight
         let is_selected = selected_planet.0 == Some(*planet_entity);
         if is_selected {
-            painter.circle_filled(planet_pos, planet_radius + 5.0, egui::Color32::from_rgba_premultiplied(255, 255, 100, 40));
-            painter.circle_stroke(planet_pos, planet_radius + 5.0, egui::Stroke::new(1.5, egui::Color32::from_rgb(255, 255, 100)));
+            painter.circle_filled(
+                planet_pos,
+                planet_radius + 5.0,
+                egui::Color32::from_rgba_premultiplied(255, 255, 100, 40),
+            );
+            painter.circle_stroke(
+                planet_pos,
+                planet_radius + 5.0,
+                egui::Stroke::new(1.5, egui::Color32::from_rgb(255, 255, 100)),
+            );
         }
 
         // Planet body
@@ -1409,7 +1653,11 @@ fn draw_system_map(
 
         // Colonized indicator ring
         if *is_colonized {
-            painter.circle_stroke(planet_pos, planet_radius + 2.5, egui::Stroke::new(2.0, egui::Color32::from_rgb(50, 130, 255)));
+            painter.circle_stroke(
+                planet_pos,
+                planet_radius + 2.5,
+                egui::Stroke::new(2.0, egui::Color32::from_rgb(50, 130, 255)),
+            );
         }
 
         // Planet name label
@@ -1477,7 +1725,10 @@ fn draw_system_map(
             ));
 
             // Ship name
-            let design_name = design_registry.get(design_id).map(|d| d.name.as_str()).unwrap_or(design_id);
+            let design_name = design_registry
+                .get(design_id)
+                .map(|d| d.name.as_str())
+                .unwrap_or(design_id);
             painter.text(
                 egui::pos2(sx, sy + ship_size + 3.0),
                 egui::Align2::CENTER_TOP,
@@ -1628,8 +1879,7 @@ mod tests_229 {
             max_hp: 100.0,
             energy_drain: Amt::ZERO,
             capabilities: Default::default(),
-            prerequisites: prereq_tech
-                .map(|t| Condition::Atom(ConditionAtom::has_tech(t))),
+            prerequisites: prereq_tech.map(|t| Condition::Atom(ConditionAtom::has_tech(t))),
             deliverable: if shipyard_buildable {
                 Some(DeliverableMetadata {
                     cost: ResourceCost::default(),

--- a/macrocosmo/tests/colony.rs
+++ b/macrocosmo/tests/colony.rs
@@ -3,9 +3,9 @@ mod common;
 use bevy::prelude::*;
 use macrocosmo::amount::Amt;
 use macrocosmo::colony::*;
-use macrocosmo::modifier::ModifiedValue;
 use macrocosmo::components::Position;
-use macrocosmo::galaxy::{Planet, StarSystem, SystemAttributes, Sovereignty};
+use macrocosmo::galaxy::{Planet, Sovereignty, StarSystem, SystemAttributes};
+use macrocosmo::modifier::ModifiedValue;
 use macrocosmo::ship::*;
 
 use common::{advance_time, find_planet, spawn_test_colony, spawn_test_system, test_app};
@@ -13,7 +13,9 @@ use common::{advance_time, find_planet, spawn_test_colony, spawn_test_system, te
 /// Helper: add ResourceStockpile and ResourceCapacity to a star system entity.
 /// If the system already has a stockpile, it replaces it.
 fn set_system_stockpile(world: &mut World, sys: Entity, stockpile: ResourceStockpile) {
-    world.entity_mut(sys).insert((stockpile, ResourceCapacity::default()));
+    world
+        .entity_mut(sys)
+        .insert((stockpile, ResourceCapacity::default()));
 }
 
 /// Helper: spawn a star system marked as capital with a planet
@@ -66,13 +68,17 @@ fn test_production_accumulates_resources() {
 
     // Spawn colony with production rates 5/3/1 and zero stockpile
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
-        minerals: Amt::ZERO,
-        energy: Amt::ZERO,
-        research: Amt::ZERO,
-        food: Amt::ZERO,
-        authority: Amt::ZERO,
-    });
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
+            minerals: Amt::ZERO,
+            energy: Amt::ZERO,
+            research: Amt::ZERO,
+            food: Amt::ZERO,
+            authority: Amt::ZERO,
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -85,9 +91,7 @@ fn test_production_accumulates_resources() {
             research_per_hexadies: ModifiedValue::new(Amt::units(1)),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue {
-            queue: Vec::new(),
-        },
+        BuildQueue::default(),
     ));
 
     // Advance 10 hexadies
@@ -109,7 +113,8 @@ fn test_production_accumulates_resources() {
     // Research is no longer accumulated in the stockpile; it is emitted
     // as PendingResearch entities via emit_research instead.
     assert_eq!(
-        stockpile.research, Amt::ZERO,
+        stockpile.research,
+        Amt::ZERO,
         "Expected 0 research in stockpile (emitted as PendingResearch), got {}",
         stockpile.research
     );
@@ -133,13 +138,17 @@ fn test_building_queue_completes_construction() {
     let build_time = 10;
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::units(500),
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -152,10 +161,13 @@ fn test_building_queue_completes_construction() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None, None, None, None] },
+        BuildQueue::default(),
+        Buildings {
+            slots: vec![None, None, None, None],
+        },
         BuildingQueue {
             queue: vec![BuildingOrder {
+                order_id: 0,
                 building_id: BuildingId::new("mine"),
                 target_slot: 0,
                 minerals_remaining: minerals_cost,
@@ -164,6 +176,7 @@ fn test_building_queue_completes_construction() {
             }],
             demolition_queue: Vec::new(),
             upgrade_queue: Vec::new(),
+            next_order_id: 0,
         },
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -199,16 +212,20 @@ fn test_demolish_building_removes_from_slot() {
     );
 
     let demo_time = 5;
-    let (m_refund, e_refund) = (Amt::milli(150000/2), Amt::milli(50000/2));
+    let (m_refund, e_refund) = (Amt::milli(150000 / 2), Amt::milli(50000 / 2));
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -221,13 +238,14 @@ fn test_demolish_building_removes_from_slot() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings {
             slots: vec![Some(BuildingId::new("mine")), None, None, None],
         },
         BuildingQueue {
             queue: Vec::new(),
             demolition_queue: vec![DemolitionOrder {
+                order_id: 0,
                 target_slot: 0,
                 building_id: BuildingId::new("mine"),
                 time_remaining: demo_time,
@@ -235,6 +253,7 @@ fn test_demolish_building_removes_from_slot() {
                 energy_refund: e_refund,
             }],
             upgrade_queue: Vec::new(),
+            next_order_id: 0,
         },
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -266,16 +285,20 @@ fn test_demolish_refunds_resources() {
     );
 
     let demo_time = 5;
-    let (m_refund, e_refund) = (Amt::milli(150000/2), Amt::milli(50000/2));
+    let (m_refund, e_refund) = (Amt::milli(150000 / 2), Amt::milli(50000 / 2));
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -288,13 +311,14 @@ fn test_demolish_refunds_resources() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings {
             slots: vec![Some(BuildingId::new("mine")), None, None, None],
         },
         BuildingQueue {
             queue: Vec::new(),
             demolition_queue: vec![DemolitionOrder {
+                order_id: 0,
                 target_slot: 0,
                 building_id: BuildingId::new("mine"),
                 time_remaining: demo_time,
@@ -302,6 +326,7 @@ fn test_demolish_refunds_resources() {
                 energy_refund: e_refund,
             }],
             upgrade_queue: Vec::new(),
+            next_order_id: 0,
         },
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -340,16 +365,20 @@ fn test_demolish_takes_time() {
     );
 
     let demo_time = 15; // 30 / 2 = 15
-    let (m_refund, e_refund) = (Amt::milli(300000/2), Amt::milli(200000/2));
+    let (m_refund, e_refund) = (Amt::milli(300000 / 2), Amt::milli(200000 / 2));
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -362,13 +391,14 @@ fn test_demolish_takes_time() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings {
             slots: vec![Some(BuildingId::new("shipyard")), None, None, None],
         },
         BuildingQueue {
             queue: Vec::new(),
             demolition_queue: vec![DemolitionOrder {
+                order_id: 0,
                 target_slot: 0,
                 building_id: BuildingId::new("shipyard"),
                 time_remaining: demo_time,
@@ -376,6 +406,7 @@ fn test_demolish_takes_time() {
                 energy_refund: e_refund,
             }],
             upgrade_queue: Vec::new(),
+            next_order_id: 0,
         },
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -427,13 +458,17 @@ fn test_farm_produces_food() {
 
     // Colony with food_per_hexadies=5.0, a Farm building (+5.0 food bonus), starting food=0
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::units(100),
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -446,7 +481,7 @@ fn test_farm_produces_food() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::units(5)),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings {
             slots: vec![Some(BuildingId::new("farm"))],
         },
@@ -485,14 +520,7 @@ fn test_authority_deficit_penalizes_food_production() {
     let mut app = test_app();
 
     // Capital system (provides authority context)
-    let cap_sys = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let cap_sys = spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
 
     // Non-capital system
     let _remote_sys = spawn_test_system(
@@ -505,17 +533,25 @@ fn test_authority_deficit_penalizes_food_production() {
     );
 
     // Mark as capital
-    app.world_mut().entity_mut(cap_sys).get_mut::<StarSystem>().unwrap().is_capital = true;
+    app.world_mut()
+        .entity_mut(cap_sys)
+        .get_mut::<StarSystem>()
+        .unwrap()
+        .is_capital = true;
 
     // Capital colony with 0 authority (deficit)
     let planet_cap_sys = find_planet(app.world_mut(), cap_sys);
-    set_system_stockpile(app.world_mut(), cap_sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        cap_sys,
+        ResourceStockpile {
             minerals: Amt::units(1000),
             energy: Amt::units(1000),
             research: Amt::ZERO,
             food: Amt::units(1000),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_cap_sys,
@@ -528,7 +564,7 @@ fn test_authority_deficit_penalizes_food_production() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
         FoodConsumption::default(),
@@ -551,13 +587,17 @@ fn test_authority_deficit_penalizes_food_production() {
 
     for &sys in &remote_systems {
         let planet_sys = find_planet(app.world_mut(), sys);
-        set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+        set_system_stockpile(
+            app.world_mut(),
+            sys,
+            ResourceStockpile {
                 minerals: Amt::ZERO,
                 energy: Amt::ZERO,
                 research: Amt::ZERO,
                 food: Amt::ZERO,
                 authority: Amt::ZERO,
-            });
+            },
+        );
         app.world_mut().spawn((
             Colony {
                 planet: planet_sys,
@@ -565,12 +605,12 @@ fn test_authority_deficit_penalizes_food_production() {
                 growth_rate: 0.0,
             },
             Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
-            energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
-            research_per_hexadies: ModifiedValue::new(Amt::ZERO),
-            food_per_hexadies: ModifiedValue::new(Amt::units(10)),
-        },
-            BuildQueue { queue: Vec::new() },
+                minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::units(10)),
+            },
+            BuildQueue::default(),
             ProductionFocus::default(),
             MaintenanceCost::default(),
             FoodConsumption::default(),
@@ -580,7 +620,10 @@ fn test_authority_deficit_penalizes_food_production() {
     advance_time(&mut app, 10);
 
     // Check a remote colony's food: 10.0/hd * 0.5 (penalty) * 10 hd = 50.0, minus consumption
-    let stockpile = app.world().get::<ResourceStockpile>(remote_systems[0]).unwrap();
+    let stockpile = app
+        .world()
+        .get::<ResourceStockpile>(remote_systems[0])
+        .unwrap();
     // Without penalty: 100.0 food. With 0.5 penalty: ~50.0 food (minus small consumption)
     assert!(
         stockpile.food.to_f64() < 60.0,
@@ -611,13 +654,17 @@ fn test_maintenance_deducts_energy_integration() {
 
     // Colony with Mine (0.2 E/hd) and Shipyard (1.0 E/hd) = 1.2 E/hd total maintenance
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::units(100),
             research: Amt::ZERO,
             food: Amt::units(10000),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -630,9 +677,12 @@ fn test_maintenance_deducts_energy_integration() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::units(10)),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings {
-            slots: vec![Some(BuildingId::new("mine")), Some(BuildingId::new("shipyard"))],
+            slots: vec![
+                Some(BuildingId::new("mine")),
+                Some(BuildingId::new("shipyard")),
+            ],
         },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -677,13 +727,17 @@ fn test_population_capped_by_carrying_capacity() {
     );
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(10000),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -696,7 +750,7 @@ fn test_population_capped_by_carrying_capacity() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::units(10)),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
         FoodConsumption::default(),
@@ -758,7 +812,7 @@ fn test_habitability_affects_growth_rate() {
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::units(100)), // abundant food so K isn't food-limited
             },
-            BuildQueue { queue: Vec::new() },
+            BuildQueue::default(),
             ProductionFocus::default(),
             MaintenanceCost::default(),
             FoodConsumption::default(),
@@ -768,7 +822,9 @@ fn test_habitability_affects_growth_rate() {
     let ideal_planet = find_planet(ideal_app.world_mut(), ideal_sys);
     ideal_app.world_mut().spawn(colony_bundle(ideal_planet));
     let marginal_planet = find_planet(marginal_app.world_mut(), marginal_sys);
-    marginal_app.world_mut().spawn(colony_bundle(marginal_planet));
+    marginal_app
+        .world_mut()
+        .spawn(colony_bundle(marginal_planet));
 
     for _ in 0..60 {
         advance_time(&mut ideal_app, 1);
@@ -815,13 +871,17 @@ fn test_food_limits_carrying_capacity() {
     );
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(10000),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -834,7 +894,7 @@ fn test_food_limits_carrying_capacity() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::units(5)),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
         FoodConsumption::default(),
@@ -898,7 +958,7 @@ fn test_resource_capacity_clamps_stockpile() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings { slots: vec![] },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -942,13 +1002,17 @@ fn test_production_focus_weights() {
     );
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -961,7 +1025,7 @@ fn test_production_focus_weights() {
             research_per_hexadies: ModifiedValue::new(Amt::units(1)),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings { slots: vec![] },
         BuildingQueue::default(),
         ProductionFocus::minerals(), // minerals_weight=2.0, energy_weight=0.5
@@ -1014,13 +1078,17 @@ fn test_build_queue_partial_resources() {
     let build_time = 10;
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::units(20),
             energy: Amt::units(200),
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -1033,10 +1101,13 @@ fn test_build_queue_partial_resources() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None, None, None, None] },
+        BuildQueue::default(),
+        Buildings {
+            slots: vec![None, None, None, None],
+        },
         BuildingQueue {
             queue: vec![BuildingOrder {
+                order_id: 0,
                 building_id: BuildingId::new("mine"),
                 target_slot: 0,
                 minerals_remaining: minerals_cost,
@@ -1045,6 +1116,7 @@ fn test_build_queue_partial_resources() {
             }],
             demolition_queue: Vec::new(),
             upgrade_queue: Vec::new(),
+            next_order_id: 0,
         },
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -1092,13 +1164,17 @@ fn test_build_queue_requires_shipyard() {
 
     // Colony WITHOUT Shipyard, but with a ship build order
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::units(500),
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -1113,6 +1189,7 @@ fn test_build_queue_requires_shipyard() {
         },
         BuildQueue {
             queue: vec![BuildOrder {
+                order_id: 0,
                 kind: macrocosmo::colony::BuildKind::default(),
                 design_id: "explorer_mk1".to_string(),
                 display_name: "Explorer".to_string(),
@@ -1123,8 +1200,11 @@ fn test_build_queue_requires_shipyard() {
                 build_time_total: 60,
                 build_time_remaining: 60,
             }],
+            next_order_id: 0,
         },
-        Buildings { slots: vec![Some(BuildingId::new("mine")), None, None, None] }, // No Shipyard!
+        Buildings {
+            slots: vec![Some(BuildingId::new("mine")), None, None, None],
+        }, // No Shipyard!
         BuildingQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -1168,13 +1248,17 @@ fn test_starvation_reduces_population() {
     );
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::ZERO, // No food!
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -1187,7 +1271,7 @@ fn test_starvation_reduces_population() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO), // No food production
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings { slots: vec![] },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -1223,13 +1307,17 @@ fn test_starvation_population_floor() {
     );
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -1242,7 +1330,7 @@ fn test_starvation_population_floor() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings { slots: vec![] },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -1275,32 +1363,41 @@ fn test_capital_produces_authority() {
 
     // Spawn capital colony with zero authority
     let planet_cap_sys = find_planet(app.world_mut(), cap_sys);
-    set_system_stockpile(app.world_mut(), cap_sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        cap_sys,
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::units(500),
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        });
-    let colony_entity = app.world_mut().spawn((
-        Colony {
-            planet: planet_cap_sys,
-            population: 100.0,
-            growth_rate: 0.01,
         },
-        Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
-        },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
-        BuildingQueue::default(),
-        ProductionFocus::default(),
-        MaintenanceCost::default(),
-        FoodConsumption::default(),
-    )).id();
+    );
+    let colony_entity = app
+        .world_mut()
+        .spawn((
+            Colony {
+                planet: planet_cap_sys,
+                population: 100.0,
+                growth_rate: 0.01,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                research_per_hexadies: ModifiedValue::new(Amt::units(1)),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue::default(),
+            Buildings {
+                slots: vec![None; 4],
+            },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
 
     // Advance 10 hexadies
     advance_time(&mut app, 10);
@@ -1320,53 +1417,59 @@ fn test_empire_scale_authority_cost() {
     let mut app = test_app();
 
     let cap_sys = spawn_capital_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0]);
-    let remote_sys = spawn_test_system(
-        app.world_mut(),
-        "Remote",
-        [5.0, 0.0, 0.0],
-        0.7,
-        true,
-        true,
-    );
+    let remote_sys = spawn_test_system(app.world_mut(), "Remote", [5.0, 0.0, 0.0], 0.7, true, true);
 
     // Capital colony starts with some authority
     let planet_cap_sys = find_planet(app.world_mut(), cap_sys);
-    set_system_stockpile(app.world_mut(), cap_sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        cap_sys,
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::units(500),
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::units(5), // start with 5
-        });
-    let capital_colony = app.world_mut().spawn((
-        Colony {
-            planet: planet_cap_sys,
-            population: 100.0,
-            growth_rate: 0.01,
         },
-        Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
-        },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
-        BuildingQueue::default(),
-        ProductionFocus::default(),
-        MaintenanceCost::default(),
-        FoodConsumption::default(),
-    )).id();
+    );
+    let capital_colony = app
+        .world_mut()
+        .spawn((
+            Colony {
+                planet: planet_cap_sys,
+                population: 100.0,
+                growth_rate: 0.01,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                research_per_hexadies: ModifiedValue::new(Amt::units(1)),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue::default(),
+            Buildings {
+                slots: vec![None; 4],
+            },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
 
     // Remote colony (non-capital)
     let planet_remote_sys = find_planet(app.world_mut(), remote_sys);
-    set_system_stockpile(app.world_mut(), remote_sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        remote_sys,
+        ResourceStockpile {
             minerals: Amt::units(100),
             energy: Amt::units(100),
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_remote_sys,
@@ -1379,8 +1482,10 @@ fn test_empire_scale_authority_cost() {
             research_per_hexadies: ModifiedValue::new(Amt::new(0, 500)),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
+        BuildQueue::default(),
+        Buildings {
+            slots: vec![None; 4],
+        },
         BuildingQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -1407,14 +1512,7 @@ fn test_authority_deficit_reduces_non_capital_production() {
     let mut app = test_app();
 
     let cap_sys = spawn_capital_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0]);
-    let remote_sys = spawn_test_system(
-        app.world_mut(),
-        "Remote",
-        [5.0, 0.0, 0.0],
-        0.7,
-        true,
-        true,
-    );
+    let remote_sys = spawn_test_system(app.world_mut(), "Remote", [5.0, 0.0, 0.0], 0.7, true, true);
 
     // Capital colony with zero authority -- will be in deficit
     // Note: tick_authority runs before tick_production in the chain.
@@ -1441,13 +1539,17 @@ fn test_authority_deficit_reduces_non_capital_production() {
     // Capital colony: authority = 0, so after tick_authority it stays 0
     // because cost (3 * 0.5 = 1.5) > production (1.0), net = -0.5, capped to 0
     let planet_cap_sys = find_planet(app.world_mut(), cap_sys);
-    set_system_stockpile(app.world_mut(), cap_sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        cap_sys,
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::units(500),
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_cap_sys,
@@ -1460,8 +1562,10 @@ fn test_authority_deficit_reduces_non_capital_production() {
             research_per_hexadies: ModifiedValue::new(Amt::units(1)),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
+        BuildQueue::default(),
+        Buildings {
+            slots: vec![None; 4],
+        },
         BuildingQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -1470,41 +1574,54 @@ fn test_authority_deficit_reduces_non_capital_production() {
 
     // Three remote colonies with known production rates
     let planet_remote_sys = find_planet(app.world_mut(), remote_sys);
-    set_system_stockpile(app.world_mut(), remote_sys, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        remote_sys,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        });
-    let remote_colony = app.world_mut().spawn((
-        Colony {
-            planet: planet_remote_sys,
-            population: 50.0,
-            growth_rate: 0.005,
         },
-        Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(10)),
-            energy_per_hexadies: ModifiedValue::new(Amt::units(10)),
-            research_per_hexadies: ModifiedValue::new(Amt::ZERO),
-            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
-        },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
-        BuildingQueue::default(),
-        ProductionFocus::default(),
-        MaintenanceCost::default(),
-        FoodConsumption::default(),
-    )).id();
+    );
+    let remote_colony = app
+        .world_mut()
+        .spawn((
+            Colony {
+                planet: planet_remote_sys,
+                population: 50.0,
+                growth_rate: 0.005,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::units(10)),
+                energy_per_hexadies: ModifiedValue::new(Amt::units(10)),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue::default(),
+            Buildings {
+                slots: vec![None; 4],
+            },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
 
     let planet_remote_sys2 = find_planet(app.world_mut(), remote_sys2);
-    set_system_stockpile(app.world_mut(), remote_sys2, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        remote_sys2,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_remote_sys2,
@@ -1517,8 +1634,10 @@ fn test_authority_deficit_reduces_non_capital_production() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
+        BuildQueue::default(),
+        Buildings {
+            slots: vec![None; 4],
+        },
         BuildingQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -1526,13 +1645,17 @@ fn test_authority_deficit_reduces_non_capital_production() {
     ));
 
     let planet_remote_sys3 = find_planet(app.world_mut(), remote_sys3);
-    set_system_stockpile(app.world_mut(), remote_sys3, ResourceStockpile {
+    set_system_stockpile(
+        app.world_mut(),
+        remote_sys3,
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        });
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_remote_sys3,
@@ -1545,8 +1668,10 @@ fn test_authority_deficit_reduces_non_capital_production() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
+        BuildQueue::default(),
+        Buildings {
+            slots: vec![None; 4],
+        },
         BuildingQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -1576,8 +1701,8 @@ fn test_authority_deficit_reduces_non_capital_production() {
 // #134: Ship build menu lives on the system panel, not the planet detail.
 // ---------------------------------------------------------------------------
 
-use macrocosmo::ui::system_panel::ship_build_host_colony;
 use common::create_test_building_registry;
+use macrocosmo::ui::system_panel::ship_build_host_colony;
 
 /// Helper: build a (colony_entity, system_entity) slice in the form expected by
 /// `ship_build_host_colony`.
@@ -1589,7 +1714,12 @@ fn collect_colony_systems(app: &mut App) -> Vec<(Entity, Entity)> {
     let mut colony_q = world.query::<(Entity, &Colony)>();
     colony_q
         .iter(world)
-        .filter_map(|(e, colony)| planet_systems.get(&colony.planet).copied().map(|sys| (e, sys)))
+        .filter_map(|(e, colony)| {
+            planet_systems
+                .get(&colony.planet)
+                .copied()
+                .map(|sys| (e, sys))
+        })
         .collect()
 }
 
@@ -1599,14 +1729,7 @@ fn test_134_ship_build_requires_shipyard_at_system() {
     let mut app = test_app();
     let registry = create_test_building_registry();
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "NoYard",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "NoYard", [0.0, 0.0, 0.0], 1.0, true, true);
     let _planet = find_planet(app.world_mut(), sys);
     spawn_test_colony(
         app.world_mut(),
@@ -1617,11 +1740,16 @@ fn test_134_ship_build_requires_shipyard_at_system() {
     );
 
     // SystemBuildings without a shipyard
-    let sb = SystemBuildings { slots: vec![None, None, None] };
+    let sb = SystemBuildings {
+        slots: vec![None, None, None],
+    };
     let pairs = collect_colony_systems(&mut app);
 
     let host = ship_build_host_colony(sys, &sb, &registry, &pairs);
-    assert!(host.is_none(), "Without a shipyard, the system must not host ship builds");
+    assert!(
+        host.is_none(),
+        "Without a shipyard, the system must not host ship builds"
+    );
 }
 
 #[test]
@@ -1647,7 +1775,9 @@ fn test_134_ship_build_uses_first_colony_when_shipyard_present() {
         vec![None; 4],
     );
 
-    let sb = SystemBuildings { slots: vec![Some(BuildingId::new("shipyard")), None, None] };
+    let sb = SystemBuildings {
+        slots: vec![Some(BuildingId::new("shipyard")), None, None],
+    };
     let pairs = collect_colony_systems(&mut app);
 
     let host = ship_build_host_colony(sys, &sb, &registry, &pairs);
@@ -1674,11 +1804,16 @@ fn test_134_ship_build_requires_a_colony_in_system() {
     );
     // No colony spawned.
 
-    let sb = SystemBuildings { slots: vec![Some(BuildingId::new("shipyard"))] };
+    let sb = SystemBuildings {
+        slots: vec![Some(BuildingId::new("shipyard"))],
+    };
     let pairs = collect_colony_systems(&mut app);
 
     let host = ship_build_host_colony(sys, &sb, &registry, &pairs);
-    assert!(host.is_none(), "Without a colony the system has nowhere to host a build queue");
+    assert!(
+        host.is_none(),
+        "Without a colony the system has nowhere to host a build queue"
+    );
 }
 
 #[test]
@@ -1699,13 +1834,17 @@ fn test_134_existing_shipyard_gating_still_works() {
         true,
     );
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
-        minerals: Amt::units(500),
-        energy: Amt::units(500),
-        research: Amt::ZERO,
-        food: Amt::units(100),
-        authority: Amt::ZERO,
-    });
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
+            minerals: Amt::units(500),
+            energy: Amt::units(500),
+            research: Amt::ZERO,
+            food: Amt::units(100),
+            authority: Amt::ZERO,
+        },
+    );
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -1720,6 +1859,7 @@ fn test_134_existing_shipyard_gating_still_works() {
         },
         BuildQueue {
             queue: vec![BuildOrder {
+                order_id: 0,
                 kind: macrocosmo::colony::BuildKind::default(),
                 design_id: "explorer_mk1".to_string(),
                 display_name: "Explorer".to_string(),
@@ -1730,8 +1870,11 @@ fn test_134_existing_shipyard_gating_still_works() {
                 build_time_total: 60,
                 build_time_remaining: 60,
             }],
+            next_order_id: 0,
         },
-        Buildings { slots: vec![None; 4] },
+        Buildings {
+            slots: vec![None; 4],
+        },
         BuildingQueue::default(),
         ProductionFocus::default(),
         MaintenanceCost::default(),
@@ -1776,29 +1919,40 @@ fn test_construction_does_not_progress_when_stockpile_empty() {
     let planet_sys = find_planet(app.world_mut(), sys);
     // Deliberately empty stockpile (food > 0 so the colony doesn't starve;
     // building-queue tick only cares about minerals/energy).
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
-        minerals: Amt::ZERO,
-        energy: Amt::ZERO,
-        research: Amt::ZERO,
-        food: Amt::units(100),
-        authority: Amt::ZERO,
-    });
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
+            minerals: Amt::ZERO,
+            energy: Amt::ZERO,
+            research: Amt::ZERO,
+            food: Amt::units(100),
+            authority: Amt::ZERO,
+        },
+    );
 
     let build_time = 10;
     let colony_entity = app
         .world_mut()
         .spawn((
-            Colony { planet: planet_sys, population: 10.0, growth_rate: 0.0 },
+            Colony {
+                planet: planet_sys,
+                population: 10.0,
+                growth_rate: 0.0,
+            },
             Production {
                 minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
-            Buildings { slots: vec![None, None, None, None] },
+            BuildQueue::default(),
+            Buildings {
+                slots: vec![None, None, None, None],
+            },
             BuildingQueue {
                 queue: vec![BuildingOrder {
+                    order_id: 0,
                     building_id: BuildingId::new("mine"),
                     target_slot: 0,
                     minerals_remaining: Amt::units(150),
@@ -1807,6 +1961,7 @@ fn test_construction_does_not_progress_when_stockpile_empty() {
                 }],
                 demolition_queue: Vec::new(),
                 upgrade_queue: Vec::new(),
+                next_order_id: 0,
             },
             ProductionFocus::default(),
             MaintenanceCost::default(),
@@ -1818,16 +1973,30 @@ fn test_construction_does_not_progress_when_stockpile_empty() {
     // arriving, the timer must stay pinned and the slot must stay empty.
     advance_time(&mut app, build_time * 3);
 
-    let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
-    assert_eq!(bq.queue.len(), 1, "order must still be pending: {:?}", bq.queue.len());
+    let bq = app
+        .world()
+        .get::<BuildingQueue>(colony_entity)
+        .expect("queue");
+    assert_eq!(
+        bq.queue.len(),
+        1,
+        "order must still be pending: {:?}",
+        bq.queue.len()
+    );
     let order = &bq.queue[0];
     assert_eq!(
         order.build_time_remaining, build_time,
         "Starved order must not drain its timer (got {}, expected {})",
         order.build_time_remaining, build_time
     );
-    let buildings = app.world().get::<Buildings>(colony_entity).expect("buildings");
-    assert_eq!(buildings.slots[0], None, "Slot must stay empty while order is starved");
+    let buildings = app
+        .world()
+        .get::<Buildings>(colony_entity)
+        .expect("buildings");
+    assert_eq!(
+        buildings.slots[0], None,
+        "Slot must stay empty while order is starved"
+    );
 }
 
 /// Planet-level upgrade order must stall while resources are unavailable.
@@ -1845,43 +2014,55 @@ fn test_upgrade_does_not_progress_when_stockpile_empty() {
     );
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
-        minerals: Amt::ZERO,
-        energy: Amt::ZERO,
-        research: Amt::ZERO,
-        food: Amt::units(100),
-        authority: Amt::ZERO,
-    });
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
+            minerals: Amt::ZERO,
+            energy: Amt::ZERO,
+            research: Amt::ZERO,
+            food: Amt::units(100),
+            authority: Amt::ZERO,
+        },
+    );
 
     let build_time = 8;
     let colony_entity = app
         .world_mut()
         .spawn((
-            Colony { planet: planet_sys, population: 10.0, growth_rate: 0.0 },
+            Colony {
+                planet: planet_sys,
+                population: 10.0,
+                growth_rate: 0.0,
+            },
             Production {
                 minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
+            BuildQueue::default(),
             // Use an empty slot (no pre-existing building) to avoid any
             // sync_building_modifiers side-effect that would feed the
             // system stockpile via production bonuses — we want an
             // unambiguous "no minerals / no energy" scenario for this
             // starvation test. The upgrade code does not inspect the
             // current slot; it just writes target_id into it on completion.
-            Buildings { slots: vec![None, None, None, None] },
+            Buildings {
+                slots: vec![None, None, None, None],
+            },
             BuildingQueue {
                 queue: Vec::new(),
                 demolition_queue: Vec::new(),
                 upgrade_queue: vec![UpgradeOrder {
+                    order_id: 0,
                     slot_index: 0,
                     target_id: BuildingId::new("advanced_mine"),
                     minerals_remaining: Amt::units(200),
                     energy_remaining: Amt::units(80),
                     build_time_remaining: build_time,
                 }],
+                next_order_id: 0,
             },
             ProductionFocus::default(),
             MaintenanceCost::default(),
@@ -1891,13 +2072,23 @@ fn test_upgrade_does_not_progress_when_stockpile_empty() {
 
     advance_time(&mut app, build_time * 3);
 
-    let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
-    assert_eq!(bq.upgrade_queue.len(), 1, "upgrade order must still be pending");
+    let bq = app
+        .world()
+        .get::<BuildingQueue>(colony_entity)
+        .expect("queue");
+    assert_eq!(
+        bq.upgrade_queue.len(),
+        1,
+        "upgrade order must still be pending"
+    );
     assert_eq!(
         bq.upgrade_queue[0].build_time_remaining, build_time,
         "Starved upgrade must not drain its timer"
     );
-    let buildings = app.world().get::<Buildings>(colony_entity).expect("buildings");
+    let buildings = app
+        .world()
+        .get::<Buildings>(colony_entity)
+        .expect("buildings");
     assert_eq!(
         buildings.slots[0], None,
         "Upgrade must not have replaced the (empty) slot while starved"
@@ -1921,13 +2112,17 @@ fn test_upgrade_completes_when_resources_finally_arrive() {
 
     let planet_sys = find_planet(app.world_mut(), sys);
     // Start with empty stockpile.
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
-        minerals: Amt::ZERO,
-        energy: Amt::ZERO,
-        research: Amt::ZERO,
-        food: Amt::units(100),
-        authority: Amt::ZERO,
-    });
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
+            minerals: Amt::ZERO,
+            energy: Amt::ZERO,
+            research: Amt::ZERO,
+            food: Amt::units(100),
+            authority: Amt::ZERO,
+        },
+    );
 
     let build_time = 6;
     let minerals_cost = Amt::units(100);
@@ -1935,28 +2130,36 @@ fn test_upgrade_completes_when_resources_finally_arrive() {
     let colony_entity = app
         .world_mut()
         .spawn((
-            Colony { planet: planet_sys, population: 10.0, growth_rate: 0.0 },
+            Colony {
+                planet: planet_sys,
+                population: 10.0,
+                growth_rate: 0.0,
+            },
             Production {
                 minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
+            BuildQueue::default(),
             // Empty slot — see test_upgrade_does_not_progress_when_stockpile_empty
             // for rationale (avoid sync_building_modifiers back-filling the
             // stockpile via production bonuses).
-            Buildings { slots: vec![None, None, None, None] },
+            Buildings {
+                slots: vec![None, None, None, None],
+            },
             BuildingQueue {
                 queue: Vec::new(),
                 demolition_queue: Vec::new(),
                 upgrade_queue: vec![UpgradeOrder {
+                    order_id: 0,
                     slot_index: 0,
                     target_id: BuildingId::new("advanced_mine"),
                     minerals_remaining: minerals_cost,
                     energy_remaining: energy_cost,
                     build_time_remaining: build_time,
                 }],
+                next_order_id: 0,
             },
             ProductionFocus::default(),
             MaintenanceCost::default(),
@@ -1967,28 +2170,45 @@ fn test_upgrade_completes_when_resources_finally_arrive() {
     // Starve for a long time — the clock must hold.
     advance_time(&mut app, 30);
     {
-        let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
-        assert_eq!(bq.upgrade_queue.len(), 1, "still pending after long starvation");
+        let bq = app
+            .world()
+            .get::<BuildingQueue>(colony_entity)
+            .expect("queue");
+        assert_eq!(
+            bq.upgrade_queue.len(),
+            1,
+            "still pending after long starvation"
+        );
         assert_eq!(bq.upgrade_queue[0].build_time_remaining, build_time);
     }
 
     // Resources finally arrive in bulk.
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
-        minerals: minerals_cost.add(Amt::units(50)),
-        energy: energy_cost.add(Amt::units(50)),
-        research: Amt::ZERO,
-        food: Amt::units(100),
-        authority: Amt::ZERO,
-    });
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
+            minerals: minerals_cost.add(Amt::units(50)),
+            energy: energy_cost.add(Amt::units(50)),
+            research: Amt::ZERO,
+            food: Amt::units(100),
+            authority: Amt::ZERO,
+        },
+    );
 
     advance_time(&mut app, build_time + 5);
 
-    let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
+    let bq = app
+        .world()
+        .get::<BuildingQueue>(colony_entity)
+        .expect("queue");
     assert!(
         bq.upgrade_queue.is_empty(),
         "upgrade should have completed after resources arrived"
     );
-    let buildings = app.world().get::<Buildings>(colony_entity).expect("buildings");
+    let buildings = app
+        .world()
+        .get::<Buildings>(colony_entity)
+        .expect("buildings");
     assert_eq!(
         buildings.slots[0],
         Some(BuildingId::new("advanced_mine")),
@@ -2013,26 +2233,34 @@ fn test_zero_cost_upgrade_progresses_on_time() {
 
     let planet_sys = find_planet(app.world_mut(), sys);
     // Stockpile is zero but so is cost — order should still complete.
-    set_system_stockpile(app.world_mut(), sys, ResourceStockpile {
-        minerals: Amt::ZERO,
-        energy: Amt::ZERO,
-        research: Amt::ZERO,
-        food: Amt::units(100),
-        authority: Amt::ZERO,
-    });
+    set_system_stockpile(
+        app.world_mut(),
+        sys,
+        ResourceStockpile {
+            minerals: Amt::ZERO,
+            energy: Amt::ZERO,
+            research: Amt::ZERO,
+            food: Amt::units(100),
+            authority: Amt::ZERO,
+        },
+    );
 
     let build_time = 4;
     let colony_entity = app
         .world_mut()
         .spawn((
-            Colony { planet: planet_sys, population: 10.0, growth_rate: 0.0 },
+            Colony {
+                planet: planet_sys,
+                population: 10.0,
+                growth_rate: 0.0,
+            },
             Production {
                 minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
+            BuildQueue::default(),
             Buildings {
                 slots: vec![Some(BuildingId::new("mine")), None, None, None],
             },
@@ -2040,12 +2268,14 @@ fn test_zero_cost_upgrade_progresses_on_time() {
                 queue: Vec::new(),
                 demolition_queue: Vec::new(),
                 upgrade_queue: vec![UpgradeOrder {
+                    order_id: 0,
                     slot_index: 0,
                     target_id: BuildingId::new("advanced_mine"),
                     minerals_remaining: Amt::ZERO,
                     energy_remaining: Amt::ZERO,
                     build_time_remaining: build_time,
                 }],
+                next_order_id: 0,
             },
             ProductionFocus::default(),
             MaintenanceCost::default(),
@@ -2055,12 +2285,18 @@ fn test_zero_cost_upgrade_progresses_on_time() {
 
     advance_time(&mut app, build_time + 2);
 
-    let bq = app.world().get::<BuildingQueue>(colony_entity).expect("queue");
+    let bq = app
+        .world()
+        .get::<BuildingQueue>(colony_entity)
+        .expect("queue");
     assert!(
         bq.upgrade_queue.is_empty(),
         "zero-cost upgrade should complete on time alone"
     );
-    let buildings = app.world().get::<Buildings>(colony_entity).expect("buildings");
+    let buildings = app
+        .world()
+        .get::<Buildings>(colony_entity)
+        .expect("buildings");
     assert_eq!(
         buildings.slots[0],
         Some(BuildingId::new("advanced_mine")),
@@ -2092,12 +2328,14 @@ fn test_system_upgrade_does_not_progress_when_stockpile_empty() {
             queue: Vec::new(),
             demolition_queue: Vec::new(),
             upgrade_queue: vec![UpgradeOrder {
+                order_id: 0,
                 slot_index: 0,
                 target_id: BuildingId::new("advanced_shipyard"),
                 minerals_remaining: Amt::units(300),
                 energy_remaining: Amt::units(120),
                 build_time_remaining: 10,
             }],
+            next_order_id: 0,
         },
         ResourceStockpile {
             minerals: Amt::ZERO,
@@ -2124,7 +2362,10 @@ fn test_system_upgrade_does_not_progress_when_stockpile_empty() {
         bq.upgrade_queue[0].build_time_remaining, 10,
         "timer must not drain while starved"
     );
-    let sb = app.world().get::<SystemBuildings>(sys).expect("system buildings");
+    let sb = app
+        .world()
+        .get::<SystemBuildings>(sys)
+        .expect("system buildings");
     assert_eq!(
         sb.slots[0],
         Some(BuildingId::new("shipyard")),
@@ -2155,6 +2396,7 @@ fn test_system_building_queue_persists_order_during_construction() {
         },
         SystemBuildingQueue {
             queue: vec![BuildingOrder {
+                order_id: 0,
                 target_slot: 0,
                 building_id: BuildingId::new("shipyard"),
                 minerals_remaining: Amt::units(300),
@@ -2163,6 +2405,7 @@ fn test_system_building_queue_persists_order_during_construction() {
             }],
             demolition_queue: Vec::new(),
             upgrade_queue: Vec::new(),
+            next_order_id: 0,
         },
         ResourceStockpile {
             // Stockpile the full cost so the timer actually ticks down.

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -1,19 +1,21 @@
-use bevy::prelude::*;
 use bevy::input::mouse::AccumulatedMouseScroll;
+use bevy::prelude::*;
 use macrocosmo::amount::Amt;
 use macrocosmo::colony::*;
-use macrocosmo::scripting::building_api::BuildingId;
-use macrocosmo::species;
 use macrocosmo::communication::{self, CommandLog};
 use macrocosmo::components::Position;
+use macrocosmo::condition::ScopedFlags;
 use macrocosmo::event_system::{EventBus, EventSystem};
 use macrocosmo::events::{EventLog, GameEvent};
-use macrocosmo::galaxy::{Anomalies, Planet, Sovereignty, StarSystem, SystemAttributes, SystemModifiers};
+use macrocosmo::galaxy::{
+    Anomalies, Planet, Sovereignty, StarSystem, SystemAttributes, SystemModifiers,
+};
 use macrocosmo::knowledge::*;
 use macrocosmo::modifier::ModifiedValue;
-use macrocosmo::condition::ScopedFlags;
 use macrocosmo::player::{Empire, Faction, PlayerEmpire};
+use macrocosmo::scripting::building_api::BuildingId;
 use macrocosmo::ship::*;
+use macrocosmo::species;
 use macrocosmo::technology::{self, TechKnowledge};
 use macrocosmo::time_system::{GameClock, GameSpeed};
 use macrocosmo::visualization;
@@ -27,8 +29,8 @@ use macrocosmo::visualization;
 /// to work. Real (Lua) buildings primarily grant job slots; see
 /// `scripts/buildings/basic.lua`.
 pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
-    use macrocosmo::scripting::building_api::{BuildingDefinition, CapabilityParams};
     use macrocosmo::modifier::ParsedModifier;
+    use macrocosmo::scripting::building_api::{BuildingDefinition, CapabilityParams};
     use std::collections::HashMap;
     let pm = |target: &str, base_add: f64| ParsedModifier {
         target: target.to_string(),
@@ -38,82 +40,140 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
     };
     let mut registry = macrocosmo::colony::BuildingRegistry::default();
     registry.insert(BuildingDefinition {
-        id: "mine".into(), name: "Mine".into(), description: String::new(),
-        minerals_cost: Amt::units(150), energy_cost: Amt::units(50), build_time: 10,
+        id: "mine".into(),
+        name: "Mine".into(),
+        description: String::new(),
+        minerals_cost: Amt::units(150),
+        energy_cost: Amt::units(50),
+        build_time: 10,
         maintenance: Amt::new(0, 200),
-        production_bonus_minerals: Amt::ZERO, production_bonus_energy: Amt::ZERO,
-        production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
+        production_bonus_minerals: Amt::ZERO,
+        production_bonus_energy: Amt::ZERO,
+        production_bonus_research: Amt::ZERO,
+        production_bonus_food: Amt::ZERO,
         modifiers: vec![pm("colony.minerals_per_hexadies", 3.0)],
-        is_system_building: false, capabilities: HashMap::new(),
-        upgrade_to: Vec::new(), is_direct_buildable: true,
+        is_system_building: false,
+        capabilities: HashMap::new(),
+        upgrade_to: Vec::new(),
+        is_direct_buildable: true,
         prerequisites: None,
     });
     registry.insert(BuildingDefinition {
-        id: "power_plant".into(), name: "PowerPlant".into(), description: String::new(),
-        minerals_cost: Amt::units(50), energy_cost: Amt::units(150), build_time: 10,
+        id: "power_plant".into(),
+        name: "PowerPlant".into(),
+        description: String::new(),
+        minerals_cost: Amt::units(50),
+        energy_cost: Amt::units(150),
+        build_time: 10,
         maintenance: Amt::ZERO,
-        production_bonus_minerals: Amt::ZERO, production_bonus_energy: Amt::ZERO,
-        production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
+        production_bonus_minerals: Amt::ZERO,
+        production_bonus_energy: Amt::ZERO,
+        production_bonus_research: Amt::ZERO,
+        production_bonus_food: Amt::ZERO,
         modifiers: vec![pm("colony.energy_per_hexadies", 3.0)],
-        is_system_building: false, capabilities: HashMap::new(),
-        upgrade_to: Vec::new(), is_direct_buildable: true,
+        is_system_building: false,
+        capabilities: HashMap::new(),
+        upgrade_to: Vec::new(),
+        is_direct_buildable: true,
         prerequisites: None,
     });
     registry.insert(BuildingDefinition {
-        id: "research_lab".into(), name: "ResearchLab".into(), description: String::new(),
-        minerals_cost: Amt::units(100), energy_cost: Amt::units(100), build_time: 15,
+        id: "research_lab".into(),
+        name: "ResearchLab".into(),
+        description: String::new(),
+        minerals_cost: Amt::units(100),
+        energy_cost: Amt::units(100),
+        build_time: 15,
         maintenance: Amt::new(0, 500),
-        production_bonus_minerals: Amt::ZERO, production_bonus_energy: Amt::ZERO,
-        production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
+        production_bonus_minerals: Amt::ZERO,
+        production_bonus_energy: Amt::ZERO,
+        production_bonus_research: Amt::ZERO,
+        production_bonus_food: Amt::ZERO,
         modifiers: vec![pm("colony.research_per_hexadies", 2.0)],
-        is_system_building: true, capabilities: HashMap::new(),
-        upgrade_to: Vec::new(), is_direct_buildable: true,
+        is_system_building: true,
+        capabilities: HashMap::new(),
+        upgrade_to: Vec::new(),
+        is_direct_buildable: true,
         prerequisites: None,
     });
     let mut shipyard_caps = HashMap::new();
-    shipyard_caps.insert("shipyard".to_string(), CapabilityParams {
-        params: { let mut m = HashMap::new(); m.insert("concurrent_builds".to_string(), 1.0); m },
-    });
+    shipyard_caps.insert(
+        "shipyard".to_string(),
+        CapabilityParams {
+            params: {
+                let mut m = HashMap::new();
+                m.insert("concurrent_builds".to_string(), 1.0);
+                m
+            },
+        },
+    );
     registry.insert(BuildingDefinition {
-        id: "shipyard".into(), name: "Shipyard".into(), description: String::new(),
-        minerals_cost: Amt::units(300), energy_cost: Amt::units(200), build_time: 30,
+        id: "shipyard".into(),
+        name: "Shipyard".into(),
+        description: String::new(),
+        minerals_cost: Amt::units(300),
+        energy_cost: Amt::units(200),
+        build_time: 30,
         maintenance: Amt::units(1),
-        production_bonus_minerals: Amt::ZERO, production_bonus_energy: Amt::ZERO,
-        production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
+        production_bonus_minerals: Amt::ZERO,
+        production_bonus_energy: Amt::ZERO,
+        production_bonus_research: Amt::ZERO,
+        production_bonus_food: Amt::ZERO,
         modifiers: Vec::new(),
-        is_system_building: true, capabilities: shipyard_caps,
-        upgrade_to: Vec::new(), is_direct_buildable: true,
+        is_system_building: true,
+        capabilities: shipyard_caps,
+        upgrade_to: Vec::new(),
+        is_direct_buildable: true,
         prerequisites: None,
     });
     let mut port_caps = HashMap::new();
-    port_caps.insert("port".to_string(), CapabilityParams {
-        params: {
-            let mut m = HashMap::new();
-            m.insert("ftl_range_bonus".to_string(), 10.0);
-            m.insert("travel_time_factor".to_string(), 0.8);
-            m
+    port_caps.insert(
+        "port".to_string(),
+        CapabilityParams {
+            params: {
+                let mut m = HashMap::new();
+                m.insert("ftl_range_bonus".to_string(), 10.0);
+                m.insert("travel_time_factor".to_string(), 0.8);
+                m
+            },
         },
-    });
+    );
     registry.insert(BuildingDefinition {
-        id: "port".into(), name: "Port".into(), description: String::new(),
-        minerals_cost: Amt::units(400), energy_cost: Amt::units(300), build_time: 40,
+        id: "port".into(),
+        name: "Port".into(),
+        description: String::new(),
+        minerals_cost: Amt::units(400),
+        energy_cost: Amt::units(300),
+        build_time: 40,
         maintenance: Amt::new(0, 500),
-        production_bonus_minerals: Amt::ZERO, production_bonus_energy: Amt::ZERO,
-        production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
+        production_bonus_minerals: Amt::ZERO,
+        production_bonus_energy: Amt::ZERO,
+        production_bonus_research: Amt::ZERO,
+        production_bonus_food: Amt::ZERO,
         modifiers: Vec::new(),
-        is_system_building: true, capabilities: port_caps,
-        upgrade_to: Vec::new(), is_direct_buildable: true,
+        is_system_building: true,
+        capabilities: port_caps,
+        upgrade_to: Vec::new(),
+        is_direct_buildable: true,
         prerequisites: None,
     });
     registry.insert(BuildingDefinition {
-        id: "farm".into(), name: "Farm".into(), description: String::new(),
-        minerals_cost: Amt::units(100), energy_cost: Amt::units(50), build_time: 20,
+        id: "farm".into(),
+        name: "Farm".into(),
+        description: String::new(),
+        minerals_cost: Amt::units(100),
+        energy_cost: Amt::units(50),
+        build_time: 20,
         maintenance: Amt::new(0, 300),
-        production_bonus_minerals: Amt::ZERO, production_bonus_energy: Amt::ZERO,
-        production_bonus_research: Amt::ZERO, production_bonus_food: Amt::ZERO,
+        production_bonus_minerals: Amt::ZERO,
+        production_bonus_energy: Amt::ZERO,
+        production_bonus_research: Amt::ZERO,
+        production_bonus_food: Amt::ZERO,
         modifiers: vec![pm("colony.food_per_hexadies", 5.0)],
-        is_system_building: false, capabilities: HashMap::new(),
-        upgrade_to: Vec::new(), is_direct_buildable: true,
+        is_system_building: false,
+        capabilities: HashMap::new(),
+        upgrade_to: Vec::new(),
+        is_direct_buildable: true,
         prerequisites: None,
     });
     registry
@@ -161,7 +221,9 @@ pub fn spawn_test_empire(world: &mut World) -> Entity {
 ///
 /// Returns `(space_creature_faction, ancient_defense_faction)` entities.
 pub fn setup_test_hostile_factions(world: &mut World) -> (Entity, Entity) {
-    use macrocosmo::faction::{FactionOwner, FactionRelations, FactionView, HostileFactions, RelationState};
+    use macrocosmo::faction::{
+        FactionOwner, FactionRelations, FactionView, HostileFactions, RelationState,
+    };
     use macrocosmo::galaxy::{HostilePresence, HostileType};
 
     // Find or create the player empire.
@@ -198,10 +260,26 @@ pub fn setup_test_hostile_factions(world: &mut World) -> (Entity, Entity) {
     // Seed default hostile relations: Neutral + -100 standing both directions.
     {
         let mut rel = world.resource_mut::<FactionRelations>();
-        rel.set(empire, space_creature, FactionView::new(RelationState::Neutral, -100.0));
-        rel.set(space_creature, empire, FactionView::new(RelationState::Neutral, -100.0));
-        rel.set(empire, ancient_defense, FactionView::new(RelationState::Neutral, -100.0));
-        rel.set(ancient_defense, empire, FactionView::new(RelationState::Neutral, -100.0));
+        rel.set(
+            empire,
+            space_creature,
+            FactionView::new(RelationState::Neutral, -100.0),
+        );
+        rel.set(
+            space_creature,
+            empire,
+            FactionView::new(RelationState::Neutral, -100.0),
+        );
+        rel.set(
+            empire,
+            ancient_defense,
+            FactionView::new(RelationState::Neutral, -100.0),
+        );
+        rel.set(
+            ancient_defense,
+            empire,
+            FactionView::new(RelationState::Neutral, -100.0),
+        );
     }
 
     // Attach FactionOwner to every existing HostilePresence based on hostile_type.
@@ -542,7 +620,10 @@ pub fn full_test_app() -> App {
         )
             .chain(),
     );
-    app.add_systems(Update, (update_sovereignty, apply_pending_colonization_orders));
+    app.add_systems(
+        Update,
+        (update_sovereignty, apply_pending_colonization_orders),
+    );
 
     // --- Knowledge system (from KnowledgePlugin) ---
     app.add_systems(Update, propagate_knowledge);
@@ -592,8 +673,7 @@ pub fn full_test_app() -> App {
     // it will early-return. Registered here for query-conflict detection.
     app.add_systems(
         Update,
-        technology::apply_tech_effects
-            .after(technology::tick_research),
+        technology::apply_tech_effects.after(technology::tick_research),
     );
     app.add_systems(
         Update,
@@ -613,10 +693,7 @@ pub fn full_test_app() -> App {
             macrocosmo::events::auto_pause_on_event,
         ),
     );
-    app.add_systems(
-        Update,
-        macrocosmo::event_system::tick_events,
-    );
+    app.add_systems(Update, macrocosmo::event_system::tick_events);
 
     // --- Time systems (from GameTimePlugin) ---
     app.add_systems(
@@ -632,12 +709,7 @@ pub fn full_test_app() -> App {
     app.add_systems(Update, macrocosmo::player::update_player_location);
 
     // --- Visualization systems (excluding Gizmos-dependent ones) ---
-    app.add_systems(
-        Update,
-        (
-            visualization::camera_controls,
-        ),
-    );
+    app.add_systems(Update, (visualization::camera_controls,));
 
     // --- Faction systems (#171) ---
     app.add_systems(Update, macrocosmo::faction::tick_diplomatic_actions);
@@ -659,12 +731,10 @@ pub fn full_test_app() -> App {
 /// directly instead of using `advance_time`.
 pub fn advance_time(app: &mut App, hexadies: i64) {
     let needs_migration = {
-        let mut q = app
-            .world_mut()
-            .query_filtered::<Entity, (
-                With<macrocosmo::galaxy::HostilePresence>,
-                Without<macrocosmo::faction::FactionOwner>,
-            )>();
+        let mut q = app.world_mut().query_filtered::<Entity, (
+            With<macrocosmo::galaxy::HostilePresence>,
+            Without<macrocosmo::faction::FactionOwner>,
+        )>();
         q.iter(app.world()).next().is_some()
     };
     if needs_migration {
@@ -761,7 +831,8 @@ pub fn spawn_test_colony(
 
     // Separate buildings into planet and system buildings
     let mut planet_buildings = Vec::new();
-    let mut system_building_slots: Vec<Option<BuildingId>> = vec![None; DEFAULT_SYSTEM_BUILDING_SLOTS];
+    let mut system_building_slots: Vec<Option<BuildingId>> =
+        vec![None; DEFAULT_SYSTEM_BUILDING_SLOTS];
     let mut sys_slot_idx = 0;
     for b in &buildings {
         if let Some(bid) = b {
@@ -795,7 +866,9 @@ pub fn spawn_test_colony(
     // Add SystemBuildings and SystemBuildingQueue to the StarSystem if not already present
     if world.get::<SystemBuildings>(system).is_none() {
         world.entity_mut(system).insert((
-            SystemBuildings { slots: system_building_slots },
+            SystemBuildings {
+                slots: system_building_slots,
+            },
             SystemBuildingQueue::default(),
         ));
     }
@@ -813,10 +886,10 @@ pub fn spawn_test_colony(
                 research_per_hexadies: ModifiedValue::new(Amt::units(1)),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue {
-                queue: Vec::new(),
+            BuildQueue::default(),
+            Buildings {
+                slots: planet_buildings,
             },
-            Buildings { slots: planet_buildings },
             BuildingQueue::default(),
             ProductionFocus::default(),
             MaintenanceCost::default(),
@@ -845,7 +918,9 @@ pub fn find_planet(world: &mut World, system: Entity) -> Entity {
 /// Find the player empire entity in the world.
 pub fn empire_entity(world: &mut World) -> Entity {
     let mut query = world.query_filtered::<Entity, With<PlayerEmpire>>();
-    query.single(world).expect("No player empire found in test world")
+    query
+        .single(world)
+        .expect("No player empire found in test world")
 }
 
 /// #236: Test fixture builders for hull + module registries that mirror the
@@ -854,44 +929,119 @@ pub fn empire_entity(world: &mut World) -> Entity {
 pub fn create_test_hull_registry() -> macrocosmo::ship_design::HullRegistry {
     use macrocosmo::ship_design::{HullDefinition, HullRegistry, HullSlot, ModuleModifier};
     let mut hulls = HullRegistry::default();
-    let slot = |t: &str, c: u32| HullSlot { slot_type: t.to_string(), count: c };
+    let slot = |t: &str, c: u32| HullSlot {
+        slot_type: t.to_string(),
+        count: c,
+    };
     hulls.insert(HullDefinition {
-        id: "corvette".into(), name: "Corvette".into(), description: String::new(),
-        base_hp: 50.0, base_speed: 0.75, base_evasion: 30.0,
-        slots: vec![slot("ftl", 1), slot("sublight", 1), slot("weapon", 2), slot("defense", 1), slot("utility", 1), slot("power", 1)],
-        build_cost_minerals: Amt::units(200), build_cost_energy: Amt::units(100),
-        build_time: 60, maintenance: Amt::new(0, 500),
-        modifiers: vec![], prerequisites: None,
+        id: "corvette".into(),
+        name: "Corvette".into(),
+        description: String::new(),
+        base_hp: 50.0,
+        base_speed: 0.75,
+        base_evasion: 30.0,
+        slots: vec![
+            slot("ftl", 1),
+            slot("sublight", 1),
+            slot("weapon", 2),
+            slot("defense", 1),
+            slot("utility", 1),
+            slot("power", 1),
+        ],
+        build_cost_minerals: Amt::units(200),
+        build_cost_energy: Amt::units(100),
+        build_time: 60,
+        maintenance: Amt::new(0, 500),
+        modifiers: vec![],
+        prerequisites: None,
     });
     hulls.insert(HullDefinition {
-        id: "frigate".into(), name: "Frigate".into(), description: String::new(),
-        base_hp: 120.0, base_speed: 0.5, base_evasion: 15.0,
-        slots: vec![slot("ftl", 1), slot("sublight", 1), slot("weapon", 3), slot("defense", 2), slot("utility", 2), slot("power", 1), slot("command", 1)],
-        build_cost_minerals: Amt::units(400), build_cost_energy: Amt::units(200),
-        build_time: 120, maintenance: Amt::units(1),
-        modifiers: vec![], prerequisites: None,
+        id: "frigate".into(),
+        name: "Frigate".into(),
+        description: String::new(),
+        base_hp: 120.0,
+        base_speed: 0.5,
+        base_evasion: 15.0,
+        slots: vec![
+            slot("ftl", 1),
+            slot("sublight", 1),
+            slot("weapon", 3),
+            slot("defense", 2),
+            slot("utility", 2),
+            slot("power", 1),
+            slot("command", 1),
+        ],
+        build_cost_minerals: Amt::units(400),
+        build_cost_energy: Amt::units(200),
+        build_time: 120,
+        maintenance: Amt::units(1),
+        modifiers: vec![],
+        prerequisites: None,
     });
     hulls.insert(HullDefinition {
-        id: "scout_hull".into(), name: "Scout Hull".into(), description: String::new(),
-        base_hp: 40.0, base_speed: 0.85, base_evasion: 35.0,
-        slots: vec![slot("ftl", 1), slot("sublight", 1), slot("utility", 2), slot("weapon", 1), slot("power", 1)],
-        build_cost_minerals: Amt::units(150), build_cost_energy: Amt::units(80),
-        build_time: 45, maintenance: Amt::new(0, 400),
+        id: "scout_hull".into(),
+        name: "Scout Hull".into(),
+        description: String::new(),
+        base_hp: 40.0,
+        base_speed: 0.85,
+        base_evasion: 35.0,
+        slots: vec![
+            slot("ftl", 1),
+            slot("sublight", 1),
+            slot("utility", 2),
+            slot("weapon", 1),
+            slot("power", 1),
+        ],
+        build_cost_minerals: Amt::units(150),
+        build_cost_energy: Amt::units(80),
+        build_time: 45,
+        maintenance: Amt::new(0, 400),
         modifiers: vec![
-            ModuleModifier { target: "ship.survey_speed".into(), base_add: 0.0, multiplier: 1.3, add: 0.0 },
-            ModuleModifier { target: "ship.speed".into(), base_add: 0.0, multiplier: 1.15, add: 0.0 },
+            ModuleModifier {
+                target: "ship.survey_speed".into(),
+                base_add: 0.0,
+                multiplier: 1.3,
+                add: 0.0,
+            },
+            ModuleModifier {
+                target: "ship.speed".into(),
+                base_add: 0.0,
+                multiplier: 1.15,
+                add: 0.0,
+            },
         ],
         prerequisites: None,
     });
     hulls.insert(HullDefinition {
-        id: "courier_hull".into(), name: "Courier Hull".into(), description: String::new(),
-        base_hp: 35.0, base_speed: 0.80, base_evasion: 25.0,
-        slots: vec![slot("ftl", 1), slot("sublight", 1), slot("utility", 2), slot("power", 1)],
-        build_cost_minerals: Amt::units(100), build_cost_energy: Amt::units(50),
-        build_time: 30, maintenance: Amt::new(0, 300),
+        id: "courier_hull".into(),
+        name: "Courier Hull".into(),
+        description: String::new(),
+        base_hp: 35.0,
+        base_speed: 0.80,
+        base_evasion: 25.0,
+        slots: vec![
+            slot("ftl", 1),
+            slot("sublight", 1),
+            slot("utility", 2),
+            slot("power", 1),
+        ],
+        build_cost_minerals: Amt::units(100),
+        build_cost_energy: Amt::units(50),
+        build_time: 30,
+        maintenance: Amt::new(0, 300),
         modifiers: vec![
-            ModuleModifier { target: "ship.cargo_capacity".into(), base_add: 0.0, multiplier: 1.5, add: 0.0 },
-            ModuleModifier { target: "ship.ftl_range".into(), base_add: 0.0, multiplier: 1.2, add: 0.0 },
+            ModuleModifier {
+                target: "ship.cargo_capacity".into(),
+                base_add: 0.0,
+                multiplier: 1.5,
+                add: 0.0,
+            },
+            ModuleModifier {
+                target: "ship.ftl_range".into(),
+                base_add: 0.0,
+                multiplier: 1.2,
+                add: 0.0,
+            },
         ],
         prerequisites: None,
     });
@@ -899,42 +1049,92 @@ pub fn create_test_hull_registry() -> macrocosmo::ship_design::HullRegistry {
 }
 
 pub fn create_test_module_registry() -> macrocosmo::ship_design::ModuleRegistry {
-    use macrocosmo::ship_design::{ModuleDefinition, ModuleRegistry, ModuleModifier};
+    use macrocosmo::ship_design::{ModuleDefinition, ModuleModifier, ModuleRegistry};
     let mut modules = ModuleRegistry::default();
     modules.insert(ModuleDefinition {
-        id: "ftl_drive".into(), name: "FTL Drive".into(), description: String::new(),
+        id: "ftl_drive".into(),
+        name: "FTL Drive".into(),
+        description: String::new(),
         slot_type: "ftl".into(),
-        modifiers: vec![ModuleModifier { target: "ship.ftl_range".into(), base_add: 15.0, multiplier: 0.0, add: 0.0 }],
-        weapon: None, cost_minerals: Amt::units(100), cost_energy: Amt::units(50),
-        prerequisites: None, upgrade_to: Vec::new(),
+        modifiers: vec![ModuleModifier {
+            target: "ship.ftl_range".into(),
+            base_add: 15.0,
+            multiplier: 0.0,
+            add: 0.0,
+        }],
+        weapon: None,
+        cost_minerals: Amt::units(100),
+        cost_energy: Amt::units(50),
+        prerequisites: None,
+        upgrade_to: Vec::new(),
     });
     modules.insert(ModuleDefinition {
-        id: "afterburner".into(), name: "Afterburner".into(), description: String::new(),
+        id: "afterburner".into(),
+        name: "Afterburner".into(),
+        description: String::new(),
         slot_type: "sublight".into(),
-        modifiers: vec![ModuleModifier { target: "ship.speed".into(), base_add: 0.0, multiplier: 0.2, add: 0.0 }],
-        weapon: None, cost_minerals: Amt::units(60), cost_energy: Amt::units(40),
-        prerequisites: None, upgrade_to: Vec::new(),
+        modifiers: vec![ModuleModifier {
+            target: "ship.speed".into(),
+            base_add: 0.0,
+            multiplier: 0.2,
+            add: 0.0,
+        }],
+        weapon: None,
+        cost_minerals: Amt::units(60),
+        cost_energy: Amt::units(40),
+        prerequisites: None,
+        upgrade_to: Vec::new(),
     });
     modules.insert(ModuleDefinition {
-        id: "survey_equipment".into(), name: "Survey Equipment".into(), description: String::new(),
+        id: "survey_equipment".into(),
+        name: "Survey Equipment".into(),
+        description: String::new(),
         slot_type: "utility".into(),
-        modifiers: vec![ModuleModifier { target: "ship.survey_speed".into(), base_add: 1.0, multiplier: 0.0, add: 0.0 }],
-        weapon: None, cost_minerals: Amt::units(60), cost_energy: Amt::units(40),
-        prerequisites: None, upgrade_to: Vec::new(),
+        modifiers: vec![ModuleModifier {
+            target: "ship.survey_speed".into(),
+            base_add: 1.0,
+            multiplier: 0.0,
+            add: 0.0,
+        }],
+        weapon: None,
+        cost_minerals: Amt::units(60),
+        cost_energy: Amt::units(40),
+        prerequisites: None,
+        upgrade_to: Vec::new(),
     });
     modules.insert(ModuleDefinition {
-        id: "colony_module".into(), name: "Colony Module".into(), description: String::new(),
+        id: "colony_module".into(),
+        name: "Colony Module".into(),
+        description: String::new(),
         slot_type: "utility".into(),
-        modifiers: vec![ModuleModifier { target: "ship.colonize_speed".into(), base_add: 1.0, multiplier: 0.0, add: 0.0 }],
-        weapon: None, cost_minerals: Amt::units(300), cost_energy: Amt::units(200),
-        prerequisites: None, upgrade_to: Vec::new(),
+        modifiers: vec![ModuleModifier {
+            target: "ship.colonize_speed".into(),
+            base_add: 1.0,
+            multiplier: 0.0,
+            add: 0.0,
+        }],
+        weapon: None,
+        cost_minerals: Amt::units(300),
+        cost_energy: Amt::units(200),
+        prerequisites: None,
+        upgrade_to: Vec::new(),
     });
     modules.insert(ModuleDefinition {
-        id: "cargo_bay".into(), name: "Cargo Bay".into(), description: String::new(),
+        id: "cargo_bay".into(),
+        name: "Cargo Bay".into(),
+        description: String::new(),
         slot_type: "utility".into(),
-        modifiers: vec![ModuleModifier { target: "ship.cargo_capacity".into(), base_add: 500.0, multiplier: 0.0, add: 0.0 }],
-        weapon: None, cost_minerals: Amt::units(30), cost_energy: Amt::ZERO,
-        prerequisites: None, upgrade_to: Vec::new(),
+        modifiers: vec![ModuleModifier {
+            target: "ship.cargo_capacity".into(),
+            base_add: 500.0,
+            multiplier: 0.0,
+            add: 0.0,
+        }],
+        weapon: None,
+        cost_minerals: Amt::units(30),
+        cost_energy: Amt::ZERO,
+        prerequisites: None,
+        upgrade_to: Vec::new(),
     });
     modules
 }
@@ -952,7 +1152,10 @@ fn build_derived_design(
     use macrocosmo::ship_design::{DesignSlotAssignment, ShipDesignDefinition};
     let assignments: Vec<DesignSlotAssignment> = module_assignments
         .iter()
-        .map(|(s, m)| DesignSlotAssignment { slot_type: s.to_string(), module_id: m.to_string() })
+        .map(|(s, m)| DesignSlotAssignment {
+            slot_type: s.to_string(),
+            module_id: m.to_string(),
+        })
         .collect();
     let mut def = ShipDesignDefinition {
         id: id.into(),
@@ -960,10 +1163,15 @@ fn build_derived_design(
         description: String::new(),
         hull_id: hull_id.into(),
         modules: assignments,
-        can_survey: false, can_colonize: false,
+        can_survey: false,
+        can_colonize: false,
         maintenance: Amt::ZERO,
-        build_cost_minerals: Amt::ZERO, build_cost_energy: Amt::ZERO,
-        build_time: 0, hp: 0.0, sublight_speed: 0.0, ftl_range: 0.0,
+        build_cost_minerals: Amt::ZERO,
+        build_cost_energy: Amt::ZERO,
+        build_time: 0,
+        hp: 0.0,
+        sublight_speed: 0.0,
+        ftl_range: 0.0,
         revision: 0,
     };
     macrocosmo::ship_design::apply_derived_to_definition(&mut def, hulls, modules);
@@ -980,24 +1188,40 @@ pub fn create_test_design_registry() -> macrocosmo::ship_design::ShipDesignRegis
     let mut registry = ShipDesignRegistry::default();
 
     registry.insert(build_derived_design(
-        "explorer_mk1", "Explorer Mk.I", "corvette",
+        "explorer_mk1",
+        "Explorer Mk.I",
+        "corvette",
         &[("ftl", "ftl_drive"), ("utility", "survey_equipment")],
-        &hulls, &modules,
+        &hulls,
+        &modules,
     ));
     registry.insert(build_derived_design(
-        "colony_ship_mk1", "Colony Ship Mk.I", "frigate",
+        "colony_ship_mk1",
+        "Colony Ship Mk.I",
+        "frigate",
         &[("ftl", "ftl_drive"), ("utility", "colony_module")],
-        &hulls, &modules,
+        &hulls,
+        &modules,
     ));
     registry.insert(build_derived_design(
-        "courier_mk1", "Courier Mk.I", "courier_hull",
-        &[("ftl", "ftl_drive"), ("sublight", "afterburner"), ("utility", "cargo_bay")],
-        &hulls, &modules,
+        "courier_mk1",
+        "Courier Mk.I",
+        "courier_hull",
+        &[
+            ("ftl", "ftl_drive"),
+            ("sublight", "afterburner"),
+            ("utility", "cargo_bay"),
+        ],
+        &hulls,
+        &modules,
     ));
     registry.insert(build_derived_design(
-        "scout_mk1", "Scout Mk.I", "scout_hull",
+        "scout_mk1",
+        "Scout Mk.I",
+        "scout_hull",
         &[("ftl", "ftl_drive"), ("utility", "survey_equipment")],
-        &hulls, &modules,
+        &hulls,
+        &modules,
     ));
     registry
 }
@@ -1011,7 +1235,9 @@ pub fn spawn_test_ship(
     pos: [f64; 3],
 ) -> Entity {
     let design_registry = create_test_design_registry();
-    let design = design_registry.get(design_id).expect(&format!("unknown test design: {}", design_id));
+    let design = design_registry
+        .get(design_id)
+        .expect(&format!("unknown test design: {}", design_id));
     let hull_hp = design.hp;
     world
         .spawn((

--- a/macrocosmo/tests/events.rs
+++ b/macrocosmo/tests/events.rs
@@ -3,13 +3,16 @@ mod common;
 use bevy::prelude::*;
 use macrocosmo::amount::{Amt, SignedAmt};
 use macrocosmo::colony::*;
-use macrocosmo::modifier::ModifiedValue;
 use macrocosmo::event_system::{EventDefinition, EventSystem, EventTrigger};
 use macrocosmo::events::{EventLog, GameEventKind};
+use macrocosmo::modifier::ModifiedValue;
 
 use macrocosmo::modifier::Modifier;
 
-use common::{advance_time, find_planet, spawn_test_colony, spawn_test_system, test_app, test_app_with_event_log};
+use common::{
+    advance_time, find_planet, spawn_test_colony, spawn_test_system, test_app,
+    test_app_with_event_log,
+};
 
 #[test]
 fn test_expired_modifier_has_on_expire_event() {
@@ -25,13 +28,7 @@ fn test_expired_modifier_has_on_expire_event() {
         true,
     );
 
-    let colony_id = spawn_test_colony(
-        app.world_mut(),
-        sys,
-        Amt::ZERO,
-        Amt::ZERO,
-        vec![],
-    );
+    let colony_id = spawn_test_colony(app.world_mut(), sys, Amt::ZERO, Amt::ZERO, vec![]);
 
     // Push a modifier with duration=5 and on_expire_event="test_event"
     {
@@ -137,8 +134,8 @@ fn test_periodic_event_fires() {
 
 #[test]
 fn test_tick_timed_effects_cleans_all_components() {
-    use macrocosmo::modifier::Modifier;
     use macrocosmo::amount::SignedAmt;
+    use macrocosmo::modifier::Modifier;
 
     let mut app = test_app();
 
@@ -218,7 +215,11 @@ fn test_tick_timed_effects_cleans_all_components() {
     // Verify Production modifier removed
     let prod = app.world().get::<Production>(colony).unwrap();
     assert_eq!(
-        prod.minerals_per_hexadies.modifiers().iter().filter(|m| m.id == "timed_prod").count(),
+        prod.minerals_per_hexadies
+            .modifiers()
+            .iter()
+            .filter(|m| m.id == "timed_prod")
+            .count(),
         0,
         "Production timed modifier should have been removed"
     );
@@ -226,7 +227,12 @@ fn test_tick_timed_effects_cleans_all_components() {
     // Verify MaintenanceCost modifier removed
     let maint = app.world().get::<MaintenanceCost>(colony).unwrap();
     assert_eq!(
-        maint.energy_per_hexadies.modifiers().iter().filter(|m| m.id == "timed_maint").count(),
+        maint
+            .energy_per_hexadies
+            .modifiers()
+            .iter()
+            .filter(|m| m.id == "timed_maint")
+            .count(),
         0,
         "MaintenanceCost timed modifier should have been removed"
     );
@@ -234,7 +240,11 @@ fn test_tick_timed_effects_cleans_all_components() {
     // Verify FoodConsumption modifier removed
     let fc = app.world().get::<FoodConsumption>(colony).unwrap();
     assert_eq!(
-        fc.food_per_hexadies.modifiers().iter().filter(|m| m.id == "timed_food").count(),
+        fc.food_per_hexadies
+            .modifiers()
+            .iter()
+            .filter(|m| m.id == "timed_food")
+            .count(),
         0,
         "FoodConsumption timed modifier should have been removed"
     );
@@ -244,9 +254,9 @@ fn test_tick_timed_effects_cleans_all_components() {
 
 #[test]
 fn test_on_expire_event_fires_named_event() {
+    use macrocosmo::amount::SignedAmt;
     use macrocosmo::event_system::{EventDefinition, EventSystem, EventTrigger};
     use macrocosmo::modifier::Modifier;
-    use macrocosmo::amount::SignedAmt;
 
     let mut app = test_app();
 
@@ -329,89 +339,120 @@ fn test_food_depletion_alert() {
 
     // Colony with food = 0
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::units(500),
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
-    let _colony = app.world_mut().spawn((
-        Colony { planet: planet_sys, population: 100.0, growth_rate: 0.01 },
-        Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![] },
-        BuildingQueue::default(),
-        ProductionFocus::default(),
-        MaintenanceCost::default(),
-        FoodConsumption::default(),
-    )).id();
+        ResourceCapacity::default(),
+    ));
+    let _colony = app
+        .world_mut()
+        .spawn((
+            Colony {
+                planet: planet_sys,
+                population: 100.0,
+                growth_rate: 0.01,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                research_per_hexadies: ModifiedValue::new(Amt::units(1)),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue::default(),
+            Buildings { slots: vec![] },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
 
     advance_time(&mut app, 1);
     app.update();
 
     let log = app.world().resource::<EventLog>();
-    let alerts: Vec<_> = log.entries.iter()
+    let alerts: Vec<_> = log
+        .entries
+        .iter()
         .filter(|e| e.kind == GameEventKind::ResourceAlert)
         .collect();
     assert!(!alerts.is_empty(), "Expected a food depletion alert");
-    assert!(alerts[0].description.contains("Starvation"), "Alert should mention starvation");
+    assert!(
+        alerts[0].description.contains("Starvation"),
+        "Alert should mention starvation"
+    );
     assert!(alerts[0].related_system == Some(sys));
 }
 
 #[test]
 fn test_energy_depletion_alert() {
     let mut app = test_app_with_event_log();
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "NoPower",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "NoPower", [0.0, 0.0, 0.0], 1.0, true, true);
 
     // Colony with energy = 0
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
-    let _colony = app.world_mut().spawn((
-        Colony { planet: planet_sys, population: 100.0, growth_rate: 0.01 },
-        Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
-            research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![] },
-        BuildingQueue::default(),
-        ProductionFocus::default(),
-        MaintenanceCost::default(),
-        FoodConsumption::default(),
-    )).id();
+        ResourceCapacity::default(),
+    ));
+    let _colony = app
+        .world_mut()
+        .spawn((
+            Colony {
+                planet: planet_sys,
+                population: 100.0,
+                growth_rate: 0.01,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::units(1)),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue::default(),
+            Buildings { slots: vec![] },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
 
     advance_time(&mut app, 1);
     // Second update so collect_events picks up messages from previous frame
     app.update();
 
     let log = app.world().resource::<EventLog>();
-    let alerts: Vec<_> = log.entries.iter()
+    let alerts: Vec<_> = log
+        .entries
+        .iter()
         .filter(|e| e.kind == GameEventKind::ResourceAlert)
         .collect();
-    assert!(!alerts.is_empty(), "Expected an energy depletion alert, got: {:?}", alerts.iter().map(|a| &a.description).collect::<Vec<_>>());
-    let energy_alerts: Vec<_> = alerts.iter().filter(|a| a.description.contains("Energy depleted")).collect();
-    assert!(!energy_alerts.is_empty(), "Alert should mention energy depletion, got: {:?}", alerts.iter().map(|a| &a.description).collect::<Vec<_>>());
+    assert!(
+        !alerts.is_empty(),
+        "Expected an energy depletion alert, got: {:?}",
+        alerts.iter().map(|a| &a.description).collect::<Vec<_>>()
+    );
+    let energy_alerts: Vec<_> = alerts
+        .iter()
+        .filter(|a| a.description.contains("Energy depleted"))
+        .collect();
+    assert!(
+        !energy_alerts.is_empty(),
+        "Alert should mention energy depletion, got: {:?}",
+        alerts.iter().map(|a| &a.description).collect::<Vec<_>>()
+    );
     assert!(energy_alerts[0].related_system == Some(sys));
 }
 
@@ -428,41 +469,62 @@ fn test_alert_cooldown() {
     );
     // Colony with food = 0 and no food production
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::units(500),
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
-    let _colony = app.world_mut().spawn((
-        Colony { planet: planet_sys, population: 100.0, growth_rate: 0.01 },
-        Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![] },
-        BuildingQueue::default(),
-        ProductionFocus::default(),
-        MaintenanceCost::default(),
-        FoodConsumption::default(),
-    )).id();
+        ResourceCapacity::default(),
+    ));
+    let _colony = app
+        .world_mut()
+        .spawn((
+            Colony {
+                planet: planet_sys,
+                population: 100.0,
+                growth_rate: 0.01,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                research_per_hexadies: ModifiedValue::new(Amt::units(1)),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue::default(),
+            Buildings { slots: vec![] },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+        ))
+        .id();
 
     // First tick: alert fires
     advance_time(&mut app, 1);
     app.update(); // collect messages
-    let count_1 = app.world().resource::<EventLog>().entries.iter()
+    let count_1 = app
+        .world()
+        .resource::<EventLog>()
+        .entries
+        .iter()
         .filter(|e| e.kind == GameEventKind::ResourceAlert)
         .count();
-    assert_eq!(count_1, 1, "First tick should produce exactly one food alert");
+    assert_eq!(
+        count_1, 1,
+        "First tick should produce exactly one food alert"
+    );
 
     // Advance less than 30 hexadies: no duplicate
     advance_time(&mut app, 10);
     app.update(); // collect messages
-    let count_2 = app.world().resource::<EventLog>().entries.iter()
+    let count_2 = app
+        .world()
+        .resource::<EventLog>()
+        .entries
+        .iter()
         .filter(|e| e.kind == GameEventKind::ResourceAlert)
         .count();
     assert_eq!(count_2, 1, "Alert should not repeat within cooldown period");
@@ -470,8 +532,15 @@ fn test_alert_cooldown() {
     // Advance past 30 hexadies total from first alert: alert fires again
     advance_time(&mut app, 25);
     app.update(); // collect messages
-    let count_3 = app.world().resource::<EventLog>().entries.iter()
+    let count_3 = app
+        .world()
+        .resource::<EventLog>()
+        .entries
+        .iter()
         .filter(|e| e.kind == GameEventKind::ResourceAlert)
         .count();
-    assert!(count_3 >= 2, "Alert should fire again after cooldown expires");
+    assert!(
+        count_3 >= 2,
+        "Alert should fire again after cooldown expires"
+    );
 }

--- a/macrocosmo/tests/job_system.rs
+++ b/macrocosmo/tests/job_system.rs
@@ -179,8 +179,10 @@ fn spawn_colony_with(
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
-            Buildings { slots: slot_entries },
+            BuildQueue::default(),
+            Buildings {
+                slots: slot_entries,
+            },
             BuildingQueue::default(),
             ProductionFocus::default(),
             MaintenanceCost::default(),
@@ -212,7 +214,14 @@ fn test_job_slot_computed_from_building_modifiers() {
     install_basic_jobs(&mut app);
     app.insert_resource(slot_based_building_registry());
 
-    let sys = spawn_test_system(app.world_mut(), "Test Sys", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Test Sys",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
     let colony = spawn_colony_with(
         &mut app,
         sys,
@@ -225,12 +234,20 @@ fn test_job_slot_computed_from_building_modifiers() {
 
     let jobs = app.world().get::<ColonyJobs>(colony).unwrap();
     assert_eq!(
-        jobs.slots.iter().find(|s| s.job_id == "miner").unwrap().capacity,
+        jobs.slots
+            .iter()
+            .find(|s| s.job_id == "miner")
+            .unwrap()
+            .capacity,
         5,
         "mine should grant 5 miner slots"
     );
     assert_eq!(
-        jobs.slots.iter().find(|s| s.job_id == "farmer").unwrap().capacity,
+        jobs.slots
+            .iter()
+            .find(|s| s.job_id == "farmer")
+            .unwrap()
+            .capacity,
         5,
         "farm should grant 5 farmer slots"
     );
@@ -242,14 +259,15 @@ fn test_pop_assigned_to_slots_contributes_production() {
     install_basic_jobs(&mut app);
     app.insert_resource(slot_based_building_registry());
 
-    let sys = spawn_test_system(app.world_mut(), "Prod Sys", [0.0, 0.0, 0.0], 1.0, true, true);
-    let _colony = spawn_colony_with(
-        &mut app,
-        sys,
-        5,
-        vec!["mine"],
-        vec![("miner", 0)],
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Prod Sys",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
     );
+    let _colony = spawn_colony_with(&mut app, sys, 5, vec!["mine"], vec![("miner", 0)]);
     advance_time(&mut app, 1);
 
     // 5 miners × 0.6 = 3.0 minerals/hexady, minus 1 hexady already elapsed.
@@ -270,7 +288,14 @@ fn test_unemployed_pop_does_not_produce() {
     install_basic_jobs(&mut app);
     app.insert_resource(slot_based_building_registry());
 
-    let sys = spawn_test_system(app.world_mut(), "Idle Sys", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Idle Sys",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
     // Pop=5 but no buildings → 0 slots → 0 assigned → 0 production.
     let _colony = spawn_colony_with(&mut app, sys, 5, vec![], vec![("miner", 0)]);
 
@@ -308,13 +333,7 @@ fn test_species_scoped_modifier_applies_only_to_assigned_job() {
     app.insert_resource(species);
 
     let sys = spawn_test_system(app.world_mut(), "Spc Sys", [0.0, 0.0, 0.0], 1.0, true, true);
-    let _colony = spawn_colony_with(
-        &mut app,
-        sys,
-        5,
-        vec!["mine"],
-        vec![("miner", 0)],
-    );
+    let _colony = spawn_colony_with(&mut app, sys, 5, vec!["mine"], vec![("miner", 0)]);
 
     advance_time(&mut app, 1);
 
@@ -338,7 +357,14 @@ fn test_automated_building_produces_without_pop() {
     // Leave the default `test_app` fixture registry in place (mine/farm push
     // directly into colony.<X>_per_hexadies).
 
-    let sys = spawn_test_system(app.world_mut(), "Auto Sys", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Auto Sys",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
     // Zero pops — automation path should still produce.
     let _colony = spawn_colony_with(&mut app, sys, 0, vec!["mine"], vec![]);
 
@@ -358,7 +384,14 @@ fn test_building_demolition_clears_slots() {
     install_basic_jobs(&mut app);
     app.insert_resource(slot_based_building_registry());
 
-    let sys = spawn_test_system(app.world_mut(), "Demo Sys", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Demo Sys",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
     let colony = spawn_colony_with(
         &mut app,
         sys,
@@ -432,7 +465,14 @@ fn test_target_prefix_routes_to_job_bucket() {
     });
     app.insert_resource(registry);
 
-    let sys = spawn_test_system(app.world_mut(), "Route Sys", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Route Sys",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
     let _colony = spawn_colony_with(&mut app, sys, 5, vec!["mine"], vec![("miner", 0)]);
 
     advance_time(&mut app, 1);
@@ -451,8 +491,8 @@ fn test_target_prefix_routes_to_job_bucket() {
 fn test_auto_prefix_in_define_job() {
     // `define_job { modifiers = { { target = "colony.X", ... } } }` gets its
     // target auto-prefixed to `job:<self_id>::colony.X` at parse time.
-    use macrocosmo::scripting::species_api::parse_job_definitions;
     use macrocosmo::scripting::ScriptEngine;
+    use macrocosmo::scripting::species_api::parse_job_definitions;
 
     let engine = ScriptEngine::new().unwrap();
     engine
@@ -476,10 +516,18 @@ fn test_auto_prefix_in_define_job() {
     assert_eq!(defs.len(), 1);
     let trader = &defs[0];
     assert_eq!(trader.modifiers.len(), 2);
-    assert!(trader.modifiers.iter().any(|m| m.target
-        == "job:trader::colony.minerals_per_hexadies"));
-    assert!(trader.modifiers.iter().any(|m| m.target
-        == "job:trader::colony.energy_per_hexadies"));
+    assert!(
+        trader
+            .modifiers
+            .iter()
+            .any(|m| m.target == "job:trader::colony.minerals_per_hexadies")
+    );
+    assert!(
+        trader
+            .modifiers
+            .iter()
+            .any(|m| m.target == "job:trader::colony.energy_per_hexadies")
+    );
 }
 
 #[test]
@@ -500,14 +548,15 @@ fn test_tech_effect_increases_slot_count() {
     install_basic_jobs(&mut app);
     app.insert_resource(slot_based_building_registry());
 
-    let sys = spawn_test_system(app.world_mut(), "Tech Sys", [0.0, 0.0, 0.0], 1.0, true, true);
-    let colony = spawn_colony_with(
-        &mut app,
-        sys,
-        10,
-        vec!["mine"],
-        vec![("miner", 0)],
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Tech Sys",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
     );
+    let colony = spawn_colony_with(&mut app, sys, 10, vec!["mine"], vec![("miner", 0)]);
     advance_time(&mut app, 1);
 
     // Baseline: mine gives miner_slot = 5.
@@ -527,7 +576,11 @@ fn test_tech_effect_increases_slot_count() {
     // into ColonyJobRates, slot-count tech effects go through the same
     // BuildingRegistry path used by upgrades).
     let _ = colony; // slot modification via direct Buildings mutation:
-    app.world_mut().get_mut::<Buildings>(colony).unwrap().slots.push(Some(BuildingId::new("mine")));
+    app.world_mut()
+        .get_mut::<Buildings>(colony)
+        .unwrap()
+        .slots
+        .push(Some(BuildingId::new("mine")));
     advance_time(&mut app, 1);
 
     let miner_cap = app
@@ -597,7 +650,7 @@ fn spawn_capital_like_colony(
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
+            BuildQueue::default(),
             Buildings {
                 slots: buildings
                     .into_iter()
@@ -626,7 +679,14 @@ fn test_issue_250_capital_production_reflects_buildings_and_jobs() {
     install_basic_jobs(&mut app);
     app.insert_resource(slot_based_building_registry());
 
-    let sys = spawn_test_system(app.world_mut(), "Issue250", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Issue250",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
     app.world_mut().entity_mut(sys).insert((
         ResourceStockpile {
             minerals: Amt::ZERO,
@@ -679,7 +739,14 @@ fn test_issue_250_aggregator_runs_while_paused() {
     install_basic_jobs(&mut app);
     app.insert_resource(slot_based_building_registry());
 
-    let sys = spawn_test_system(app.world_mut(), "PausedProd", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "PausedProd",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
     app.world_mut().entity_mut(sys).insert((
         ResourceStockpile {
             minerals: Amt::ZERO,
@@ -728,8 +795,8 @@ fn test_issue_250_aggregator_runs_while_paused() {
 
 #[test]
 fn test_issue_250_lua_building_modifiers_parse_correctly() {
-    use macrocosmo::scripting::building_api::parse_building_definitions;
     use macrocosmo::scripting::ScriptEngine;
+    use macrocosmo::scripting::building_api::parse_building_definitions;
 
     let engine = ScriptEngine::new().expect("ScriptEngine::new()");
     let init = engine.scripts_dir().join("init.lua");
@@ -739,11 +806,15 @@ fn test_issue_250_lua_building_modifiers_parse_correctly() {
     let ids: Vec<&str> = defs.iter().map(|d| d.id.as_str()).collect();
     eprintln!("[issue #250] building ids: {ids:?}");
 
-    let mine = defs.iter().find(|d| d.id == "mine").expect("mine not defined");
+    let mine = defs
+        .iter()
+        .find(|d| d.id == "mine")
+        .expect("mine not defined");
     eprintln!("[issue #250] mine.modifiers = {:?}", mine.modifiers);
     assert!(
-        mine.modifiers.iter().any(|m| m.target == "colony.miner_slot"
-            && (m.base_add - 5.0).abs() < 1e-9),
+        mine.modifiers
+            .iter()
+            .any(|m| m.target == "colony.miner_slot" && (m.base_add - 5.0).abs() < 1e-9),
         "mine should declare modifier colony.miner_slot base_add=5; got {:?}",
         mine.modifiers
     );
@@ -757,17 +828,20 @@ fn test_issue_250_lua_building_modifiers_parse_correctly() {
         power
             .modifiers
             .iter()
-            .any(|m| m.target == "colony.power_worker_slot"
-                && (m.base_add - 5.0).abs() < 1e-9),
+            .any(|m| m.target == "colony.power_worker_slot" && (m.base_add - 5.0).abs() < 1e-9),
         "power_plant should declare modifier colony.power_worker_slot base_add=5; got {:?}",
         power.modifiers
     );
 
-    let farm = defs.iter().find(|d| d.id == "farm").expect("farm not defined");
+    let farm = defs
+        .iter()
+        .find(|d| d.id == "farm")
+        .expect("farm not defined");
     eprintln!("[issue #250] farm.modifiers = {:?}", farm.modifiers);
     assert!(
-        farm.modifiers.iter().any(|m| m.target == "colony.farmer_slot"
-            && (m.base_add - 5.0).abs() < 1e-9),
+        farm.modifiers
+            .iter()
+            .any(|m| m.target == "colony.farmer_slot" && (m.base_add - 5.0).abs() < 1e-9),
         "farm should declare modifier colony.farmer_slot base_add=5; got {:?}",
         farm.modifiers
     );
@@ -775,8 +849,8 @@ fn test_issue_250_lua_building_modifiers_parse_correctly() {
 
 #[test]
 fn test_issue_250_lua_job_modifiers_parse_correctly() {
-    use macrocosmo::scripting::species_api::parse_job_definitions;
     use macrocosmo::scripting::ScriptEngine;
+    use macrocosmo::scripting::species_api::parse_job_definitions;
 
     let engine = ScriptEngine::new().expect("ScriptEngine::new()");
     let init = engine.scripts_dir().join("init.lua");
@@ -807,11 +881,9 @@ fn test_issue_250_lua_job_modifiers_parse_correctly() {
         power_worker.modifiers
     );
     assert!(
-        power_worker
-            .modifiers
-            .iter()
-            .any(|m| m.target == "job:power_worker::colony.energy_per_hexadies"
-                && (m.base_add - 6.0).abs() < 1e-9),
+        power_worker.modifiers.iter().any(|m| m.target
+            == "job:power_worker::colony.energy_per_hexadies"
+            && (m.base_add - 6.0).abs() < 1e-9),
         "power_worker per-pop rate should be 6.0; got {:?}",
         power_worker.modifiers
     );

--- a/macrocosmo/tests/jobs.rs
+++ b/macrocosmo/tests/jobs.rs
@@ -5,7 +5,6 @@ use macrocosmo::amount::Amt;
 use macrocosmo::colony::*;
 use macrocosmo::modifier::ModifiedValue;
 
-
 use common::{advance_time, find_planet, spawn_test_system, test_app};
 
 #[test]
@@ -25,52 +24,62 @@ fn test_job_auto_assignment() {
 
     // Spawn a colony with population 10, job slots [miner:5, farmer:5]
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::units(100),
             energy: Amt::units(100),
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
-    let colony = app.world_mut().spawn((
-        Colony {
-            planet: planet_sys,
-            population: 10.0,
-            growth_rate: 0.01,
         },
-        Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
-        },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
-        BuildingQueue::default(),
-        ProductionFocus::default(),
-        MaintenanceCost::default(),
-        FoodConsumption::default(),
-        ColonyPopulation {
-            species: vec![ColonySpecies {
-                species_id: "human".to_string(),
-                population: 10,
-            }],
-        },
-        ColonyJobs {
-            slots: vec![
-                JobSlot {
-                    job_id: "miner".to_string(),
-                    capacity: 5,
-                    assigned: 0, capacity_from_buildings: 0,
-                },
-                JobSlot {
-                    job_id: "farmer".to_string(),
-                    capacity: 5,
-                    assigned: 0, capacity_from_buildings: 0,
-                },
-            ],
-        },
-    )).id();
+        ResourceCapacity::default(),
+    ));
+    let colony = app
+        .world_mut()
+        .spawn((
+            Colony {
+                planet: planet_sys,
+                population: 10.0,
+                growth_rate: 0.01,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                research_per_hexadies: ModifiedValue::new(Amt::units(1)),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue::default(),
+            Buildings {
+                slots: vec![None; 4],
+            },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+            ColonyPopulation {
+                species: vec![ColonySpecies {
+                    species_id: "human".to_string(),
+                    population: 10,
+                }],
+            },
+            ColonyJobs {
+                slots: vec![
+                    JobSlot {
+                        job_id: "miner".to_string(),
+                        capacity: 5,
+                        assigned: 0,
+                        capacity_from_buildings: 0,
+                    },
+                    JobSlot {
+                        job_id: "farmer".to_string(),
+                        capacity: 5,
+                        assigned: 0,
+                        capacity_from_buildings: 0,
+                    },
+                ],
+            },
+        ))
+        .id();
 
     // Run one update to trigger sync_job_assignment
     advance_time(&mut app, 1);
@@ -82,7 +91,11 @@ fn test_job_auto_assignment() {
     assert_eq!(jobs.slots[1].assigned, 5); // farmer full
 
     // Now reduce population to 7
-    app.world_mut().get_mut::<ColonyPopulation>(colony).unwrap().species[0].population = 7;
+    app.world_mut()
+        .get_mut::<ColonyPopulation>(colony)
+        .unwrap()
+        .species[0]
+        .population = 7;
 
     advance_time(&mut app, 1);
 
@@ -93,7 +106,11 @@ fn test_job_auto_assignment() {
     assert_eq!(jobs.slots[1].assigned, 2); // farmer reduced
 
     // Reduce population to 3
-    app.world_mut().get_mut::<ColonyPopulation>(colony).unwrap().species[0].population = 3;
+    app.world_mut()
+        .get_mut::<ColonyPopulation>(colony)
+        .unwrap()
+        .species[0]
+        .population = 3;
 
     advance_time(&mut app, 1);
 
@@ -120,52 +137,62 @@ fn test_job_auto_assignment_excess_population() {
     );
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::units(100),
             energy: Amt::units(100),
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
-    let colony = app.world_mut().spawn((
-        Colony {
-            planet: planet_sys,
-            population: 15.0,
-            growth_rate: 0.01,
         },
-        Production {
-            minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
-            research_per_hexadies: ModifiedValue::new(Amt::units(1)),
-            food_per_hexadies: ModifiedValue::new(Amt::ZERO),
-        },
-        BuildQueue { queue: Vec::new() },
-        Buildings { slots: vec![None; 4] },
-        BuildingQueue::default(),
-        ProductionFocus::default(),
-        MaintenanceCost::default(),
-        FoodConsumption::default(),
-        ColonyPopulation {
-            species: vec![ColonySpecies {
-                species_id: "human".to_string(),
-                population: 15,
-            }],
-        },
-        ColonyJobs {
-            slots: vec![
-                JobSlot {
-                    job_id: "miner".to_string(),
-                    capacity: 5,
-                    assigned: 0, capacity_from_buildings: 0,
-                },
-                JobSlot {
-                    job_id: "farmer".to_string(),
-                    capacity: 5,
-                    assigned: 0, capacity_from_buildings: 0,
-                },
-            ],
-        },
-    )).id();
+        ResourceCapacity::default(),
+    ));
+    let colony = app
+        .world_mut()
+        .spawn((
+            Colony {
+                planet: planet_sys,
+                population: 15.0,
+                growth_rate: 0.01,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                energy_per_hexadies: ModifiedValue::new(Amt::units(5)),
+                research_per_hexadies: ModifiedValue::new(Amt::units(1)),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            BuildQueue::default(),
+            Buildings {
+                slots: vec![None; 4],
+            },
+            BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+            ColonyPopulation {
+                species: vec![ColonySpecies {
+                    species_id: "human".to_string(),
+                    population: 15,
+                }],
+            },
+            ColonyJobs {
+                slots: vec![
+                    JobSlot {
+                        job_id: "miner".to_string(),
+                        capacity: 5,
+                        assigned: 0,
+                        capacity_from_buildings: 0,
+                    },
+                    JobSlot {
+                        job_id: "farmer".to_string(),
+                        capacity: 5,
+                        assigned: 0,
+                        capacity_from_buildings: 0,
+                    },
+                ],
+            },
+        ))
+        .id();
 
     advance_time(&mut app, 1);
 

--- a/macrocosmo/tests/knowledge.rs
+++ b/macrocosmo/tests/knowledge.rs
@@ -11,7 +11,10 @@ use macrocosmo::player::*;
 use macrocosmo::ship::*;
 use macrocosmo::technology::TechKnowledge;
 
-use common::{advance_time, empire_entity, find_planet, full_test_app, spawn_test_colony, spawn_test_system, test_app};
+use common::{
+    advance_time, empire_entity, find_planet, full_test_app, spawn_test_colony, spawn_test_system,
+    test_app,
+};
 
 /// Helper: set up an app with tech research + propagation systems for knowledge tests.
 fn tech_knowledge_app() -> App {
@@ -24,14 +27,8 @@ fn test_knowledge_propagation_light_delay() {
     let mut app = test_app();
 
     // Player at origin
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
 
     // System-B at 10 LY away
     let sys_b = spawn_test_system(
@@ -44,7 +41,12 @@ fn test_knowledge_propagation_light_delay() {
     );
 
     // Spawn player stationed at capital
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // At time 0, no knowledge should exist of System-B (light hasn't arrived)
     app.update();
@@ -104,7 +106,8 @@ fn test_remote_command_has_light_delay() {
     );
 
     // Spawn player at system A
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     // Spawn explorer at system B with FTL range
     let ship_entity = common::spawn_test_ship(
@@ -115,7 +118,10 @@ fn test_remote_command_has_light_delay() {
         [10.0, 0.0, 0.0],
     );
     // Give it FTL range to reach system C
-    app.world_mut().get_mut::<Ship>(ship_entity).unwrap().ftl_range = 20.0;
+    app.world_mut()
+        .get_mut::<Ship>(ship_entity)
+        .unwrap()
+        .ftl_range = 20.0;
 
     // Calculate expected delay: 10 ly -> 600 hexadies
     let expected_delay = light_delay_hexadies(10.0);
@@ -123,7 +129,9 @@ fn test_remote_command_has_light_delay() {
 
     // Simulate what the UI does: create a PendingShipCommand with light delay
     let current_time = 100;
-    app.world_mut().resource_mut::<macrocosmo::time_system::GameClock>().elapsed = current_time;
+    app.world_mut()
+        .resource_mut::<macrocosmo::time_system::GameClock>()
+        .elapsed = current_time;
 
     app.world_mut().spawn(PendingShipCommand {
         ship: ship_entity,
@@ -174,7 +182,8 @@ fn test_pending_command_executes_on_arrival() {
     );
 
     // Spawn player at system A
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     // Spawn colony at sys_a so port check passes
     spawn_test_colony(
@@ -193,10 +202,15 @@ fn test_pending_command_executes_on_arrival() {
         sys_a,
         [0.0, 0.0, 0.0],
     );
-    app.world_mut().get_mut::<Ship>(ship_entity).unwrap().ftl_range = 20.0;
+    app.world_mut()
+        .get_mut::<Ship>(ship_entity)
+        .unwrap()
+        .ftl_range = 20.0;
 
     let current_time = 100;
-    app.world_mut().resource_mut::<macrocosmo::time_system::GameClock>().elapsed = current_time;
+    app.world_mut()
+        .resource_mut::<macrocosmo::time_system::GameClock>()
+        .elapsed = current_time;
 
     // Create a PendingShipCommand with arrives_at = now (simulating 0 delay that
     // was routed through the pending system anyway, or a command that has arrived)
@@ -248,7 +262,8 @@ fn test_pending_survey_command_executes_after_delay() {
         false,
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     let ship_entity = common::spawn_test_ship(
         app.world_mut(),
@@ -259,7 +274,9 @@ fn test_pending_survey_command_executes_after_delay() {
     );
 
     let current_time = 100;
-    app.world_mut().resource_mut::<macrocosmo::time_system::GameClock>().elapsed = current_time;
+    app.world_mut()
+        .resource_mut::<macrocosmo::time_system::GameClock>()
+        .elapsed = current_time;
 
     // 3 ly delay = 180 hexadies
     let delay = light_delay_hexadies(3.0);
@@ -310,7 +327,8 @@ fn test_enqueue_command_despawned_ship_no_crash() {
         false,
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     let ship_entity = common::spawn_test_ship(
         app.world_mut(),
@@ -321,7 +339,9 @@ fn test_enqueue_command_despawned_ship_no_crash() {
     );
 
     let current_time = 100;
-    app.world_mut().resource_mut::<macrocosmo::time_system::GameClock>().elapsed = current_time;
+    app.world_mut()
+        .resource_mut::<macrocosmo::time_system::GameClock>()
+        .elapsed = current_time;
 
     // Queue an EnqueueCommand that arrives after delay
     app.world_mut().spawn(PendingShipCommand {
@@ -375,7 +395,8 @@ fn test_enqueue_command_adds_to_queue() {
         false,
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     let ship_entity = common::spawn_test_ship(
         app.world_mut(),
@@ -394,7 +415,9 @@ fn test_enqueue_command_adds_to_queue() {
     };
 
     let current_time = 100;
-    app.world_mut().resource_mut::<macrocosmo::time_system::GameClock>().elapsed = current_time;
+    app.world_mut()
+        .resource_mut::<macrocosmo::time_system::GameClock>()
+        .elapsed = current_time;
 
     // Queue an EnqueueCommand to move to sys_c after delay
     app.world_mut().spawn(PendingShipCommand {
@@ -406,12 +429,19 @@ fn test_enqueue_command_adds_to_queue() {
     // Before arrival: command queue should be empty
     advance_time(&mut app, 50);
     let queue = app.world().get::<CommandQueue>(ship_entity).unwrap();
-    assert!(queue.commands.is_empty(), "Queue should be empty before command arrives");
+    assert!(
+        queue.commands.is_empty(),
+        "Queue should be empty before command arrives"
+    );
 
     // After arrival: command should be in queue (ship still in FTL, so queue not consumed)
     advance_time(&mut app, 150);
     let queue = app.world().get::<CommandQueue>(ship_entity).unwrap();
-    assert_eq!(queue.commands.len(), 1, "Queue should have 1 command after arrival");
+    assert_eq!(
+        queue.commands.len(),
+        1,
+        "Queue should have 1 command after arrival"
+    );
     assert!(
         matches!(queue.commands[0], QueuedCommand::MoveTo { system } if system == sys_c),
         "Queued command should be MoveTo sys_c"
@@ -422,26 +452,31 @@ fn test_enqueue_command_adds_to_queue() {
 
 #[test]
 fn test_tech_propagates_to_capital_immediately() {
-    use macrocosmo::technology::{
-        RecentlyResearched, TechId, TechKnowledge,
-    };
+    use macrocosmo::technology::{RecentlyResearched, TechId, TechKnowledge};
 
     let mut app = tech_knowledge_app();
 
     // Spawn capital system
-    let capital = app.world_mut().spawn((
-        StarSystem {
-            name: "Capital".into(),
-            surveyed: true,
-            is_capital: true,
+    let capital = app
+        .world_mut()
+        .spawn((
+            StarSystem {
+                name: "Capital".into(),
+                surveyed: true,
+                is_capital: true,
                 star_type: "default".to_string(),
-        },
-        Position::from([0.0, 0.0, 0.0]),
-        Sovereignty::default(),
-        TechKnowledge::default(),
-    )).id();
+            },
+            Position::from([0.0, 0.0, 0.0]),
+            Sovereignty::default(),
+            TechKnowledge::default(),
+        ))
+        .id();
     app.world_mut().spawn((
-        Planet { name: "Capital I".into(), system: capital , planet_type: "default".to_string() },
+        Planet {
+            name: "Capital I".into(),
+            system: capital,
+            planet_type: "default".to_string(),
+        },
         SystemAttributes {
             habitability: 1.0,
             mineral_richness: 0.5,
@@ -477,33 +512,40 @@ fn test_tech_propagates_to_capital_immediately() {
     // Capital should have the tech immediately
     let knowledge = app.world().get::<TechKnowledge>(capital).unwrap();
     assert!(
-        knowledge.known_techs.contains(&TechId("social_xenolinguistics".into())),
+        knowledge
+            .known_techs
+            .contains(&TechId("social_xenolinguistics".into())),
         "Capital should know tech immediately after research"
     );
 }
 
 #[test]
 fn test_tech_propagates_to_remote_with_delay() {
-    use macrocosmo::technology::{
-        RecentlyResearched, TechId, TechKnowledge,
-    };
+    use macrocosmo::technology::{RecentlyResearched, TechId, TechKnowledge};
 
     let mut app = tech_knowledge_app();
 
     // Capital at origin
-    let capital = app.world_mut().spawn((
-        StarSystem {
-            name: "Capital".into(),
-            surveyed: true,
-            is_capital: true,
+    let capital = app
+        .world_mut()
+        .spawn((
+            StarSystem {
+                name: "Capital".into(),
+                surveyed: true,
+                is_capital: true,
                 star_type: "default".to_string(),
-        },
-        Position::from([0.0, 0.0, 0.0]),
-        Sovereignty::default(),
-        TechKnowledge::default(),
-    )).id();
+            },
+            Position::from([0.0, 0.0, 0.0]),
+            Sovereignty::default(),
+            TechKnowledge::default(),
+        ))
+        .id();
     app.world_mut().spawn((
-        Planet { name: "Capital I".into(), system: capital , planet_type: "default".to_string() },
+        Planet {
+            name: "Capital I".into(),
+            system: capital,
+            planet_type: "default".to_string(),
+        },
         SystemAttributes {
             habitability: 1.0,
             mineral_richness: 0.5,
@@ -515,19 +557,26 @@ fn test_tech_propagates_to_remote_with_delay() {
     ));
 
     // Remote system at 1 LY (light delay = 60 hexadies)
-    let remote = app.world_mut().spawn((
-        StarSystem {
-            name: "Remote".into(),
-            surveyed: true,
-            is_capital: false,
+    let remote = app
+        .world_mut()
+        .spawn((
+            StarSystem {
+                name: "Remote".into(),
+                surveyed: true,
+                is_capital: false,
                 star_type: "default".to_string(),
-        },
-        Position::from([1.0, 0.0, 0.0]),
-        Sovereignty::default(),
-        TechKnowledge::default(),
-    )).id();
+            },
+            Position::from([1.0, 0.0, 0.0]),
+            Sovereignty::default(),
+            TechKnowledge::default(),
+        ))
+        .id();
     app.world_mut().spawn((
-        Planet { name: "Remote I".into(), system: remote , planet_type: "default".to_string() },
+        Planet {
+            name: "Remote I".into(),
+            system: remote,
+            planet_type: "default".to_string(),
+        },
         SystemAttributes {
             habitability: 0.7,
             mineral_richness: 0.5,
@@ -569,12 +618,18 @@ fn test_tech_propagates_to_remote_with_delay() {
 
     // Capital should have it immediately
     let capital_knowledge = app.world().get::<TechKnowledge>(capital).unwrap();
-    assert!(capital_knowledge.known_techs.contains(&TechId("physics_sensor_arrays".into())));
+    assert!(
+        capital_knowledge
+            .known_techs
+            .contains(&TechId("physics_sensor_arrays".into()))
+    );
 
     // Remote should NOT have it yet (need 60 hexadies for 1 LY)
     let remote_knowledge = app.world().get::<TechKnowledge>(remote).unwrap();
     assert!(
-        !remote_knowledge.known_techs.contains(&TechId("physics_sensor_arrays".into())),
+        !remote_knowledge
+            .known_techs
+            .contains(&TechId("physics_sensor_arrays".into())),
         "Remote system should not know tech before light delay"
     );
 
@@ -582,7 +637,9 @@ fn test_tech_propagates_to_remote_with_delay() {
     advance_time(&mut app, 59);
     let remote_knowledge = app.world().get::<TechKnowledge>(remote).unwrap();
     assert!(
-        !remote_knowledge.known_techs.contains(&TechId("physics_sensor_arrays".into())),
+        !remote_knowledge
+            .known_techs
+            .contains(&TechId("physics_sensor_arrays".into())),
         "Remote system should not know tech at tick 60 (arrives_at = 60, spawned at tick 1)"
     );
 
@@ -590,7 +647,9 @@ fn test_tech_propagates_to_remote_with_delay() {
     advance_time(&mut app, 1);
     let remote_knowledge = app.world().get::<TechKnowledge>(remote).unwrap();
     assert!(
-        remote_knowledge.known_techs.contains(&TechId("physics_sensor_arrays".into())),
+        remote_knowledge
+            .known_techs
+            .contains(&TechId("physics_sensor_arrays".into())),
         "Remote system should know tech after light delay"
     );
 }
@@ -604,19 +663,26 @@ fn test_uncolonized_system_no_propagation() {
     let mut app = tech_knowledge_app();
 
     // Capital at origin
-    let capital = app.world_mut().spawn((
-        StarSystem {
-            name: "Capital".into(),
-            surveyed: true,
-            is_capital: true,
+    let capital = app
+        .world_mut()
+        .spawn((
+            StarSystem {
+                name: "Capital".into(),
+                surveyed: true,
+                is_capital: true,
                 star_type: "default".to_string(),
-        },
-        Position::from([0.0, 0.0, 0.0]),
-        Sovereignty::default(),
-        TechKnowledge::default(),
-    )).id();
+            },
+            Position::from([0.0, 0.0, 0.0]),
+            Sovereignty::default(),
+            TechKnowledge::default(),
+        ))
+        .id();
     app.world_mut().spawn((
-        Planet { name: "Capital I".into(), system: capital , planet_type: "default".to_string() },
+        Planet {
+            name: "Capital I".into(),
+            system: capital,
+            planet_type: "default".to_string(),
+        },
         SystemAttributes {
             habitability: 1.0,
             mineral_richness: 0.5,
@@ -628,17 +694,20 @@ fn test_uncolonized_system_no_propagation() {
     ));
 
     // Uncolonized system (no colony spawned for it)
-    let _uncolonized = app.world_mut().spawn((
-        StarSystem {
-            name: "Uncolonized".into(),
-            surveyed: true,
-            is_capital: false,
+    let _uncolonized = app
+        .world_mut()
+        .spawn((
+            StarSystem {
+                name: "Uncolonized".into(),
+                surveyed: true,
+                is_capital: false,
                 star_type: "default".to_string(),
-        },
-        Position::from([1.0, 0.0, 0.0]),
-        Sovereignty::default(),
-        TechKnowledge::default(),
-    )).id();
+            },
+            Position::from([1.0, 0.0, 0.0]),
+            Sovereignty::default(),
+            TechKnowledge::default(),
+        ))
+        .id();
 
     // Colony only at capital
     spawn_test_colony(
@@ -682,14 +751,8 @@ fn test_knowledge_snapshot_hostile_presence() {
     let mut app = test_app();
 
     // Player at origin
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
 
     // Remote system at 1 LY with hostiles
     let sys_hostile = spawn_test_system(
@@ -702,7 +765,12 @@ fn test_knowledge_snapshot_hostile_presence() {
     );
 
     // Spawn player
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // Spawn hostile presence at remote system
     app.world_mut().spawn(HostilePresence {
@@ -721,34 +789,33 @@ fn test_knowledge_snapshot_hostile_presence() {
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
     let knowledge = store.get(sys_hostile).unwrap();
 
-    assert!(knowledge.data.has_hostile, "Should have hostile presence in snapshot");
-    assert!((knowledge.data.hostile_strength - 5.0).abs() < 0.01, "Hostile strength should be 5.0");
+    assert!(
+        knowledge.data.has_hostile,
+        "Should have hostile presence in snapshot"
+    );
+    assert!(
+        (knowledge.data.hostile_strength - 5.0).abs() < 0.01,
+        "Hostile strength should be 5.0"
+    );
 }
 
 #[test]
 fn test_knowledge_snapshot_system_attributes() {
     let mut app = test_app();
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
 
     // Remote system at 1 LY with specific attributes
-    let sys_remote = spawn_test_system(
-        app.world_mut(),
-        "Remote",
-        [1.0, 0.0, 0.0],
-        0.7,
-        true,
-        false,
-    );
+    let sys_remote =
+        spawn_test_system(app.world_mut(), "Remote", [1.0, 0.0, 0.0], 0.7, true, false);
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // Advance past light delay
     advance_time(&mut app, 61);
@@ -769,25 +836,18 @@ fn test_ship_knowledge_propagation() {
 
     let mut app = test_app();
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
 
-    let sys_remote = spawn_test_system(
-        app.world_mut(),
-        "Remote",
-        [1.0, 0.0, 0.0],
-        0.7,
-        true,
-        false,
-    );
+    let sys_remote =
+        spawn_test_system(app.world_mut(), "Remote", [1.0, 0.0, 0.0], 0.7, true, false);
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // Spawn ship at remote system
     let ship_entity = common::spawn_test_ship(
@@ -816,7 +876,10 @@ fn test_ship_knowledge_propagation() {
         let empire = empire_entity(app.world_mut());
         let store = app.world().get::<KnowledgeStore>(empire).unwrap();
         let ship_snap = store.get_ship(ship_entity);
-        assert!(ship_snap.is_some(), "Should have ship knowledge after light delay");
+        assert!(
+            ship_snap.is_some(),
+            "Should have ship knowledge after light delay"
+        );
         let snap = ship_snap.unwrap();
         assert_eq!(snap.name, "Scout-1");
         assert_eq!(snap.design_id, "explorer_mk1");
@@ -831,16 +894,15 @@ fn test_ship_knowledge_local_system_immediate() {
 
     let mut app = test_app();
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // Spawn ship at capital (local system — 0 light delay)
     let ship_entity = common::spawn_test_ship(
@@ -857,14 +919,20 @@ fn test_ship_knowledge_local_system_immediate() {
     let empire = empire_entity(app.world_mut());
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
     let ship_snap = store.get_ship(ship_entity);
-    assert!(ship_snap.is_some(), "Local ship should be known immediately");
-    assert_eq!(ship_snap.unwrap().last_known_state, ShipSnapshotState::Docked);
+    assert!(
+        ship_snap.is_some(),
+        "Local ship should be known immediately"
+    );
+    assert_eq!(
+        ship_snap.unwrap().last_known_state,
+        ShipSnapshotState::Docked
+    );
 }
 
 #[test]
 fn test_knowledge_store_ship_update_newer_replaces() {
-    use macrocosmo::knowledge::{ShipSnapshot, ShipSnapshotState};
     use bevy::ecs::world::World;
+    use macrocosmo::knowledge::{ShipSnapshot, ShipSnapshotState};
 
     let mut world = World::new();
     let entity = world.spawn_empty().id();
@@ -903,8 +971,8 @@ fn test_knowledge_store_ship_update_newer_replaces() {
 
 #[test]
 fn test_knowledge_store_ship_older_does_not_replace() {
-    use macrocosmo::knowledge::{ShipSnapshot, ShipSnapshotState};
     use bevy::ecs::world::World;
+    use macrocosmo::knowledge::{ShipSnapshot, ShipSnapshotState};
 
     let mut world = World::new();
     let entity = world.spawn_empty().id();
@@ -937,7 +1005,10 @@ fn test_knowledge_store_ship_older_does_not_replace() {
     });
 
     let snap = store.get_ship(entity).unwrap();
-    assert_eq!(snap.observed_at, 20, "Newer observation should not be replaced by older");
+    assert_eq!(
+        snap.observed_at, 20,
+        "Newer observation should not be replaced by older"
+    );
     assert_eq!(snap.last_known_state, ShipSnapshotState::InTransit);
 }
 
@@ -1008,23 +1079,16 @@ fn test_sensor_buoy_detects_sublight_ship_in_range() {
     let mut app = test_app();
     install_sensor_buoy_definition(&mut app);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
-    let sys_remote = spawn_test_system(
-        app.world_mut(),
-        "Remote",
-        [3.5, 0.0, 0.0],
-        0.5,
-        true,
-        false,
-    );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys_remote =
+        spawn_test_system(app.world_mut(), "Remote", [3.5, 0.0, 0.0], 0.5, true, false);
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     spawn_sensor_buoy(app.world_mut(), [3.0, 0.0, 0.0]);
 
@@ -1074,14 +1138,8 @@ fn test_sensor_buoy_detects_remote_docked_ship_via_buoy_path() {
     let mut app = test_app();
     install_sensor_buoy_definition(&mut app);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_outpost = spawn_test_system(
         app.world_mut(),
         "Outpost",
@@ -1090,7 +1148,12 @@ fn test_sensor_buoy_detects_remote_docked_ship_via_buoy_path() {
         true,
         false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     spawn_sensor_buoy(app.world_mut(), [5.0, 0.0, 0.0]);
 
@@ -1122,14 +1185,8 @@ fn test_sensor_buoy_does_not_detect_ftl_ship() {
     let mut app = test_app();
     install_sensor_buoy_definition(&mut app);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote_a = spawn_test_system(
         app.world_mut(),
         "RemoteA",
@@ -1146,7 +1203,12 @@ fn test_sensor_buoy_does_not_detect_ftl_ship() {
         true,
         false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     let buoy_pos = [10.0, 0.0, 0.0];
     spawn_sensor_buoy(app.world_mut(), buoy_pos);
@@ -1207,14 +1269,8 @@ fn test_sensor_buoy_does_not_detect_ship_out_of_range() {
     let mut app = test_app();
     install_sensor_buoy_definition(&mut app);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote = spawn_test_system(
         app.world_mut(),
         "Remote",
@@ -1223,7 +1279,12 @@ fn test_sensor_buoy_does_not_detect_ship_out_of_range() {
         true,
         false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     spawn_sensor_buoy(app.world_mut(), [5.0, 0.0, 0.0]);
 
@@ -1253,14 +1314,8 @@ fn test_sensor_buoy_detects_docked_ship_in_range() {
     let mut app = test_app();
     install_sensor_buoy_definition(&mut app);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_outpost = spawn_test_system(
         app.world_mut(),
         "Outpost",
@@ -1269,7 +1324,12 @@ fn test_sensor_buoy_detects_docked_ship_in_range() {
         true,
         false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     spawn_sensor_buoy(app.world_mut(), [10.0, 0.0, 0.0]);
 
@@ -1300,14 +1360,7 @@ fn test_sensor_buoy_no_player_no_panic() {
     let mut app = test_app();
     install_sensor_buoy_definition(&mut app);
 
-    let _sys = spawn_test_system(
-        app.world_mut(),
-        "Lone",
-        [0.0, 0.0, 0.0],
-        0.5,
-        true,
-        false,
-    );
+    let _sys = spawn_test_system(app.world_mut(), "Lone", [0.0, 0.0, 0.0], 0.5, true, false);
 
     spawn_sensor_buoy(app.world_mut(), [5.0, 0.0, 0.0]);
 
@@ -1325,52 +1378,57 @@ fn test_sublight_ship_knowledge_uses_light_speed_delay() {
     // test_app() spawns the empire entity.
     let mut app = test_app();
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // Spawn a ship in SubLight transit between (10, 0, 0) and (12, 0, 0); long enough
     // travel that during our test window (0..120 hd) the ship has not yet arrived.
     // At t=120 hd the ship will be at roughly (10 + 0.5*2, 0, 0) = (11, 0, 0) which
     // is ~11 LY from the player at the capital.
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Far-Scout".to_string(),
-            design_id: "explorer_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.75,
-            ftl_range: 0.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::SubLight {
-            origin: [10.0, 0.0, 0.0],
-            destination: [12.0, 0.0, 0.0],
-            target_system: None,
-            departed_at: 0,
-            arrival_at: sublight_travel_hexadies(2.0, 0.75), // 160 hd
-        },
-        Position::from([10.0, 0.0, 0.0]),
-        ShipHitpoints {
-            hull: 50.0, hull_max: 50.0,
-            armor: 0.0, armor_max: 0.0,
-            shield: 0.0, shield_max: 0.0,
-            shield_regen: 0.0,
-        },
-        ShipModifiers::default(),
-        CommandQueue::default(),
-        Cargo::default(),
-        RulesOfEngagement::default(),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Far-Scout".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.75,
+                ftl_range: 0.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::SubLight {
+                origin: [10.0, 0.0, 0.0],
+                destination: [12.0, 0.0, 0.0],
+                target_system: None,
+                departed_at: 0,
+                arrival_at: sublight_travel_hexadies(2.0, 0.75), // 160 hd
+            },
+            Position::from([10.0, 0.0, 0.0]),
+            ShipHitpoints {
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            ShipModifiers::default(),
+            CommandQueue::default(),
+            Cargo::default(),
+            RulesOfEngagement::default(),
+        ))
+        .id();
 
     // Advance enough that, at light delay >= 600 hd (10 LY), we have NOT yet
     // received any snapshot for the ship.
@@ -1389,14 +1447,21 @@ fn test_sublight_ship_knowledge_uses_light_speed_delay() {
     // least the light delay (650+ hd).
     advance_time(&mut app, 700);
     let empire = empire_entity(app.world_mut());
-    let clock = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let clock = app
+        .world()
+        .resource::<macrocosmo::time_system::GameClock>()
+        .elapsed;
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-    let snap = store.get_ship(ship_entity).expect("Should have ship knowledge by now");
+    let snap = store
+        .get_ship(ship_entity)
+        .expect("Should have ship knowledge by now");
     let lag = clock - snap.observed_at;
     assert!(
         lag >= 600,
         "SubLight ship snapshot must lag clock by at least the light delay (~600 hd for ~10 LY); got lag={} (clock={}, observed_at={})",
-        lag, clock, snap.observed_at
+        lag,
+        clock,
+        snap.observed_at
     );
 }
 
@@ -1407,60 +1472,73 @@ fn test_sublight_ship_nearby_knowledge_negligible_delay() {
     // test_app() spawns the empire entity.
     let mut app = test_app();
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // SubLight ship interpolating very close to the player (well under 0.05 LY).
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Near-Scout".to_string(),
-            design_id: "explorer_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.75,
-            ftl_range: 0.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::SubLight {
-            origin: [0.0, 0.0, 0.0],
-            destination: [0.01, 0.0, 0.0],
-            target_system: None,
-            departed_at: 0,
-            arrival_at: 1000,
-        },
-        Position::from([0.0, 0.0, 0.0]),
-        ShipHitpoints {
-            hull: 50.0, hull_max: 50.0,
-            armor: 0.0, armor_max: 0.0,
-            shield: 0.0, shield_max: 0.0,
-            shield_regen: 0.0,
-        },
-        ShipModifiers::default(),
-        CommandQueue::default(),
-        Cargo::default(),
-        RulesOfEngagement::default(),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Near-Scout".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.75,
+                ftl_range: 0.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::SubLight {
+                origin: [0.0, 0.0, 0.0],
+                destination: [0.01, 0.0, 0.0],
+                target_system: None,
+                departed_at: 0,
+                arrival_at: 1000,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+            ShipHitpoints {
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            ShipModifiers::default(),
+            CommandQueue::default(),
+            Cargo::default(),
+            RulesOfEngagement::default(),
+        ))
+        .id();
 
     advance_time(&mut app, 5);
 
     let empire = empire_entity(app.world_mut());
-    let clock = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let clock = app
+        .world()
+        .resource::<macrocosmo::time_system::GameClock>()
+        .elapsed;
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-    let snap = store.get_ship(ship_entity).expect("Nearby ship must be in KnowledgeStore");
+    let snap = store
+        .get_ship(ship_entity)
+        .expect("Nearby ship must be in KnowledgeStore");
     let lag = clock - snap.observed_at;
     // Light delay for ~0.01 LY = ceil(0.01 * 60) = 1 hd; allow some slack.
-    assert!(lag <= 5,
-        "Nearby SubLight ship snapshot should have negligible lag, got {}", lag);
+    assert!(
+        lag <= 5,
+        "Nearby SubLight ship snapshot should have negligible lag, got {}",
+        lag
+    );
 }
 
 /// #185 + #188: Loitering ships are also reported through KnowledgeStore with the
@@ -1472,43 +1550,50 @@ fn test_loitering_ship_knowledge_uses_light_speed_delay() {
     // test_app() spawns the empire entity.
     let mut app = test_app();
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(),
-        "Capital",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     let loiter_pos = [10.0, 0.0, 0.0];
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Deep-Loiter".to_string(),
-            design_id: "explorer_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.75,
-            ftl_range: 0.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::Loitering { position: loiter_pos },
-        Position::from(loiter_pos),
-        ShipHitpoints {
-            hull: 50.0, hull_max: 50.0,
-            armor: 0.0, armor_max: 0.0,
-            shield: 0.0, shield_max: 0.0,
-            shield_regen: 0.0,
-        },
-        ShipModifiers::default(),
-        CommandQueue::default(),
-        Cargo::default(),
-        RulesOfEngagement::default(),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Deep-Loiter".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.75,
+                ftl_range: 0.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::Loitering {
+                position: loiter_pos,
+            },
+            Position::from(loiter_pos),
+            ShipHitpoints {
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            ShipModifiers::default(),
+            CommandQueue::default(),
+            Cargo::default(),
+            RulesOfEngagement::default(),
+        ))
+        .id();
 
     // Before light delay (10 LY = 600 hd): no knowledge.
     advance_time(&mut app, 100);
@@ -1525,7 +1610,9 @@ fn test_loitering_ship_knowledge_uses_light_speed_delay() {
     advance_time(&mut app, 700);
     let empire = empire_entity(app.world_mut());
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-    let snap = store.get_ship(ship_entity).expect("Should have Loitering snapshot");
+    let snap = store
+        .get_ship(ship_entity)
+        .expect("Should have Loitering snapshot");
     match &snap.last_known_state {
         ShipSnapshotState::Loitering { position } => {
             assert!((position[0] - loiter_pos[0]).abs() < 1e-9);
@@ -1579,7 +1666,10 @@ fn spawn_ftl_comm_relay(world: &mut World, name: &str, pos: [f64; 3]) -> Entity 
                 name: name.to_string(),
                 owner: macrocosmo::ship::Owner::Neutral,
             },
-            StructureHitpoints { current: 50.0, max: 50.0 },
+            StructureHitpoints {
+                current: 50.0,
+                max: 50.0,
+            },
             Position::from(pos),
         ))
         .id()
@@ -1604,20 +1694,39 @@ fn test_ftl_comm_relay_bidirectional_propagates_remote_ship_at_ftl_speed() {
     let mut app = test_app();
     install_ftl_comm_relay_definition(&mut app, 3.0);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote = spawn_test_system(
-        app.world_mut(), "Remote", [20.5, 0.0, 0.0], 0.5, true, false,
+        app.world_mut(),
+        "Remote",
+        [20.5, 0.0, 0.0],
+        0.5,
+        true,
+        false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [2.0, 0.0, 0.0]);
     let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [20.0, 0.0, 0.0]);
-    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional).unwrap();
+    pair_relay_command(
+        app.world_mut(),
+        relay_a,
+        relay_b,
+        CommDirection::Bidirectional,
+    )
+    .unwrap();
 
     let ship_entity = common::spawn_test_ship(
-        app.world_mut(), "Remote-Scout", "courier_mk1", sys_remote, [20.5, 0.0, 0.0],
+        app.world_mut(),
+        "Remote-Scout",
+        "courier_mk1",
+        sys_remote,
+        [20.5, 0.0, 0.0],
     );
 
     advance_time(&mut app, 100);
@@ -1626,7 +1735,10 @@ fn test_ftl_comm_relay_bidirectional_propagates_remote_ship_at_ftl_speed() {
     let snap = store
         .get_ship(ship_entity)
         .expect("Relay should have delivered remote ship knowledge at FTL speed");
-    assert_eq!(snap.observed_at, 100, "FTL relay delivers with no light delay");
+    assert_eq!(
+        snap.observed_at, 100,
+        "FTL relay delivers with no light delay"
+    );
     assert_eq!(snap.name, "Remote-Scout");
 }
 
@@ -1647,13 +1759,22 @@ fn test_ftl_comm_relay_oneway_reverse_direction_does_not_propagate() {
     let mut app = test_app();
     install_ftl_comm_relay_definition(&mut app, 3.0);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote = spawn_test_system(
-        app.world_mut(), "Remote", [20.5, 0.0, 0.0], 0.5, true, false,
+        app.world_mut(),
+        "Remote",
+        [20.5, 0.0, 0.0],
+        0.5,
+        true,
+        false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // Relay-A near PLAYER, Relay-B near SHIP. OneWay A→B means A sends, B
     // receives. But A's source-range covers nothing near the ship, and B
@@ -1663,7 +1784,11 @@ fn test_ftl_comm_relay_oneway_reverse_direction_does_not_propagate() {
     pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::OneWay).unwrap();
 
     let ship_entity = common::spawn_test_ship(
-        app.world_mut(), "Remote-Scout", "courier_mk1", sys_remote, [20.5, 0.0, 0.0],
+        app.world_mut(),
+        "Remote-Scout",
+        "courier_mk1",
+        sys_remote,
+        [20.5, 0.0, 0.0],
     );
 
     advance_time(&mut app, 100);
@@ -1688,19 +1813,32 @@ fn test_ftl_comm_relay_oneway_forward_direction_propagates() {
 
     // Player is near Relay-B this time; ship is near Relay-A.
     let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [20.0, 0.0, 0.0], 1.0, true, true,
+        app.world_mut(),
+        "Capital",
+        [20.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
     );
-    let sys_remote = spawn_test_system(
-        app.world_mut(), "Remote", [0.5, 0.0, 0.0], 0.5, true, false,
-    );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    let sys_remote =
+        spawn_test_system(app.world_mut(), "Remote", [0.5, 0.0, 0.0], 0.5, true, false);
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [0.0, 0.0, 0.0]);
     let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [20.5, 0.0, 0.0]);
     pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::OneWay).unwrap();
 
     let ship_entity = common::spawn_test_ship(
-        app.world_mut(), "Remote-Scout", "courier_mk1", sys_remote, [0.5, 0.0, 0.0],
+        app.world_mut(),
+        "Remote-Scout",
+        "courier_mk1",
+        sys_remote,
+        [0.5, 0.0, 0.0],
     );
 
     advance_time(&mut app, 100);
@@ -1721,20 +1859,39 @@ fn test_ftl_comm_relay_destroyed_becomes_unpaired() {
     let mut app = test_app();
     install_ftl_comm_relay_definition(&mut app, 3.0);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote = spawn_test_system(
-        app.world_mut(), "Remote", [20.5, 0.0, 0.0], 0.5, true, false,
+        app.world_mut(),
+        "Remote",
+        [20.5, 0.0, 0.0],
+        0.5,
+        true,
+        false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [2.0, 0.0, 0.0]);
     let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [20.0, 0.0, 0.0]);
-    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional).unwrap();
+    pair_relay_command(
+        app.world_mut(),
+        relay_a,
+        relay_b,
+        CommDirection::Bidirectional,
+    )
+    .unwrap();
 
     let ship_entity = common::spawn_test_ship(
-        app.world_mut(), "Remote-Scout", "courier_mk1", sys_remote, [20.5, 0.0, 0.0],
+        app.world_mut(),
+        "Remote-Scout",
+        "courier_mk1",
+        sys_remote,
+        [20.5, 0.0, 0.0],
     );
 
     // First tick: both relays live, ship snapshot gets populated.
@@ -1742,7 +1899,10 @@ fn test_ftl_comm_relay_destroyed_becomes_unpaired() {
     {
         let empire = empire_entity(app.world_mut());
         let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-        assert!(store.get_ship(ship_entity).is_some(), "Relay chain should work while paired");
+        assert!(
+            store.get_ship(ship_entity).is_some(),
+            "Relay chain should work while paired"
+        );
     }
 
     // Destroy Relay-B. Next tick, verify_relay_pairings_system strips
@@ -1760,7 +1920,11 @@ fn test_ftl_comm_relay_destroyed_becomes_unpaired() {
     // Despawn the old ship and spawn a new one; no relay should pick it up.
     app.world_mut().despawn(ship_entity);
     let new_ship = common::spawn_test_ship(
-        app.world_mut(), "Fresh-Scout", "courier_mk1", sys_remote, [20.5, 0.0, 0.0],
+        app.world_mut(),
+        "Fresh-Scout",
+        "courier_mk1",
+        sys_remote,
+        [20.5, 0.0, 0.0],
     );
 
     advance_time(&mut app, 50); // light delay at 20.5 ly is ~1230 hd, still far off
@@ -1832,27 +1996,52 @@ fn test_ftl_comm_relay_chain_a_b_c_hops() {
     let mut app = test_app();
     install_ftl_comm_relay_definition(&mut app, 3.0);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote = spawn_test_system(
-        app.world_mut(), "Remote", [20.5, 0.0, 0.0], 0.5, true, false,
+        app.world_mut(),
+        "Remote",
+        [20.5, 0.0, 0.0],
+        0.5,
+        true,
+        false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // First hop: A ↔ B1 (leaves room for chain expansion but not strictly
     // required by this test — we keep it to document the "chain" intent).
     let relay_a = spawn_ftl_comm_relay(app.world_mut(), "A", [2.0, 0.0, 0.0]);
     let relay_b1 = spawn_ftl_comm_relay(app.world_mut(), "B1", [4.0, 0.0, 0.0]);
-    pair_relay_command(app.world_mut(), relay_a, relay_b1, CommDirection::Bidirectional).unwrap();
+    pair_relay_command(
+        app.world_mut(),
+        relay_a,
+        relay_b1,
+        CommDirection::Bidirectional,
+    )
+    .unwrap();
 
     // Second hop: B2 ↔ C.
     let relay_b2 = spawn_ftl_comm_relay(app.world_mut(), "B2", [2.5, 0.0, 0.0]);
     let relay_c = spawn_ftl_comm_relay(app.world_mut(), "C", [20.0, 0.0, 0.0]);
-    pair_relay_command(app.world_mut(), relay_b2, relay_c, CommDirection::Bidirectional).unwrap();
+    pair_relay_command(
+        app.world_mut(),
+        relay_b2,
+        relay_c,
+        CommDirection::Bidirectional,
+    )
+    .unwrap();
 
     let ship_entity = common::spawn_test_ship(
-        app.world_mut(), "Far-Scout", "courier_mk1", sys_remote, [20.5, 0.0, 0.0],
+        app.world_mut(),
+        "Far-Scout",
+        "courier_mk1",
+        sys_remote,
+        [20.5, 0.0, 0.0],
     );
 
     advance_time(&mut app, 50);
@@ -1875,19 +2064,31 @@ fn test_ftl_comm_relay_chain_a_b_c_hops() {
 fn test_perceived_info_reports_last_updated() {
     let mut app = test_app();
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_distant = spawn_test_system(
-        app.world_mut(), "Distant", [10.0, 0.0, 0.0], 0.7, true, false,
+        app.world_mut(),
+        "Distant",
+        [10.0, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // 10 ly of light delay = 600 hexadies. Advance exactly that far — the
     // observation snapped this tick was made at t=0 (current - delay).
     advance_time(&mut app, 600);
 
-    let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let now = app
+        .world()
+        .resource::<macrocosmo::time_system::GameClock>()
+        .elapsed;
     let empire = empire_entity(app.world_mut());
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
     let perceived = macrocosmo::knowledge::perceived_system(store, sys_distant, now)
@@ -1895,12 +2096,17 @@ fn test_perceived_info_reports_last_updated() {
 
     // `observed_at` is the light-departure time. For a 10 ly target the
     // first observation should be snapped at t = now - 600.
-    assert_eq!(perceived.last_updated, now - 600,
-        "last_updated must match observed_at (light-departure hexadies)");
+    assert_eq!(
+        perceived.last_updated,
+        now - 600,
+        "last_updated must match observed_at (light-departure hexadies)"
+    );
     assert_eq!(perceived.age(now), 600);
     // At exactly the threshold the overlay flips to Stale.
-    assert!(perceived.is_stale(now),
-        "age == STALE_THRESHOLD_HEXADIES should overlay source to Stale");
+    assert!(
+        perceived.is_stale(now),
+        "age == STALE_THRESHOLD_HEXADIES should overlay source to Stale"
+    );
 }
 
 /// Propagated observations are tagged `Direct`. Once enough in-game time
@@ -1910,27 +2116,40 @@ fn test_perceived_info_reports_last_updated() {
 fn test_perceived_info_source_reflects_origin() {
     let mut app = test_app();
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
-    let sys_b = spawn_test_system(
-        app.world_mut(), "Near", [2.0, 0.0, 0.0], 0.7, true, false,
-    );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys_b = spawn_test_system(app.world_mut(), "Near", [2.0, 0.0, 0.0], 0.7, true, false);
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // 2 ly → 120 hd delay. Advance past that so the Direct observation lands.
     advance_time(&mut app, 200);
 
-    let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let now = app
+        .world()
+        .resource::<macrocosmo::time_system::GameClock>()
+        .elapsed;
     let empire = empire_entity(app.world_mut());
     {
         let store = app.world().get::<KnowledgeStore>(empire).unwrap();
         // Underlying entry carries Direct source.
-        let entry = store.get(sys_b).expect("Near system should be observed by now");
-        assert_eq!(entry.source, macrocosmo::knowledge::ObservationSource::Direct);
+        let entry = store
+            .get(sys_b)
+            .expect("Near system should be observed by now");
+        assert_eq!(
+            entry.source,
+            macrocosmo::knowledge::ObservationSource::Direct
+        );
 
         let perceived = macrocosmo::knowledge::perceived_system(store, sys_b, now).unwrap();
-        assert_eq!(perceived.source, macrocosmo::knowledge::ObservationSource::Direct);
+        assert_eq!(
+            perceived.source,
+            macrocosmo::knowledge::ObservationSource::Direct
+        );
         assert!(!perceived.is_stale(now));
     }
 
@@ -1940,12 +2159,18 @@ fn test_perceived_info_source_reflects_origin() {
     {
         let store = app.world().get::<KnowledgeStore>(empire).unwrap();
         let entry_after = store.get(sys_b).unwrap();
-        assert_eq!(entry_after.source, macrocosmo::knowledge::ObservationSource::Direct,
-            "underlying source must not be mutated by overlay");
+        assert_eq!(
+            entry_after.source,
+            macrocosmo::knowledge::ObservationSource::Direct,
+            "underlying source must not be mutated by overlay"
+        );
 
         let perceived = macrocosmo::knowledge::perceived_system(store, sys_b, distant_now).unwrap();
-        assert_eq!(perceived.source, macrocosmo::knowledge::ObservationSource::Stale,
-            "accessor overlays source=Stale when age >= STALE_THRESHOLD_HEXADIES");
+        assert_eq!(
+            perceived.source,
+            macrocosmo::knowledge::ObservationSource::Stale,
+            "accessor overlays source=Stale when age >= STALE_THRESHOLD_HEXADIES"
+        );
         assert!(perceived.is_stale(distant_now));
     }
 }
@@ -2018,7 +2243,10 @@ fn test_relay_does_not_overwrite_scout() {
         },
         source: ObservationSource::Scout,
     });
-    assert_eq!(store.get(sys_entity).unwrap().source, ObservationSource::Scout);
+    assert_eq!(
+        store.get(sys_entity).unwrap().source,
+        ObservationSource::Scout
+    );
 
     // Relay propagation ticks keep running and try to write a newer entry.
     store.update(SystemKnowledge {
@@ -2128,13 +2356,22 @@ fn test_sensor_buoy_info_propagates_via_relay() {
     install_sensor_buoy_definition(&mut app);
     install_ftl_comm_relay_definition(&mut app, 5.0);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote = spawn_test_system(
-        app.world_mut(), "Remote", [30.0, 0.0, 0.0], 0.5, true, false,
+        app.world_mut(),
+        "Remote",
+        [30.0, 0.0, 0.0],
+        0.5,
+        true,
+        false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // Sensor buoy watches the remote system (not required for the system
     // snapshot path itself, but models the "Sensor Buoy → Relay" spec).
@@ -2142,10 +2379,19 @@ fn test_sensor_buoy_info_propagates_via_relay() {
 
     let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [28.0, 0.0, 0.0]);
     let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [1.0, 0.0, 0.0]);
-    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional).unwrap();
+    pair_relay_command(
+        app.world_mut(),
+        relay_a,
+        relay_b,
+        CommDirection::Bidirectional,
+    )
+    .unwrap();
 
     advance_time(&mut app, 100);
-    let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let now = app
+        .world()
+        .resource::<macrocosmo::time_system::GameClock>()
+        .elapsed;
     let empire = empire_entity(app.world_mut());
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
 
@@ -2186,27 +2432,47 @@ fn test_relay_destruction_degrades_info_freshness() {
     install_sensor_buoy_definition(&mut app);
     install_ftl_comm_relay_definition(&mut app, 5.0);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote = spawn_test_system(
-        app.world_mut(), "Remote", [30.0, 0.0, 0.0], 0.5, true, false,
+        app.world_mut(),
+        "Remote",
+        [30.0, 0.0, 0.0],
+        0.5,
+        true,
+        false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
     spawn_sensor_buoy(app.world_mut(), [30.0, 0.0, 0.0]);
 
     let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [28.0, 0.0, 0.0]);
     let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [1.0, 0.0, 0.0]);
-    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional).unwrap();
+    pair_relay_command(
+        app.world_mut(),
+        relay_a,
+        relay_b,
+        CommDirection::Bidirectional,
+    )
+    .unwrap();
 
     // Phase 1: chain is live. Remote system is known via relay at t=100.
     advance_time(&mut app, 100);
     let fresh_observed_at;
     {
-        let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+        let now = app
+            .world()
+            .resource::<macrocosmo::time_system::GameClock>()
+            .elapsed;
         let empire = empire_entity(app.world_mut());
         let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-        let entry = store.get(sys_remote).expect("relay delivers phase-1 snapshot");
+        let entry = store
+            .get(sys_remote)
+            .expect("relay delivers phase-1 snapshot");
         assert_eq!(entry.source, ObservationSource::Relay);
         assert_eq!(entry.observed_at, now);
         fresh_observed_at = entry.observed_at;
@@ -2229,7 +2495,9 @@ fn test_relay_destruction_degrades_info_freshness() {
     {
         let empire = empire_entity(app.world_mut());
         let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-        let entry = store.get(sys_remote).expect("prior relay snapshot still present");
+        let entry = store
+            .get(sys_remote)
+            .expect("prior relay snapshot still present");
         assert_eq!(
             entry.observed_at, fresh_observed_at,
             "no new relay writes after chain destroyed — observed_at must stall"
@@ -2246,10 +2514,15 @@ fn test_relay_destruction_degrades_info_freshness() {
     // That confirms the "light-speed fallback" aspect of the spec.
     advance_time(&mut app, 2000);
     {
-        let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+        let now = app
+            .world()
+            .resource::<macrocosmo::time_system::GameClock>()
+            .elapsed;
         let empire = empire_entity(app.world_mut());
         let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-        let entry = store.get(sys_remote).expect("direct light-speed path eventually lands");
+        let entry = store
+            .get(sys_remote)
+            .expect("direct light-speed path eventually lands");
         assert_eq!(
             entry.source,
             ObservationSource::Direct,
@@ -2277,33 +2550,55 @@ fn test_relay_chain_aggregates_system_resources() {
     let mut app = test_app();
     install_ftl_comm_relay_definition(&mut app, 5.0);
 
-    let sys_capital = spawn_test_system(
-        app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true,
-    );
+    let sys_capital =
+        spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
     let sys_remote = spawn_test_system(
-        app.world_mut(), "RemoteColony", [30.0, 0.0, 0.0], 0.6, true, false,
+        app.world_mut(),
+        "RemoteColony",
+        [30.0, 0.0, 0.0],
+        0.6,
+        true,
+        false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_capital }));
+    app.world_mut().spawn((
+        Player,
+        StationedAt {
+            system: sys_capital,
+        },
+    ));
 
     // Attach a stockpile to the remote system so the snapshot has non-trivial
     // content to verify.
-    app.world_mut().entity_mut(sys_remote).insert(ResourceStockpile {
-        minerals: Amt::units(777),
-        energy: Amt::units(321),
-        research: Amt::ZERO,
-        food: Amt::units(50),
-        authority: Amt::units(10),
-    });
+    app.world_mut()
+        .entity_mut(sys_remote)
+        .insert(ResourceStockpile {
+            minerals: Amt::units(777),
+            energy: Amt::units(321),
+            research: Amt::ZERO,
+            food: Amt::units(50),
+            authority: Amt::units(10),
+        });
 
     let relay_a = spawn_ftl_comm_relay(app.world_mut(), "Relay-A", [28.0, 0.0, 0.0]);
     let relay_b = spawn_ftl_comm_relay(app.world_mut(), "Relay-B", [1.0, 0.0, 0.0]);
-    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional).unwrap();
+    pair_relay_command(
+        app.world_mut(),
+        relay_a,
+        relay_b,
+        CommDirection::Bidirectional,
+    )
+    .unwrap();
 
     advance_time(&mut app, 50);
-    let now = app.world().resource::<macrocosmo::time_system::GameClock>().elapsed;
+    let now = app
+        .world()
+        .resource::<macrocosmo::time_system::GameClock>()
+        .elapsed;
     let empire = empire_entity(app.world_mut());
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-    let entry = store.get(sys_remote).expect("relay delivers remote system snapshot");
+    let entry = store
+        .get(sys_remote)
+        .expect("relay delivers remote system snapshot");
     assert_eq!(entry.source, ObservationSource::Relay);
     assert_eq!(entry.observed_at, now);
     assert_eq!(entry.data.minerals, Amt::units(777));
@@ -2318,8 +2613,16 @@ fn test_relay_chain_aggregates_system_resources() {
 fn test_system_snapshot_includes_colonies_after_propagation() {
     let mut app = test_app();
     let capital = spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
-    let remote = spawn_test_system(app.world_mut(), "Remote", [10.0, 0.0, 0.0], 0.8, true, false);
-    app.world_mut().spawn((Player, StationedAt { system: capital }));
+    let remote = spawn_test_system(
+        app.world_mut(),
+        "Remote",
+        [10.0, 0.0, 0.0],
+        0.8,
+        true,
+        false,
+    );
+    app.world_mut()
+        .spawn((Player, StationedAt { system: capital }));
 
     let remote_planet = find_planet(app.world_mut(), remote);
     let colony = spawn_test_colony(
@@ -2334,7 +2637,9 @@ fn test_system_snapshot_includes_colonies_after_propagation() {
 
     let empire = empire_entity(app.world_mut());
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
-    let entry = store.get(remote).expect("remote system knowledge must exist");
+    let entry = store
+        .get(remote)
+        .expect("remote system knowledge must exist");
     assert_eq!(entry.data.colonies.len(), 1, "one colony snapshot expected");
     let cs = &entry.data.colonies[0];
     assert_eq!(cs.colony_entity, colony);
@@ -2348,8 +2653,16 @@ fn test_system_snapshot_includes_colonies_after_propagation() {
 fn test_colony_snapshot_preserves_build_queue_entries() {
     let mut app = test_app();
     let capital = spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
-    let remote = spawn_test_system(app.world_mut(), "Remote", [10.0, 0.0, 0.0], 0.8, true, false);
-    app.world_mut().spawn((Player, StationedAt { system: capital }));
+    let remote = spawn_test_system(
+        app.world_mut(),
+        "Remote",
+        [10.0, 0.0, 0.0],
+        0.8,
+        true,
+        false,
+    );
+    app.world_mut()
+        .spawn((Player, StationedAt { system: capital }));
 
     let remote_planet = find_planet(app.world_mut(), remote);
     let colony = spawn_test_colony(
@@ -2362,6 +2675,7 @@ fn test_colony_snapshot_preserves_build_queue_entries() {
     {
         let mut bq = app.world_mut().get_mut::<BuildingQueue>(colony).unwrap();
         bq.queue.push(BuildingOrder {
+            order_id: 0,
             building_id: BuildingId::new("mine"),
             target_slot: 1,
             minerals_remaining: Amt::units(150),
@@ -2375,7 +2689,12 @@ fn test_colony_snapshot_preserves_build_queue_entries() {
     let empire = empire_entity(app.world_mut());
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
     let entry = store.get(remote).unwrap();
-    let cs = entry.data.colonies.iter().find(|c| c.colony_entity == colony).unwrap();
+    let cs = entry
+        .data
+        .colonies
+        .iter()
+        .find(|c| c.colony_entity == colony)
+        .unwrap();
     assert_eq!(cs.build_queue.len(), 1);
     assert_eq!(cs.build_queue[0].target_slot, 1);
     assert_eq!(cs.build_queue[0].building_id.0, "mine");
@@ -2389,7 +2708,8 @@ fn test_local_colony_snapshot_also_populated() {
     // observation tick.
     let mut app = test_app();
     let capital = spawn_test_system(app.world_mut(), "Capital", [0.0, 0.0, 0.0], 1.0, true, true);
-    app.world_mut().spawn((Player, StationedAt { system: capital }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: capital }));
 
     let capital_planet = find_planet(app.world_mut(), capital);
     let colony = spawn_test_colony(
@@ -2408,5 +2728,3 @@ fn test_local_colony_snapshot_also_populated() {
     assert_eq!(entry.data.colonies.len(), 1);
     assert_eq!(entry.data.colonies[0].colony_entity, colony);
 }
-
-

--- a/macrocosmo/tests/modifiers.rs
+++ b/macrocosmo/tests/modifiers.rs
@@ -7,7 +7,9 @@ use macrocosmo::colony::*;
 use macrocosmo::modifier::{ModifiedValue, Modifier};
 use macrocosmo::ship::*;
 
-use common::{advance_time, empire_entity, find_planet, spawn_test_colony, spawn_test_system, test_app};
+use common::{
+    advance_time, empire_entity, find_planet, spawn_test_colony, spawn_test_system, test_app,
+};
 
 // Modifier affects production output
 
@@ -36,13 +38,16 @@ fn test_modifier_affects_production_output() {
     });
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
+        },
+        ResourceCapacity::default(),
+    ));
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -55,7 +60,7 @@ fn test_modifier_affects_production_output() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings { slots: vec![] },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -148,13 +153,16 @@ fn test_maintenance_modifier_affects_energy() {
     });
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::units(100),
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
+        },
+        ResourceCapacity::default(),
+    ));
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -167,9 +175,14 @@ fn test_maintenance_modifier_affects_energy() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings {
-            slots: vec![Some(BuildingId::new("mine")), Some(BuildingId::new("shipyard")), None, None],
+            slots: vec![
+                Some(BuildingId::new("mine")),
+                Some(BuildingId::new("shipyard")),
+                None,
+                None,
+            ],
         },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -229,13 +242,16 @@ fn test_food_consumption_modifier() {
     });
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
+        },
+        ResourceCapacity::default(),
+    ));
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -248,7 +264,7 @@ fn test_food_consumption_modifier() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings { slots: vec![] },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -307,16 +323,22 @@ fn test_authority_params_modifier() {
     );
 
     // Mark as capital
-    app.world_mut().get_mut::<macrocosmo::galaxy::StarSystem>(sys).unwrap().is_capital = true;
+    app.world_mut()
+        .get_mut::<macrocosmo::galaxy::StarSystem>(sys)
+        .unwrap()
+        .is_capital = true;
 
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
+        },
+        ResourceCapacity::default(),
+    ));
     app.world_mut().spawn((
         Colony {
             planet: planet_sys,
@@ -329,7 +351,7 @@ fn test_authority_params_modifier() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings { slots: vec![] },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -371,7 +393,10 @@ fn test_construction_params_modify_ship_cost() {
     // Modify it
     {
         let empire = empire_entity(app.world_mut());
-        let mut params = app.world_mut().get_mut::<ConstructionParams>(empire).unwrap();
+        let mut params = app
+            .world_mut()
+            .get_mut::<ConstructionParams>(empire)
+            .unwrap();
         params.ship_cost_modifier.push_modifier(Modifier {
             id: "tech_cheaper_ships".to_string(),
             label: "Cheaper Ships".to_string(),
@@ -479,13 +504,7 @@ fn test_timed_modifier_expires_in_game() {
     );
 
     // Spawn colony with base mineral production = 5/hd, no buildings
-    let colony_id = spawn_test_colony(
-        app.world_mut(),
-        sys,
-        Amt::ZERO,
-        Amt::ZERO,
-        vec![],
-    );
+    let colony_id = spawn_test_colony(app.world_mut(), sys, Amt::ZERO, Amt::ZERO, vec![]);
 
     // Push a +20% mineral production modifier that expires in 5 hd
     {

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -29,8 +29,7 @@ fn build_app() -> App {
     let mut app = test_app();
     app.add_systems(
         Update,
-        communication::process_pending_commands
-            .after(macrocosmo::time_system::advance_game_time),
+        communication::process_pending_commands.after(macrocosmo::time_system::advance_game_time),
     );
     app
 }
@@ -73,12 +72,13 @@ fn spawn_pending_remote_command(
     // production where `send_remote_command` records the entry.)
     let empire = empire_entity(app.world_mut());
     if let Some(mut log) = app.world_mut().get_mut::<CommandLog>(empire) {
-        log.entries.push(macrocosmo::communication::CommandLogEntry {
-            description: "test".to_string(),
-            sent_at,
-            arrives_at,
-            arrived: false,
-        });
+        log.entries
+            .push(macrocosmo::communication::CommandLogEntry {
+                description: "test".to_string(),
+                sent_at,
+                arrives_at,
+                arrived: false,
+            });
     }
 }
 
@@ -108,13 +108,8 @@ fn run_until_arrival(app: &mut App, arrives_at: i64) {
 #[test]
 fn queue_building_planet_arrives_and_enqueues() {
     let mut app = build_app();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let colony = spawn_test_colony(
         app.world_mut(),
         planet,
@@ -128,10 +123,13 @@ fn queue_building_planet_arrives_and_enqueues() {
         sys,
         0,
         10,
-        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Queue {
+        RemoteCommand::Colony(ColonyCommand {
+            scope: BuildingScope::Planet(planet),
+            kind: BuildingKind::Queue {
                 building_id: "mine".to_string(),
                 target_slot: 1,
-            } }),
+            },
+        }),
     );
 
     // Before arrival the queue should be empty.
@@ -149,13 +147,8 @@ fn queue_building_planet_arrives_and_enqueues() {
 #[test]
 fn queue_building_system_arrives_and_enqueues() {
     let mut app = build_app();
-    let (sys, _planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, _planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     // spawn_test_colony also attaches SystemBuildings/SystemBuildingQueue to
     // the system entity.
     let _colony = spawn_test_colony(
@@ -171,10 +164,13 @@ fn queue_building_system_arrives_and_enqueues() {
         sys,
         0,
         10,
-        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::System, kind: BuildingKind::Queue {
+        RemoteCommand::Colony(ColonyCommand {
+            scope: BuildingScope::System,
+            kind: BuildingKind::Queue {
                 building_id: "shipyard".to_string(),
                 target_slot: 0,
-            } }),
+            },
+        }),
     );
 
     run_until_arrival(&mut app, 10);
@@ -192,13 +188,8 @@ fn queue_building_system_arrives_and_enqueues() {
 #[test]
 fn demolish_building_planet_arrives_and_enqueues() {
     let mut app = build_app();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let colony = spawn_test_colony(
         app.world_mut(),
         planet,
@@ -212,7 +203,10 @@ fn demolish_building_planet_arrives_and_enqueues() {
         sys,
         0,
         5,
-        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Demolish { target_slot: 0 } }),
+        RemoteCommand::Colony(ColonyCommand {
+            scope: BuildingScope::Planet(planet),
+            kind: BuildingKind::Demolish { target_slot: 0 },
+        }),
     );
 
     run_until_arrival(&mut app, 5);
@@ -237,13 +231,8 @@ fn upgrade_building_planet_without_path_warns_and_noops() {
     // naive upgrade request should warn but not enqueue anything. This
     // verifies the path-lookup branch.
     let mut app = build_app();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let colony = spawn_test_colony(
         app.world_mut(),
         planet,
@@ -257,10 +246,13 @@ fn upgrade_building_planet_without_path_warns_and_noops() {
         sys,
         0,
         5,
-        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Upgrade {
+        RemoteCommand::Colony(ColonyCommand {
+            scope: BuildingScope::Planet(planet),
+            kind: BuildingKind::Upgrade {
                 slot_index: 0,
                 target_id: "advanced_mine".to_string(),
-            } }),
+            },
+        }),
     );
 
     run_until_arrival(&mut app, 5);
@@ -279,13 +271,8 @@ fn upgrade_building_planet_without_path_warns_and_noops() {
 #[test]
 fn queue_ship_build_arrives_and_enqueues() {
     let mut app = build_app();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let colony = spawn_test_colony(
         app.world_mut(),
         planet,
@@ -299,7 +286,11 @@ fn queue_ship_build_arrives_and_enqueues() {
         sys,
         0,
         20,
-        RemoteCommand::ShipBuild { host_colony: colony, design_id: "explorer_mk1".to_string(), build_kind: BuildKind::Ship },
+        RemoteCommand::ShipBuild {
+            host_colony: colony,
+            design_id: "explorer_mk1".to_string(),
+            build_kind: BuildKind::Ship,
+        },
     );
 
     run_until_arrival(&mut app, 20);
@@ -317,13 +308,8 @@ fn queue_ship_build_arrives_and_enqueues() {
 #[test]
 fn queue_deliverable_build_arrives_and_enqueues() {
     let mut app = build_app();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let colony = spawn_test_colony(
         app.world_mut(),
         planet,
@@ -338,14 +324,14 @@ fn queue_deliverable_build_arrives_and_enqueues() {
         0,
         20,
         RemoteCommand::DeliverableBuild {
-                host_colony: colony,
-                def_id: "sensor_buoy".to_string(),
-                display_name: "Sensor Buoy".to_string(),
-                cargo_size: 2,
-                minerals_cost: Amt::units(100),
-                energy_cost: Amt::units(50),
-                build_time: 30,
-            },
+            host_colony: colony,
+            def_id: "sensor_buoy".to_string(),
+            display_name: "Sensor Buoy".to_string(),
+            cargo_size: 2,
+            minerals_cost: Amt::units(100),
+            energy_cost: Amt::units(50),
+            build_time: 30,
+        },
     );
 
     run_until_arrival(&mut app, 20);
@@ -368,13 +354,8 @@ fn queue_deliverable_build_arrives_and_enqueues() {
 #[test]
 fn pending_colony_command_not_applied_before_arrival() {
     let mut app = build_app();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let colony = spawn_test_colony(
         app.world_mut(),
         planet,
@@ -388,10 +369,13 @@ fn pending_colony_command_not_applied_before_arrival() {
         sys,
         0,
         100,
-        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Queue {
+        RemoteCommand::Colony(ColonyCommand {
+            scope: BuildingScope::Planet(planet),
+            kind: BuildingKind::Queue {
                 building_id: "mine".to_string(),
                 target_slot: 0,
-            } }),
+            },
+        }),
     );
 
     // Advance halfway.
@@ -424,13 +408,8 @@ fn pending_colony_command_not_applied_before_arrival() {
 #[test]
 fn local_dispatch_applies_same_frame() {
     let mut app = build_app_with_dispatch();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Home",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true);
     let colony = spawn_test_colony(
         app.world_mut(),
         planet,
@@ -438,18 +417,20 @@ fn local_dispatch_applies_same_frame() {
         Amt::units(1000),
         vec![None, None, None, None],
     );
-    app.world_mut()
-        .spawn((Player, StationedAt { system: sys }));
+    app.world_mut().spawn((Player, StationedAt { system: sys }));
 
     app.world_mut()
         .resource_mut::<PendingColonyDispatches>()
         .queue
         .push(PendingColonyDispatch {
             target_system: sys,
-            command: RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Queue {
+            command: RemoteCommand::Colony(ColonyCommand {
+                scope: BuildingScope::Planet(planet),
+                kind: BuildingKind::Queue {
                     building_id: "mine".to_string(),
                     target_slot: 0,
-                } }),
+                },
+            }),
         });
 
     // Align LastProductionTick so the build queue tick sees delta=1.
@@ -481,20 +462,10 @@ fn local_dispatch_applies_same_frame() {
 #[test]
 fn remote_dispatch_delayed_by_light_speed() {
     let mut app = build_app_with_dispatch();
-    let (home_sys, _home_planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Home",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
-    let (target_sys, target_planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (home_sys, _home_planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true);
+    let (target_sys, target_planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let target_colony = spawn_test_colony(
         app.world_mut(),
         target_planet,
@@ -510,10 +481,13 @@ fn remote_dispatch_delayed_by_light_speed() {
         .queue
         .push(PendingColonyDispatch {
             target_system: target_sys,
-            command: RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(target_planet), kind: BuildingKind::Queue {
+            command: RemoteCommand::Colony(ColonyCommand {
+                scope: BuildingScope::Planet(target_planet),
+                kind: BuildingKind::Queue {
                     building_id: "mine".to_string(),
                     target_slot: 0,
-                } }),
+                },
+            }),
         });
 
     // Run one frame. Dispatch drains and spawns PendingCommand;
@@ -566,20 +540,10 @@ fn remote_dispatch_delayed_by_light_speed() {
 #[test]
 fn remote_system_level_dispatch_delayed() {
     let mut app = build_app_with_dispatch();
-    let (home_sys, _home_planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Home",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
-    let (target_sys, _target_planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (home_sys, _home_planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true);
+    let (target_sys, _target_planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     // spawn_test_colony attaches SystemBuildings/SystemBuildingQueue to the
     // star system entity.
     let _target_colony = spawn_test_colony(
@@ -597,18 +561,18 @@ fn remote_system_level_dispatch_delayed() {
         .queue
         .push(PendingColonyDispatch {
             target_system: target_sys,
-            command: RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::System, kind: BuildingKind::Queue {
+            command: RemoteCommand::Colony(ColonyCommand {
+                scope: BuildingScope::System,
+                kind: BuildingKind::Queue {
                     building_id: "shipyard".to_string(),
                     target_slot: 0,
-                } }),
+                },
+            }),
         });
 
     advance_time(&mut app, 1);
 
-    let sbq = app
-        .world()
-        .get::<SystemBuildingQueue>(target_sys)
-        .unwrap();
+    let sbq = app.world().get::<SystemBuildingQueue>(target_sys).unwrap();
     assert!(
         sbq.queue.is_empty(),
         "remote system queue should be empty before light delay"
@@ -617,20 +581,13 @@ fn remote_system_level_dispatch_delayed() {
     let arrives_at = 1 + macrocosmo::physics::light_delay_hexadies(10.0);
     run_until_arrival(&mut app, arrives_at);
 
-    let sbq = app
-        .world()
-        .get::<SystemBuildingQueue>(target_sys)
-        .unwrap();
+    let sbq = app.world().get::<SystemBuildingQueue>(target_sys).unwrap();
     let sys_bldgs = app
         .world()
         .get::<macrocosmo::colony::SystemBuildings>(target_sys)
         .unwrap();
     let present = sbq.queue.iter().any(|o| o.target_slot == 0)
-        || sys_bldgs
-            .slots
-            .get(0)
-            .and_then(|s| s.as_ref())
-            .is_some();
+        || sys_bldgs.slots.get(0).and_then(|s| s.as_ref()).is_some();
     assert!(
         present,
         "remote system-level command should apply once clock reaches arrives_at"
@@ -642,20 +599,10 @@ fn remote_system_level_dispatch_delayed() {
 #[test]
 fn remote_ship_build_dispatch_delayed() {
     let mut app = build_app_with_dispatch();
-    let (home_sys, _home_planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Home",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
-    let (target_sys, target_planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (home_sys, _home_planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true);
+    let (target_sys, target_planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let target_colony = spawn_test_colony(
         app.world_mut(),
         target_planet,
@@ -671,7 +618,11 @@ fn remote_ship_build_dispatch_delayed() {
         .queue
         .push(PendingColonyDispatch {
             target_system: target_sys,
-            command: RemoteCommand::ShipBuild { host_colony: target_colony, design_id: "explorer_mk1".to_string(), build_kind: BuildKind::Ship },
+            command: RemoteCommand::ShipBuild {
+                host_colony: target_colony,
+                design_id: "explorer_mk1".to_string(),
+                build_kind: BuildKind::Ship,
+            },
         });
 
     advance_time(&mut app, 1);
@@ -701,13 +652,8 @@ fn remote_ship_build_dispatch_delayed() {
 #[test]
 fn arrival_marks_command_log_entry() {
     let mut app = build_app();
-    let (sys, planet) = spawn_test_system_with_planet(
-        app.world_mut(),
-        "Target",
-        [10.0, 0.0, 0.0],
-        1.0,
-        true,
-    );
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
     let _colony = spawn_test_colony(
         app.world_mut(),
         planet,
@@ -721,10 +667,13 @@ fn arrival_marks_command_log_entry() {
         sys,
         0,
         10,
-        RemoteCommand::Colony(ColonyCommand { scope: BuildingScope::Planet(planet), kind: BuildingKind::Queue {
+        RemoteCommand::Colony(ColonyCommand {
+            scope: BuildingScope::Planet(planet),
+            kind: BuildingKind::Queue {
                 building_id: "mine".to_string(),
                 target_slot: 0,
-            } }),
+            },
+        }),
     );
 
     run_until_arrival(&mut app, 10);
@@ -738,3 +687,432 @@ fn arrival_marks_command_log_entry() {
     assert!(log.entries[0].arrived, "entry should be marked arrived");
 }
 
+// --------------------------------------------------------------------------
+// #275: Cancel commands — order_id based
+// --------------------------------------------------------------------------
+
+/// Helper that seeds a planet-level building order on a colony's
+/// BuildingQueue via the public `push_build_order` helper so the returned
+/// `order_id` matches what the cancel command will reference.
+fn seed_building_order(app: &mut App, colony: Entity) -> u64 {
+    use macrocosmo::colony::BuildingOrder;
+    let mut bq = app
+        .world_mut()
+        .get_mut::<BuildingQueue>(colony)
+        .expect("colony has BuildingQueue");
+    bq.push_build_order(BuildingOrder {
+        order_id: 0,
+        building_id: BuildingId::new("mine"),
+        target_slot: 1,
+        minerals_remaining: Amt::units(100),
+        energy_remaining: Amt::units(50),
+        build_time_remaining: 50,
+    })
+}
+
+/// #275 Phase 1: `BuildingQueue::push_build_order` auto-assigns ids so
+/// sequentially pushed orders get distinct ids starting at 1.
+#[test]
+fn push_order_assigns_unique_incrementing_ids() {
+    let mut app = build_app();
+    let (_sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "S", [0.0, 0.0, 0.0], 1.0, true);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+    let id1 = seed_building_order(&mut app, colony);
+    let id2 = seed_building_order(&mut app, colony);
+    let id3 = seed_building_order(&mut app, colony);
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+    assert_eq!(id3, 3);
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert_eq!(bq.queue[0].order_id, 1);
+    assert_eq!(bq.queue[1].order_id, 2);
+    assert_eq!(bq.queue[2].order_id, 3);
+    assert_eq!(bq.next_order_id, 4);
+}
+
+/// #275 Phase 2: `CancelBuildingOrder` at zero distance (local) applies
+/// the same frame it's dispatched — mirrors the Queue path.
+#[test]
+fn local_cancel_building_order_applies_same_frame() {
+    let mut app = build_app_with_dispatch();
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+    app.world_mut().spawn((Player, StationedAt { system: sys }));
+    let order_id = seed_building_order(&mut app, colony);
+
+    app.world_mut()
+        .resource_mut::<PendingColonyDispatches>()
+        .queue
+        .push(PendingColonyDispatch {
+            target_system: sys,
+            command: RemoteCommand::CancelBuildingOrder { order_id },
+        });
+
+    // Align LastProductionTick so delta=1 (no giant catch-up).
+    app.world_mut()
+        .resource_mut::<macrocosmo::colony::LastProductionTick>()
+        .0 = 0;
+    advance_time(&mut app, 1);
+
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert!(
+        bq.queue.is_empty(),
+        "local cancel should remove the order same frame"
+    );
+}
+
+/// #275 Phase 2: remote cancel is delayed by light-speed. Order stays
+/// enqueued until arrival.
+#[test]
+fn remote_cancel_building_order_delayed() {
+    let mut app = build_app_with_dispatch();
+    let (home_sys, _home_planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true);
+    let (target_sys, target_planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
+    let target_colony = spawn_test_colony(
+        app.world_mut(),
+        target_planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+    app.world_mut()
+        .spawn((Player, StationedAt { system: home_sys }));
+    let order_id = seed_building_order(&mut app, target_colony);
+
+    app.world_mut()
+        .resource_mut::<PendingColonyDispatches>()
+        .queue
+        .push(PendingColonyDispatch {
+            target_system: target_sys,
+            command: RemoteCommand::CancelBuildingOrder { order_id },
+        });
+
+    advance_time(&mut app, 1);
+    // Order should still be present before light-delay elapses.
+    let bq = app.world().get::<BuildingQueue>(target_colony).unwrap();
+    assert_eq!(bq.queue.len(), 1, "cancel should not apply before arrival");
+
+    let arrives_at = 1 + macrocosmo::physics::light_delay_hexadies(10.0);
+    run_until_arrival(&mut app, arrives_at);
+
+    let bq = app.world().get::<BuildingQueue>(target_colony).unwrap();
+    assert!(
+        bq.queue.is_empty(),
+        "remote cancel should remove order once light delay elapses"
+    );
+}
+
+/// #275 Phase 2: Cancel against a non-existent order_id logs a warn but
+/// does not panic / affect unrelated orders. Simulates the race where
+/// the order completed (or was cancelled by a previous dispatch) during
+/// the light-speed trip.
+#[test]
+fn cancel_missing_order_is_noop_warn() {
+    let mut app = build_app();
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+    // Seed one real order whose id we will NOT cancel.
+    let _real = seed_building_order(&mut app, colony);
+
+    spawn_pending_remote_command(
+        &mut app,
+        sys,
+        0,
+        5,
+        RemoteCommand::CancelBuildingOrder { order_id: 9999 },
+    );
+
+    run_until_arrival(&mut app, 5);
+
+    let bq = app.world().get::<BuildingQueue>(colony).unwrap();
+    assert_eq!(
+        bq.queue.len(),
+        1,
+        "unrelated order must stay put when cancel misses"
+    );
+}
+
+/// #275 Phase 2 (regression): `CancelBuildingOrder` must not cross
+/// system boundaries. `order_id` counters are per-queue so the same
+/// numeric id can exist independently on different systems; a cancel
+/// dispatched for system A should only scan colonies in system A.
+#[test]
+fn cancel_scoped_to_target_system_does_not_affect_other_systems() {
+    let mut app = build_app();
+    let (sys_a, planet_a) =
+        spawn_test_system_with_planet(app.world_mut(), "A", [0.0, 0.0, 0.0], 1.0, true);
+    let (sys_b, planet_b) =
+        spawn_test_system_with_planet(app.world_mut(), "B", [20.0, 0.0, 0.0], 1.0, true);
+    let colony_a = spawn_test_colony(
+        app.world_mut(),
+        planet_a,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+    let colony_b = spawn_test_colony(
+        app.world_mut(),
+        planet_b,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![None, None, None, None],
+    );
+    // Seed one order on each colony. Both will get order_id=1 because
+    // each BuildingQueue has its own counter.
+    let id_a = seed_building_order(&mut app, colony_a);
+    let id_b = seed_building_order(&mut app, colony_b);
+    assert_eq!(id_a, id_b, "pre-condition: per-queue counters collide");
+
+    // Dispatch a cancel to system B for order_id=1. System A's order
+    // must stay put.
+    spawn_pending_remote_command(
+        &mut app,
+        sys_b,
+        0,
+        5,
+        RemoteCommand::CancelBuildingOrder { order_id: 1 },
+    );
+    run_until_arrival(&mut app, 5);
+
+    let bq_a = app.world().get::<BuildingQueue>(colony_a).unwrap();
+    let bq_b = app.world().get::<BuildingQueue>(colony_b).unwrap();
+    assert_eq!(
+        bq_a.queue.len(),
+        1,
+        "system A order must not be cancelled by a dispatch to system B"
+    );
+    assert!(
+        bq_b.queue.is_empty(),
+        "system B order should have been cancelled"
+    );
+    let _ = sys_a; // suppress unused
+}
+
+/// #275 Phase 2: `CancelBuildingOrder` also targets the system-level
+/// `SystemBuildingQueue` when the id lives there (scope derived at
+/// arrival, not at send time).
+#[test]
+fn cancel_system_level_order() {
+    let mut app = build_app();
+    let (sys, _planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
+    // spawn_test_colony attaches SystemBuildings/SystemBuildingQueue.
+    let _colony = spawn_test_colony(
+        app.world_mut(),
+        sys,
+        Amt::units(1000),
+        Amt::units(1000),
+        vec![],
+    );
+    use macrocosmo::colony::BuildingOrder;
+    let sys_order_id = {
+        let mut sbq = app.world_mut().get_mut::<SystemBuildingQueue>(sys).unwrap();
+        sbq.push_build_order(BuildingOrder {
+            order_id: 0,
+            building_id: BuildingId::new("shipyard"),
+            target_slot: 0,
+            minerals_remaining: Amt::units(200),
+            energy_remaining: Amt::units(100),
+            build_time_remaining: 30,
+        })
+    };
+
+    spawn_pending_remote_command(
+        &mut app,
+        sys,
+        0,
+        5,
+        RemoteCommand::CancelBuildingOrder {
+            order_id: sys_order_id,
+        },
+    );
+    run_until_arrival(&mut app, 5);
+
+    let sbq = app.world().get::<SystemBuildingQueue>(sys).unwrap();
+    assert!(
+        sbq.queue.is_empty(),
+        "system-level order should be cancelled"
+    );
+}
+
+/// #275 Phase 2: `CancelShipOrder { host_colony, order_id }` removes a
+/// pending ship BuildOrder from the specified colony's BuildQueue.
+#[test]
+fn cancel_ship_order_removes_from_host_colony_queue() {
+    let mut app = build_app();
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(10_000),
+        Amt::units(10_000),
+        vec![],
+    );
+    // Seed a ship order and grab its id.
+    let ship_order_id = {
+        use macrocosmo::colony::BuildOrder;
+        let mut bq = app.world_mut().get_mut::<BuildQueue>(colony).unwrap();
+        bq.push_order(BuildOrder {
+            order_id: 0,
+            kind: BuildKind::Ship,
+            design_id: "explorer_mk1".to_string(),
+            display_name: "Explorer".to_string(),
+            minerals_cost: Amt::units(500),
+            minerals_invested: Amt::ZERO,
+            energy_cost: Amt::units(300),
+            energy_invested: Amt::ZERO,
+            build_time_total: 60,
+            build_time_remaining: 60,
+        })
+    };
+
+    spawn_pending_remote_command(
+        &mut app,
+        sys,
+        0,
+        5,
+        RemoteCommand::CancelShipOrder {
+            host_colony: colony,
+            order_id: ship_order_id,
+        },
+    );
+    run_until_arrival(&mut app, 5);
+
+    let bq = app.world().get::<BuildQueue>(colony).unwrap();
+    assert!(bq.queue.is_empty(), "ship order should be cancelled");
+}
+
+/// #275 Phase 2: Cancelling a ship order with an unknown id is a warn+
+/// noop — queue unchanged. Simulates the race where the order already
+/// completed (producing a Ship entity) before the cancel arrived.
+#[test]
+fn cancel_ship_order_with_missing_id_is_noop() {
+    let mut app = build_app();
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Target", [10.0, 0.0, 0.0], 1.0, true);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(10_000),
+        Amt::units(10_000),
+        vec![],
+    );
+    // Seed a ship order whose id we will NOT cancel.
+    let _real = {
+        use macrocosmo::colony::BuildOrder;
+        let mut bq = app.world_mut().get_mut::<BuildQueue>(colony).unwrap();
+        bq.push_order(BuildOrder {
+            order_id: 0,
+            kind: BuildKind::Ship,
+            design_id: "explorer_mk1".to_string(),
+            display_name: "Explorer".to_string(),
+            minerals_cost: Amt::units(500),
+            minerals_invested: Amt::ZERO,
+            energy_cost: Amt::units(300),
+            energy_invested: Amt::ZERO,
+            build_time_total: 60,
+            build_time_remaining: 60,
+        })
+    };
+
+    spawn_pending_remote_command(
+        &mut app,
+        sys,
+        0,
+        5,
+        RemoteCommand::CancelShipOrder {
+            host_colony: colony,
+            order_id: 9999,
+        },
+    );
+    run_until_arrival(&mut app, 5);
+
+    let bq = app.world().get::<BuildQueue>(colony).unwrap();
+    assert_eq!(bq.queue.len(), 1, "unrelated ship order must stay put");
+}
+
+/// #275 Phase 1: `order_id` and `next_order_id` survive save/load.
+#[test]
+fn order_id_preserved_across_save_load() {
+    use macrocosmo::colony::{BuildOrder, BuildQueue as LiveBuildQueue};
+    use macrocosmo::persistence::savebag::{SavedBuildOrder, SavedBuildQueue};
+
+    let live = LiveBuildQueue {
+        queue: vec![
+            BuildOrder {
+                order_id: 7,
+                kind: BuildKind::Ship,
+                design_id: "x".into(),
+                display_name: "x".into(),
+                minerals_cost: Amt::units(1),
+                minerals_invested: Amt::ZERO,
+                energy_cost: Amt::units(1),
+                energy_invested: Amt::ZERO,
+                build_time_total: 10,
+                build_time_remaining: 10,
+            },
+            BuildOrder {
+                order_id: 9,
+                kind: BuildKind::Ship,
+                design_id: "y".into(),
+                display_name: "y".into(),
+                minerals_cost: Amt::units(1),
+                minerals_invested: Amt::ZERO,
+                energy_cost: Amt::units(1),
+                energy_invested: Amt::ZERO,
+                build_time_total: 10,
+                build_time_remaining: 10,
+            },
+        ],
+        next_order_id: 10,
+    };
+    let saved = SavedBuildQueue::from_live(&live);
+    assert_eq!(saved.next_order_id, 10);
+    assert_eq!(saved.queue[0].order_id, 7);
+    assert_eq!(saved.queue[1].order_id, 9);
+    let restored: LiveBuildQueue = saved.into_live();
+    assert_eq!(restored.next_order_id, 10);
+    assert_eq!(restored.queue[0].order_id, 7);
+    assert_eq!(restored.queue[1].order_id, 9);
+
+    // Serde round-trip (bincode) covers the #[serde(default)] paths too.
+    let one = SavedBuildOrder::from_live(&BuildOrder {
+        order_id: 42,
+        kind: BuildKind::Ship,
+        design_id: "z".into(),
+        display_name: "z".into(),
+        minerals_cost: Amt::units(1),
+        minerals_invested: Amt::ZERO,
+        energy_cost: Amt::units(1),
+        energy_invested: Amt::ZERO,
+        build_time_total: 1,
+        build_time_remaining: 1,
+    });
+    let json = serde_json::to_string(&one).expect("serialize");
+    let back: SavedBuildOrder = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.order_id, 42);
+}

--- a/macrocosmo/tests/save_load.rs
+++ b/macrocosmo/tests/save_load.rs
@@ -12,7 +12,7 @@ use macrocosmo::components::Position;
 use macrocosmo::faction::{FactionOwner, FactionRelations, FactionView, RelationState};
 use macrocosmo::galaxy::{GalaxyConfig, Planet, Sovereignty, StarSystem, SystemAttributes};
 use macrocosmo::persistence::{
-    capture_save, load::load_game_from_reader, save::save_game_to_writer, SaveId, SCRIPTS_VERSION,
+    SCRIPTS_VERSION, SaveId, capture_save, load::load_game_from_reader, save::save_game_to_writer,
 };
 use macrocosmo::player::{Faction, PlayerEmpire};
 use macrocosmo::scripting::game_rng::GameRng;
@@ -244,7 +244,7 @@ fn test_save_load_preserves_galaxy() {
 
     // Spot-check Earth planet's link to its system survives the remap.
     let mut saw_earth = false;
-    for (planet, ) in dst.query::<(&Planet,)>().iter(&dst) {
+    for (planet,) in dst.query::<(&Planet,)>().iter(&dst) {
         if planet.name == "Earth" {
             saw_earth = true;
             // The system entity is freshly allocated, but looking it up should
@@ -333,7 +333,10 @@ fn test_save_load_preserves_game_rng_deterministic() {
             ys.push(gb.random::<u64>());
         }
     }
-    assert_eq!(xs, ys, "two loads of the same save must yield identical RNG streams");
+    assert_eq!(
+        xs, ys,
+        "two loads of the same save must yield identical RNG streams"
+    );
 }
 
 #[test]
@@ -344,7 +347,7 @@ fn test_save_load_preserves_scripts_version_mismatch_warns() {
     // and continues. We simulate a mismatch by hand-crafting a GameSave with
     // a different scripts_version, re-encoding, and asserting that load
     // succeeds.
-    use macrocosmo::persistence::save::{GameSave, SavedResources, SAVE_VERSION};
+    use macrocosmo::persistence::save::{GameSave, SAVE_VERSION, SavedResources};
 
     let save = GameSave {
         version: SAVE_VERSION,
@@ -379,17 +382,15 @@ fn test_save_load_preserves_scripts_version_mismatch_warns() {
 // ===========================================================================
 
 use macrocosmo::colony::{
-    BuildKind, BuildOrder, BuildQueue, Buildings, BuildingQueue, ColonyJobRates,
+    BuildKind, BuildOrder, BuildQueue, BuildingQueue, Buildings, ColonyJobRates,
 };
-use macrocosmo::deep_space::{
-    CommDirection, DeepSpaceStructure, FTLCommRelay, StructureHitpoints,
-};
+use macrocosmo::deep_space::{CommDirection, DeepSpaceStructure, FTLCommRelay, StructureHitpoints};
 use macrocosmo::events::{EventLog, GameEvent, GameEventKind};
+use macrocosmo::knowledge::facts::{CombatVictor, KnowledgeFact};
 use macrocosmo::knowledge::{
     KnowledgeStore, ObservationSource, PendingFactQueue, PerceivedFact, SystemKnowledge,
     SystemSnapshot,
 };
-use macrocosmo::knowledge::facts::{CombatVictor, KnowledgeFact};
 use macrocosmo::notifications::{NotificationPriority, NotificationQueue};
 use macrocosmo::scripting::building_api::BuildingId;
 use macrocosmo::ship::{
@@ -427,9 +428,12 @@ fn seed_world_with_ship() -> (World, Entity, Entity) {
             },
             ShipState::Docked { system: sol },
             macrocosmo::ship::ShipHitpoints {
-                hull: 50.0, hull_max: 50.0,
-                armor: 0.0, armor_max: 0.0,
-                shield: 0.0, shield_max: 0.0,
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
                 shield_regen: 0.0,
             },
         ))
@@ -477,7 +481,10 @@ fn test_save_load_preserves_command_queue() {
         .find(|(_, s)| s.name == "Alpha Centauri")
         .map(|(e, _)| e)
         .unwrap();
-    assert_eq!(survey_target, alpha_dst, "Entity remap must route to the same star system");
+    assert_eq!(
+        survey_target, alpha_dst,
+        "Entity remap must route to the same star system"
+    );
 }
 
 #[test]
@@ -524,8 +531,18 @@ fn test_save_load_preserves_colony_jobs_and_rates() {
     src.entity_mut(colony_ent).insert((
         ColonyJobs {
             slots: vec![
-                JobSlot { job_id: "miner".into(), capacity: 10, assigned: 5, capacity_from_buildings: 8 },
-                JobSlot { job_id: "farmer".into(), capacity: 6, assigned: 6, capacity_from_buildings: 4 },
+                JobSlot {
+                    job_id: "miner".into(),
+                    capacity: 10,
+                    assigned: 5,
+                    capacity_from_buildings: 8,
+                },
+                JobSlot {
+                    job_id: "farmer".into(),
+                    capacity: 6,
+                    assigned: 6,
+                    capacity_from_buildings: 4,
+                },
             ],
         },
         {
@@ -548,7 +565,9 @@ fn test_save_load_preserves_colony_jobs_and_rates() {
     assert_eq!(jobs.slots.len(), 2);
     assert_eq!(jobs.slots[0].job_id, "miner");
     assert_eq!(jobs.slots[0].assigned, 5);
-    let bucket = rates.get("miner", "colony.minerals_per_hexadies").expect("bucket must exist");
+    let bucket = rates
+        .get("miner", "colony.minerals_per_hexadies")
+        .expect("bucket must exist");
     assert_eq!(bucket.base(), Amt::units(3));
 }
 
@@ -563,6 +582,7 @@ fn test_save_load_preserves_build_queue() {
     src.entity_mut(colony_ent).insert((
         BuildQueue {
             queue: vec![BuildOrder {
+                order_id: 0,
                 kind: BuildKind::Ship,
                 design_id: "explorer_mk1".into(),
                 display_name: "Explorer".into(),
@@ -573,6 +593,7 @@ fn test_save_load_preserves_build_queue() {
                 build_time_total: 60,
                 build_time_remaining: 45,
             }],
+            next_order_id: 0,
         },
         Buildings {
             slots: vec![
@@ -726,7 +747,10 @@ fn test_save_load_preserves_tech_tree() {
         .iter(&dst)
         .next()
         .expect("TechTree + ResearchQueue must round-trip");
-    assert!(tt.researched.contains(&TechId("industrial_automated_mining".into())));
+    assert!(
+        tt.researched
+            .contains(&TechId("industrial_automated_mining".into()))
+    );
     assert!(tt.researched.contains(&TechId("physics_ftl_drive".into())));
     assert_eq!(rq.current, Some(TechId("social_central_planning".into())));
     assert!((rq.accumulated - 42.5).abs() < 1e-9);
@@ -822,8 +846,15 @@ fn test_save_load_preserves_ftl_comm_relay_pairing() {
                 name: "Relay A".into(),
                 owner: Owner::Empire(empire),
             },
-            Position { x: 1.0, y: 0.0, z: 0.0 },
-            StructureHitpoints { current: 50.0, max: 50.0 },
+            Position {
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            StructureHitpoints {
+                current: 50.0,
+                max: 50.0,
+            },
         ))
         .id();
     let relay_b = src
@@ -833,8 +864,15 @@ fn test_save_load_preserves_ftl_comm_relay_pairing() {
                 name: "Relay B".into(),
                 owner: Owner::Empire(empire),
             },
-            Position { x: 49.0, y: 0.0, z: 0.0 },
-            StructureHitpoints { current: 50.0, max: 50.0 },
+            Position {
+                x: 49.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            StructureHitpoints {
+                current: 50.0,
+                max: 50.0,
+            },
         ))
         .id();
     src.entity_mut(relay_a).insert(FTLCommRelay {
@@ -859,7 +897,10 @@ fn test_save_load_preserves_ftl_comm_relay_pairing() {
     assert_eq!(relays.len(), 2);
     // Each should reference the other.
     for (self_e, paired) in &relays {
-        let partner_pair = relays.iter().find(|(e, _)| *e == *paired).expect("partner must exist");
+        let partner_pair = relays
+            .iter()
+            .find(|(e, _)| *e == *paired)
+            .expect("partner must exist");
         assert_eq!(partner_pair.1, *self_e, "pairing is symmetric post-load");
     }
 }
@@ -980,12 +1021,19 @@ fn test_save_load_preserves_pending_colony_command() {
         .expect("colony must round-trip");
 
     let mut q = dst.query::<&PendingCommand>();
-    let cmd = q.iter(&dst).next().expect("pending command must round-trip");
+    let cmd = q
+        .iter(&dst)
+        .next()
+        .expect("pending command must round-trip");
     assert_eq!(cmd.target_system, alpha_dst, "target_system Entity remap");
     assert_eq!(cmd.sent_at, 100);
     assert_eq!(cmd.arrives_at, 700);
     match &cmd.command {
-        RemoteCommand::ShipBuild { host_colony, design_id, .. } => {
+        RemoteCommand::ShipBuild {
+            host_colony,
+            design_id,
+            ..
+        } => {
             assert_eq!(*host_colony, colony_dst, "host_colony Entity remap");
             assert_eq!(design_id, "explorer_mk1");
         }
@@ -1100,4 +1148,3 @@ fn test_save_load_preserves_colony_snapshot() {
     assert_eq!(cs.build_queue[0].building_id.0, "farm");
     assert_eq!(cs.build_queue[0].build_time_remaining, 7);
 }
-

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -3,24 +3,22 @@ mod common;
 use bevy::prelude::*;
 use macrocosmo::amount::Amt;
 use macrocosmo::colony::*;
-use macrocosmo::modifier::ModifiedValue;
 use macrocosmo::components::Position;
 use macrocosmo::galaxy::{Sovereignty, StarSystem};
 use macrocosmo::knowledge::*;
+use macrocosmo::modifier::ModifiedValue;
 use macrocosmo::physics::sublight_travel_hexadies;
 use macrocosmo::player::*;
 use macrocosmo::ship::*;
 use macrocosmo::technology;
 use macrocosmo::time_system::GameClock;
 
-use common::{advance_time, empire_entity, find_planet, full_test_app, spawn_test_colony, spawn_test_system, test_app};
+use common::{
+    advance_time, empire_entity, find_planet, full_test_app, spawn_test_colony, spawn_test_system,
+    test_app,
+};
 
-fn spawn_ftl_explorer(
-    world: &mut World,
-    name: &str,
-    system: Entity,
-    pos: [f64; 3],
-) -> Entity {
+fn spawn_ftl_explorer(world: &mut World, name: &str, system: Entity, pos: [f64; 3]) -> Entity {
     world
         .spawn((
             Ship {
@@ -82,28 +80,31 @@ fn test_sublight_travel_and_arrival() {
     assert_eq!(travel_time, 80);
 
     // Spawn explorer docked at System-A
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Scout-1".to_string(),
-            design_id: "explorer_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.75,
-            ftl_range: 0.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::SubLight {
-            origin: [0.0, 0.0, 0.0],
-            destination: [1.0, 0.0, 0.0],
-            target_system: Some(sys_b),
-            departed_at: 0,
-            arrival_at: travel_time,
-        },
-        Position::from([0.0, 0.0, 0.0]),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Scout-1".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.75,
+                ftl_range: 0.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::SubLight {
+                origin: [0.0, 0.0, 0.0],
+                destination: [1.0, 0.0, 0.0],
+                target_system: Some(sys_b),
+                departed_at: 0,
+                arrival_at: travel_time,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+        ))
+        .id();
 
     // Advance exactly to arrival time
     advance_time(&mut app, travel_time);
@@ -114,12 +115,19 @@ fn test_sublight_travel_and_arrival() {
         ShipState::Docked { system } => {
             assert_eq!(*system, sys_b, "Ship should be docked at System-B");
         }
-        _ => panic!("Expected ship to be Docked, got {:?}", std::mem::discriminant(state)),
+        _ => panic!(
+            "Expected ship to be Docked, got {:?}",
+            std::mem::discriminant(state)
+        ),
     }
 
     // Position should match System-B
     let pos = app.world().get::<Position>(ship_entity).unwrap();
-    assert!((pos.x - 1.0).abs() < 1e-9, "Ship x should be 1.0, got {}", pos.x);
+    assert!(
+        (pos.x - 1.0).abs() < 1e-9,
+        "Ship x should be 1.0, got {}",
+        pos.x
+    );
     assert!((pos.y).abs() < 1e-9, "Ship y should be 0.0, got {}", pos.y);
 }
 
@@ -146,38 +154,47 @@ fn test_survey_completes_and_marks_system() {
     );
 
     // Spawn explorer in Surveying state targeting System-B
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Scout-1".to_string(),
-            design_id: "explorer_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.75,
-            ftl_range: 0.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::Surveying {
-            target_system: sys_b,
-            started_at: 0,
-            completes_at: SURVEY_DURATION_HEXADIES,
-        },
-        Position::from([0.0, 0.0, 0.0]),
-        ShipHitpoints {
-            hull: 50.0, hull_max: 50.0,
-            armor: 0.0, armor_max: 0.0,
-            shield: 0.0, shield_max: 0.0,
-            shield_regen: 0.0,
-        },
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Scout-1".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.75,
+                ftl_range: 0.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::Surveying {
+                target_system: sys_b,
+                started_at: 0,
+                completes_at: SURVEY_DURATION_HEXADIES,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+            ShipHitpoints {
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+        ))
+        .id();
 
     // Advance by survey duration
     advance_time(&mut app, SURVEY_DURATION_HEXADIES);
 
     // System-B should now be surveyed
-    let star = app.world().get::<macrocosmo::galaxy::StarSystem>(sys_b).unwrap();
+    let star = app
+        .world()
+        .get::<macrocosmo::galaxy::StarSystem>(sys_b)
+        .unwrap();
     assert!(star.surveyed, "System-B should be marked as surveyed");
 
     // Ship should be back to Docked at the target system
@@ -215,27 +232,30 @@ fn test_ftl_travel_and_arrival() {
 
     // FTL arrival at 120 sd
     let arrival_at: i64 = 120;
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Colony-1".to_string(),
-            design_id: "colony_ship_mk1".to_string(),
-            hull_id: "freighter".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.5,
-            ftl_range: 30.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::InFTL {
-            origin_system: sys_a,
-            destination_system: sys_b,
-            departed_at: 0,
-            arrival_at,
-        },
-        Position::from([0.0, 0.0, 0.0]),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Colony-1".to_string(),
+                design_id: "colony_ship_mk1".to_string(),
+                hull_id: "freighter".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.5,
+                ftl_range: 30.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::InFTL {
+                origin_system: sys_a,
+                destination_system: sys_b,
+                departed_at: 0,
+                arrival_at,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+        ))
+        .id();
 
     // Advance to arrival
     advance_time(&mut app, arrival_at);
@@ -244,14 +264,21 @@ fn test_ftl_travel_and_arrival() {
     let state = app.world().get::<ShipState>(ship_entity).unwrap();
     match state {
         ShipState::Docked { system } => {
-            assert_eq!(*system, sys_b, "Ship should be docked at System-B after FTL");
+            assert_eq!(
+                *system, sys_b,
+                "Ship should be docked at System-B after FTL"
+            );
         }
         _ => panic!("Expected ship to be Docked after FTL travel"),
     }
 
     // Position should match System-B (20, 0, 0)
     let pos = app.world().get::<Position>(ship_entity).unwrap();
-    assert!((pos.x - 20.0).abs() < 1e-9, "Ship x should be 20.0, got {}", pos.x);
+    assert!(
+        (pos.x - 20.0).abs() < 1e-9,
+        "Ship x should be 20.0, got {}",
+        pos.x
+    );
 }
 
 #[test]
@@ -270,15 +297,24 @@ fn test_build_queue_spawns_ship() {
 
     // Colony with ample resources and a build order for an Explorer
     let planet_sys = find_planet(app.world_mut(), sys);
-    app.world_mut().entity_mut(sys).insert((ResourceStockpile {
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
             minerals: Amt::units(1000),
             energy: Amt::units(1000),
             research: Amt::ZERO,
             food: Amt::ZERO,
             authority: Amt::ZERO,
-        }, ResourceCapacity::default(),
+        },
+        ResourceCapacity::default(),
         SystemBuildings {
-            slots: vec![Some(BuildingId::new("shipyard")), None, None, None, None, None],
+            slots: vec![
+                Some(BuildingId::new("shipyard")),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
         },
         SystemBuildingQueue::default(),
     ));
@@ -296,6 +332,7 @@ fn test_build_queue_spawns_ship() {
         },
         BuildQueue {
             queue: vec![BuildOrder {
+                order_id: 0,
                 kind: macrocosmo::colony::BuildKind::default(),
                 design_id: "explorer_mk1".to_string(),
                 display_name: "Explorer".to_string(),
@@ -306,6 +343,7 @@ fn test_build_queue_spawns_ship() {
                 build_time_total: 60,
                 build_time_remaining: 0, // set to 0 so it completes with resources
             }],
+            next_order_id: 0,
         },
         Buildings {
             slots: vec![None, None, None, None],
@@ -336,7 +374,10 @@ fn test_build_queue_spawns_ship() {
     // Build queue should be empty now
     let mut bq_query = app.world_mut().query::<&BuildQueue>();
     let bq = bq_query.iter(app.world()).next().unwrap();
-    assert!(bq.queue.is_empty(), "Build queue should be empty after completion");
+    assert!(
+        bq.queue.is_empty(),
+        "Build queue should be empty after completion"
+    );
 }
 
 // CRITICAL: Owner::Empire ships (#3)
@@ -357,31 +398,37 @@ fn test_empire_owned_ships() {
     );
 
     // Spawn a ship with Owner::Empire
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Imperial Scout".to_string(),
-            design_id: "explorer_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Empire(empire),
-            sublight_speed: 0.75,
-            ftl_range: 10.0,
-            player_aboard: false,
-            home_port: sys,
-            design_revision: 0,
-        },
-        ShipState::Docked { system: sys },
-        Position::from([0.0, 0.0, 0.0]),
-        ShipHitpoints {
-            hull: 50.0, hull_max: 50.0,
-            armor: 0.0, armor_max: 0.0,
-            shield: 0.0, shield_max: 0.0,
-            shield_regen: 0.0,
-        },
-        ShipModifiers::default(),
-        CommandQueue::default(),
-        Cargo::default(),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Imperial Scout".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Empire(empire),
+                sublight_speed: 0.75,
+                ftl_range: 10.0,
+                player_aboard: false,
+                home_port: sys,
+                design_revision: 0,
+            },
+            ShipState::Docked { system: sys },
+            Position::from([0.0, 0.0, 0.0]),
+            ShipHitpoints {
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            ShipModifiers::default(),
+            CommandQueue::default(),
+            Cargo::default(),
+        ))
+        .id();
 
     // Verify the owner is correctly set
     let ship = app.world().get::<Ship>(ship_entity).unwrap();
@@ -426,62 +473,58 @@ fn test_ftl_range_bonus_extends_range() {
 
     // Set ftl_range_bonus to 5.0
     {
-        let mut params = app.world_mut().get_mut::<technology::GlobalParams>(empire).unwrap();
+        let mut params = app
+            .world_mut()
+            .get_mut::<technology::GlobalParams>(empire)
+            .unwrap();
         params.ftl_range_bonus = 5.0;
     }
 
-    let sys_a = spawn_test_system(
-        app.world_mut(),
-        "Origin",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys_a = spawn_test_system(app.world_mut(), "Origin", [0.0, 0.0, 0.0], 1.0, true, true);
 
     // System at 12 LY -- within range (10 base + 5 bonus = 15)
-    let sys_b = spawn_test_system(
-        app.world_mut(),
-        "Near",
-        [12.0, 0.0, 0.0],
-        0.7,
-        true,
-        false,
-    );
+    let sys_b = spawn_test_system(app.world_mut(), "Near", [12.0, 0.0, 0.0], 0.7, true, false);
 
     // Spawn ship with ftl_range = 10.0 and Owner::Empire
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "FTL Scout".to_string(),
-            design_id: "explorer_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Empire(empire),
-            sublight_speed: 0.75,
-            ftl_range: 10.0,
-            player_aboard: false,
-            home_port: sys_a,
-            design_revision: 0,
-        },
-        ShipState::Docked { system: sys_a },
-        Position::from([0.0, 0.0, 0.0]),
-        ShipHitpoints {
-            hull: 50.0, hull_max: 50.0,
-            armor: 0.0, armor_max: 0.0,
-            shield: 0.0, shield_max: 0.0,
-            shield_regen: 0.0,
-        },
-        ShipModifiers::default(),
-        CommandQueue::default(),
-        Cargo::default(),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "FTL Scout".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Empire(empire),
+                sublight_speed: 0.75,
+                ftl_range: 10.0,
+                player_aboard: false,
+                home_port: sys_a,
+                design_revision: 0,
+            },
+            ShipState::Docked { system: sys_a },
+            Position::from([0.0, 0.0, 0.0]),
+            ShipHitpoints {
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            ShipModifiers::default(),
+            CommandQueue::default(),
+            Cargo::default(),
+        ))
+        .id();
 
     // Issue FTL command via command queue
     {
-        let mut queue = app.world_mut().get_mut::<CommandQueue>(ship_entity).unwrap();
-        queue.commands.push(QueuedCommand::MoveTo {
-            system: sys_b,
-        });
+        let mut queue = app
+            .world_mut()
+            .get_mut::<CommandQueue>(ship_entity)
+            .unwrap();
+        queue.commands.push(QueuedCommand::MoveTo { system: sys_b });
     }
 
     advance_time(&mut app, 1);
@@ -531,14 +574,7 @@ fn test_scrap_ship_refund_amounts() {
 fn test_scrap_ship_despawns_entity() {
     let mut app = test_app();
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Sol",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Sol", [0.0, 0.0, 0.0], 1.0, true, true);
 
     let ship = common::spawn_test_ship(
         app.world_mut(),
@@ -559,14 +595,7 @@ fn test_scrap_ship_despawns_entity() {
 fn test_scrap_ship_refunds_resources() {
     let mut app = test_app();
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Sol",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Sol", [0.0, 0.0, 0.0], 1.0, true, true);
 
     let colony = spawn_test_colony(
         app.world_mut(),
@@ -587,7 +616,8 @@ fn test_scrap_ship_refunds_resources() {
     // #236: explorer_mk1 derived build cost = 360 min / 190 energy, refund 50%.
     let design_registry = common::create_test_design_registry();
     let empty_module_registry = macrocosmo::ship_design::ModuleRegistry::default();
-    let (refund_m, refund_e) = design_registry.scrap_refund("explorer_mk1", &[], &empty_module_registry);
+    let (refund_m, refund_e) =
+        design_registry.scrap_refund("explorer_mk1", &[], &empty_module_registry);
     assert_eq!(refund_m, Amt::units(180));
     assert_eq!(refund_e, Amt::units(95));
 
@@ -604,7 +634,7 @@ fn test_scrap_ship_refunds_resources() {
     // Verify resources were added
     let stockpile = app.world().get::<ResourceStockpile>(sys).unwrap();
     assert_eq!(stockpile.minerals, Amt::units(280)); // 100 + 180 refund
-    assert_eq!(stockpile.energy, Amt::units(195));   // 100 + 95 refund
+    assert_eq!(stockpile.energy, Amt::units(195)); // 100 + 95 refund
 
     // Verify ship is gone
     assert!(app.world().get_entity(ship).is_err());
@@ -652,12 +682,8 @@ fn test_clear_command_queue() {
 
     // Add commands to queue
     let mut queue = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
-    queue.commands.push(QueuedCommand::MoveTo {
-        system: sys_b,
-    });
-    queue.commands.push(QueuedCommand::MoveTo {
-        system: sys_c,
-    });
+    queue.commands.push(QueuedCommand::MoveTo { system: sys_b });
+    queue.commands.push(QueuedCommand::MoveTo { system: sys_c });
 
     // Verify commands exist
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
@@ -669,7 +695,10 @@ fn test_clear_command_queue() {
 
     // Verify empty
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
-    assert!(queue.commands.is_empty(), "Command queue should be empty after clear");
+    assert!(
+        queue.commands.is_empty(),
+        "Command queue should be empty after clear"
+    );
 }
 
 /// Cancelling an individual command removes only that command.
@@ -712,15 +741,9 @@ fn test_cancel_individual_command() {
 
     // Add 3 commands to queue
     let mut queue = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
-    queue.commands.push(QueuedCommand::MoveTo {
-        system: sys_a,
-    });
-    queue.commands.push(QueuedCommand::MoveTo {
-        system: sys_b,
-    });
-    queue.commands.push(QueuedCommand::MoveTo {
-        system: sys_c,
-    });
+    queue.commands.push(QueuedCommand::MoveTo { system: sys_a });
+    queue.commands.push(QueuedCommand::MoveTo { system: sys_b });
+    queue.commands.push(QueuedCommand::MoveTo { system: sys_c });
 
     // Cancel the middle command (index 1)
     let mut queue = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
@@ -728,10 +751,17 @@ fn test_cancel_individual_command() {
 
     // Verify: 2 commands remain, the second system should be sys_c
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
-    assert_eq!(queue.commands.len(), 2, "Should have 2 commands after cancelling one");
+    assert_eq!(
+        queue.commands.len(),
+        2,
+        "Should have 2 commands after cancelling one"
+    );
     match &queue.commands[1] {
         QueuedCommand::MoveTo { system, .. } => {
-            assert_eq!(*system, sys_c, "Second remaining command should target System-C");
+            assert_eq!(
+                *system, sys_c,
+                "Second remaining command should target System-C"
+            );
         }
         _ => panic!("Expected MoveTo command"),
     }
@@ -841,15 +871,24 @@ fn test_ftl_survey_stores_data_on_ship() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [3.0, 0.0, 0.0],
-        0.7, false, false,
+        app.world_mut(),
+        "System-B",
+        [3.0, 0.0, 0.0],
+        0.7,
+        false,
+        false,
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     let ship = spawn_ftl_explorer(app.world_mut(), "FTL-Scout", sys_b, [3.0, 0.0, 0.0]);
     *app.world_mut().get_mut::<ShipState>(ship).unwrap() = ShipState::Surveying {
@@ -861,7 +900,10 @@ fn test_ftl_survey_stores_data_on_ship() {
     common::advance_time(&mut app, SURVEY_DURATION_HEXADIES);
 
     let star = app.world().get::<StarSystem>(sys_b).unwrap();
-    assert!(!star.surveyed, "FTL ship should NOT mark system as surveyed immediately");
+    assert!(
+        !star.surveyed,
+        "FTL ship should NOT mark system as surveyed immediately"
+    );
 
     let survey_data = app.world().get::<SurveyData>(ship);
     assert!(survey_data.is_some(), "FTL ship should carry survey data");
@@ -873,15 +915,24 @@ fn test_ftl_survey_auto_queues_return() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [3.0, 0.0, 0.0],
-        0.7, false, false,
+        app.world_mut(),
+        "System-B",
+        [3.0, 0.0, 0.0],
+        0.7,
+        false,
+        false,
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     let ship = spawn_ftl_explorer(app.world_mut(), "FTL-Scout", sys_b, [3.0, 0.0, 0.0]);
     *app.world_mut().get_mut::<ShipState>(ship).unwrap() = ShipState::Surveying {
@@ -896,9 +947,10 @@ fn test_ftl_survey_auto_queues_return() {
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
 
     let in_ftl_to_a = matches!(state, ShipState::InFTL { destination_system, .. } if *destination_system == sys_a);
-    let queued_ftl_to_a = queue.commands.iter().any(|cmd| {
-        matches!(cmd, QueuedCommand::MoveTo { system, .. } if *system == sys_a)
-    });
+    let queued_ftl_to_a = queue
+        .commands
+        .iter()
+        .any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system, .. } if *system == sys_a));
 
     assert!(
         in_ftl_to_a || queued_ftl_to_a,
@@ -911,15 +963,24 @@ fn test_ftl_survey_delivers_on_dock_at_player_system() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [3.0, 0.0, 0.0],
-        0.7, false, false,
+        app.world_mut(),
+        "System-B",
+        [3.0, 0.0, 0.0],
+        0.7,
+        false,
+        false,
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     let ship = spawn_ftl_explorer(app.world_mut(), "FTL-Scout", sys_a, [0.0, 0.0, 0.0]);
     app.world_mut().entity_mut(ship).insert(SurveyData {
@@ -932,10 +993,16 @@ fn test_ftl_survey_delivers_on_dock_at_player_system() {
     common::advance_time(&mut app, 1);
 
     let star = app.world().get::<StarSystem>(sys_b).unwrap();
-    assert!(star.surveyed, "System should be marked surveyed after delivery");
+    assert!(
+        star.surveyed,
+        "System should be marked surveyed after delivery"
+    );
 
     let survey_data = app.world().get::<SurveyData>(ship);
-    assert!(survey_data.is_none(), "Survey data should be cleared after delivery");
+    assert!(
+        survey_data.is_none(),
+        "Survey data should be cleared after delivery"
+    );
 }
 
 #[test]
@@ -943,18 +1010,30 @@ fn test_non_ftl_survey_marks_system_immediately() {
     let mut app = common::test_app();
 
     let _sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [3.0, 0.0, 0.0],
-        0.7, false, false,
+        app.world_mut(),
+        "System-B",
+        [3.0, 0.0, 0.0],
+        0.7,
+        false,
+        false,
     );
 
     // #236: courier_mk1 now has FTL via derive — force ftl_range to 0 on
     // this instance so the test covers the non-FTL survey codepath.
     let ship = common::spawn_test_ship(
-        app.world_mut(), "Scout-1", "courier_mk1", sys_b, [3.0, 0.0, 0.0],
+        app.world_mut(),
+        "Scout-1",
+        "courier_mk1",
+        sys_b,
+        [3.0, 0.0, 0.0],
     );
     app.world_mut().get_mut::<Ship>(ship).unwrap().ftl_range = 0.0;
     *app.world_mut().get_mut::<ShipState>(ship).unwrap() = ShipState::Surveying {
@@ -966,10 +1045,16 @@ fn test_non_ftl_survey_marks_system_immediately() {
     common::advance_time(&mut app, SURVEY_DURATION_HEXADIES);
 
     let star = app.world().get::<StarSystem>(sys_b).unwrap();
-    assert!(star.surveyed, "Non-FTL ship should mark system as surveyed immediately");
+    assert!(
+        star.surveyed,
+        "Non-FTL ship should mark system as surveyed immediately"
+    );
 
     let survey_data = app.world().get::<SurveyData>(ship);
-    assert!(survey_data.is_none(), "Non-FTL ship should not carry survey data");
+    assert!(
+        survey_data.is_none(),
+        "Non-FTL ship should not carry survey data"
+    );
 }
 
 // --- Regression: FTL must not jump to unsurveyed systems ---
@@ -979,20 +1064,30 @@ fn test_plan_ftl_route_rejects_unsurveyed_destination() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false, // surveyed=true
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false, // surveyed=true
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [5.0, 0.0, 0.0],
-        0.7, false, false, // surveyed=false
+        app.world_mut(),
+        "System-B",
+        [5.0, 0.0, 0.0],
+        0.7,
+        false,
+        false, // surveyed=false
     );
 
     let ship = spawn_ftl_explorer(app.world_mut(), "Scout", sys_a, [0.0, 0.0, 0.0]);
 
     // Queue MoveTo unsurveyed system
-    app.world_mut().get_mut::<CommandQueue>(ship).unwrap().commands.push(
-        QueuedCommand::MoveTo { system: sys_b },
-    );
+    app.world_mut()
+        .get_mut::<CommandQueue>(ship)
+        .unwrap()
+        .commands
+        .push(QueuedCommand::MoveTo { system: sys_b });
 
     // Process command queue — should NOT FTL (unsurveyed), should sublight
     common::advance_time(&mut app, 1);
@@ -1010,20 +1105,30 @@ fn test_plan_ftl_route_allows_surveyed_destination() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false, // surveyed=true
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false, // surveyed=true
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [5.0, 0.0, 0.0],
-        0.7, true, false, // surveyed=true
+        app.world_mut(),
+        "System-B",
+        [5.0, 0.0, 0.0],
+        0.7,
+        true,
+        false, // surveyed=true
     );
 
     let ship = spawn_ftl_explorer(app.world_mut(), "Scout", sys_a, [0.0, 0.0, 0.0]);
 
     // Queue MoveTo surveyed system within FTL range
-    app.world_mut().get_mut::<CommandQueue>(ship).unwrap().commands.push(
-        QueuedCommand::MoveTo { system: sys_b },
-    );
+    app.world_mut()
+        .get_mut::<CommandQueue>(ship)
+        .unwrap()
+        .commands
+        .push(QueuedCommand::MoveTo { system: sys_b });
 
     common::advance_time(&mut app, 1);
 
@@ -1040,23 +1145,34 @@ fn test_survey_return_uses_ftl_to_surveyed_home() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [5.0, 0.0, 0.0],
-        0.7, false, false, // unsurveyed target
+        app.world_mut(),
+        "System-B",
+        [5.0, 0.0, 0.0],
+        0.7,
+        false,
+        false, // unsurveyed target
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     // Spawn FTL explorer docked at sys_b (as if it arrived by sublight and completed survey)
     let ship = spawn_ftl_explorer(app.world_mut(), "Scout", sys_b, [5.0, 0.0, 0.0]);
 
     // Queue return MoveTo home (surveyed)
-    app.world_mut().get_mut::<CommandQueue>(ship).unwrap().commands.push(
-        QueuedCommand::MoveTo { system: sys_a },
-    );
+    app.world_mut()
+        .get_mut::<CommandQueue>(ship)
+        .unwrap()
+        .commands
+        .push(QueuedCommand::MoveTo { system: sys_a });
 
     common::advance_time(&mut app, 1);
 
@@ -1076,24 +1192,38 @@ fn test_multi_hop_ftl_route() {
 
     // A --8ly-- B --8ly-- C (all surveyed, FTL range 10ly, can't direct A→C at 16ly)
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let _sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [8.0, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [8.0, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
     let sys_c = common::spawn_test_system(
-        app.world_mut(), "System-C", [16.0, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-C",
+        [16.0, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
 
     // FTL range 10ly — can reach B from A, C from B, but NOT C from A directly
     let ship = spawn_ftl_explorer(app.world_mut(), "Scout", sys_a, [0.0, 0.0, 0.0]);
 
-    app.world_mut().get_mut::<CommandQueue>(ship).unwrap().commands.push(
-        QueuedCommand::MoveTo { system: sys_c },
-    );
+    app.world_mut()
+        .get_mut::<CommandQueue>(ship)
+        .unwrap()
+        .commands
+        .push(QueuedCommand::MoveTo { system: sys_c });
 
     // First tick: should FTL to intermediate hop (B)
     common::advance_time(&mut app, 1);
@@ -1107,7 +1237,10 @@ fn test_multi_hop_ftl_route() {
     // Queue should still have remaining hop(s) to C
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
     assert!(
-        queue.commands.iter().any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system } if *system == sys_c)),
+        queue
+            .commands
+            .iter()
+            .any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system } if *system == sys_c)),
         "Queue should contain remaining MoveTo for final destination"
     );
 }
@@ -1124,23 +1257,37 @@ fn test_hybrid_ftl_sublight_route() {
     // FTL range 10ly: can FTL A→B, but C is unsurveyed so no FTL to C
     // Hybrid: FTL A→B, sublight B→C should be faster than sublight A→C direct
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [5.0, 0.0, 0.0],
-        0.7, true, false, // surveyed
+        app.world_mut(),
+        "System-B",
+        [5.0, 0.0, 0.0],
+        0.7,
+        true,
+        false, // surveyed
     );
     let sys_c = common::spawn_test_system(
-        app.world_mut(), "System-C", [10.0, 0.0, 0.0],
-        0.7, false, false, // unsurveyed
+        app.world_mut(),
+        "System-C",
+        [10.0, 0.0, 0.0],
+        0.7,
+        false,
+        false, // unsurveyed
     );
 
     let ship = spawn_ftl_explorer(app.world_mut(), "Scout", sys_a, [0.0, 0.0, 0.0]);
 
-    app.world_mut().get_mut::<CommandQueue>(ship).unwrap().commands.push(
-        QueuedCommand::MoveTo { system: sys_c },
-    );
+    app.world_mut()
+        .get_mut::<CommandQueue>(ship)
+        .unwrap()
+        .commands
+        .push(QueuedCommand::MoveTo { system: sys_c });
 
     common::advance_time(&mut app, 1);
 
@@ -1149,7 +1296,10 @@ fn test_hybrid_ftl_sublight_route() {
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
 
     let in_ftl_to_b = matches!(state, ShipState::InFTL { destination_system, .. } if *destination_system == sys_b);
-    let has_move_to_b = queue.commands.iter().any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system } if *system == sys_b));
+    let has_move_to_b = queue
+        .commands
+        .iter()
+        .any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system } if *system == sys_b));
 
     assert!(
         in_ftl_to_b || has_move_to_b,
@@ -1157,7 +1307,10 @@ fn test_hybrid_ftl_sublight_route() {
     );
 
     // C should still be in the queue for after the waypoint
-    let has_move_to_c = queue.commands.iter().any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system } if *system == sys_c));
+    let has_move_to_c = queue
+        .commands
+        .iter()
+        .any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system } if *system == sys_c));
     assert!(has_move_to_c, "Final destination C should remain in queue");
 }
 
@@ -1166,20 +1319,33 @@ fn test_survey_data_not_delivered_at_wrong_system() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [5.0, 0.0, 0.0],
-        0.7, false, false,
+        app.world_mut(),
+        "System-B",
+        [5.0, 0.0, 0.0],
+        0.7,
+        false,
+        false,
     );
     let sys_c = common::spawn_test_system(
-        app.world_mut(), "System-C", [10.0, 0.0, 0.0],
-        0.7, false, false,
+        app.world_mut(),
+        "System-C",
+        [10.0, 0.0, 0.0],
+        0.7,
+        false,
+        false,
     );
 
     // Player stationed at System-A
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     // Ship docked at System-C (NOT the player's system), carrying survey data for B
     let ship = spawn_ftl_explorer(app.world_mut(), "Scout", sys_c, [10.0, 0.0, 0.0]);
@@ -1194,10 +1360,16 @@ fn test_survey_data_not_delivered_at_wrong_system() {
 
     // System-B should NOT be surveyed (ship is not at player's system)
     let star = app.world().get::<StarSystem>(sys_b).unwrap();
-    assert!(!star.surveyed, "Survey data should NOT be delivered at non-player system");
+    assert!(
+        !star.surveyed,
+        "Survey data should NOT be delivered at non-player system"
+    );
 
     // SurveyData should still be on ship
-    assert!(app.world().get::<SurveyData>(ship).is_some(), "SurveyData should remain on ship");
+    assert!(
+        app.world().get::<SurveyData>(ship).is_some(),
+        "SurveyData should remain on ship"
+    );
 }
 
 // --- Regression: Auto-insert move when Survey queued at wrong system ---
@@ -1207,20 +1379,30 @@ fn test_queued_survey_auto_inserts_move() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [5.0, 0.0, 0.0],
-        0.7, false, false, // unsurveyed
+        app.world_mut(),
+        "System-B",
+        [5.0, 0.0, 0.0],
+        0.7,
+        false,
+        false, // unsurveyed
     );
 
     let ship = spawn_ftl_explorer(app.world_mut(), "Scout", sys_a, [0.0, 0.0, 0.0]);
 
     // Queue Survey for system B while docked at A
-    app.world_mut().get_mut::<CommandQueue>(ship).unwrap().commands.push(
-        QueuedCommand::Survey { system: sys_b },
-    );
+    app.world_mut()
+        .get_mut::<CommandQueue>(ship)
+        .unwrap()
+        .commands
+        .push(QueuedCommand::Survey { system: sys_b });
 
     // Process: should auto-insert MoveTo before Survey
     common::advance_time(&mut app, 1);
@@ -1231,17 +1413,25 @@ fn test_queued_survey_auto_inserts_move() {
     let state = app.world().get::<ShipState>(ship).unwrap().clone();
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
     let in_sublight = matches!(state, ShipState::SubLight { .. });
-    let has_move_queued = queue.commands.iter().any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system } if *system == sys_b));
+    let has_move_queued = queue
+        .commands
+        .iter()
+        .any(|cmd| matches!(cmd, QueuedCommand::MoveTo { system } if *system == sys_b));
     assert!(
         in_sublight || has_move_queued,
         "Ship should be in SubLight or have MoveTo queued. in_sublight={}, has_move={}, queue_len={}",
-        in_sublight, has_move_queued, queue.commands.len()
+        in_sublight,
+        has_move_queued,
+        queue.commands.len()
     );
 
     // Queue should still have Survey queued for after arrival
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
     assert!(
-        queue.commands.iter().any(|cmd| matches!(cmd, QueuedCommand::Survey { system } if *system == sys_b)),
+        queue
+            .commands
+            .iter()
+            .any(|cmd| matches!(cmd, QueuedCommand::Survey { system } if *system == sys_b)),
         "Survey should remain queued for after arrival"
     );
 }
@@ -1253,16 +1443,28 @@ fn test_command_queue_predicted_position() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [5.0, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [5.0, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
     let sys_c = common::spawn_test_system(
-        app.world_mut(), "System-C", [10.0, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-C",
+        [10.0, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
 
     let ship = spawn_ftl_explorer(app.world_mut(), "Scout", sys_a, [0.0, 0.0, 0.0]);
@@ -1289,21 +1491,33 @@ fn test_ftl_survey_uses_light_speed_when_faster() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [2.0, 0.0, 0.0],
-        0.7, false, false,
+        app.world_mut(),
+        "System-B",
+        [2.0, 0.0, 0.0],
+        0.7,
+        false,
+        false,
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     // Set ftl_speed_multiplier very low so FTL is slower than light
     // At 0.05x, effective FTL speed = 0.5c, FTL return at 2 ly = 240 hd, light delay = 120 hd
     let empire = empire_entity(app.world_mut());
     {
-        let mut params = app.world_mut().get_mut::<technology::GlobalParams>(empire).unwrap();
+        let mut params = app
+            .world_mut()
+            .get_mut::<technology::GlobalParams>(empire)
+            .unwrap();
         params.ftl_speed_multiplier = 0.05;
     }
 
@@ -1317,10 +1531,16 @@ fn test_ftl_survey_uses_light_speed_when_faster() {
     common::advance_time(&mut app, SURVEY_DURATION_HEXADIES);
 
     let star = app.world().get::<StarSystem>(sys_b).unwrap();
-    assert!(star.surveyed, "System should be marked surveyed via light-speed propagation");
+    assert!(
+        star.surveyed,
+        "System should be marked surveyed via light-speed propagation"
+    );
 
     let survey_data = app.world().get::<SurveyData>(ship);
-    assert!(survey_data.is_none(), "Ship should not carry survey data when light-speed is faster");
+    assert!(
+        survey_data.is_none(),
+        "Ship should not carry survey data when light-speed is faster"
+    );
 }
 
 #[test]
@@ -1328,15 +1548,24 @@ fn test_ftl_survey_uses_carry_back_when_ftl_faster() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [2.0, 0.0, 0.0],
-        0.7, false, false,
+        app.world_mut(),
+        "System-B",
+        [2.0, 0.0, 0.0],
+        0.7,
+        false,
+        false,
     );
 
-    app.world_mut().spawn((Player, StationedAt { system: sys_a }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_a }));
 
     let ship = spawn_ftl_explorer(app.world_mut(), "FTL-Scout", sys_b, [2.0, 0.0, 0.0]);
     *app.world_mut().get_mut::<ShipState>(ship).unwrap() = ShipState::Surveying {
@@ -1348,10 +1577,16 @@ fn test_ftl_survey_uses_carry_back_when_ftl_faster() {
     common::advance_time(&mut app, SURVEY_DURATION_HEXADIES);
 
     let star = app.world().get::<StarSystem>(sys_b).unwrap();
-    assert!(!star.surveyed, "System should NOT be marked surveyed when FTL return is faster");
+    assert!(
+        !star.surveyed,
+        "System should NOT be marked surveyed when FTL return is faster"
+    );
 
     let survey_data = app.world().get::<SurveyData>(ship);
-    assert!(survey_data.is_some(), "Ship should carry survey data for FTL carry-back");
+    assert!(
+        survey_data.is_some(),
+        "Ship should carry survey data for FTL carry-back"
+    );
 }
 
 // --- Regression: Non-FTL ship should not attempt FTL routing ---
@@ -1361,24 +1596,38 @@ fn test_non_ftl_ship_no_ftl_routing_loop() {
     let mut app = common::test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [5.0, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [5.0, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
 
     // #236: courier_mk1 now has FTL via derive — force ftl_range to 0 on
     // this instance to exercise the non-FTL routing path.
     let ship = common::spawn_test_ship(
-        app.world_mut(), "Courier-1", "courier_mk1", sys_a, [0.0, 0.0, 0.0],
+        app.world_mut(),
+        "Courier-1",
+        "courier_mk1",
+        sys_a,
+        [0.0, 0.0, 0.0],
     );
     app.world_mut().get_mut::<Ship>(ship).unwrap().ftl_range = 0.0;
 
-    app.world_mut().get_mut::<CommandQueue>(ship).unwrap().commands.push(
-        QueuedCommand::MoveTo { system: sys_b },
-    );
+    app.world_mut()
+        .get_mut::<CommandQueue>(ship)
+        .unwrap()
+        .commands
+        .push(QueuedCommand::MoveTo { system: sys_b });
 
     common::advance_time(&mut app, 1);
 
@@ -1391,7 +1640,10 @@ fn test_non_ftl_ship_no_ftl_routing_loop() {
 
     // Queue should be empty (command consumed)
     let queue = app.world().get::<CommandQueue>(ship).unwrap();
-    assert!(queue.commands.is_empty(), "Queue should be empty after command consumed");
+    assert!(
+        queue.commands.is_empty(),
+        "Queue should be empty after command consumed"
+    );
 }
 
 /// Hull modifiers from HullDefinition should be pushed to ShipModifiers
@@ -1413,8 +1665,14 @@ fn test_hull_modifiers_applied_to_ship() {
             base_speed: 0.85,
             base_evasion: 35.0,
             slots: vec![
-                HullSlot { slot_type: "utility".to_string(), count: 2 },
-                HullSlot { slot_type: "ftl".to_string(), count: 1 },
+                HullSlot {
+                    slot_type: "utility".to_string(),
+                    count: 2,
+                },
+                HullSlot {
+                    slot_type: "ftl".to_string(),
+                    count: 1,
+                },
             ],
             build_cost_minerals: Amt::units(150),
             build_cost_energy: Amt::units(80),
@@ -1438,14 +1696,7 @@ fn test_hull_modifiers_applied_to_ship() {
         });
     }
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Sol",
-        [0.0, 0.0, 0.0],
-        0.4,
-        true,
-        false,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Sol", [0.0, 0.0, 0.0], 0.4, true, false);
 
     let ship = {
         let world = app.world_mut();
@@ -1486,7 +1737,10 @@ fn test_hull_modifiers_applied_to_ship() {
     let mods = app.world().get::<ShipModifiers>(ship).unwrap();
     // survey_speed should have 1 modifier with multiplier 1.3
     assert_eq!(mods.survey_speed.modifiers().len(), 1);
-    assert_eq!(mods.survey_speed.modifiers()[0].id, "hull_scout_hull_ship.survey_speed");
+    assert_eq!(
+        mods.survey_speed.modifiers()[0].id,
+        "hull_scout_hull_ship.survey_speed"
+    );
     // speed should have 1 modifier with multiplier 1.15
     assert_eq!(mods.speed.modifiers().len(), 1);
     assert_eq!(mods.speed.modifiers()[0].id, "hull_scout_hull_ship.speed");
@@ -1513,23 +1767,37 @@ fn courier_route_resource_transport_picks_up_at_start() {
     let mut app = test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [1.0, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [1.0, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
     install_stockpile(app.world_mut(), sys_a, Amt::units(1000), Amt::units(800));
     install_stockpile(app.world_mut(), sys_b, Amt::ZERO, Amt::ZERO);
 
     let courier = common::spawn_test_ship(
-        app.world_mut(), "Hermes", "courier_mk1", sys_a, [0.0, 0.0, 0.0],
+        app.world_mut(),
+        "Hermes",
+        "courier_mk1",
+        sys_a,
+        [0.0, 0.0, 0.0],
     );
-    app.world_mut().entity_mut(courier).insert(CourierRoute::new(
-        vec![sys_a, sys_b],
-        CourierMode::ResourceTransport,
-    ));
+    app.world_mut()
+        .entity_mut(courier)
+        .insert(CourierRoute::new(
+            vec![sys_a, sys_b],
+            CourierMode::ResourceTransport,
+        ));
 
     // First tick: the courier is at sys_a (its current waypoint), so it
     // should load up to capacity and queue MoveTo sys_b.
@@ -1537,11 +1805,17 @@ fn courier_route_resource_transport_picks_up_at_start() {
 
     let cargo = app.world().get::<Cargo>(courier).unwrap();
     let cap = COURIER_DEFAULT_CARGO_CAPACITY;
-    assert_eq!(cargo.minerals, cap, "courier should be loaded with minerals");
+    assert_eq!(
+        cargo.minerals, cap,
+        "courier should be loaded with minerals"
+    );
     assert_eq!(cargo.energy, cap, "courier should be loaded with energy");
 
     let route = app.world().get::<CourierRoute>(courier).unwrap();
-    assert_eq!(route.current_index, 1, "next waypoint should be index 1 (sys_b)");
+    assert_eq!(
+        route.current_index, 1,
+        "next waypoint should be index 1 (sys_b)"
+    );
 
     let stockpile_a = app.world().get::<ResourceStockpile>(sys_a).unwrap();
     assert_eq!(stockpile_a.minerals, Amt::units(1000).sub(cap));
@@ -1553,12 +1827,20 @@ fn courier_route_resource_transport_delivers_at_destination() {
     let mut app = test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [0.5, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [0.5, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
     install_stockpile(app.world_mut(), sys_a, Amt::ZERO, Amt::ZERO);
     install_stockpile(app.world_mut(), sys_b, Amt::ZERO, Amt::ZERO);
@@ -1568,7 +1850,11 @@ fn courier_route_resource_transport_delivers_at_destination() {
     // attempt to pick up (nothing available), and queue the move back
     // toward sys_a (the next waypoint after wrapping).
     let courier = common::spawn_test_ship(
-        app.world_mut(), "Hermes", "courier_mk1", sys_b, [0.5, 0.0, 0.0],
+        app.world_mut(),
+        "Hermes",
+        "courier_mk1",
+        sys_b,
+        [0.5, 0.0, 0.0],
     );
     app.world_mut().entity_mut(courier).insert(Cargo {
         minerals: Amt::units(300),
@@ -1587,15 +1873,24 @@ fn courier_route_resource_transport_delivers_at_destination() {
     let stockpile_b = app.world().get::<ResourceStockpile>(sys_b).unwrap();
     let expected_remaining_m = Amt::units(300).sub(cap.min(Amt::units(300)));
     let expected_remaining_e = Amt::units(100).sub(cap.min(Amt::units(100)));
-    assert_eq!(stockpile_b.minerals, expected_remaining_m, "minerals after deliver+pickup");
-    assert_eq!(stockpile_b.energy, expected_remaining_e, "energy after deliver+pickup");
+    assert_eq!(
+        stockpile_b.minerals, expected_remaining_m,
+        "minerals after deliver+pickup"
+    );
+    assert_eq!(
+        stockpile_b.energy, expected_remaining_e,
+        "energy after deliver+pickup"
+    );
 
     let cargo = app.world().get::<Cargo>(courier).unwrap();
     assert_eq!(cargo.minerals, cap.min(Amt::units(300)));
     assert_eq!(cargo.energy, cap.min(Amt::units(100)));
 
     let route = app.world().get::<CourierRoute>(courier).unwrap();
-    assert_eq!(route.current_index, 0, "after sys_b, index should wrap to sys_a");
+    assert_eq!(
+        route.current_index, 0,
+        "after sys_b, index should wrap to sys_a"
+    );
 
     // The queue may already be empty in the same frame if process_command_queue
     // consumed the MoveTo and started travel — verify by checking either
@@ -1605,7 +1900,10 @@ fn courier_route_resource_transport_delivers_at_destination() {
     let dispatched = !queue.commands.is_empty()
         || matches!(state, ShipState::SubLight { target_system: Some(t), .. } if *t == sys_a)
         || matches!(state, ShipState::InFTL { destination_system, .. } if *destination_system == sys_a);
-    assert!(dispatched, "courier should be dispatched toward sys_a (queued or in transit)");
+    assert!(
+        dispatched,
+        "courier should be dispatched toward sys_a (queued or in transit)"
+    );
 }
 
 #[test]
@@ -1615,23 +1913,37 @@ fn courier_route_resource_transport_full_round_trip() {
     let mut app = test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [0.5, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [0.5, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
     install_stockpile(app.world_mut(), sys_a, Amt::units(1000), Amt::units(1000));
     install_stockpile(app.world_mut(), sys_b, Amt::ZERO, Amt::ZERO);
 
     let courier = common::spawn_test_ship(
-        app.world_mut(), "Hermes", "courier_mk1", sys_a, [0.0, 0.0, 0.0],
+        app.world_mut(),
+        "Hermes",
+        "courier_mk1",
+        sys_a,
+        [0.0, 0.0, 0.0],
     );
-    app.world_mut().entity_mut(courier).insert(CourierRoute::new(
-        vec![sys_a, sys_b],
-        CourierMode::ResourceTransport,
-    ));
+    app.world_mut()
+        .entity_mut(courier)
+        .insert(CourierRoute::new(
+            vec![sys_a, sys_b],
+            CourierMode::ResourceTransport,
+        ));
 
     // Tick 1: pickup at sys_a, queue MoveTo sys_b.
     common::advance_time(&mut app, 1);
@@ -1657,12 +1969,16 @@ fn courier_route_resource_transport_full_round_trip() {
     assert!(
         cargo_after.minerals > Amt::ZERO || cargo_after.energy > Amt::ZERO,
         "Courier should be carrying a fresh load after sys_b dock; got M:{} E:{}",
-        cargo_after.minerals, cargo_after.energy
+        cargo_after.minerals,
+        cargo_after.energy
     );
 
     // Route index should have advanced past sys_b (wrapped to 0 = sys_a).
     let route_after = app.world().get::<CourierRoute>(courier).unwrap();
-    assert_eq!(route_after.current_index, 0, "route should wrap back to sys_a");
+    assert_eq!(
+        route_after.current_index, 0,
+        "route should wrap back to sys_a"
+    );
 }
 
 #[test]
@@ -1670,22 +1986,31 @@ fn courier_route_paused_does_not_dispatch() {
     let mut app = test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [1.0, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [1.0, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
     install_stockpile(app.world_mut(), sys_a, Amt::units(500), Amt::units(500));
 
     let courier = common::spawn_test_ship(
-        app.world_mut(), "Hermes", "courier_mk1", sys_a, [0.0, 0.0, 0.0],
+        app.world_mut(),
+        "Hermes",
+        "courier_mk1",
+        sys_a,
+        [0.0, 0.0, 0.0],
     );
-    let mut route = CourierRoute::new(
-        vec![sys_a, sys_b],
-        CourierMode::ResourceTransport,
-    );
+    let mut route = CourierRoute::new(vec![sys_a, sys_b], CourierMode::ResourceTransport);
     route.paused = true;
     app.world_mut().entity_mut(courier).insert(route);
 
@@ -1695,7 +2020,10 @@ fn courier_route_paused_does_not_dispatch() {
     assert_eq!(cargo.minerals, Amt::ZERO, "paused route should not pick up");
     assert_eq!(cargo.energy, Amt::ZERO, "paused route should not pick up");
     let queue = app.world().get::<CommandQueue>(courier).unwrap();
-    assert!(queue.commands.is_empty(), "paused route should not queue moves");
+    assert!(
+        queue.commands.is_empty(),
+        "paused route should not queue moves"
+    );
 }
 
 #[test]
@@ -1703,16 +2031,28 @@ fn courier_route_knowledge_relay_delivers_pre_loaded_cargo() {
     let mut app = test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [0.3, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [0.3, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
     let sys_x = common::spawn_test_system(
-        app.world_mut(), "System-X", [10.0, 0.0, 0.0],
-        0.5, false, false,
+        app.world_mut(),
+        "System-X",
+        [10.0, 0.0, 0.0],
+        0.5,
+        false,
+        false,
     );
 
     // Empire's KnowledgeStore: install a stale snapshot of sys_x (observed_at=5).
@@ -1738,33 +2078,45 @@ fn courier_route_knowledge_relay_delivers_pre_loaded_cargo() {
     // current_index points at sys_b so the tick will execute deliver+pickup
     // immediately.
     let courier = common::spawn_test_ship(
-        app.world_mut(), "Hermes", "courier_mk1", sys_b, [0.3, 0.0, 0.0],
+        app.world_mut(),
+        "Hermes",
+        "courier_mk1",
+        sys_b,
+        [0.3, 0.0, 0.0],
     );
     let mut route = CourierRoute::new(vec![sys_a, sys_b], CourierMode::KnowledgeRelay);
     route.current_index = 1;
     app.world_mut().entity_mut(courier).insert(route);
-    app.world_mut().entity_mut(courier).insert(CourierKnowledgeCargo {
-        entries: vec![SystemKnowledge {
-            system: sys_x,
-            observed_at: 50,
-            received_at: 50,
-            data: SystemSnapshot {
-                name: "System-X".to_string(),
-                position: [10.0, 0.0, 0.0],
-                surveyed: true,
-                ..Default::default()
-            },
-            source: macrocosmo::knowledge::ObservationSource::Direct,
-        }],
-    });
+    app.world_mut()
+        .entity_mut(courier)
+        .insert(CourierKnowledgeCargo {
+            entries: vec![SystemKnowledge {
+                system: sys_x,
+                observed_at: 50,
+                received_at: 50,
+                data: SystemSnapshot {
+                    name: "System-X".to_string(),
+                    position: [10.0, 0.0, 0.0],
+                    surveyed: true,
+                    ..Default::default()
+                },
+                source: macrocosmo::knowledge::ObservationSource::Direct,
+            }],
+        });
 
     common::advance_time(&mut app, 1);
 
     let empire = common::empire_entity(app.world_mut());
     let store = app.world().get::<KnowledgeStore>(empire).unwrap();
     let entry = store.get(sys_x).expect("sys_x knowledge entry");
-    assert_eq!(entry.observed_at, 50, "newer cargo snapshot should win on delivery");
-    assert!(entry.data.surveyed, "newer snapshot's surveyed flag should propagate");
+    assert_eq!(
+        entry.observed_at, 50,
+        "newer cargo snapshot should win on delivery"
+    );
+    assert!(
+        entry.data.surveyed,
+        "newer snapshot's surveyed flag should propagate"
+    );
 }
 
 #[test]
@@ -1772,12 +2124,20 @@ fn courier_route_knowledge_relay_pickup_refreshes_received_at() {
     let mut app = test_app();
 
     let sys_a = common::spawn_test_system(
-        app.world_mut(), "System-A", [0.0, 0.0, 0.0],
-        1.0, true, false,
+        app.world_mut(),
+        "System-A",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
     );
     let sys_b = common::spawn_test_system(
-        app.world_mut(), "System-B", [0.3, 0.0, 0.0],
-        0.7, true, false,
+        app.world_mut(),
+        "System-B",
+        [0.3, 0.0, 0.0],
+        0.7,
+        true,
+        false,
     );
 
     // Empire knowledge has a stale entry for sys_a observed long ago.
@@ -1799,22 +2159,40 @@ fn courier_route_knowledge_relay_pickup_refreshes_received_at() {
     }
 
     let courier = common::spawn_test_ship(
-        app.world_mut(), "Hermes", "courier_mk1", sys_a, [0.0, 0.0, 0.0],
+        app.world_mut(),
+        "Hermes",
+        "courier_mk1",
+        sys_a,
+        [0.0, 0.0, 0.0],
     );
-    app.world_mut().entity_mut(courier).insert(CourierRoute::new(
-        vec![sys_a, sys_b],
-        CourierMode::KnowledgeRelay,
-    ));
+    app.world_mut()
+        .entity_mut(courier)
+        .insert(CourierRoute::new(
+            vec![sys_a, sys_b],
+            CourierMode::KnowledgeRelay,
+        ));
     // Set the clock high so the pickup's received_at update is observable.
     app.world_mut().resource_mut::<GameClock>().elapsed = 100;
 
     app.update();
 
-    let bag = app.world().get::<CourierKnowledgeCargo>(courier)
+    let bag = app
+        .world()
+        .get::<CourierKnowledgeCargo>(courier)
         .expect("courier should have CourierKnowledgeCargo after first tick");
-    assert!(!bag.entries.is_empty(), "bag should have copied store entries on pickup");
-    let sys_a_entry = bag.entries.iter().find(|k| k.system == sys_a).expect("sys_a entry");
-    assert_eq!(sys_a_entry.received_at, 100, "received_at should refresh to current time on pickup");
+    assert!(
+        !bag.entries.is_empty(),
+        "bag should have copied store entries on pickup"
+    );
+    let sys_a_entry = bag
+        .entries
+        .iter()
+        .find(|k| k.system == sys_a)
+        .expect("sys_a entry");
+    assert_eq!(
+        sys_a_entry.received_at, 100,
+        "received_at should refresh to current time on pickup"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1834,7 +2212,10 @@ fn install_refit_fixture(app: &mut App) {
         base_hp: 50.0,
         base_speed: 0.75,
         base_evasion: 30.0,
-        slots: vec![HullSlot { slot_type: "weapon".into(), count: 1 }],
+        slots: vec![HullSlot {
+            slot_type: "weapon".into(),
+            count: 1,
+        }],
         build_cost_minerals: Amt::units(200),
         build_cost_energy: Amt::units(100),
         build_time: 60,
@@ -1907,9 +2288,12 @@ fn spawn_rev_test_ship(world: &mut World, system: Entity, design_revision: u64) 
             ShipState::Docked { system },
             Position::from([0.0, 0.0, 0.0]),
             ShipHitpoints {
-                hull: 50.0, hull_max: 50.0,
-                armor: 0.0, armor_max: 0.0,
-                shield: 0.0, shield_max: 0.0,
+                hull: 50.0,
+                hull_max: 50.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
                 shield_regen: 0.0,
             },
             CommandQueue::default(),
@@ -1923,16 +2307,22 @@ fn spawn_rev_test_ship(world: &mut World, system: Entity, design_revision: u64) 
 
 #[test]
 fn editing_design_bumps_revision_flagging_existing_ships() {
-    use macrocosmo::ship_design::{
-        DesignSlotAssignment, ShipDesignDefinition, ShipDesignRegistry,
-    };
+    use macrocosmo::ship_design::{DesignSlotAssignment, ShipDesignDefinition, ShipDesignRegistry};
     let mut app = test_app();
     install_refit_fixture(&mut app);
 
-    let sys = app.world_mut().spawn((
-        StarSystem { name: "S".into(), star_type: "g_main".into(), is_capital: false, surveyed: true },
-        Position::from([0.0, 0.0, 0.0]),
-    )).id();
+    let sys = app
+        .world_mut()
+        .spawn((
+            StarSystem {
+                name: "S".into(),
+                star_type: "g_main".into(),
+                is_capital: false,
+                surveyed: true,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+        ))
+        .id();
 
     let ship = spawn_rev_test_ship(app.world_mut(), sys, 0);
 
@@ -1954,33 +2344,48 @@ fn editing_design_bumps_revision_flagging_existing_ships() {
     assert_eq!(new_rev, 1);
 
     // Ship's recorded revision should now be behind the registry's.
-    let design = app.world().resource::<ShipDesignRegistry>().get("rev_test").unwrap();
+    let design = app
+        .world()
+        .resource::<ShipDesignRegistry>()
+        .get("rev_test")
+        .unwrap();
     let ship_rev = app.world().get::<Ship>(ship).unwrap().design_revision;
     assert!(
         ship_rev < design.revision,
         "ship should be flagged as needing refit (ship={} < design={})",
-        ship_rev, design.revision,
+        ship_rev,
+        design.revision,
     );
 }
 
 #[test]
 fn refit_completes_brings_ship_in_sync_with_design() {
-    use macrocosmo::ship_design::{
-        DesignSlotAssignment, ShipDesignRegistry,
-    };
+    use macrocosmo::ship_design::{DesignSlotAssignment, ShipDesignRegistry};
     let mut app = test_app();
     install_refit_fixture(&mut app);
 
-    let sys = app.world_mut().spawn((
-        StarSystem { name: "S".into(), star_type: "g_main".into(), is_capital: false, surveyed: true },
-        Position::from([0.0, 0.0, 0.0]),
-    )).id();
+    let sys = app
+        .world_mut()
+        .spawn((
+            StarSystem {
+                name: "S".into(),
+                star_type: "g_main".into(),
+                is_capital: false,
+                surveyed: true,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+        ))
+        .id();
 
     let ship = spawn_rev_test_ship(app.world_mut(), sys, 0);
 
     // Edit the design (revision 0 -> 1) and capture the new modules.
-    let mut design = app.world().resource::<ShipDesignRegistry>()
-        .get("rev_test").unwrap().clone();
+    let mut design = app
+        .world()
+        .resource::<ShipDesignRegistry>()
+        .get("rev_test")
+        .unwrap()
+        .clone();
     design.modules = vec![DesignSlotAssignment {
         slot_type: "weapon".into(),
         module_id: "laser_mk2".into(),
@@ -2029,16 +2434,22 @@ fn refit_in_flight_does_not_apply_when_design_edited_again() {
     // If the design is bumped *during* a refit, the ship still completes
     // refit to the revision recorded when refit started — it remains "behind"
     // the latest design but isn't stuck at the older revision either.
-    use macrocosmo::ship_design::{
-        DesignSlotAssignment, ShipDesignRegistry,
-    };
+    use macrocosmo::ship_design::{DesignSlotAssignment, ShipDesignRegistry};
     let mut app = test_app();
     install_refit_fixture(&mut app);
 
-    let sys = app.world_mut().spawn((
-        StarSystem { name: "S".into(), star_type: "g_main".into(), is_capital: false, surveyed: true },
-        Position::from([0.0, 0.0, 0.0]),
-    )).id();
+    let sys = app
+        .world_mut()
+        .spawn((
+            StarSystem {
+                name: "S".into(),
+                star_type: "g_main".into(),
+                is_capital: false,
+                surveyed: true,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+        ))
+        .id();
     let ship = spawn_rev_test_ship(app.world_mut(), sys, 0);
 
     // Bump design once and start refit at target=1.
@@ -2057,7 +2468,8 @@ fn refit_in_flight_does_not_apply_when_design_edited_again() {
         started_at: now,
         completes_at: now + 5,
         new_modules: vec![EquippedModule {
-            slot_type: "weapon".into(), module_id: "laser_mk2".into(),
+            slot_type: "weapon".into(),
+            module_id: "laser_mk2".into(),
         }],
         target_revision: 1,
     };
@@ -2080,8 +2492,12 @@ fn refit_in_flight_does_not_apply_when_design_edited_again() {
     // Ship is at target_revision 1, still behind the live design (2) — that's
     // the expected behavior: a fresh refit must be triggered.
     assert_eq!(ship_comp.design_revision, 1);
-    let live_rev = app.world().resource::<ShipDesignRegistry>()
-        .get("rev_test").unwrap().revision;
+    let live_rev = app
+        .world()
+        .resource::<ShipDesignRegistry>()
+        .get("rev_test")
+        .unwrap()
+        .revision;
     assert_eq!(live_rev, 2);
     assert!(ship_comp.design_revision < live_rev);
 }
@@ -2095,42 +2511,38 @@ fn test_sublight_arrival_with_no_target_system_transitions_to_loitering() {
     let mut app = test_app();
 
     // System at origin (so player has a base for tests using KnowledgeStore later).
-    let _sys = spawn_test_system(
-        app.world_mut(),
-        "Origin",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        false,
-    );
+    let _sys = spawn_test_system(app.world_mut(), "Origin", [0.0, 0.0, 0.0], 1.0, true, false);
 
     // Travel time for 1 LY at 0.75c = 80 hexadies.
     let travel_time = sublight_travel_hexadies(1.0, 0.75);
     assert_eq!(travel_time, 80);
 
     let dest = [1.0_f64, 0.0, 0.0];
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Loiterer".to_string(),
-            design_id: "explorer_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.75,
-            ftl_range: 0.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::SubLight {
-            origin: [0.0, 0.0, 0.0],
-            destination: dest,
-            target_system: None,
-            departed_at: 0,
-            arrival_at: travel_time,
-        },
-        Position::from([0.0, 0.0, 0.0]),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Loiterer".to_string(),
+                design_id: "explorer_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.75,
+                ftl_range: 0.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::SubLight {
+                origin: [0.0, 0.0, 0.0],
+                destination: dest,
+                target_system: None,
+                departed_at: 0,
+                arrival_at: travel_time,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+        ))
+        .id();
 
     advance_time(&mut app, travel_time);
 
@@ -2160,14 +2572,7 @@ fn test_move_to_coordinates_command_results_in_loitering_arrival() {
     // test_app() already spawns the empire entity.
     let mut app = test_app();
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Origin",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Origin", [0.0, 0.0, 0.0], 1.0, true, true);
 
     let ship = common::spawn_test_ship(
         app.world_mut(),
@@ -2188,8 +2593,15 @@ fn test_move_to_coordinates_command_results_in_loitering_arrival() {
     {
         let state = app.world().get::<ShipState>(ship).unwrap();
         match state {
-            ShipState::SubLight { target_system, destination, .. } => {
-                assert_eq!(*target_system, None, "MoveToCoordinates must use target_system=None");
+            ShipState::SubLight {
+                target_system,
+                destination,
+                ..
+            } => {
+                assert_eq!(
+                    *target_system, None,
+                    "MoveToCoordinates must use target_system=None"
+                );
                 assert!((destination[0] - target[0]).abs() < 1e-9);
             }
             _ => panic!("Expected SubLight after queue dispatch"),
@@ -2205,8 +2617,10 @@ fn test_move_to_coordinates_command_results_in_loitering_arrival() {
         ShipState::Loitering { position } => {
             assert!((position[0] - target[0]).abs() < 1e-9);
         }
-        _ => panic!("Expected Loitering after MoveToCoordinates arrival, got {:?}",
-            std::mem::discriminant(state)),
+        _ => panic!(
+            "Expected Loitering after MoveToCoordinates arrival, got {:?}",
+            std::mem::discriminant(state)
+        ),
     }
 }
 
@@ -2239,31 +2653,39 @@ fn test_loitering_ship_not_engaged_by_resolve_combat() {
 
     // Spawn a Loitering ship at the SAME coordinates as the hostile system but with
     // ShipState::Loitering — combat should ignore it because it's not Docked.
-    let ship_entity = app.world_mut().spawn((
-        Ship {
-            name: "Loiter-1".to_string(),
-            design_id: "courier_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.85,
-            ftl_range: 0.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::Loitering { position: [0.0, 0.0, 0.0] },
-        Position::from([0.0, 0.0, 0.0]),
-        ShipHitpoints {
-            hull: 0.01, hull_max: 20.0,
-            armor: 0.0, armor_max: 0.0,
-            shield: 0.0, shield_max: 0.0,
-            shield_regen: 0.0,
-        },
-        ShipModifiers::default(),
-        CommandQueue::default(),
-        Cargo::default(),
-    )).id();
+    let ship_entity = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Loiter-1".to_string(),
+                design_id: "courier_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.85,
+                ftl_range: 0.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::Loitering {
+                position: [0.0, 0.0, 0.0],
+            },
+            Position::from([0.0, 0.0, 0.0]),
+            ShipHitpoints {
+                hull: 0.01,
+                hull_max: 20.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            ShipModifiers::default(),
+            CommandQueue::default(),
+            Cargo::default(),
+        ))
+        .id();
 
     // Run several ticks of combat — the Loitering ship would be obliterated if it
     // were in combat (hull is 0.01 vs strength 100), but it must survive.
@@ -2283,53 +2705,49 @@ fn test_loitering_ship_can_leave_via_move_to_system() {
     let mut app = test_app();
 
     // Two systems: origin (capital, surveyed) and target.
-    let _sys_origin = spawn_test_system(
-        app.world_mut(),
-        "Origin",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
-    let sys_target = spawn_test_system(
-        app.world_mut(),
-        "Target",
-        [2.0, 0.0, 0.0],
-        0.7,
-        true,
-        false,
-    );
+    let _sys_origin =
+        spawn_test_system(app.world_mut(), "Origin", [0.0, 0.0, 0.0], 1.0, true, true);
+    let sys_target =
+        spawn_test_system(app.world_mut(), "Target", [2.0, 0.0, 0.0], 0.7, true, false);
 
     // Spawn a non-FTL ship at deep-space coordinates (1.0, 0.0, 0.0), Loitering.
-    let ship = app.world_mut().spawn((
-        Ship {
-            name: "Loiterer".to_string(),
-            design_id: "courier_mk1".to_string(),
-            hull_id: "corvette".to_string(),
-            modules: Vec::new(),
-            owner: Owner::Neutral,
-            sublight_speed: 0.85,
-            ftl_range: 0.0,
-            player_aboard: false,
-            home_port: Entity::PLACEHOLDER,
-            design_revision: 0,
-        },
-        ShipState::Loitering { position: [1.0, 0.0, 0.0] },
-        Position::from([1.0, 0.0, 0.0]),
-        ShipHitpoints {
-            hull: 35.0, hull_max: 35.0,
-            armor: 0.0, armor_max: 0.0,
-            shield: 0.0, shield_max: 0.0,
-            shield_regen: 0.0,
-        },
-        ShipModifiers::default(),
-        CommandQueue {
-            commands: vec![QueuedCommand::MoveTo { system: sys_target }],
-            ..Default::default()
-        },
-        Cargo::default(),
-        RulesOfEngagement::default(),
-    )).id();
+    let ship = app
+        .world_mut()
+        .spawn((
+            Ship {
+                name: "Loiterer".to_string(),
+                design_id: "courier_mk1".to_string(),
+                hull_id: "corvette".to_string(),
+                modules: Vec::new(),
+                owner: Owner::Neutral,
+                sublight_speed: 0.85,
+                ftl_range: 0.0,
+                player_aboard: false,
+                home_port: Entity::PLACEHOLDER,
+                design_revision: 0,
+            },
+            ShipState::Loitering {
+                position: [1.0, 0.0, 0.0],
+            },
+            Position::from([1.0, 0.0, 0.0]),
+            ShipHitpoints {
+                hull: 35.0,
+                hull_max: 35.0,
+                armor: 0.0,
+                armor_max: 0.0,
+                shield: 0.0,
+                shield_max: 0.0,
+                shield_regen: 0.0,
+            },
+            ShipModifiers::default(),
+            CommandQueue {
+                commands: vec![QueuedCommand::MoveTo { system: sys_target }],
+                ..Default::default()
+            },
+            Cargo::default(),
+            RulesOfEngagement::default(),
+        ))
+        .id();
 
     // After one tick, the Loitering ship should have entered SubLight toward sys_target.
     advance_time(&mut app, 1);
@@ -2337,8 +2755,11 @@ fn test_loitering_ship_can_leave_via_move_to_system() {
     let state = app.world().get::<ShipState>(ship).unwrap();
     match state {
         ShipState::SubLight { target_system, .. } => {
-            assert_eq!(*target_system, Some(sys_target),
-                "Loitering->MoveTo must enter SubLight with the target system set");
+            assert_eq!(
+                *target_system,
+                Some(sys_target),
+                "Loitering->MoveTo must enter SubLight with the target system set"
+            );
         }
         _ => panic!(
             "Expected SubLight after MoveTo from Loitering, got {:?}",
@@ -2403,7 +2824,8 @@ fn test_scout_command_dispatches_ship() {
         true, // surveyed so FTL route works
         false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_home }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_home }));
 
     let ship = spawn_scout_ship(app.world_mut(), sys_home, [0.0, 0.0, 0.0]);
 
@@ -2481,9 +2903,8 @@ fn test_scout_report_via_ftl_comm() {
     // empire KnowledgeStore with source=Scout and observed_at = observation
     // completion time.
     use macrocosmo::deep_space::{
-        pair_relay_command, CapabilityParams, CommDirection, DeepSpaceStructure,
-        DeliverableMetadata, ResourceCost, StructureDefinition, StructureHitpoints,
-        StructureRegistry,
+        CapabilityParams, CommDirection, DeepSpaceStructure, DeliverableMetadata, ResourceCost,
+        StructureDefinition, StructureHitpoints, StructureRegistry, pair_relay_command,
     };
     use std::collections::HashMap;
 
@@ -2523,7 +2944,8 @@ fn test_scout_report_via_ftl_comm() {
         true,
         false,
     );
-    app.world_mut().spawn((Player, StationedAt { system: sys_home }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_home }));
 
     // Relay A near home (within 3 ly of player at home origin).
     let relay_a = app
@@ -2557,8 +2979,13 @@ fn test_scout_report_via_ftl_comm() {
             Position::from([19.0, 0.0, 0.0]),
         ))
         .id();
-    pair_relay_command(app.world_mut(), relay_a, relay_b, CommDirection::Bidirectional)
-        .expect("pairing");
+    pair_relay_command(
+        app.world_mut(),
+        relay_a,
+        relay_b,
+        CommDirection::Bidirectional,
+    )
+    .expect("pairing");
 
     // Scout ship with FTL range 10 — can't reach target in one hop, but
     // we'll teleport it manually to simplify the test (skip movement logic).
@@ -2617,15 +3044,10 @@ fn test_scout_report_via_return() {
     let mut app = test_app();
     let sys_home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
     // Target at 5 ly (FTL-reachable direct jump).
-    let sys_target = spawn_test_system(
-        app.world_mut(),
-        "Target",
-        [5.0, 0.0, 0.0],
-        0.5,
-        true,
-        false,
-    );
-    app.world_mut().spawn((Player, StationedAt { system: sys_home }));
+    let sys_target =
+        spawn_test_system(app.world_mut(), "Target", [5.0, 0.0, 0.0], 0.5, true, false);
+    app.world_mut()
+        .spawn((Player, StationedAt { system: sys_home }));
 
     let ship = spawn_scout_ship(app.world_mut(), sys_target, [5.0, 0.0, 0.0]);
 
@@ -2713,22 +3135,9 @@ fn test_scout_report_via_return() {
 #[test]
 fn test_moveto_from_loitering_routes_ship_out() {
     let mut app = test_app();
-    let sys_home = spawn_test_system(
-        app.world_mut(),
-        "Home",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        false,
-    );
-    let sys_target = spawn_test_system(
-        app.world_mut(),
-        "Target",
-        [5.0, 0.0, 0.0],
-        1.0,
-        true,
-        false,
-    );
+    let sys_home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, false);
+    let sys_target =
+        spawn_test_system(app.world_mut(), "Target", [5.0, 0.0, 0.0], 1.0, true, false);
 
     let loiter_pos = [2.0, 0.0, 0.0];
     let ship = app
@@ -2746,7 +3155,9 @@ fn test_moveto_from_loitering_routes_ship_out() {
                 home_port: sys_home,
                 design_revision: 0,
             },
-            ShipState::Loitering { position: loiter_pos },
+            ShipState::Loitering {
+                position: loiter_pos,
+            },
             Position::from(loiter_pos),
             ShipHitpoints {
                 hull: 50.0,

--- a/macrocosmo/tests/smoke.rs
+++ b/macrocosmo/tests/smoke.rs
@@ -3,9 +3,9 @@ mod common;
 use bevy::prelude::*;
 use macrocosmo::amount::Amt;
 use macrocosmo::colony::*;
-use macrocosmo::modifier::ModifiedValue;
 use macrocosmo::components::Position;
 use macrocosmo::galaxy::{Planet, Sovereignty, StarSystem, SystemAttributes};
+use macrocosmo::modifier::ModifiedValue;
 use macrocosmo::player::*;
 use macrocosmo::ship::*;
 use macrocosmo::time_system::GameClock;
@@ -26,7 +26,8 @@ fn all_systems_no_query_conflict() {
     let mut app = common::full_test_app();
 
     // Capital star system with all components
-    let capital = app.world_mut()
+    let capital = app
+        .world_mut()
         .spawn((
             StarSystem {
                 name: "Capital".into(),
@@ -41,7 +42,8 @@ fn all_systems_no_query_conflict() {
             },
         ))
         .id();
-    let capital_planet = app.world_mut()
+    let capital_planet = app
+        .world_mut()
         .spawn((
             Planet {
                 name: "Capital I".into(),
@@ -60,7 +62,8 @@ fn all_systems_no_query_conflict() {
         .id();
 
     // Second star system (unsurveyed target)
-    let _target = app.world_mut()
+    let _target = app
+        .world_mut()
         .spawn((
             StarSystem {
                 name: "Target".into(),
@@ -89,7 +92,8 @@ fn all_systems_no_query_conflict() {
     ));
 
     // Third star system (surveyed, not colonized)
-    let _surveyed = app.world_mut()
+    let _surveyed = app
+        .world_mut()
         .spawn((
             StarSystem {
                 name: "Surveyed".into(),
@@ -118,16 +122,20 @@ fn all_systems_no_query_conflict() {
     ));
 
     // Player stationed at capital
-    app.world_mut().spawn((Player, StationedAt { system: capital }));
+    app.world_mut()
+        .spawn((Player, StationedAt { system: capital }));
 
     // Colony at capital
-    app.world_mut().entity_mut(capital).insert((ResourceStockpile {
+    app.world_mut().entity_mut(capital).insert((
+        ResourceStockpile {
             minerals: Amt::units(500),
             energy: Amt::units(500),
             research: Amt::ZERO,
             food: Amt::units(100),
             authority: Amt::ZERO,
-        }, ResourceCapacity::default()));
+        },
+        ResourceCapacity::default(),
+    ));
     app.world_mut().spawn((
         Colony {
             planet: capital_planet,
@@ -142,6 +150,7 @@ fn all_systems_no_query_conflict() {
         },
         BuildQueue {
             queue: vec![],
+            next_order_id: 0,
         },
         Buildings {
             slots: vec![

--- a/macrocosmo/tests/tech_broadcast.rs
+++ b/macrocosmo/tests/tech_broadcast.rs
@@ -15,8 +15,8 @@ use bevy::prelude::*;
 
 use macrocosmo::amount::Amt;
 use macrocosmo::colony::{
-    Buildings, BuildQueue, BuildingQueue, Colony, ColonyJobRates, FoodConsumption,
-    MaintenanceCost, Production, ProductionFocus, ResourceCapacity, ResourceStockpile,
+    BuildQueue, BuildingQueue, Buildings, Colony, ColonyJobRates, FoodConsumption, MaintenanceCost,
+    Production, ProductionFocus, ResourceCapacity, ResourceStockpile,
 };
 use macrocosmo::modifier::{ModifiedValue, ParsedModifier};
 use macrocosmo::scripting::building_api::BuildingId;
@@ -24,13 +24,13 @@ use macrocosmo::species::{
     ColonyJobs, ColonyPopulation, ColonySpecies, JobDefinition, JobRegistry, JobSlot,
 };
 use macrocosmo::technology::{
-    apply_tech_effects, sync_tech_colony_modifiers, EmpireModifiers, RecentlyResearched, TechCost,
-    TechEffectsLog, TechId, TechTree, Technology,
+    EmpireModifiers, RecentlyResearched, TechCost, TechEffectsLog, TechId, TechTree, Technology,
+    apply_tech_effects, sync_tech_colony_modifiers,
 };
 
 use common::{
-    advance_time, empire_entity, find_planet, spawn_test_system,
-    spawn_test_system_with_planet, test_app,
+    advance_time, empire_entity, find_planet, spawn_test_system, spawn_test_system_with_planet,
+    test_app,
 };
 
 // ---------------------------------------------------------------------------
@@ -154,8 +154,10 @@ fn spawn_simple_colony(app: &mut App, sys: Entity, pop: u32) -> Entity {
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
-            Buildings { slots: vec![None; 5] },
+            BuildQueue::default(),
+            Buildings {
+                slots: vec![None; 5],
+            },
             BuildingQueue::default(),
             ProductionFocus::default(),
             MaintenanceCost::default(),
@@ -186,14 +188,7 @@ fn test_tech_modifier_reaches_colony_production() {
         r#"scope:push_modifier("colony.minerals_per_hexadies", { multiplier = 0.15 })"#,
     );
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Sys",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Sys", [0.0, 0.0, 0.0], 1.0, true, true);
     let colony = spawn_simple_colony(&mut app, sys, 0);
     // Seed a base mineral production so the multiplier is observable.
     app.world_mut()
@@ -227,14 +222,7 @@ fn test_tech_job_scoped_modifier_reaches_colony_job_rate() {
 
     // Slot-granting registry so buildings produce miner slots.
     app.insert_resource(job_slot_registry());
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Sys",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Sys", [0.0, 0.0, 0.0], 1.0, true, true);
     let colony = spawn_colony_with_building(&mut app, sys, 5, vec!["mine"]);
 
     mark_tech_researched(&mut app, "test_miner_boost");
@@ -309,7 +297,7 @@ fn test_tech_modifier_applies_to_new_colony() {
 #[test]
 fn test_colony_job_rates_attached_on_spawn() {
     use macrocosmo::colony::{
-        ColonizationOrder, ColonizationQueue, COLONIZATION_POPULATION_TRANSFER,
+        COLONIZATION_POPULATION_TRANSFER, ColonizationOrder, ColonizationQueue,
     };
 
     // Path 1: `spawn_colony_on_planet` is exercised in the setup module's own
@@ -367,14 +355,7 @@ fn test_tech_modifier_idempotent() {
         r#"scope:push_modifier("colony.minerals_per_hexadies", { multiplier = 0.5 })"#,
     );
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Sys",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Sys", [0.0, 0.0, 0.0], 1.0, true, true);
     let colony = spawn_simple_colony(&mut app, sys, 0);
     app.world_mut()
         .get_mut::<Production>(colony)
@@ -423,14 +404,7 @@ fn test_tech_slot_modifier_increases_capacity() {
         r#"scope:push_modifier("colony.miner_slot", { base_add = 2.0 })"#,
     );
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Sys",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Sys", [0.0, 0.0, 0.0], 1.0, true, true);
     let colony = spawn_colony_with_building(&mut app, sys, 10, vec!["mine"]);
 
     // Before the tech, mine alone grants 5 miner slots.
@@ -520,14 +494,7 @@ fn test_industrial_automated_mining_boosts_minerals() {
         r#"scope:push_modifier("colony.minerals_per_hexadies", { multiplier = 0.15 })"#,
     );
 
-    let sys = spawn_test_system(
-        app.world_mut(),
-        "Sys",
-        [0.0, 0.0, 0.0],
-        1.0,
-        true,
-        true,
-    );
+    let sys = spawn_test_system(app.world_mut(), "Sys", [0.0, 0.0, 0.0], 1.0, true, true);
     let colony = spawn_simple_colony(&mut app, sys, 0);
     // Baseline: 20 minerals/hexady from a pre-existing source (e.g. mine).
     app.world_mut()
@@ -546,7 +513,10 @@ fn test_industrial_automated_mining_boosts_minerals() {
     );
 
     // Clear stockpile, research the tech, measure again.
-    app.world_mut().get_mut::<ResourceStockpile>(sys).unwrap().minerals = Amt::ZERO;
+    app.world_mut()
+        .get_mut::<ResourceStockpile>(sys)
+        .unwrap()
+        .minerals = Amt::ZERO;
     mark_tech_researched(&mut app, "industrial_automated_mining");
     advance_time(&mut app, 1);
     let stockpile_post = app.world().get::<ResourceStockpile>(sys).unwrap();
@@ -599,9 +569,12 @@ fn test_existing_balance_preserved() {
             research_per_hexadies: ModifiedValue::new(Amt::ZERO),
             food_per_hexadies: ModifiedValue::new(Amt::ZERO),
         },
-        BuildQueue { queue: Vec::new() },
+        BuildQueue::default(),
         Buildings {
-            slots: vec![Some(BuildingId::new("mine")), Some(BuildingId::new("power_plant"))],
+            slots: vec![
+                Some(BuildingId::new("mine")),
+                Some(BuildingId::new("power_plant")),
+            ],
         },
         BuildingQueue::default(),
         ProductionFocus::default(),
@@ -726,7 +699,7 @@ fn spawn_colony_with_building(
                 research_per_hexadies: ModifiedValue::new(Amt::ZERO),
                 food_per_hexadies: ModifiedValue::new(Amt::ZERO),
             },
-            BuildQueue { queue: Vec::new() },
+            BuildQueue::default(),
             Buildings { slots },
             BuildingQueue::default(),
             ProductionFocus::default(),
@@ -745,4 +718,3 @@ fn spawn_colony_with_building(
         ))
         .id()
 }
-


### PR DESCRIPTION
## Summary

Re-introduces the Cancel UI for ship/building build queues that was deliberately cut from #270. The previous proposal used `queue_index`, which is racy under the ~600hd light-speed delay (queue can shift between send and arrival). This PR fixes that with a stable `order_id`.

### Phase 1 — stable `order_id`
- `BuildOrder` / `BuildingOrder` / `DemolitionOrder` / `UpgradeOrder` gain `order_id: u64`.
- `BuildQueue` / `BuildingQueue` / `SystemBuildingQueue` get a shared `next_order_id` counter plus `push_*_order` / `cancel_order` helpers.
- Savebag fields use `#[serde(default)]` — no migration (pre-alpha).

### Phase 2 — Cancel RemoteCommand variants
- `RemoteCommand::CancelBuildingOrder { order_id }` — planet/system-level building queues. Scope is **derived at arrival** (the handler searches colonies in `target_system` first, then `SystemBuildingQueue`). Scoping to `target_system` is essential because per-queue counters can collide across systems.
- `RemoteCommand::CancelShipOrder { host_colony, order_id }` — carries the host colony explicitly since ship queues are per-colony.
- Both ride the existing `PendingColonyDispatches` → `send_remote_command` → `process_pending_commands` light-speed pipeline. Local cancel (delay=0) applies same frame.
- Missing `order_id` on arrival → warn + drop. Never panics. No refund on construction cancel; demolition cancel revokes the pending refund.

### Phase 3 — UI
- Small `×` cancel button on every in-progress queue row:
  - planet building construction / demolition / upgrade
  - system building construction / demolition / upgrade
  - ship / deliverable build queue (carries `host_colony` for the ship variant)
- Reuses `PendingColonyDispatches`, no new UI plumbing.

## Test plan

+9 tests in `tests/remote_colony_commands.rs` (12 → 21):

- [x] `push_order_assigns_unique_incrementing_ids` — Phase 1 counter starts at 1, increments, `next_order_id` persists
- [x] `order_id_preserved_across_save_load` — savebag round-trip + serde `#[serde(default)]`
- [x] `local_cancel_building_order_applies_same_frame` — local dispatch, delay=0
- [x] `remote_cancel_building_order_delayed` — 10 ly → ~600 hd delay, queue intact until arrival
- [x] `cancel_missing_order_is_noop_warn` — race: unrelated order untouched
- [x] `cancel_scoped_to_target_system_does_not_affect_other_systems` — cross-system false-hit regression (per-queue counters collide; scope must hold)
- [x] `cancel_system_level_order` — `SystemBuildingQueue` path
- [x] `cancel_ship_order_removes_from_host_colony_queue` — ship cancel path
- [x] `cancel_ship_order_with_missing_id_is_noop` — race: ship already built

Workspace: **1874 tests pass** (prev 1865, +9 new).

## Adversarial review notes

Self-review surfaced one real bug pre-commit:

- **Cross-system false-hit.** Initial draft of `apply_cancel_building_order` iterated over every `Colony` in the world and cancelled the first matching `order_id`. Because each queue's `next_order_id` starts at 1, colony A's order #1 and colony B's order #1 are independent — a cancel dispatched to B could accidentally clobber A's order. Fixed by threading a `Planet` read query through `apply_remote_command` and scoping the iteration to colonies whose `planet.system == target_system`. Regression test added.

Design tradeoffs considered:

- **No refund on cancel.** Keeping cancellation behaviour minimal — invested resources are forfeit on construction cancel. Refund semantics can be layered on later without changing the wire protocol.
- **Cancel carries no scope.** Keeps the send-side UI dumb (just needs the id). Arrival handler disambiguates planet vs system queue by searching. This is cheap because each queue's ids are unique.
- **`CancelShipOrder` keeps `host_colony`.** Ship queues are per-colony, and the player's UI already knows which colony holds the order — no information loss.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)