### PR TITLE
#281: macrocosmo:building_built event + on_built / on_upgraded hooks

### DIFF
--- a/macrocosmo/src/colony/building_queue.rs
+++ b/macrocosmo/src/colony/building_queue.rs
@@ -609,7 +609,25 @@ pub fn tick_building_queue(
                         "Building '{}' completed in slot {}",
                         completed.building_id, completed.target_slot
                     );
+                    let completed_id = completed.building_id.0.clone();
+                    let completed_slot = completed.target_slot;
                     buildings.slots[completed.target_slot] = Some(completed.building_id);
+                    // #281: Fire macrocosmo:building_built for planet-level
+                    // construction. Payload carries cause/building_id/system/
+                    // colony/slot so Lua filter handlers (incl. definition
+                    // `on_built` hooks) can react to the specific building.
+                    let mut payload = std::collections::HashMap::new();
+                    payload.insert("cause".to_string(), "construction".to_string());
+                    payload.insert("building_id".to_string(), completed_id);
+                    payload.insert("slot".to_string(), completed_slot.to_string());
+                    payload.insert("system".to_string(), sys.to_bits().to_string());
+                    payload.insert("colony".to_string(), colony_entity.to_bits().to_string());
+                    event_system.fire_event_with_payload(
+                        crate::event_system::BUILDING_BUILT_EVENT,
+                        Some(colony_entity),
+                        clock.elapsed,
+                        payload,
+                    );
                 } else {
                     warn!(
                         "Building '{}' completed but target slot {} is out of range (max {})",
@@ -715,6 +733,23 @@ pub fn tick_building_queue(
                     old_name, completed.target_id, completed.slot_index
                 );
                 event_system.fire_event("building_upgraded", Some(colony_entity), clock.elapsed);
+                // #281: Fire macrocosmo:building_built with cause="upgrade" so
+                // Lua definition `on_upgraded` hooks (and external filters)
+                // see the completion alongside the legacy
+                // `building_upgraded` event.
+                let mut payload = std::collections::HashMap::new();
+                payload.insert("cause".to_string(), "upgrade".to_string());
+                payload.insert("building_id".to_string(), completed.target_id.0.clone());
+                payload.insert("previous_id".to_string(), old_name);
+                payload.insert("slot".to_string(), completed.slot_index.to_string());
+                payload.insert("system".to_string(), sys.to_bits().to_string());
+                payload.insert("colony".to_string(), colony_entity.to_bits().to_string());
+                event_system.fire_event_with_payload(
+                    crate::event_system::BUILDING_BUILT_EVENT,
+                    Some(colony_entity),
+                    clock.elapsed,
+                    payload,
+                );
             }
         }
 

--- a/macrocosmo/src/colony/system_buildings.rs
+++ b/macrocosmo/src/colony/system_buildings.rs
@@ -298,7 +298,23 @@ pub fn tick_system_building_queue(
                         "System building '{}' completed in slot {}",
                         completed.building_id, completed.target_slot
                     );
+                    let completed_id = completed.building_id.0.clone();
+                    let completed_slot = completed.target_slot;
                     buildings.slots[completed.target_slot] = Some(completed.building_id);
+                    // #281: Fire macrocosmo:building_built for system-level
+                    // construction. `colony` is omitted since system
+                    // buildings attach to the StarSystem entity itself.
+                    let mut payload = std::collections::HashMap::new();
+                    payload.insert("cause".to_string(), "construction".to_string());
+                    payload.insert("building_id".to_string(), completed_id);
+                    payload.insert("slot".to_string(), completed_slot.to_string());
+                    payload.insert("system".to_string(), system_entity.to_bits().to_string());
+                    event_system.fire_event_with_payload(
+                        crate::event_system::BUILDING_BUILT_EVENT,
+                        Some(system_entity),
+                        clock.elapsed,
+                        payload,
+                    );
                 }
             }
         }
@@ -385,6 +401,20 @@ pub fn tick_system_building_queue(
                     old_name, completed.target_id, completed.slot_index
                 );
                 event_system.fire_event("building_upgraded", Some(system_entity), clock.elapsed);
+                // #281: Fire macrocosmo:building_built with cause="upgrade"
+                // for system-level upgrade completion.
+                let mut payload = std::collections::HashMap::new();
+                payload.insert("cause".to_string(), "upgrade".to_string());
+                payload.insert("building_id".to_string(), completed.target_id.0.clone());
+                payload.insert("previous_id".to_string(), old_name);
+                payload.insert("slot".to_string(), completed.slot_index.to_string());
+                payload.insert("system".to_string(), system_entity.to_bits().to_string());
+                event_system.fire_event_with_payload(
+                    crate::event_system::BUILDING_BUILT_EVENT,
+                    Some(system_entity),
+                    clock.elapsed,
+                    payload,
+                );
             }
         }
 
@@ -433,6 +463,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
             prerequisites: None,
+            on_built: None,
+            on_upgraded: None,
         });
 
         let mut port_caps = HashMap::new();
@@ -465,6 +497,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
             prerequisites: None,
+            on_built: None,
+            on_upgraded: None,
         });
         registry
     }

--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -200,6 +200,16 @@ pub struct DeliverableDefinition {
     /// build_time describe the upstream→this transition. Cf. `upgrade_to`
     /// which describes this→downstream transitions.
     pub upgrade_from: Option<UpgradeEdge>,
+
+    /// #281: Optional Lua hook invoked when this structure finishes
+    /// construction. Auto-subscribed as a filtered handler on
+    /// `macrocosmo:building_built` during `load_structure_definitions`.
+    pub on_built: Option<crate::event_system::LuaFunctionRef>,
+    /// #281: Reserved for future deep-space upgrade paths. Parsed from Lua
+    /// and auto-subscribed on `macrocosmo:building_built` with
+    /// `cause = "upgrade"` filter, but the current deep-space completion
+    /// path fires `cause = "construction"` exclusively.
+    pub on_upgraded: Option<crate::event_system::LuaFunctionRef>,
 }
 
 impl DeliverableDefinition {
@@ -344,6 +354,8 @@ pub fn default_structure_definitions() -> Vec<StructureDefinition> {
             }),
             upgrade_to: Vec::new(),
             upgrade_from: None,
+                    on_built: None,
+            on_upgraded: None,
         },
         StructureDefinition {
             id: "ftl_comm_relay".to_string(),
@@ -369,6 +381,8 @@ pub fn default_structure_definitions() -> Vec<StructureDefinition> {
             }),
             upgrade_to: Vec::new(),
             upgrade_from: None,
+                    on_built: None,
+            on_upgraded: None,
         },
         StructureDefinition {
             id: "interdictor".to_string(),
@@ -394,6 +408,8 @@ pub fn default_structure_definitions() -> Vec<StructureDefinition> {
             }),
             upgrade_to: Vec::new(),
             upgrade_from: None,
+                    on_built: None,
+            on_upgraded: None,
         },
     ]
 }
