### PR TITLE
#295: S-1 Sovereignty derived-view (Core ship based)

### DIFF
--- a/macrocosmo/src/colony/authority.rs
+++ b/macrocosmo/src/colony/authority.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use crate::amount::Amt;
-use crate::faction::{FactionOwner, system_owner};
+use crate::faction::{system_owner, FactionOwner};
 use crate::galaxy::{AtSystem, Planet, Sovereignty, StarSystem};
 use crate::modifier::ModifiedValue;
 use crate::ship::Owner;

--- a/macrocosmo/src/colony/authority.rs
+++ b/macrocosmo/src/colony/authority.rs
@@ -1,14 +1,13 @@
 use bevy::prelude::*;
 
 use crate::amount::Amt;
-use crate::galaxy::{Planet, StarSystem, Sovereignty};
+use crate::faction::{FactionOwner, system_owner};
+use crate::galaxy::{AtSystem, Planet, Sovereignty, StarSystem};
 use crate::modifier::ModifiedValue;
 use crate::ship::Owner;
 use crate::time_system::GameClock;
 
-use super::{
-    Colony, LastProductionTick, ResourceCapacity, ResourceStockpile,
-};
+use super::{Colony, LastProductionTick, ResourceCapacity, ResourceStockpile};
 
 /// Default authority produced per hexady by the capital colony.
 /// #160: canonical value is `GameBalance.base_authority_per_hexadies`.
@@ -117,29 +116,33 @@ pub fn tick_authority(
     }
 }
 
