### PR TITLE
#309: restore combat tests — add FactionOwner via spawn_raw_hostile helper

### DIFF
--- a/macrocosmo/tests/combat.rs
+++ b/macrocosmo/tests/combat.rs
@@ -22,7 +22,7 @@ fn test_hostile_destroyed_when_hp_zero() {
     );
 
     // Spawn a hostile with low HP so it gets destroyed quickly
-    let hostile_entity = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 0.05, max_hp: 10.0 }, HostileStats { strength: 0.0, evasion: 0.0 }, Hostile)).id();
+    let hostile_entity = common::spawn_raw_hostile(app.world_mut(), sys, 0.05, 10.0, 0.0, 0.0, "space_creature");
 
     // Register a weapon module in the ModuleRegistry
     app.world_mut().resource_mut::<macrocosmo::ship_design::ModuleRegistry>().insert(
@@ -105,7 +105,7 @@ fn test_ship_destroyed_when_hp_zero_in_combat() {
     );
 
     // Spawn a powerful hostile
-    app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 1000.0, max_hp: 1000.0 }, HostileStats { strength: 100.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), sys, 1000.0, 1000.0, 100.0, 0.0, "space_creature");
 
     // Spawn a very weak ship with nearly no hull HP
     let ship_entity = app.world_mut().spawn((
@@ -159,7 +159,7 @@ fn test_no_combat_when_no_ships_present() {
     );
 
     // Spawn hostile - should not be affected without ships present
-    let hostile_entity = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 10.0, max_hp: 10.0 }, HostileStats { strength: 5.0, evasion: 0.0 }, Hostile)).id();
+    let hostile_entity = common::spawn_raw_hostile(app.world_mut(), sys, 10.0, 10.0, 5.0, 0.0, "space_creature");
 
     advance_time(&mut app, 1);
 
@@ -182,7 +182,7 @@ fn test_combat_takes_multiple_ticks() {
     );
 
     // Hostile with significant HP
-    let hostile_entity = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 1000.0, max_hp: 1000.0 }, HostileStats { strength: 0.01, evasion: 0.0 }, Hostile)).id();
+    let hostile_entity = common::spawn_raw_hostile(app.world_mut(), sys, 1000.0, 1000.0, 0.01, 0.0, "space_creature");
 
     // Register a weapon module
     app.world_mut().resource_mut::<macrocosmo::ship_design::ModuleRegistry>().insert(
@@ -409,7 +409,7 @@ fn test_combat_damages_3_layers() {
     );
 
     // Spawn hostile with significant strength
-    app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 10000.0, max_hp: 10000.0 }, HostileStats { strength: 10.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), sys, 10000.0, 10000.0, 10.0, 0.0, "space_creature");
 
     // Register armor and shield modules
     {
@@ -499,7 +499,7 @@ fn test_hull_zero_destroys_ship() {
         false,
     );
 
-    app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 10000.0, max_hp: 10000.0 }, HostileStats { strength: 100.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), sys, 10000.0, 10000.0, 100.0, 0.0, "space_creature");
 
     let ship_entity = app.world_mut().spawn((
         Ship {
@@ -583,11 +583,11 @@ fn test_weapon_cooldown() {
     });
 
     // Hostile A: attacked by fast gun
-    let hostile_a = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 10000.0, max_hp: 10000.0 }, HostileStats { strength: 0.0, evasion: 0.0 }, Hostile)).id();
+    let hostile_a = common::spawn_raw_hostile(app.world_mut(), sys, 10000.0, 10000.0, 0.0, 0.0, "space_creature");
 
     // Hostile B: attacked by slow gun (separate system)
     let sys_b = spawn_test_system(app.world_mut(), "Cooldown-B", [100.0, 0.0, 0.0], 0.7, true, false);