@@ -524,6 +540,7 @@ pub fn tick_platform_upgrade(
     registry: Res<StructureRegistry>,
     clock: Res<crate::time_system::GameClock>,
     mut events: MessageWriter<crate::events::GameEvent>,
+    mut event_system: ResMut<crate::event_system::EventSystem>,
     mut platforms: Query<(
         Entity,
         &mut DeepSpaceStructure,
@@ -567,6 +584,7 @@ pub fn tick_platform_upgrade(
         // Update the structure identity.
         if let Some(new_def) = registry.get(&target_id) {
             let old_name = structure.name.clone();
+            let old_definition_id = structure.definition_id.clone();
             structure.definition_id = target_id.clone();
             structure.name = new_def.name.clone();
             // Bump lifetime cost by the edge cost.
@@ -585,6 +603,22 @@ pub fn tick_platform_upgrade(
                 description: desc.clone(),
                 related_system: None,
             });
+            // #281: Fire macrocosmo:building_built for deep-space structure
+            // completion (platform → target). Treated as cause="construction"
+            // since the platform is an ephemeral kit, not a first-class
+            // structure the player had "built" in the modding sense.
+            // `previous_id` carries the platform/kit id so hooks can still
+            // chain off the specific construction path.
+            let mut payload = std::collections::HashMap::new();
+            payload.insert("cause".to_string(), "construction".to_string());
+            payload.insert("building_id".to_string(), target_id.clone());
+            payload.insert("previous_id".to_string(), old_definition_id);
+            event_system.fire_event_with_payload(
+                crate::event_system::BUILDING_BUILT_EVENT,
+                Some(entity),
+                clock.elapsed,
+                payload,
+            );
             let origin_pos: Option<[f64; 3]> =
                 positions.get(entity).ok().map(|p| p.as_array());
             if let (Some(v), Some(op)) = (vantage, origin_pos) {
@@ -1301,6 +1335,8 @@ mod tests {
             }),
             upgrade_to: Vec::new(),
             upgrade_from: None,
+                    on_built: None,
+            on_upgraded: None,
         });
 
         assert_eq!(registry.definitions.len(), 3);
@@ -1445,6 +1481,8 @@ mod tests {
             deliverable: None,
             upgrade_to: Vec::new(),
             upgrade_from: None,
+            on_built: None,
+            on_upgraded: None,
         }
     }
 

--- a/macrocosmo/src/event_system.rs
+++ b/macrocosmo/src/event_system.rs
@@ -221,6 +221,13 @@ impl EventSystem {
 // Built-in events use "macrocosmo:" prefix.
 // Examples: "macrocosmo:building_lost", "macrocosmo:ship_lost", "macrocosmo:tech_researched"
 
+/// #281: Event id fired when a building/structure finishes construction or an
+/// upgrade path completes. Payload keys: `cause` (`"construction"` |
+/// `"upgrade"`), `building_id`, `slot` (when applicable), `system` (entity id
+/// as decimal string), `colony` (planet building only), `previous_id`
+/// (upgrade only).
+pub const BUILDING_BUILT_EVENT: &str = "macrocosmo:building_built";
+
 /// Central event bus for dispatching events to Lua handlers.
 ///
 /// Handlers are stored in the Lua global `_event_handlers` table to avoid

--- a/macrocosmo/src/scripting/building_api.rs
+++ b/macrocosmo/src/scripting/building_api.rs
@@ -4,6 +4,7 @@ use bevy::prelude::*;
 
 use crate::amount::Amt;
 use crate::condition::Condition;
+use crate::event_system::LuaFunctionRef;
 use crate::modifier::ParsedModifier;
 use crate::scripting::condition_parser::parse_prerequisites_field;
 use crate::scripting::modifier_api::parse_parsed_modifiers;
@@ -53,6 +54,14 @@ pub struct BuildingDefinition {
     /// Optional Condition tree gating construction / upgrade of this building.
     /// Populated from the Lua `prerequisites = has_tech(...)` / `all(...)` / ... field.
     pub prerequisites: Option<Condition>,
+    /// #281: Optional Lua hook invoked when a building of this id finishes
+    /// fresh construction (cause = "construction"). Auto-subscribed as a
+    /// filtered handler on `macrocosmo:building_built` during registry load.
+    pub on_built: Option<LuaFunctionRef>,
+    /// #281: Optional Lua hook invoked when an upgrade to a building of this
+    /// id completes (cause = "upgrade"). The event payload carries
+    /// `previous_id` so the hook can distinguish upgrade sources.
+    pub on_upgraded: Option<LuaFunctionRef>,
 }
 
 /// Parameters for a named building capability.
@@ -209,6 +218,10 @@ pub fn parse_building_definitions(lua: &mlua::Lua) -> Result<Vec<BuildingDefinit
         let upgrade_to = parse_upgrade_to_table(&table)?;
         let prerequisites = parse_prerequisites_field(&table)?;
         let modifiers = parse_parsed_modifiers(&table, "modifiers", None)?;
+        // #281: `on_built` fires after fresh construction completes;
+        // `on_upgraded` fires after an upgrade path to this id completes.
+        let on_built = crate::scripting::parse_lua_function_field(lua, &table, "on_built")?;
+        let on_upgraded = crate::scripting::parse_lua_function_field(lua, &table, "on_upgraded")?;
 
         result.push(BuildingDefinition {
             id,
@@ -228,6 +241,8 @@ pub fn parse_building_definitions(lua: &mlua::Lua) -> Result<Vec<BuildingDefinit
             upgrade_to,
             is_direct_buildable,
             prerequisites,
+            on_built,
+            on_upgraded,
         });
     }
 
@@ -447,6 +462,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
             prerequisites: None,
+            on_built: None,
+            on_upgraded: None,
         });
 
         let mine = registry.get("mine").unwrap();
@@ -473,6 +490,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
             prerequisites: None,
+            on_built: None,
+            on_upgraded: None,
         });
 
         assert_eq!(registry.buildings.len(), 2);
@@ -574,6 +593,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
             prerequisites: None,
+            on_built: None,
+            on_upgraded: None,
         });
 
         // Replace with updated values
@@ -595,6 +616,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
             prerequisites: None,
+            on_built: None,
+            on_upgraded: None,
         });
 
         assert_eq!(registry.buildings.len(), 1);
@@ -681,6 +704,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
             prerequisites: None,
+            on_built: None,
+            on_upgraded: None,
         });
 
         // Upgrade-only planet building
@@ -702,6 +727,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: false,
             prerequisites: None,
+            on_built: None,
+            on_upgraded: None,
         });
 
         // planet_buildings() should only return direct-buildable ones

--- a/macrocosmo/src/scripting/helpers.rs
+++ b/macrocosmo/src/scripting/helpers.rs
@@ -1,5 +1,7 @@
 use mlua::prelude::*;
 
+use crate::event_system::LuaFunctionRef;
+
 /// Extract an ID string from a Lua value that is either:
 /// - A plain string -> used as-is
 /// - A reference table (from `define_xxx` or `forward_ref`) -> reads the `id` field