-/// Updates sovereignty of star systems based on colony presence.
+/// #295 (S-1): Derive sovereignty of each star system from Core ship presence.
+///
+/// A system is sovereign to `faction` when (and only when) a Core ship owned by
+/// `faction` is stationed in that system. Removing the Core ship removes
+/// sovereignty — colony presence alone does not confer ownership.
+///
+/// `Sovereignty.owner` is retained here as a cached derived view so that
+/// savebag / existing readers keep working without change. Readers that need
+/// live owner data should call [`system_owner`] directly.
+///
+/// TODO(#298): `control_score` semantics are placeholder (1.0 when owned, 0.0
+/// otherwise). Real control-score dynamics (population, garrison, distance
+/// decay) come in S-4.
 pub fn update_sovereignty(
-    colonies: Query<&Colony>,
     mut sovereignties: Query<(Entity, &mut Sovereignty)>,
-    empire_q: Query<Entity, With<crate::player::PlayerEmpire>>,
-    planets: Query<&Planet>,
+    at_system: Query<(&AtSystem, &FactionOwner)>,
 ) {
-    let player_empire = empire_q.single().ok();
-
-    let mut colony_pop: std::collections::HashMap<Entity, f64> = std::collections::HashMap::new();
-    for colony in &colonies {
-        if let Some(sys) = colony.system(&planets) {
-            *colony_pop.entry(sys).or_insert(0.0) += colony.population;
-        }
-    }
-
     for (entity, mut sov) in &mut sovereignties {
-        if let Some(&pop) = colony_pop.get(&entity) {
-            sov.owner = player_empire.map(Owner::Empire);
-            sov.control_score = pop;
-        } else {
-            sov.owner = None;
-            sov.control_score = 0.0;
+        match system_owner(entity, &at_system) {
+            Some(faction) => {
+                sov.owner = Some(Owner::Empire(faction));
+                sov.control_score = 1.0;
+            }
+            None => {
+                sov.owner = None;
+                sov.control_score = 0.0;
+            }
         }
     }
 }

--- a/macrocosmo/src/faction/mod.rs
+++ b/macrocosmo/src/faction/mod.rs
@@ -892,6 +892,31 @@ pub fn faction_can_diplomacy(
         .unwrap_or(false)
 }
 
+/// #295 (S-1): Derive the sovereign owner of a star system from the Core ship
+/// present in that system. Returns `Some(faction_entity)` when a Core ship with
+/// a [`FactionOwner`] sits in `system`, `None` otherwise.
+///
+/// The sovereign owner of a system is defined by the Core ship stationed there
+/// — removing the Core ship removes sovereignty. This replaces the previous
+/// colony-presence-based hardcoded `player_empire` heuristic.
+///
+/// TODO(#296): Filter by a dedicated `CoreShip` marker once S-3 lands. Until
+/// then, this helper filters by `With<AtSystem>` — currently populated only on
+/// hostile entities, so `system_owner` effectively returns `None` for all
+/// player-held systems until S-2 (#297) attaches `FactionOwner` to ships and
+/// S-3 (#296) introduces the `CoreShip` marker.
+pub fn system_owner(
+    system: Entity,
+    at_system: &Query<(&crate::galaxy::AtSystem, &FactionOwner)>,
+) -> Option<Entity> {
+    for (at, owner) in at_system.iter() {
+        if at.0 == system {
+            return Some(owner.0);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/macrocosmo/src/galaxy/generation.rs
+++ b/macrocosmo/src/galaxy/generation.rs
@@ -569,8 +569,10 @@ pub(crate) fn initialize_systems(
             star_type: star_type.id.clone(),
         };
 
-        // Capital sovereignty will be set by update_sovereignty once
-        // the empire entity is spawned; start with default for all.
+        // #295 (S-1): Sovereignty is now a derived view of Core ship
+        // presence — `update_sovereignty` writes `owner` based on a
+        // `(AtSystem, FactionOwner)` query. Start at default (None) for
+        // all systems; ownership appears once a Core ship enters.
         let sovereignty = Sovereignty::default();
 
         // Build SystemModifiers with any known ship.* targets from the star type

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -981,6 +981,18 @@ pub fn empire_entity(world: &mut World) -> Entity {
         .expect("No player empire found in test world")
 }
 
+/// #295 (S-1): Spawn a mock "Core ship" bearing `(AtSystem, FactionOwner)` so
+/// `update_sovereignty` sees the system as owned by `faction`.
+///
+/// This is a placeholder for the real Core ship that S-3 (#296) will define.
+/// Tests targeting sovereignty behaviour call this helper instead of waiting
+/// for the S-3 marker and auto-spawn systems.
+pub fn spawn_mock_core_ship(world: &mut World, system: Entity, faction: Entity) -> Entity {
+    use macrocosmo::faction::FactionOwner;
+    use macrocosmo::galaxy::AtSystem;
+    world.spawn((AtSystem(system), FactionOwner(faction))).id()
+}
+
 /// #236: Test fixture builders for hull + module registries that mirror the
 /// Lua preset content. Designs are built from these via `design_derived` so
 /// the test registry always reflects the canonical derivation formula.

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -465,9 +465,14 @@ fn test_empire_owned_ships() {
 
     advance_time(&mut app2, 1);
 
-    // Sovereignty should be set to the empire owner
+    // #295 (S-1): Sovereignty is now derived from Core ship presence, not
+    // colony population. Without a Core ship (S-3 #296 not yet landed), a
+    // system with only colonies has no sovereign owner.
+    // TODO(#296): Restore `Some(Owner::Empire(empire2))` assertion once Core
+    // ships are auto-spawned at empire founding.
+    let _ = empire2;
     let sov = app2.world().get::<Sovereignty>(sys2).unwrap();
-    assert_eq!(sov.owner, Some(Owner::Empire(empire2)));
+    assert_eq!(sov.owner, None);
 }
 
 #[test]

--- a/macrocosmo/tests/sovereignty.rs
+++ b/macrocosmo/tests/sovereignty.rs
@@ -1,0 +1,155 @@
+//! #295 (S-1): Regression tests for Core-ship-derived sovereignty.
+//!
+//! These tests pin down the behaviour of `faction::system_owner` and
+//! `update_sovereignty` after the refactor that removed colony-population
+//! based ownership in favour of Core ship presence.
+
+mod common;
+
+use bevy::prelude::*;
+use common::{
+    advance_time, empire_entity, full_test_app, spawn_mock_core_ship, spawn_test_colony,
+    spawn_test_system,
+};
+use macrocosmo::amount::Amt;
+use macrocosmo::faction::{FactionOwner, system_owner};
+use macrocosmo::galaxy::{AtSystem, Sovereignty};
+use macrocosmo::ship::Owner;
+
+/// With no Core ship stationed in a system, `system_owner` returns None.
+#[test]
+fn system_owner_returns_none_when_no_core_ship() {
+    let mut app = full_test_app();
+    let sys = spawn_test_system(app.world_mut(), "Lonely", [0.0, 0.0, 0.0], 1.0, true, false);
+
+    // No Core ship spawned — query should yield nothing for this system.
+    let mut q = app
+        .world_mut()
+        .query::<(&AtSystem, &FactionOwner)>();
+    let query: Vec<_> = q.iter(app.world()).collect();
+    // The query type mirrors the helper; run the helper directly through an
+    // adapter system to exercise the exact signature.
+    let _ = query; // exercise the query at least once
+
+    // Use a tiny system to invoke the helper with a real `Query` handle.
+    let result = std::sync::Arc::new(std::sync::Mutex::new(Some(Entity::PLACEHOLDER)));
+    let result_w = result.clone();
+    let sys_target = sys;
+    app.add_systems(
+        Update,
+        move |at_system: Query<(&AtSystem, &FactionOwner)>| {
+            *result_w.lock().unwrap() = system_owner(sys_target, &at_system);
+        },
+    );
+    app.update();
+    assert_eq!(*result.lock().unwrap(), None);
+}
+
+/// With a Core ship stationed, `system_owner` returns that ship's faction.
+#[test]
+fn system_owner_returns_faction_when_core_ship_present() {
+    let mut app = full_test_app();
+    let sys = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, false);
+    let empire = empire_entity(app.world_mut());
+    spawn_mock_core_ship(app.world_mut(), sys, empire);
+
+    let result = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let result_w = result.clone();
+    app.add_systems(
+        Update,
+        move |at_system: Query<(&AtSystem, &FactionOwner)>| {
+            *result_w.lock().unwrap() = system_owner(sys, &at_system);
+        },
+    );
+    app.update();
+    assert_eq!(*result.lock().unwrap(), Some(empire));
+}
+
+/// `update_sovereignty` respects Core ship presence: a colony alone is not
+/// enough to confer ownership. This is the key regression guard against the
+/// previous "any colony means player_empire owns it" heuristic.
+#[test]
+fn update_sovereignty_ignores_colony_without_core_ship() {
+    let mut app = full_test_app();
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "NoCoreYet",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+
+    // Colony without any Core ship.
+    spawn_test_colony(
+        app.world_mut(),
+        sys,
+        Amt::units(100),
+        Amt::units(100),
+        vec![],
+    );
+
+    advance_time(&mut app, 1);
+
+    let sov = app.world().get::<Sovereignty>(sys).unwrap();
+    assert_eq!(sov.owner, None);
+    assert_eq!(sov.control_score, 0.0);
+}
+
+/// With a Core ship present, `update_sovereignty` writes the Core ship's
+/// faction into `Sovereignty.owner`.
+#[test]
+fn update_sovereignty_sets_owner_when_core_ship_present() {
+    let mut app = full_test_app();
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "CoreHeld",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let empire = empire_entity(app.world_mut());
+    spawn_mock_core_ship(app.world_mut(), sys, empire);
+
+    advance_time(&mut app, 1);
+
+    let sov = app.world().get::<Sovereignty>(sys).unwrap();
+    assert_eq!(sov.owner, Some(Owner::Empire(empire)));
+    assert_eq!(sov.control_score, 1.0);
+}
+
+/// When the Core ship despawns, sovereignty reverts to None on the next tick.
+#[test]
+fn update_sovereignty_reverts_when_core_ship_despawned() {
+    let mut app = full_test_app();
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "TransitionSys",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let empire = empire_entity(app.world_mut());
+    let core = spawn_mock_core_ship(app.world_mut(), sys, empire);
+
+    advance_time(&mut app, 1);
+
+    assert_eq!(
+        app.world().get::<Sovereignty>(sys).unwrap().owner,
+        Some(Owner::Empire(empire))
+    );
+
+    // Despawn the Core ship and re-tick.
+    app.world_mut().despawn(core);
+    advance_time(&mut app, 1);
+
+    let sov = app.world().get::<Sovereignty>(sys).unwrap();
+    assert_eq!(sov.owner, None);
+    assert_eq!(sov.control_score, 0.0);
+}
+
+// TODO(#297): multi-faction test (two Core ships, two factions, one
+// system) requires FactionOwner cascade and clearer ownership conflict
+// semantics — gated behind S-2.


### PR DESCRIPTION
## Summary

Refactor `Sovereignty.owner` from a colony-population heuristic into a derived view of Core ship presence, unblocking the S-2/S-3/S-4 sovereignty redesign sequence.

- **Commit 1** — add `faction::system_owner(system, at_system_query) -> Option<Entity>` helper that returns the `FactionOwner` of the first `(AtSystem, FactionOwner)` entity stationed in `system`. TODO(#296) to filter by a dedicated `CoreShip` marker once S-3 lands.
- **Commit 2** — rewrite `update_sovereignty` to derive `Sovereignty.owner` from `system_owner` instead of hardcoding `player_empire` whenever a colony exists. The `Sovereignty.owner` field is kept as a cached derived view so savebag and existing readers continue to work unchanged. `control_score` becomes a placeholder until S-4 (#298).
- **Commit 3** — add `tests/sovereignty.rs` with five regression tests covering `system_owner` + `update_sovereignty` behaviour, plus a `spawn_mock_core_ship` helper in `tests/common/mod.rs`.

(Commit 4 is a one-line rustfmt fix for the authority.rs import order.)

## Test plan

- [x] `cargo test --workspace` — all 46 test binaries green, 0 failures
- [x] New `tests/sovereignty.rs` — 5 tests pin down: no-core → None, core present → faction, colony-only → None (key regression), core present → owner + control_score = 1.0, core despawn → reverts to None
- [x] Existing `tests/ship.rs::test_sovereignty_with_empire_owned_ship` — updated to expect `None` (no Core ship auto-spawn yet), with TODO(#296) to restore once S-3 lands
- [x] `all_systems_no_query_conflict` integration test — still green (new helper's `Query<(&AtSystem, &FactionOwner)>` is disjoint from `Query<&mut Sovereignty>`)

## Breaking changes

- `Sovereignty.owner` now reflects Core ship presence, not colony presence. Until S-3 (#296) lands, no player system has a Core ship, so `Sovereignty.owner == None` for all systems in a default game. Callers reading `Sovereignty.owner` as "does this empire hold this system?" will observe this change. The field itself is retained (cached) so struct-literal savebag / test fixtures keep compiling.

## Unblocks

- S-2 (#297) — FactionOwner cascade to ships / colonies
- S-3 (#296) — CoreShip marker + auto-spawn
- S-4 (#298) — real control_score dynamics

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)