### PR TITLE
fix: generate_galaxy graceful degradation when HostileFactions absent

### DIFF
--- a/macrocosmo/src/galaxy/generation.rs
+++ b/macrocosmo/src/galaxy/generation.rs
@@ -420,7 +420,7 @@ pub(crate) fn initialize_systems(
     planet_types: &[PlanetTypeDefinition],
     planet_weights: &[f64],
     overrides: &[SystemInitOverride],
-    hostile_factions: &HostileFactions,
+    hostile_factions: HostileFactions,
 ) {
     let actual_count = systems.len();
 
@@ -695,7 +695,7 @@ pub fn generate_galaxy(
     predefined_registry: Option<Res<PredefinedSystemRegistry>>,
     map_type_registry: Option<Res<MapTypeRegistry>>,
     rng_seed: Option<Res<crate::observer::RngSeed>>,
-    hostile_factions: Res<HostileFactions>,
+    hostile_factions: Option<Res<HostileFactions>>,
 ) {
     let mut rng: rand::rngs::StdRng = match rng_seed.as_deref().and_then(|s| s.0) {
         Some(seed) => {
@@ -774,7 +774,7 @@ pub fn generate_galaxy(
         &planet_types,
         &planet_weights,
         &overrides,
-        &hostile_factions,
+        hostile_factions.as_deref().copied().unwrap_or_default(),
     );
 }
 


### PR DESCRIPTION
## Summary

#293 follow-up added \`Res<HostileFactions>\` as a required param on \`generate_galaxy\`, breaking 19 tests (galaxy, galaxy_connectivity, galaxy_generation_hooks, map_types) that invoke \`generate_galaxy\` directly without \`FactionRelationsPlugin\`.

Wrap the param in \`Option<Res<_>>\` and fall back to \`HostileFactions::default()\` (empty) when missing — hostiles simply aren't spawned (the existing per-entity \`Option<Entity>\` fallback handles this case with warn+skip).

Production code is unaffected: \`FactionRelationsPlugin\` still \`init_resource\`s the resource, so the app always sees \`Some(_)\`.

## Test plan

- Before: 7 failing binaries (combat, galaxy, galaxy_connectivity, galaxy_generation_hooks, map_types, player, doc)
- After: 3 (combat, player — fixed by #311; doc — environmental dyld issue unrelated)
- Galaxy-adjacent test binaries (galaxy / galaxy_connectivity / galaxy_generation_hooks / map_types) now all green

## Concurrent with

- #311 (test-side fixup — raw hostile spawn helper). Independent — this PR is production code, #311 is tests.