@@ -17,4 +19,30 @@ pub fn extract_id_from_lua_value(value: &mlua::Value) -> Result<String, mlua::Er
 /// This is the public API for use by Rust-side parsers.
 pub fn extract_ref_id(value: &mlua::Value) -> Result<String, mlua::Error> {
     extract_id_from_lua_value(value)
+}
+
+/// #281: Read an optional Lua function from a field on a definition table and
+/// store it as a proper `mlua::RegistryKey` wrapped inside a
+/// [`LuaFunctionRef`]. Returns `None` when the field is nil/absent. Errors
+/// when the field is present but is neither a function nor nil.
+///
+/// This mirrors the private helper in `event_api.rs::parse_lua_function_ref`
+/// (introduced in #263) and is re-exposed here so multiple `define_xxx`
+/// parsers (`building_api`, `structure_api`, ...) can share it without
+/// duplicating the registry-key wiring.
+pub fn parse_lua_function_field(
+    lua: &mlua::Lua,
+    table: &mlua::Table,
+    field: &str,
+) -> Result<Option<LuaFunctionRef>, mlua::Error> {
+    let value: mlua::Value = table.get(field)?;
+    match value {
+        mlua::Value::Function(f) => Ok(Some(LuaFunctionRef::from_function(lua, f)?)),
+        mlua::Value::Nil => Ok(None),
+        _ => Err(mlua::Error::RuntimeError(format!(
+            "Expected function or nil for field '{}', got {:?}",
+            field,
+            value.type_name()
+        ))),
+    }
 }

--- a/macrocosmo/src/scripting/mod.rs
+++ b/macrocosmo/src/scripting/mod.rs
@@ -28,7 +28,7 @@ pub use engine::{
     SCRIPTS_DIR_ENV_VAR,
 };
 pub use game_rng::{register_game_rand, GameRng};
-pub use helpers::{extract_id_from_lua_value, extract_ref_id};
+pub use helpers::{extract_id_from_lua_value, extract_ref_id, parse_lua_function_field};
 
 use bevy::prelude::*;
 
@@ -79,6 +79,19 @@ impl Plugin for ScriptingPlugin {
             .add_systems(
                 Startup,
                 load_event_definitions.after(load_all_scripts),
+            )
+            // #281: After the building/structure registries are populated,
+            // walk their `on_built` / `on_upgraded` fields and register
+            // filtered handlers on `_event_handlers` so the dispatcher
+            // treats them like any other `on("macrocosmo:building_built", ...)`
+            // registration. Runs before `run_lifecycle_hooks` so lifecycle
+            // code that fires events at game start observes the hooks.
+            .add_systems(
+                Startup,
+                register_building_built_hooks
+                    .after(crate::colony::load_building_registry)
+                    .after(crate::deep_space::load_structure_definitions)
+                    .before(lifecycle::run_lifecycle_hooks),
             )
             .add_systems(
                 Startup,
@@ -293,6 +306,94 @@ pub fn load_region_spec_queue(mut commands: Commands, engine: Res<ScriptEngine>)
         }
     }
     commands.insert_resource(queue);
+}
+
+/// #281: Walk the loaded BuildingRegistry / StructureRegistry and register
+/// their `on_built` / `on_upgraded` hooks as filtered entries on Lua's
+/// `_event_handlers` table. Each hook becomes equivalent to a user-written
+/// `on("macrocosmo:building_built", { building_id = ..., cause = ... }, fn)`
+/// call, so:
+///
+/// * The dispatcher already knows how to call these (no new code path).
+/// * External `on()` subscriptions and definition hooks coexist — they are
+///   all entries in the same `_event_handlers` table.
+/// * Filtering by `building_id` + `cause` means a hook on one building never
+///   fires for a different building or the wrong completion kind.
+///
+/// Hooks with no real function attached (historical
+/// `LuaFunctionRef::placeholder(i64)` test scaffolding) are skipped so we
+/// don't insert broken entries.
+pub fn register_building_built_hooks(
+    engine: Res<ScriptEngine>,
+    building_registry: Res<crate::scripting::building_api::BuildingRegistry>,
+    structure_registry: Res<crate::deep_space::StructureRegistry>,
+) {
+    let lua = engine.lua();
+    let Ok(handlers) = lua.globals().get::<mlua::Table>("_event_handlers") else {
+        warn!("register_building_built_hooks: _event_handlers table missing; skipping");
+        return;
+    };
+
+    let mut total_registered = 0usize;
+
+    let mut push_entry = |building_id: &str, cause: &str, func: mlua::Function| {
+        let entry = match lua.create_table() {
+            Ok(t) => t,
+            Err(e) => {
+                warn!("register_building_built_hooks: create_table failed: {e}");
+                return;
+            }
+        };
+        let filter = match lua.create_table() {
+            Ok(t) => t,
+            Err(e) => {
+                warn!("register_building_built_hooks: create_table (filter) failed: {e}");
+                return;
+            }
+        };
+        let _ = filter.set("building_id", building_id);
+        let _ = filter.set("cause", cause);
+        let _ = entry.set("event_id", crate::event_system::BUILDING_BUILT_EVENT);
+        let _ = entry.set("filter", filter);
+        let _ = entry.set("func", func);
+        let next_idx = handlers.len().unwrap_or(0) + 1;
+        if let Err(e) = handlers.set(next_idx, entry) {
+            warn!("register_building_built_hooks: append failed: {e}");
+            return;
+        }
+        total_registered += 1;
+    };
+
+    for def in building_registry.buildings.values() {
+        if let Some(hook_ref) = &def.on_built {
+            if let Ok(Some(func)) = hook_ref.get(lua) {
+                push_entry(&def.id, "construction", func);
+            }
+        }
+        if let Some(hook_ref) = &def.on_upgraded {
+            if let Ok(Some(func)) = hook_ref.get(lua) {
+                push_entry(&def.id, "upgrade", func);
+            }
+        }
+    }
+
+    for def in structure_registry.definitions.values() {
+        if let Some(hook_ref) = &def.on_built {
+            if let Ok(Some(func)) = hook_ref.get(lua) {
+                push_entry(&def.id, "construction", func);
+            }
+        }
+        if let Some(hook_ref) = &def.on_upgraded {
+            if let Ok(Some(func)) = hook_ref.get(lua) {
+                push_entry(&def.id, "upgrade", func);
+            }
+        }
+    }
+
+    info!(
+        "#281: registered {} definition-level building_built hook(s)",
+        total_registered
+    );
 }
 
 /// Startup system that parses Lua event definitions and registers them in EventSystem.

--- a/macrocosmo/src/scripting/structure_api.rs
+++ b/macrocosmo/src/scripting/structure_api.rs
@@ -22,7 +22,7 @@ pub fn parse_structure_definitions(lua: &mlua::Lua) -> Result<Vec<StructureDefin
     let structures: mlua::Table = lua.globals().get("_structure_definitions")?;
     for pair in structures.pairs::<i64, mlua::Table>() {
         let (_, table) = pair?;
-        result.push(parse_one(&table, /* deliverable_api */ false)?);
+        result.push(parse_one(lua, &table, /* deliverable_api */ false)?);
     }
 
     // Pass 2: `define_deliverable` — shipyard-buildable deliverables.