-    let hostile_b = app.world_mut().spawn((AtSystem(sys_b), HostileHitpoints { hp: 10000.0, max_hp: 10000.0 }, HostileStats { strength: 0.0, evasion: 0.0 }, Hostile)).id();
+    let hostile_b = common::spawn_raw_hostile(app.world_mut(), sys_b, 10000.0, 10000.0, 0.0, 0.0, "space_creature");
 
     // Ship with fast gun at sys
     app.world_mut().spawn((
@@ -667,7 +667,7 @@ fn test_shield_piercing() {
     );
 
     // Hostile with no attack
-    let hostile = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 10000.0, max_hp: 10000.0 }, HostileStats { strength: 0.0, evasion: 0.0 }, Hostile)).id();
+    let hostile = common::spawn_raw_hostile(app.world_mut(), sys, 10000.0, 10000.0, 0.0, 0.0, "space_creature");
 
     // Ship with full shields, armor, and the piercing weapon
     let _ship_entity = app.world_mut().spawn((
@@ -724,7 +724,7 @@ fn test_retreat_ships_skip_combat_no_damage_dealt() {
     );
 
     // Hostile with no attack but trackable HP
-    let hostile_entity = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 100.0, max_hp: 100.0 }, HostileStats { strength: 0.0, evasion: 0.0 }, Hostile)).id();
+    let hostile_entity = common::spawn_raw_hostile(app.world_mut(), sys, 100.0, 100.0, 0.0, 0.0, "space_creature");
 
     // Register a weapon module
     app.world_mut().resource_mut::<macrocosmo::ship_design::ModuleRegistry>().insert(
@@ -799,7 +799,7 @@ fn test_retreat_ships_dont_take_damage() {
     );
 
     // Hostile with strong attack
-    app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 10000.0, max_hp: 10000.0 }, HostileStats { strength: 100.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), sys, 10000.0, 10000.0, 100.0, 0.0, "space_creature");
 
     // Ship with Retreat ROE — should not take damage
     let ship_entity = app.world_mut().spawn((
@@ -854,7 +854,7 @@ fn test_aggressive_ships_engage_combat() {
         false,
     );
 
-    let hostile_entity = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 0.05, max_hp: 10.0 }, HostileStats { strength: 0.0, evasion: 0.0 }, Hostile)).id();
+    let hostile_entity = common::spawn_raw_hostile(app.world_mut(), sys, 0.05, 10.0, 0.0, 0.0, "space_creature");
 
     app.world_mut().resource_mut::<macrocosmo::ship_design::ModuleRegistry>().insert(
         macrocosmo::ship_design::ModuleDefinition {
@@ -926,7 +926,7 @@ fn test_defensive_ships_engage_combat_same_as_before() {
         false,
     );
 
-    let hostile_entity = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 0.05, max_hp: 10.0 }, HostileStats { strength: 0.0, evasion: 0.0 }, Hostile)).id();
+    let hostile_entity = common::spawn_raw_hostile(app.world_mut(), sys, 0.05, 10.0, 0.0, 0.0, "space_creature");
 
     app.world_mut().resource_mut::<macrocosmo::ship_design::ModuleRegistry>().insert(
         macrocosmo::ship_design::ModuleDefinition {
@@ -998,7 +998,7 @@ fn test_mixed_roe_only_non_retreat_fight() {
     );
 
     // Hostile with moderate HP and strong attack
-    app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 0.05, max_hp: 10.0 }, HostileStats { strength: 50.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), sys, 0.05, 10.0, 50.0, 0.0, "space_creature");
 
     app.world_mut().resource_mut::<macrocosmo::ship_design::ModuleRegistry>().insert(
         macrocosmo::ship_design::ModuleDefinition {
@@ -1264,7 +1264,7 @@ fn test_colonize_blocked_by_hostile() {
     );
 
     // Spawn hostile at this system (low strength so it won't kill the ship via combat)
-    app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 500.0, max_hp: 500.0 }, HostileStats { strength: 0.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), sys, 500.0, 500.0, 0.0, 0.0, "space_creature");
 
     // Spawn a colony ship that is settling at this system (completes at tick 1)
     let ship_entity = app