@@ -30,7 +30,7 @@ pub fn parse_structure_definitions(lua: &mlua::Lua) -> Result<Vec<StructureDefin
     if let Ok(deliverables) = lua.globals().get::<mlua::Table>("_deliverable_definitions") {
         for pair in deliverables.pairs::<i64, mlua::Table>() {
             let (_, table) = pair?;
-            result.push(parse_one(&table, /* deliverable_api */ true)?);
+            result.push(parse_one(lua, &table, /* deliverable_api */ true)?);
         }
     }
 
@@ -46,7 +46,7 @@ pub fn parse_structure_definitions(lua: &mlua::Lua) -> Result<Vec<StructureDefin
 ///
 /// `deliverable_api = false` means `define_structure` (world-side only). `cost`
 /// is honoured for legacy scripts but no DeliverableMetadata is synthesised.
-fn parse_one(table: &mlua::Table, deliverable_api: bool) -> Result<StructureDefinition, mlua::Error> {
+fn parse_one(lua: &mlua::Lua, table: &mlua::Table, deliverable_api: bool) -> Result<StructureDefinition, mlua::Error> {
     let id: String = table.get("id")?;
     let name: String = table.get::<Option<String>>("name")?.unwrap_or_else(|| id.clone());
     let description: String = table.get::<Option<String>>("description")?.unwrap_or_default();
@@ -104,6 +104,9 @@ fn parse_one(table: &mlua::Table, deliverable_api: bool) -> Result<StructureDefi
 
     let upgrade_to = parse_upgrade_to(table)?;
     let upgrade_from = parse_upgrade_from(table)?;
+    // #281: Definition-level lifecycle hooks.
+    let on_built = crate::scripting::parse_lua_function_field(lua, table, "on_built")?;
+    let on_upgraded = crate::scripting::parse_lua_function_field(lua, table, "on_upgraded")?;
 
     Ok(StructureDefinition {
         id,
@@ -116,6 +119,8 @@ fn parse_one(table: &mlua::Table, deliverable_api: bool) -> Result<StructureDefi
         deliverable,
         upgrade_to,
         upgrade_from,
+        on_built,
+        on_upgraded,
     })
 }
 

--- a/macrocosmo/src/technology/unlocks.rs
+++ b/macrocosmo/src/technology/unlocks.rs
@@ -276,6 +276,8 @@ mod tests {
             deliverable: None,
             upgrade_to: Vec::new(),
             upgrade_from: None,
+            on_built: None,
+            on_upgraded: None,
         }
     }
 
@@ -310,6 +312,8 @@ mod tests {
             upgrade_to: Vec::new(),
             is_direct_buildable: true,
             prerequisites: prereq,
+            on_built: None,
+            on_upgraded: None,
         }
     }
 

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -1892,6 +1892,8 @@ mod tests_229 {
             },
             upgrade_to: Vec::new(),
             upgrade_from: None,
+            on_built: None,
+            on_upgraded: None,
         }
     }
 

--- a/macrocosmo/tests/building_built_hooks.rs
+++ b/macrocosmo/tests/building_built_hooks.rs
@@ -1,0 +1,664 @@
+//! #281: Integration tests for the `macrocosmo:building_built` event and the
+//! `on_built` / `on_upgraded` definition-level hooks.
+//!
+//! The tests come in two flavours:
+//!
+//! 1. **Event-firing tests** drive an actual `test_app()` through the
+//!    building / system-building / platform-upgrade tick systems and assert
+//!    that `EventSystem.fired_log` now contains a `macrocosmo:building_built`
+//!    entry with the expected payload.
+//! 2. **Dispatch tests** exercise the Lua-side auto-subscription machinery
+//!    (`register_building_built_hooks`) by building a minimal `World` with
+//!    `ScriptEngine + EventSystem + BuildingRegistry`, running the hook
+//!    registration, pushing a synthetic `FiredEvent`, and calling
+//!    `dispatch_event_handlers` — so the test verifies the same code path a
+//!    production game uses without having to stand up a shipyard / resources
+//!    pipeline for every permutation.
+
+mod common;
+
+use bevy::prelude::*;
+use common::{
+    advance_time, find_planet, spawn_test_colony, spawn_test_system, spawn_test_system_with_planet,
+    test_app,
+};
+use macrocosmo::amount::Amt;
+use macrocosmo::colony::{
+    BuildingId, BuildingOrder, BuildingQueue, Buildings, SystemBuildingQueue, SystemBuildings,
+    UpgradeOrder,
+};
+use macrocosmo::event_system::{BUILDING_BUILT_EVENT, EventSystem, FiredEvent, LuaFunctionRef};
+use macrocosmo::scripting::building_api::{BuildingDefinition, BuildingRegistry, CapabilityParams};
+use std::collections::HashMap;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Insert a ready-to-complete construction order on the planet-level
+/// `BuildingQueue`. All costs are pre-paid and `build_time_remaining = 0` so a
+/// single tick advances the order through the completion branch.
+fn seed_planet_construction(app: &mut App, colony: Entity, building_id: &str, slot: usize) {
+    let mut bq = app.world_mut().get_mut::<BuildingQueue>(colony).unwrap();
+    bq.push_build_order(BuildingOrder {
+        order_id: 0,
+        building_id: BuildingId::new(building_id),
+        target_slot: slot,
+        minerals_remaining: Amt::ZERO,
+        energy_remaining: Amt::ZERO,
+        build_time_remaining: 0,
+    });
+}
+
+/// Same as `seed_planet_construction` but on the StarSystem-level
+/// `SystemBuildingQueue`.
+fn seed_system_construction(app: &mut App, system: Entity, building_id: &str, slot: usize) {
+    let mut sbq = app
+        .world_mut()
+        .get_mut::<SystemBuildingQueue>(system)
+        .unwrap();
+    sbq.push_build_order(BuildingOrder {
+        order_id: 0,
+        building_id: BuildingId::new(building_id),
+        target_slot: slot,
+        minerals_remaining: Amt::ZERO,
+        energy_remaining: Amt::ZERO,
+        build_time_remaining: 0,
+    });
+}
+
+/// Pre-populate a slot on a colony's `Buildings` component so an upgrade order
+/// has a source to replace. Expands the slots vec if needed.
+fn place_planet_building(app: &mut App, colony: Entity, slot: usize, building_id: &str) {
+    let mut bldgs = app.world_mut().get_mut::<Buildings>(colony).unwrap();
+    while bldgs.slots.len() <= slot {
+        bldgs.slots.push(None);
+    }
+    bldgs.slots[slot] = Some(BuildingId::new(building_id));
+}
+
+fn seed_planet_upgrade(app: &mut App, colony: Entity, slot: usize, target_id: &str) {
+    let mut bq = app.world_mut().get_mut::<BuildingQueue>(colony).unwrap();
+    bq.push_upgrade_order(UpgradeOrder {
+        order_id: 0,
+        slot_index: slot,
+        target_id: BuildingId::new(target_id),
+        minerals_remaining: Amt::ZERO,
+        energy_remaining: Amt::ZERO,
+        build_time_remaining: 0,
+    });
+}
+
+fn find_building_built(
+    event_system: &EventSystem,
+    building_id: &str,
+    cause: &str,
+) -> Option<FiredEvent> {
+    event_system
+        .fired_log
+        .iter()
+        .find(|fe| {
+            fe.event_id == BUILDING_BUILT_EVENT
+                && fe
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get("building_id"))
+                    .map(|s| s.as_str())
+                    == Some(building_id)
+                && fe
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get("cause"))
+                    .map(|s| s.as_str())
+                    == Some(cause)
+        })
+        .cloned()
+}
+
+// ============================================================================
+// Event firing — required test #1 / #2 / #4
+// ============================================================================
+
+#[test]
+fn test_building_built_event_fired_on_planet_construction_complete() {
+    let mut app = test_app();
+    let sys = spawn_test_system(app.world_mut(), "Alpha", [0.0, 0.0, 0.0], 1.0, true, true);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        sys,
+        Amt::units(100),
+        Amt::units(100),
+        vec![None, None],
+    );
+    seed_planet_construction(&mut app, colony, "mine", 0);
+
+    advance_time(&mut app, 1);
+
+    let es = app.world().resource::<EventSystem>();
+    let evt = find_building_built(es, "mine", "construction")
+        .expect("planet construction must fire macrocosmo:building_built (cause=construction)");
+    // Slot 0 completion writes the building into the slot.
+    let bldgs = app.world().get::<Buildings>(colony).unwrap();
+    assert_eq!(bldgs.slots[0].as_ref().unwrap().as_str(), "mine");
+    assert_eq!(
+        evt.payload
+            .as_ref()
+            .unwrap()
+            .get("slot")
+            .map(String::as_str),
+        Some("0")
+    );
+}
+
+#[test]
+fn test_building_built_event_fired_on_system_building_complete() {
+    let mut app = test_app();
+    let sys = spawn_test_system(app.world_mut(), "Beta", [0.0, 0.0, 0.0], 1.0, true, true);
+    let _colony = spawn_test_colony(
+        app.world_mut(),
+        sys,
+        Amt::units(100),
+        Amt::units(100),
+        vec![None],
+    );
+    seed_system_construction(&mut app, sys, "shipyard", 0);
+
+    advance_time(&mut app, 1);
+
+    let es = app.world().resource::<EventSystem>();
+    let evt = find_building_built(es, "shipyard", "construction")
+        .expect("system construction must fire macrocosmo:building_built");
+    let payload = evt.payload.as_ref().unwrap();
+    assert_eq!(payload.get("slot").map(String::as_str), Some("0"));
+    // System buildings have no `colony` key — the building is attached to the
+    // StarSystem entity itself.
+    assert!(payload.get("colony").is_none());
+    let sys_bldgs = app.world().get::<SystemBuildings>(sys).unwrap();
+    assert_eq!(sys_bldgs.slots[0].as_ref().unwrap().as_str(), "shipyard");
+}
+
+#[test]
+fn test_building_built_event_fired_on_structure_complete() {
+    // Build a tiny world that only exercises the deep-space platform upgrade
+    // path. We don't need a full colony / shipyard chain — just a
+    // ConstructionPlatform entity with sufficient accumulated resources and a
+    // StructureRegistry that describes the platform + target.
+    use macrocosmo::components::Position;
+    use macrocosmo::deep_space::{
+        CapabilityParams as DsCapabilityParams, ConstructionPlatform, DeepSpaceStructure,
+        DeliverableMetadata, LifetimeCost, ResourceCost, StructureDefinition, StructureRegistry,
+        UpgradeEdge, tick_platform_upgrade,
+    };
+    use macrocosmo::events::GameEvent;
+    use macrocosmo::ship::Owner;
+    use macrocosmo::time_system::GameClock;
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(GameClock::new(0));
+    app.insert_resource(EventSystem::default());
+    app.add_message::<GameEvent>();
+    app.init_resource::<macrocosmo::knowledge::PendingFactQueue>();
+    app.init_resource::<macrocosmo::knowledge::RelayNetwork>();
+    app.init_resource::<macrocosmo::knowledge::NextEventId>();
+    app.init_resource::<macrocosmo::knowledge::NotifiedEventIds>();
+    app.insert_resource(macrocosmo::notifications::NotificationQueue::new());
+
+    let mut registry = StructureRegistry::default();
+    registry.insert(StructureDefinition {
+        id: "kit".into(),
+        name: "Kit".into(),
+        description: String::new(),
+        max_hp: 10.0,
+        energy_drain: Amt::ZERO,
+        capabilities: HashMap::from([(
+            "construction_platform".to_string(),
+            DsCapabilityParams::default(),
+        )]),
+        prerequisites: None,
+        deliverable: Some(DeliverableMetadata {
+            cost: ResourceCost::default(),
+            build_time: 1,
+            cargo_size: 1,
+            scrap_refund: 0.0,
+        }),
+        upgrade_to: vec![UpgradeEdge {
+            target_id: "outpost".into(),
+            cost: ResourceCost::default(),
+            build_time: 1,
+        }],
+        upgrade_from: None,
+        on_built: None,
+        on_upgraded: None,
+    });
+    registry.insert(StructureDefinition {
+        id: "outpost".into(),
+        name: "Outpost".into(),
+        description: String::new(),
+        max_hp: 100.0,
+        energy_drain: Amt::ZERO,
+        capabilities: HashMap::new(),
+        prerequisites: None,
+        deliverable: None,
+        upgrade_to: Vec::new(),
+        upgrade_from: None,
+        on_built: None,
+        on_upgraded: None,
+    });
+    registry.rebuild_effective_edges();
+    app.insert_resource(registry);
+
+    let platform_entity = app
+        .world_mut()
+        .spawn((
+            DeepSpaceStructure {
+                definition_id: "kit".into(),
+                name: "Kit".into(),
+                owner: Owner::Neutral,
+            },
+            Position::from([0.0, 0.0, 0.0]),
+            LifetimeCost(ResourceCost::default()),
+            macrocosmo::deep_space::StructureHitpoints {
+                current: 10.0,
+                max: 10.0,
+            },
+            ConstructionPlatform {
+                target_id: Some("outpost".into()),
+                accumulated: ResourceCost::default(),
+            },
+        ))
+        .id();
+
+    app.add_systems(Update, tick_platform_upgrade);
+    app.update();
+
+    let es = app.world().resource::<EventSystem>();
+    let evt = find_building_built(es, "outpost", "construction")
+        .expect("deep-space platform completion must fire macrocosmo:building_built");
+    let payload = evt.payload.as_ref().unwrap();
+    assert_eq!(
+        payload.get("previous_id").map(String::as_str),
+        Some("kit"),
+        "previous_id must carry the platform/kit definition id"
+    );
+    // Sanity check: the structure identity was flipped.
+    let structure = app
+        .world()
+        .get::<DeepSpaceStructure>(platform_entity)
+        .unwrap();
+    assert_eq!(structure.definition_id, "outpost");
+}
+
+#[test]
+fn test_building_built_event_carries_correct_payload() {
+    let mut app = test_app();
+    let (sys, planet) =
+        spawn_test_system_with_planet(app.world_mut(), "Gamma", [0.0, 0.0, 0.0], 1.0, true);
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        planet,
+        Amt::units(100),
+        Amt::units(100),
+        vec![None, None, None],
+    );
+    seed_planet_construction(&mut app, colony, "power_plant", 2);
+
+    advance_time(&mut app, 1);
+
+    let es = app.world().resource::<EventSystem>();
+    let evt = find_building_built(es, "power_plant", "construction").unwrap();
+    let payload = evt.payload.as_ref().unwrap();
+    assert_eq!(
+        payload.get("cause").map(String::as_str),
+        Some("construction")
+    );
+    assert_eq!(
+        payload.get("building_id").map(String::as_str),
+        Some("power_plant")
+    );
+    assert_eq!(payload.get("slot").map(String::as_str), Some("2"));
+    // System + colony entities are serialised as `Entity::to_bits` decimal
+    // strings — round-trip them to confirm they identify the right entities.
+    let system_bits: u64 = payload.get("system").unwrap().parse().unwrap();
+    let colony_bits: u64 = payload.get("colony").unwrap().parse().unwrap();
+    assert_eq!(Entity::from_bits(system_bits), sys);
+    assert_eq!(Entity::from_bits(colony_bits), colony);
+    // `previous_id` is absent on construction.
+    assert!(payload.get("previous_id").is_none());
+}
+
+#[test]
+fn test_on_upgraded_carries_previous_id() {
+    let mut app = test_app();
+    let sys = spawn_test_system(app.world_mut(), "Delta", [0.0, 0.0, 0.0], 1.0, true, true);
+    // Put a mine already in slot 0 so the upgrade order has something to
+    // replace.
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        sys,
+        Amt::units(100),
+        Amt::units(100),
+        vec![None, None],
+    );
+    place_planet_building(&mut app, colony, 0, "mine");
+    seed_planet_upgrade(&mut app, colony, 0, "advanced_mine");
+
+    advance_time(&mut app, 1);
+
+    let es = app.world().resource::<EventSystem>();
+    let evt = find_building_built(es, "advanced_mine", "upgrade")
+        .expect("upgrade completion must fire cause=upgrade");
+    let payload = evt.payload.as_ref().unwrap();
+    assert_eq!(payload.get("previous_id").map(String::as_str), Some("mine"));
+    // Planet Buildings slot now holds the upgraded id.
+    let bldgs = app.world().get::<Buildings>(colony).unwrap();
+    assert_eq!(bldgs.slots[0].as_ref().unwrap().as_str(), "advanced_mine");
+    // Regression: the legacy `building_upgraded` event is still queued
+    // alongside. (It's queued into `pending`, so it may drain next tick
+    // rather than immediately — advance one more hexadies to flush it.)
+    advance_time(&mut app, 1);
+    let es = app.world().resource::<EventSystem>();
+    assert!(
+        es.fired_log
+            .iter()
+            .any(|fe| fe.event_id == "building_upgraded"),
+        "legacy building_upgraded event must still fire"
+    );
+    // Planet sanity.
+    let _ = find_planet(app.world_mut(), sys);
+}
+
+// ============================================================================
+// Hook dispatch — required test #5 / #6 / #7 / #9
+// ============================================================================
+//
+// These mirror the pattern used by `scripting::lifecycle` dispatch tests:
+// build a minimal `World`, register hooks via the same production path as
+// startup (`register_building_built_hooks`), push a synthetic `FiredEvent`,
+// and drive `dispatch_event_handlers` directly. This isolates the hook
+// dispatch logic from the ECS-system plumbing that the event-firing tests
+// above already cover.
+
+use macrocosmo::condition::ScopedFlags;
+use macrocosmo::deep_space::StructureRegistry;
+use macrocosmo::player::{Empire, PlayerEmpire};
+use macrocosmo::scripting::lifecycle::dispatch_event_handlers;
+use macrocosmo::scripting::{ScriptEngine, register_building_built_hooks};
+use macrocosmo::technology::{GameFlags, TechTree};
+use macrocosmo::time_system::GameClock;
+
+fn hook_test_world() -> World {
+    let mut world = World::new();
+    world.insert_resource(GameClock::new(1));
+    world.insert_resource(EventSystem::default());
+    world.insert_resource(ScriptEngine::new().unwrap());
+    world.insert_resource(BuildingRegistry::default());
+    world.insert_resource(StructureRegistry::default());
+    world.spawn((
+        Empire { name: "E".into() },
+        PlayerEmpire,
+        TechTree::default(),
+        GameFlags::default(),
+        ScopedFlags::default(),
+    ));
+    world
+}
+
+fn bare_building_def(id: &str) -> BuildingDefinition {
+    BuildingDefinition {
+        id: id.to_string(),
+        name: id.to_string(),
+        description: String::new(),
+        minerals_cost: Amt::ZERO,
+        energy_cost: Amt::ZERO,
+        build_time: 1,
+        maintenance: Amt::ZERO,
+        production_bonus_minerals: Amt::ZERO,
+        production_bonus_energy: Amt::ZERO,
+        production_bonus_research: Amt::ZERO,
+        production_bonus_food: Amt::ZERO,
+        modifiers: Vec::new(),
+        is_system_building: false,
+        capabilities: HashMap::<String, CapabilityParams>::new(),
+        upgrade_to: Vec::new(),
+        is_direct_buildable: true,
+        prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
+    }
+}
+
+/// Compile a Lua function snippet and wrap it as a `LuaFunctionRef` so it
+/// can be stored on a `BuildingDefinition::on_built` / `on_upgraded` field.
+/// The `lua_src` MUST be a `return function(evt) ... end` expression.
+fn compile_hook(world: &mut World, lua_src: &str) -> LuaFunctionRef {
+    let engine = world.resource::<ScriptEngine>();
+    let lua = engine.lua();
+    let func: mlua::Function = lua.load(lua_src).eval().unwrap();
+    LuaFunctionRef::from_function(lua, func).unwrap()
+}
+
+fn push_build_event(world: &mut World, building_id: &str, cause: &str, previous_id: Option<&str>) {
+    let mut payload = HashMap::new();
+    payload.insert("cause".to_string(), cause.to_string());
+    payload.insert("building_id".to_string(), building_id.to_string());
+    if let Some(p) = previous_id {
+        payload.insert("previous_id".to_string(), p.to_string());
+    }
+    let mut es = world.resource_mut::<EventSystem>();
+    es.fired_log.push(FiredEvent {
+        event_id: BUILDING_BUILT_EVENT.to_string(),
+        target: None,
+        fired_at: 1,
+        payload: Some(payload),
+    });
+}
+
+#[test]
+fn test_on_built_hook_invoked_for_matching_building() {
+    let mut world = hook_test_world();
+    {
+        let engine = world.resource::<ScriptEngine>();
+        engine
+            .lua()
+            .load(r#"_shipyard_called = false; _shipyard_cause = nil"#)
+            .exec()
+            .unwrap();
+    }
+    let hook = compile_hook(
+        &mut world,
+        r#"return function(evt)
+              _shipyard_called = true
+              _shipyard_cause = evt.cause
+              _shipyard_id = evt.building_id
+          end"#,
+    );
+    {
+        let mut reg = world.resource_mut::<BuildingRegistry>();
+        let mut def = bare_building_def("shipyard");
+        def.on_built = Some(hook);
+        reg.insert(def);
+    }
+
+    // Register hooks exactly the way startup does.
+    {
+        let mut sys_state: bevy::ecs::system::SystemState<(
+            Res<ScriptEngine>,
+            Res<BuildingRegistry>,
+            Res<StructureRegistry>,
+        )> = bevy::ecs::system::SystemState::new(&mut world);
+        let (engine, br, sr) = sys_state.get(&world);
+        register_building_built_hooks(engine, br, sr);
+    }
+
+    push_build_event(&mut world, "shipyard", "construction", None);
+    dispatch_event_handlers(&mut world);
+
+    let engine = world.resource::<ScriptEngine>();
+    let called: bool = engine.lua().globals().get("_shipyard_called").unwrap();
+    assert!(called, "on_built hook must fire for its own building");
+    let cause: String = engine.lua().globals().get("_shipyard_cause").unwrap();
+    assert_eq!(cause, "construction");
+    let id: String = engine.lua().globals().get("_shipyard_id").unwrap();
+    assert_eq!(id, "shipyard");
+}
+
+#[test]
+fn test_on_built_hook_not_invoked_for_other_buildings() {
+    let mut world = hook_test_world();
+    {
+        let engine = world.resource::<ScriptEngine>();
+        engine
+            .lua()
+            .load(r#"_mine_called = false; _shipyard_called = false"#)
+            .exec()
+            .unwrap();
+    }
+    let mine_hook = compile_hook(
+        &mut world,
+        r#"return function(evt) _mine_called = true end"#,
+    );
+    let shipyard_hook = compile_hook(
+        &mut world,
+        r#"return function(evt) _shipyard_called = true end"#,
+    );
+    {
+        let mut reg = world.resource_mut::<BuildingRegistry>();
+        let mut m = bare_building_def("mine");
+        m.on_built = Some(mine_hook);
+        reg.insert(m);
+        let mut s = bare_building_def("shipyard");
+        s.on_built = Some(shipyard_hook);
+        reg.insert(s);
+    }
+    {
+        let mut sys_state: bevy::ecs::system::SystemState<(
+            Res<ScriptEngine>,
+            Res<BuildingRegistry>,
+            Res<StructureRegistry>,
+        )> = bevy::ecs::system::SystemState::new(&mut world);
+        let (engine, br, sr) = sys_state.get(&world);
+        register_building_built_hooks(engine, br, sr);
+    }
+
+    // Fire only for "mine".
+    push_build_event(&mut world, "mine", "construction", None);
+    dispatch_event_handlers(&mut world);
+
+    let engine = world.resource::<ScriptEngine>();
+    let mine_called: bool = engine.lua().globals().get("_mine_called").unwrap();
+    let shipyard_called: bool = engine.lua().globals().get("_shipyard_called").unwrap();
+    assert!(mine_called, "mine hook must fire");
+    assert!(
+        !shipyard_called,
+        "shipyard hook must NOT fire when only mine was built"
+    );
+}
+
+#[test]
+fn test_on_upgraded_hook_separate_from_on_built() {
+    let mut world = hook_test_world();
+    {
+        let engine = world.resource::<ScriptEngine>();
+        engine
+            .lua()
+            .load(
+                r#"_built_called = false
+                   _upgraded_called = false
+                   _upgraded_cause = nil"#,
+            )
+            .exec()
+            .unwrap();
+    }
+    let built = compile_hook(
+        &mut world,
+        r#"return function(evt) _built_called = true end"#,
+    );
+    let upgraded = compile_hook(
+        &mut world,
+        r#"return function(evt)
+              _upgraded_called = true
+              _upgraded_cause = evt.cause
+           end"#,
+    );
+    {
+        let mut reg = world.resource_mut::<BuildingRegistry>();
+        let mut def = bare_building_def("mine");
+        def.on_built = Some(built);
+        def.on_upgraded = Some(upgraded);
+        reg.insert(def);
+    }
+    {
+        let mut sys_state: bevy::ecs::system::SystemState<(
+            Res<ScriptEngine>,
+            Res<BuildingRegistry>,
+            Res<StructureRegistry>,
+        )> = bevy::ecs::system::SystemState::new(&mut world);
+        let (engine, br, sr) = sys_state.get(&world);
+        register_building_built_hooks(engine, br, sr);
+    }
+
+    push_build_event(&mut world, "mine", "upgrade", Some("old_mine"));
+    dispatch_event_handlers(&mut world);
+
+    let engine = world.resource::<ScriptEngine>();
+    let built_called: bool = engine.lua().globals().get("_built_called").unwrap();
+    let upgraded_called: bool = engine.lua().globals().get("_upgraded_called").unwrap();
+    let cause: String = engine.lua().globals().get("_upgraded_cause").unwrap();
+    assert!(
+        !built_called,
+        "on_built must NOT fire for cause=upgrade (filtered by cause)"
+    );
+    assert!(upgraded_called, "on_upgraded must fire for cause=upgrade");
+    assert_eq!(cause, "upgrade");
+}
+
+#[test]
+fn test_definition_hook_co_exists_with_external_subscription() {
+    let mut world = hook_test_world();
+    {
+        let engine = world.resource::<ScriptEngine>();
+        engine
+            .lua()
+            .load(
+                r#"_def_called = false
+                   _ext_called = false
+                   on("macrocosmo:building_built", function(evt)
+                       _ext_called = true
+                       _ext_id = evt.building_id
+                   end)"#,
+            )
+            .exec()
+            .unwrap();
+    }
+    let def_hook = compile_hook(&mut world, r#"return function(evt) _def_called = true end"#);
+    {
+        let mut reg = world.resource_mut::<BuildingRegistry>();
+        let mut def = bare_building_def("mine");
+        def.on_built = Some(def_hook);
+        reg.insert(def);
+    }
+    {
+        let mut sys_state: bevy::ecs::system::SystemState<(
+            Res<ScriptEngine>,
+            Res<BuildingRegistry>,
+            Res<StructureRegistry>,
+        )> = bevy::ecs::system::SystemState::new(&mut world);
+        let (engine, br, sr) = sys_state.get(&world);
+        register_building_built_hooks(engine, br, sr);
+    }
+
+    push_build_event(&mut world, "mine", "construction", None);
+    dispatch_event_handlers(&mut world);
+
+    let engine = world.resource::<ScriptEngine>();
+    let def_called: bool = engine.lua().globals().get("_def_called").unwrap();
+    let ext_called: bool = engine.lua().globals().get("_ext_called").unwrap();
+    let ext_id: String = engine.lua().globals().get("_ext_id").unwrap();
+    assert!(def_called, "definition-level on_built must fire");
+    assert!(
+        ext_called,
+        "external on() subscription must also fire for the same event"
+    );
+    assert_eq!(ext_id, "mine");
+}

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -57,6 +57,8 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     registry.insert(BuildingDefinition {
         id: "power_plant".into(),
@@ -76,6 +78,8 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     registry.insert(BuildingDefinition {
         id: "research_lab".into(),
@@ -95,6 +99,8 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     let mut shipyard_caps = HashMap::new();
     shipyard_caps.insert(
@@ -125,6 +131,8 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     let mut port_caps = HashMap::new();
     port_caps.insert(
@@ -156,6 +164,8 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     registry.insert(BuildingDefinition {
         id: "farm".into(),
@@ -175,6 +185,8 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     registry
 }

--- a/macrocosmo/tests/deliverable_pipeline.rs
+++ b/macrocosmo/tests/deliverable_pipeline.rs
@@ -61,6 +61,8 @@ fn install_test_deliverables(app: &mut App) {
         }),
         upgrade_to: Vec::new(),
         upgrade_from: None,
+            on_built: None,
+        on_upgraded: None,
     });
     // Platform kit with a single upgrade edge.
     registry.insert(StructureDefinition {
@@ -92,6 +94,8 @@ fn install_test_deliverables(app: &mut App) {
             build_time: 60,
         }],
         upgrade_from: None,
+            on_built: None,
+        on_upgraded: None,
     });
     // Upgrade target — finished defense platform.
     registry.insert(StructureDefinition {
@@ -108,6 +112,8 @@ fn install_test_deliverables(app: &mut App) {
         deliverable: None, // upgrade-only
         upgrade_to: Vec::new(),
         upgrade_from: None,
+            on_built: None,
+        on_upgraded: None,
     });
     // Rebuild the effective-edges cache.
     registry.rebuild_effective_edges();

--- a/macrocosmo/tests/job_system.rs
+++ b/macrocosmo/tests/job_system.rs
@@ -46,6 +46,8 @@ fn slot_based_building_registry() -> BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     registry.insert(BuildingDefinition {
         id: "farm".into(),
@@ -65,6 +67,8 @@ fn slot_based_building_registry() -> BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     // Shipyard — capability-only, no production/slots.
     registry.insert(BuildingDefinition {
@@ -92,6 +96,8 @@ fn slot_based_building_registry() -> BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     registry
 }
@@ -462,6 +468,8 @@ fn test_target_prefix_routes_to_job_bucket() {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     app.insert_resource(registry);
 

--- a/macrocosmo/tests/knowledge.rs
+++ b/macrocosmo/tests/knowledge.rs
@@ -1044,6 +1044,8 @@ fn install_sensor_buoy_definition(app: &mut App) {
         }),
         upgrade_to: Vec::new(),
         upgrade_from: None,
+        on_built: None,
+        on_upgraded: None,
     });
 }
 
@@ -1653,6 +1655,8 @@ fn install_ftl_comm_relay_definition(app: &mut App, range_ly: f64) {
         }),
         upgrade_to: Vec::new(),
         upgrade_from: None,
+        on_built: None,
+        on_upgraded: None,
     });
 }
 

--- a/macrocosmo/tests/notification_knowledge_pipeline.rs
+++ b/macrocosmo/tests/notification_knowledge_pipeline.rs
@@ -335,6 +335,8 @@ fn test_empire_comm_relay_range_extends_coverage() {
         deliverable: None,
         upgrade_to: Vec::new(),
         upgrade_from: None,
+            on_built: None,
+        on_upgraded: None,
     });
     app.insert_resource(registry);
 

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -2932,6 +2932,8 @@ fn test_scout_report_via_ftl_comm() {
             }),
             upgrade_to: Vec::new(),
             upgrade_from: None,
+            on_built: None,
+            on_upgraded: None,
         });
     }
 