@@ -1342,7 +1342,7 @@ fn test_hostile_cleared_allows_colonization() {
     );
 
     // Spawn and immediately despawn a hostile (simulating it was defeated)
-    let hostile_entity = app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 10.0, max_hp: 10.0 }, HostileStats { strength: 10.0, evasion: 0.0 }, Hostile)).id();
+    let hostile_entity = common::spawn_raw_hostile(app.world_mut(), sys, 10.0, 10.0, 10.0, 0.0, "space_creature");
     app.world_mut().despawn(hostile_entity);
 
     // Spawn a colony ship settling at this system

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -316,6 +316,45 @@ pub fn setup_test_hostile_factions(world: &mut World) -> (Entity, Entity) {
     (space_creature, ancient_defense)
 }
 
+/// #293 follow-up: spawn a hostile entity with custom stats and the
+/// correct `FactionOwner` attached. Auto-initializes `HostileFactions`
+/// by calling `setup_test_hostile_factions` if not already populated,
+/// so call order is not load-bearing.
+pub fn spawn_raw_hostile(
+    world: &mut World,
+    sys: Entity,
+    hp: f64,
+    max_hp: f64,
+    strength: f64,
+    evasion: f64,
+    faction_id: &'static str,
+) -> Entity {
+    use macrocosmo::faction::{FactionOwner, HostileFactions};
+    use macrocosmo::galaxy::{AtSystem, Hostile, HostileHitpoints, HostileStats};
+    let needs_setup = {
+        let hf = world.resource::<HostileFactions>();
+        hf.space_creature.is_none() || hf.ancient_defense.is_none()
+    };
+    if needs_setup {
+        let _ = setup_test_hostile_factions(world);
+    }
+    let hf = *world.resource::<HostileFactions>();
+    let faction_entity = match faction_id {
+        "space_creature" => hf.space_creature.unwrap(),
+        "ancient_defense" => hf.ancient_defense.unwrap(),
+        other => panic!("unknown faction_id {:?}", other),
+    };
+    world
+        .spawn((
+            AtSystem(sys),
+            HostileHitpoints { hp, max_hp },
+            HostileStats { strength, evasion },
+            Hostile,
+            FactionOwner(faction_entity),
+        ))
+        .id()
+}
+
 /// Build a headless Bevy App with game logic systems but no rendering.
 pub fn test_app() -> App {
     let mut app = App::new();
@@ -734,14 +773,29 @@ pub fn full_test_app() -> App {
 pub fn advance_time(app: &mut App, hexadies: i64) {
     // #293: detect hostile entities lacking FactionOwner via either the
     // legacy `HostilePresence` component or the new `Hostile` marker.
-    let needs_migration = {
+    // #309: also migrate when there are `Hostile` entities alongside
+    // `Owner::Neutral` ships that have not yet been re-homed onto the test
+    // empire — `spawn_raw_hostile` attaches `FactionOwner` at spawn time,
+    // so the FactionOwner check alone can miss late-spawned neutral ships.
+    let has_hostile = {
+        let mut q = app
+            .world_mut()
+            .query_filtered::<Entity, With<macrocosmo::galaxy::Hostile>>();
+        q.iter(app.world()).next().is_some()
+    };
+    let has_faction_ownerless_hostile = {
         let mut q = app.world_mut().query_filtered::<Entity, (
             With<macrocosmo::galaxy::Hostile>,
             Without<macrocosmo::faction::FactionOwner>,
         )>();
         q.iter(app.world()).next().is_some()
     };
-    if needs_migration {
+    let has_neutral_ship = {
+        let mut q = app.world_mut().query::<&macrocosmo::ship::Ship>();
+        q.iter(app.world())
+            .any(|s| matches!(s.owner, macrocosmo::ship::Owner::Neutral))
+    };
+    if has_faction_ownerless_hostile || (has_hostile && has_neutral_ship) {
         setup_test_hostile_factions(app.world_mut());
     }
 

--- a/macrocosmo/tests/knowledge.rs
+++ b/macrocosmo/tests/knowledge.rs
@@ -773,7 +773,7 @@ fn test_knowledge_snapshot_hostile_presence() {
     ));
 
     // Spawn hostile presence at remote system
-    app.world_mut().spawn((AtSystem(sys_hostile), HostileHitpoints { hp: 100.0, max_hp: 100.0 }, HostileStats { strength: 5.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), sys_hostile, 100.0, 100.0, 5.0, 0.0, "space_creature");
 
     // Advance past light delay (1 LY = 60 hexadies)
     advance_time(&mut app, 61);

--- a/macrocosmo/tests/player.rs
+++ b/macrocosmo/tests/player.rs
@@ -339,7 +339,7 @@ fn test_player_respawn_on_ship_destruction() {
         .insert(AboardShip { ship: ship_entity });
 
     // Spawn a powerful hostile
-    app.world_mut().spawn((AtSystem(remote), HostileHitpoints { hp: 1000.0, max_hp: 1000.0 }, HostileStats { strength: 100.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), remote, 1000.0, 1000.0, 100.0, 0.0, "space_creature");
 
     // Run combat
     advance_time(&mut app, 1);
@@ -448,7 +448,7 @@ fn test_player_respawn_event_fires() {
         .entity_mut(player_entity)
         .insert(AboardShip { ship: ship_entity });
 
-    app.world_mut().spawn((AtSystem(remote), HostileHitpoints { hp: 1000.0, max_hp: 1000.0 }, HostileStats { strength: 100.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), remote, 1000.0, 1000.0, 100.0, 0.0, "space_creature");
 
     advance_time(&mut app, 1);
 

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -2652,7 +2652,7 @@ fn test_loitering_ship_not_engaged_by_resolve_combat() {
     );
 
     // Hostile in the system.
-    app.world_mut().spawn((AtSystem(sys), HostileHitpoints { hp: 1000.0, max_hp: 1000.0 }, HostileStats { strength: 100.0, evasion: 0.0 }, Hostile));
+    let _ = common::spawn_raw_hostile(app.world_mut(), sys, 1000.0, 1000.0, 100.0, 0.0, "space_creature");
 
     // Spawn a Loitering ship at the SAME coordinates as the hostile system but with
     // ShipState::Loitering — combat should ignore it because it's not Docked.


### PR DESCRIPTION
## Summary

- PR #308 (#293 HostilePresence removal) merge left 10 combat tests failing on main — raw `spawn((AtSystem, HostileHitpoints, HostileStats, Hostile))` without `FactionOwner` bypasses combat resolution.
- Add `common::spawn_raw_hostile()` helper that auto-initializes `HostileFactions` via `setup_test_hostile_factions` and attaches `FactionOwner` at spawn time, so call order is not load-bearing.
- Replace all 20 raw spawn sites (combat.rs x16, knowledge.rs x1, player.rs x2, ship.rs x1) with the helper — all using `"space_creature"` faction.
- Extend `common::advance_time` migration probe to also re-home neutral ships when any `Hostile` entity is present. The helper now attaches `FactionOwner` at spawn time, so the old `needs_migration` check (which only triggered for FactionOwner-less hostiles) would skip re-homing and leave late-spawned neutral ships unaffiliated in combat.

## Test plan

- [x] `cargo test --test combat` — 33 passed, 0 failed (was 23 passed, 10 failed on main)
- [x] `cargo test --workspace --no-fail-fast` — 1907 passed, 19 failed
- [x] The 19 remaining failures are pre-existing galaxy / map_types / galaxy_generation_hooks issues, all present on main and unrelated to #309 (verified by `git stash && cargo test` on main).
- [x] Regression coverage: #309 is itself a regression-test fix — the helper restores the test invariant that raw hostile spawns participate in combat via `FactionOwner`.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)