--- a/macrocosmo/tests/tech_broadcast.rs
+++ b/macrocosmo/tests/tech_broadcast.rs
@@ -640,6 +640,8 @@ fn job_slot_registry() -> macrocosmo::colony::BuildingRegistry {
         upgrade_to: Vec::new(),
         is_direct_buildable: true,
         prerequisites: None,
+        on_built: None,
+        on_upgraded: None,
     });
     registry
 }


### PR DESCRIPTION
## Summary

- Fires a new `macrocosmo:building_built` event from all four building/structure completion paths (planet building construction, system building construction, deep-space platform→structure promotion, and planet/system upgrade queues).
- Adds definition-level `on_built` / `on_upgraded` fields on `BuildingDefinition` and `StructureDefinition`, auto-subscribed as filtered `_event_handlers` entries keyed by `building_id` + `cause` at startup via a new `register_building_built_hooks` system. Filtering guarantees a hook only fires for its own building / completion kind, and external `on(event_id, handler)` subscriptions coexist cleanly.
- Payload: `cause` (`"construction"` | `"upgrade"`), `building_id`, `slot`, `system` (Entity bits), `colony` (planet-level only), `previous_id` (upgrade only). `event.gamestate` is attached automatically via the #263 dispatcher.

## Test plan

- [x] `test_building_built_event_fired_on_planet_construction_complete`
- [x] `test_building_built_event_fired_on_system_building_complete`
- [x] `test_building_built_event_fired_on_structure_complete`
- [x] `test_building_built_event_carries_correct_payload`
- [x] `test_on_built_hook_invoked_for_matching_building`
- [x] `test_on_built_hook_not_invoked_for_other_buildings`
- [x] `test_on_upgraded_hook_separate_from_on_built`
- [x] `test_on_upgraded_carries_previous_id`
- [x] `test_definition_hook_co_exists_with_external_subscription`
- [x] `cargo test --workspace` — 1916 passed / 0 failed
- [x] `cargo test --test smoke all_systems_no_query_conflict` — B0001 check clean

## Notes

- For deep-space structures the current completion path fires `cause = "construction"` exclusively. `on_upgraded` is parsed and auto-subscribed for API symmetry with planet/system buildings; a future issue can wire dedicated structure-upgrade transitions to `cause = "upgrade"`.
- Out of scope (per issue): `on_dismantled` hook, ship-build hook, tech-research hook, settlement/colonization hook, hook-internal mutation APIs.

## Unblocks

- #292 S-3 (Infrastructure Core)

Closes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)