### PR TITLE
#239: ModuleDefinition.build_time — design + refit time sum hull + modules

### DIFF
--- a/macrocosmo/scripts/ships/modules.lua
+++ b/macrocosmo/scripts/ships/modules.lua
@@ -1,6 +1,17 @@
 local slot_types = require("ships.slot_types")
 local tech = require("tech")
 
+-- #239: `build_time` (hexadies) contributes to the design's total build time
+-- (`hull.build_time + Σ module.build_time`). Range is 5-20 hd with a rough
+-- mapping to module weight/complexity:
+--   light utilities (5-8):  cargo_bay, ion_thruster, afterburner,
+--                           survey_equipment, scout_module
+--   mid (10-12):             fusion_reactor, weapon_laser, weapon_missile,
+--                           armor_plating, shield_generator
+--   heavy (15-20):           ftl_drive, weapon_railgun, command_array,
+--                           colony_module
+-- These are deliberately coarse — fine balance is tracked in #61.
+
 -- FTL drive modules (ftl slot)
 local ftl_drive = define_module {
     id = "ftl_drive",
@@ -10,6 +21,7 @@ local ftl_drive = define_module {
         { target = "ship.ftl_range", base_add = 15.0 },
     },
     cost = { minerals = 100, energy = 50 },
+    build_time = 15,
 }
 
 -- Sublight engine modules (sublight slot)
@@ -21,6 +33,7 @@ local afterburner = define_module {
         { target = "ship.speed", multiplier = 0.2 },
     },
     cost = { minerals = 60, energy = 40 },
+    build_time = 8,
 }
 
 local ion_thruster = define_module {
@@ -31,6 +44,7 @@ local ion_thruster = define_module {
         { target = "ship.speed", base_add = 0.1 },
     },
     cost = { minerals = 40, energy = 30 },
+    build_time = 6,
 }
 
 -- Weapon modules (weapon slot)
@@ -46,6 +60,7 @@ local weapon_laser = define_module {
         hull_damage = 3.0, hull_damage_div = 1.0,
     },
     cost = { minerals = 50, energy = 30 },
+    build_time = 10,
 }
 
 local weapon_railgun = define_module {
@@ -60,6 +75,7 @@ local weapon_railgun = define_module {
         hull_damage = 10.0, hull_damage_div = 3.0,
     },
     cost = { minerals = 100, energy = 50 },
+    build_time = 15,
 }
 
 local weapon_missile = define_module {
@@ -74,6 +90,7 @@ local weapon_missile = define_module {
         hull_damage = 8.0, hull_damage_div = 2.0,
     },
     cost = { minerals = 80, energy = 60 },
+    build_time = 12,
 }
 
 -- Defense modules (defense slot)
@@ -86,6 +103,7 @@ local armor_plating = define_module {
         { target = "ship.speed", multiplier = -0.05 },
     },
     cost = { minerals = 80 },
+    build_time = 10,
 }
 
 local shield_generator = define_module {
@@ -98,6 +116,7 @@ local shield_generator = define_module {
         { target = "ship.shield_regen", base_add = 2.0 },
     },
     cost = { minerals = 60, energy = 50 },
+    build_time = 12,
 }
 
 -- Utility modules (utility slot)
@@ -109,6 +128,7 @@ local survey_equipment = define_module {
         { target = "ship.survey_speed", base_add = 1.0 },
     },
     cost = { minerals = 60, energy = 40 },
+    build_time = 8,
 }
 
 local cargo_bay = define_module {
@@ -119,6 +139,7 @@ local cargo_bay = define_module {
         { target = "ship.cargo_capacity", base_add = 500.0 },
     },
     cost = { minerals = 30 },
+    build_time = 5,
 }
 
 local colony_module = define_module {
@@ -129,6 +150,7 @@ local colony_module = define_module {
         { target = "ship.colonize_speed", base_add = 1.0 },
     },
     cost = { minerals = 300, energy = 200 },
+    build_time = 20,
 }
 
 -- #217: Scout module — enables the Scout command and extends passive sensor
@@ -143,6 +165,7 @@ local scout_module = define_module {
         { target = "sensor.range", base_add = 1.0 },
     },
     cost = { minerals = 80, energy = 50 },
+    build_time = 8,
 }
 
 -- Power modules (power slot)
@@ -154,6 +177,7 @@ local fusion_reactor = define_module {
         { target = "ship.shield_regen", base_add = 0.5 },
     },
     cost = { minerals = 80, energy = 0 },
+    build_time = 10,
 }
 
 -- Command modules (command slot)
@@ -166,6 +190,7 @@ local command_array = define_module {
         { target = "fleet.defense", multiplier = 0.05 },
     },
     cost = { minerals = 200, energy = 100 },
+    build_time = 18,
 }
 
 return {

--- a/macrocosmo/src/scripting/ship_design_api.rs
+++ b/macrocosmo/src/scripting/ship_design_api.rs
@@ -101,6 +101,11 @@ pub fn parse_modules(lua: &mlua::Lua) -> Result<Vec<ModuleDefinition>, mlua::Err
         // still sets it will have its value silently dropped.
         let prerequisites = parse_prerequisites_field(&table)?;
 
+        // #239: optional `build_time` field (hexadies). Defaults to 0 when
+        // omitted so a module that's cheap in time authoring-wise stays
+        // invisible to the final sum.
+        let build_time: i64 = table.get::<Option<i64>>("build_time")?.unwrap_or(0);
+
         result.push(ModuleDefinition {
             id,
             name,
@@ -112,6 +117,7 @@ pub fn parse_modules(lua: &mlua::Lua) -> Result<Vec<ModuleDefinition>, mlua::Err
             cost_energy,
             prerequisites,
             upgrade_to,
+            build_time,
         });
     }
 
@@ -533,6 +539,46 @@ mod tests {
         assert_eq!(armor.modifiers[1].multiplier, -0.05);
         assert_eq!(armor.cost_minerals, Amt::units(80));
         assert_eq!(armor.cost_energy, Amt::ZERO);
+
+        // #239: build_time defaults to 0 when the Lua table omits the field.
+        assert_eq!(ftl.build_time, 0);
+        assert_eq!(armor.build_time, 0);
+    }
+
+    /// #239: `build_time` on a module is parsed and round-trips through
+    /// `parse_modules`.
+    #[test]
+    fn test_parse_modules_reads_build_time() {
+        let engine = ScriptEngine::new().unwrap();
+        let lua = engine.lua();
+
+        lua.load(
+            r#"
+            define_module {
+                id = "heavy_drive",
+                name = "Heavy Drive",
+                slot_type = "ftl",
+                cost = { minerals = 100, energy = 50 },
+                build_time = 15,
+            }
+            define_module {
+                id = "cheap_cargo",
+                name = "Cheap Cargo",
+                slot_type = "utility",
+                cost = { minerals = 30 },
+                build_time = 5,
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_modules(lua).unwrap();
+        assert_eq!(defs.len(), 2);
+        let heavy = defs.iter().find(|d| d.id == "heavy_drive").unwrap();
+        let cheap = defs.iter().find(|d| d.id == "cheap_cargo").unwrap();
+        assert_eq!(heavy.build_time, 15);
+        assert_eq!(cheap.build_time, 5);
     }
 
     #[test]

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -947,6 +947,7 @@ mod tests {
             weapon: None,
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         });
         let modules = vec![
             EquippedModule { slot_type: "weapon".into(), module_id: "test_weapon".into() },

--- a/macrocosmo/src/ship_design.rs
+++ b/macrocosmo/src/ship_design.rs
@@ -126,6 +126,12 @@ pub struct ModuleDefinition {
     pub prerequisites: Option<Condition>,
     /// Available upgrade paths from this module.
     pub upgrade_to: Vec<ModuleUpgradePath>,
+    /// #239: Build time contribution (in hexadies). The design's total build
+    /// time is `hull.build_time + Σ module.build_time`. Added to make refits
+    /// and upgrades pay a time cost proportional to the loadout, not just the
+    /// hull. Defaults to 0 when Lua omits the field so existing content keeps
+    /// compiling.
+    pub build_time: i64,
 }
 
 #[derive(Resource, Default)]
@@ -666,10 +672,17 @@ pub fn design_derived(hull: &HullDefinition, modules: &[&ModuleDefinition]) -> D
     let mut minerals = hull.build_cost_minerals;
     let mut energy = hull.build_cost_energy;
     let mut maintenance = hull.maintenance;
+    // #239: Total build time is `hull.build_time + Σ module.build_time`.
+    // Previously only the hull contributed, which made heavy loadouts (and
+    // therefore refits) disproportionately cheap in time. Summed as i64 and
+    // clamped to ≥ 1 at the end so degenerate zero-time designs never slip
+    // through the build queue.
+    let mut build_time = hull.build_time;
     for m in modules {
         minerals = minerals.add(m.cost_minerals);
         energy = energy.add(m.cost_energy);
         maintenance = maintenance.add(Amt::milli(m.cost_minerals.raw() / 10_000));
+        build_time = build_time.saturating_add(m.build_time);
     }
 
     DerivedStats {
@@ -683,9 +696,7 @@ pub fn design_derived(hull: &HullDefinition, modules: &[&ModuleDefinition]) -> D
         can_colonize: colonize_speed > 0.0,
         build_cost_minerals: minerals,
         build_cost_energy: energy,
-        // #236: ModuleDefinition has no build_time field yet; use hull.build_time.
-        // Future: per-component time contribution (separate issue).
-        build_time: hull.build_time,
+        build_time: build_time.max(1),
         maintenance,
     }
 }
@@ -755,6 +766,12 @@ pub fn refit_cost_to_design(
 
 /// Compute refit cost: new module cost - 50% of old module value.
 /// Returns (minerals, energy, time).
+///
+/// #239: Time cost is `(hull.build_time + Σ new_module.build_time) / 2`,
+/// matching the `design_derived` build_time formula halved. Before this
+/// change refits only paid `hull.build_time / 2` regardless of the new
+/// loadout, which made wholesale module swaps nearly free in time — one
+/// of the explicit motivations for the issue.
 pub fn refit_cost(
     old_modules: &[&ModuleDefinition],
     new_modules: &[&ModuleDefinition],
@@ -768,17 +785,20 @@ pub fn refit_cost(
     }
     let mut new_m = Amt::ZERO;
     let mut new_e = Amt::ZERO;
+    let mut new_build_time: i64 = 0;
     for m in new_modules {
         new_m = new_m.add(m.cost_minerals);
         new_e = new_e.add(m.cost_energy);
+        new_build_time = new_build_time.saturating_add(m.build_time);
     }
     // Refund 50% of old module value
     let refund_m = Amt::milli(old_m.raw() / 2);
     let refund_e = Amt::milli(old_e.raw() / 2);
     let cost_m = if new_m > refund_m { new_m.sub(refund_m) } else { Amt::ZERO };
     let cost_e = if new_e > refund_e { new_e.sub(refund_e) } else { Amt::ZERO };
-    // Refit time: half hull build time
-    let time = hull.build_time / 2;
+    // Refit time: half of the full (hull + modules) build time.
+    let total_time = hull.build_time.saturating_add(new_build_time);
+    let time = total_time / 2;
     (cost_m, cost_e, time.max(1))
 }
 
@@ -838,6 +858,7 @@ mod tests {
             cost_energy: Amt::units(50),
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         });
 
         let ftl = registry.get("ftl_drive").unwrap();
@@ -923,6 +944,7 @@ mod tests {
             cost_energy: Amt::ZERO,
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         };
 
         let derived = design_derived(&hull, &[&module]);
@@ -966,6 +988,7 @@ mod tests {
             cost_energy: Amt::units(50),
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         };
         let survey = ModuleDefinition {
             id: "survey_equipment".to_string(),
@@ -978,6 +1001,7 @@ mod tests {
             cost_energy: Amt::units(30),
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         };
 
         let derived = design_derived(&hull, &[&ftl, &survey]);
@@ -1029,6 +1053,7 @@ mod tests {
             cost_energy: Amt::ZERO,
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         };
         modules.insert(make("ftl_drive", "ftl"));
         modules.insert(make("weapon_laser", "weapon"));
@@ -1343,6 +1368,7 @@ mod tests {
             cost_energy: Amt::units(50),
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         };
         let afterburner = ModuleDefinition {
             id: "afterburner".into(),
@@ -1357,6 +1383,7 @@ mod tests {
             cost_energy: Amt::units(40),
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         };
         let cargo_bay = ModuleDefinition {
             id: "cargo_bay".into(),
@@ -1371,6 +1398,7 @@ mod tests {
             cost_energy: Amt::ZERO,
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         };
         (courier_hull, ftl_drive, afterburner, cargo_bay)
     }
@@ -1416,7 +1444,7 @@ mod tests {
                 ModuleModifier { target: "ship.survey_speed".into(), base_add: 1.0, multiplier: 0.0, add: 0.0 },
             ],
             weapon: None, cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO,
-            prerequisites: None, upgrade_to: Vec::new(),
+            prerequisites: None, upgrade_to: Vec::new(), build_time: 0,
         };
         let d = design_derived(&scout, &[&survey]);
         // (0 + 1.0) * (1 + 1.3) = 2.3
@@ -1444,7 +1472,7 @@ mod tests {
                 ModuleModifier { target: "ship.survey_speed".into(), base_add: 1.0, multiplier: 0.0, add: 0.0 },
             ],
             weapon: None, cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO,
-            prerequisites: None, upgrade_to: Vec::new(),
+            prerequisites: None, upgrade_to: Vec::new(), build_time: 0,
         };
 
         // Without survey module → no survey capability.
@@ -1484,5 +1512,172 @@ mod tests {
         //   hull 0.300 + ftl 100×0.0001 + afterburner 60×0.0001 + cargo 30×0.0001
         //   = 0.300 + 0.010 + 0.006 + 0.003 = 0.319
         assert_eq!(d.maintenance, Amt::new(0, 319));
+    }
+
+    // -----------------------------------------------------------------
+    // #239: ModuleDefinition.build_time contribution
+    // -----------------------------------------------------------------
+
+    /// Helper producing a minimal hull with a configurable build_time and
+    /// utility slots (so we can stack modules).
+    fn tiny_hull(build_time: i64) -> HullDefinition {
+        HullDefinition {
+            id: "tiny".into(),
+            name: "Tiny".into(),
+            description: String::new(),
+            base_hp: 10.0,
+            base_speed: 1.0,
+            base_evasion: 0.0,
+            slots: vec![HullSlot { slot_type: "utility".into(), count: 4 }],
+            build_cost_minerals: Amt::ZERO,
+            build_cost_energy: Amt::ZERO,
+            build_time,
+            maintenance: Amt::ZERO,
+            modifiers: vec![],
+            prerequisites: None,
+        }
+    }
+
+    fn tiny_module(id: &str, build_time: i64, mineral_cost: u64) -> ModuleDefinition {
+        ModuleDefinition {
+            id: id.into(),
+            name: id.into(),
+            description: String::new(),
+            slot_type: "utility".into(),
+            modifiers: vec![],
+            weapon: None,
+            cost_minerals: Amt::units(mineral_cost),
+            cost_energy: Amt::ZERO,
+            prerequisites: None,
+            upgrade_to: Vec::new(),
+            build_time,
+        }
+    }
+
+    /// #239 primary regression: design build_time is hull + Σ module.
+    #[test]
+    fn test_design_derived_build_time_sums_hull_and_modules() {
+        let hull = tiny_hull(10);
+        let a = tiny_module("a", 5, 0);
+        let b = tiny_module("b", 5, 0);
+
+        let d = design_derived(&hull, &[&a, &b]);
+        assert_eq!(d.build_time, 20, "build_time must be hull(10) + Σ(5+5)");
+
+        // No modules → build_time equals hull.build_time (clamped to ≥ 1).
+        let d_bare = design_derived(&hull, &[]);
+        assert_eq!(d_bare.build_time, 10);
+    }
+
+    /// #239: A zero hull + zero modules design still reports build_time
+    /// of at least 1 so the build queue never divides by zero.
+    #[test]
+    fn test_design_derived_build_time_clamped_to_one() {
+        let hull = tiny_hull(0);
+        let d = design_derived(&hull, &[]);
+        assert_eq!(d.build_time, 1);
+    }
+
+    /// #239: Refit time scales with Σ new_module.build_time, not only the
+    /// hull. Swapping in heavier modules costs more refit time.
+    #[test]
+    fn test_refit_cost_uses_module_build_time() {
+        let hull = tiny_hull(20); // hull alone → baseline refit time 10
+        let old_m = tiny_module("old", 0, 0);
+        let new_light = tiny_module("new_light", 0, 0);
+        let new_heavy = tiny_module("new_heavy", 10, 0);
+
+        // Light → (20 + 0)/2 = 10 hd
+        let (_, _, t_light) = refit_cost(&[&old_m], &[&new_light], &hull);
+        assert_eq!(t_light, 10);
+
+        // Heavy → (20 + 10)/2 = 15 hd. Must be strictly greater than the
+        // light case — this is the key behavioural change the issue asks
+        // for.
+        let (_, _, t_heavy) = refit_cost(&[&old_m], &[&new_heavy], &hull);
+        assert_eq!(t_heavy, 15);
+        assert!(
+            t_heavy > t_light,
+            "heavier modules must cost more refit time"
+        );
+    }
+
+    /// #239: `refit_cost_to_design` routes module lookup through the
+    /// registry and still sees the build_time contribution.
+    #[test]
+    fn test_refit_cost_to_design_includes_module_build_time() {
+        let mut hulls = HullRegistry::default();
+        hulls.insert(tiny_hull(20));
+        let mut modules = ModuleRegistry::default();
+        modules.insert(tiny_module("heavy", 10, 0));
+
+        let hull = hulls.get("tiny").unwrap();
+
+        let design = ShipDesignDefinition {
+            id: "d".into(),
+            name: "d".into(),
+            description: String::new(),
+            hull_id: "tiny".into(),
+            modules: vec![DesignSlotAssignment {
+                slot_type: "utility".into(),
+                module_id: "heavy".into(),
+            }],
+            can_survey: false,
+            can_colonize: false,
+            maintenance: Amt::ZERO,
+            build_cost_minerals: Amt::ZERO,
+            build_cost_energy: Amt::ZERO,
+            build_time: 0,
+            hp: 0.0,
+            sublight_speed: 0.0,
+            ftl_range: 0.0,
+            revision: 0,
+        };
+
+        let (_, _, t) = refit_cost_to_design(&[], &design, hull, &modules);
+        // (20 + 10)/2 = 15
+        assert_eq!(t, 15);
+    }
+
+    /// #239 regression: preset build times match the new formula. Asserts
+    /// the `design_derived` output against a hand-computed value using the
+    /// same hull + module fixture produced by `derive_fixture_courier`.
+    /// When we eventually give the courier fixture non-zero module build
+    /// times this test guards against regressions in the summation.
+    #[test]
+    fn test_preset_build_times_match_new_formula() {
+        let (hull, ftl, ab, cargo) = derive_fixture_courier();
+
+        // The courier_hull fixture carries hull.build_time = 30 and the
+        // three modules default to 0 — so the pre-#239 hull-only value and
+        // the post-#239 sum match by construction. Intentional: if anyone
+        // later gives the fixture non-zero module times without updating
+        // the expectation, the test fails and forces a consistent update.
+        let expected = hull.build_time
+            + ftl.build_time
+            + ab.build_time
+            + cargo.build_time;
+        let d = design_derived(&hull, &[&ftl, &ab, &cargo]);
+        assert_eq!(d.build_time, expected);
+    }
+
+    /// #239: Two designs with identical hull but heavier module loadout
+    /// must differ in build time. Protects against a future regression
+    /// where the summation is accidentally reduced back to
+    /// `hull.build_time`.
+    #[test]
+    fn test_heavier_loadout_costs_more_build_time() {
+        let hull = tiny_hull(10);
+        let light = tiny_module("light", 5, 0);
+        let heavy = tiny_module("heavy", 20, 0);
+
+        let d_light = design_derived(&hull, &[&light]);
+        let d_heavy = design_derived(&hull, &[&heavy]);
+        assert!(
+            d_heavy.build_time > d_light.build_time,
+            "heavier module loadout must produce a longer build time"
+        );
+        assert_eq!(d_light.build_time, 15);
+        assert_eq!(d_heavy.build_time, 30);
     }
 }

--- a/macrocosmo/src/technology/unlocks.rs
+++ b/macrocosmo/src/technology/unlocks.rs
@@ -261,6 +261,7 @@ mod tests {
             cost_energy: Amt::ZERO,
             prerequisites: prereq,
             upgrade_to: Vec::new(),
+            build_time: 0,
         }
     }
 
@@ -629,6 +630,7 @@ mod tests {
             cost_energy: Amt::ZERO,
             prerequisites: Some(Condition::Atom(ConditionAtom::has_tech("T2"))),
             upgrade_to: Vec::new(),
+            build_time: 0,
         });
 
         let mut designs = ShipDesignRegistry::default();

--- a/macrocosmo/tests/combat.rs
+++ b/macrocosmo/tests/combat.rs
@@ -50,6 +50,7 @@ fn test_hostile_destroyed_when_hp_zero() {
             cost_energy: Amt::ZERO,
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         },
     );
 
@@ -210,6 +211,7 @@ fn test_combat_takes_multiple_ticks() {
             cost_energy: Amt::ZERO,
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         },
     );
 
@@ -287,6 +289,7 @@ fn test_shield_regenerates() {
             weapon: None,
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         });
     }
 
@@ -359,6 +362,7 @@ fn test_shield_regen_caps_at_max() {
             weapon: None,
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         });
     }
 
@@ -426,6 +430,7 @@ fn test_combat_damages_3_layers() {
             weapon: None,
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         });
         module_reg.insert(macrocosmo::ship_design::ModuleDefinition {
             id: "shield_unit".to_string(),
@@ -439,6 +444,7 @@ fn test_combat_damages_3_layers() {
             weapon: None,
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         });
     }
 
@@ -565,6 +571,7 @@ fn test_weapon_cooldown() {
         }),
         cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
         upgrade_to: Vec::new(),
+        build_time: 0,
     });
     module_reg.insert(macrocosmo::ship_design::ModuleDefinition {
         id: "slow_gun".to_string(),
@@ -580,6 +587,7 @@ fn test_weapon_cooldown() {
         }),
         cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
         upgrade_to: Vec::new(),
+        build_time: 0,
     });
 
     // Hostile A: attacked by fast gun
@@ -663,6 +671,7 @@ fn test_shield_piercing() {
             }),
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         },
     );
 
@@ -742,6 +751,7 @@ fn test_retreat_ships_skip_combat_no_damage_dealt() {
             }),
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         },
     );
 
@@ -871,6 +881,7 @@ fn test_aggressive_ships_engage_combat() {
             }),
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         },
     );
 
@@ -943,6 +954,7 @@ fn test_defensive_ships_engage_combat_same_as_before() {
             }),
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         },
     );
 
@@ -1015,6 +1027,7 @@ fn test_mixed_roe_only_non_retreat_fight() {
             }),
             cost_minerals: Amt::ZERO, cost_energy: Amt::ZERO, prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         },
     );
 
@@ -1477,6 +1490,7 @@ fn install_test_weapon_module(app: &mut App) {
             cost_energy: Amt::ZERO,
             prerequisites: None,
             upgrade_to: Vec::new(),
+            build_time: 0,
         });
 }
 

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -1125,6 +1125,7 @@ pub fn create_test_module_registry() -> macrocosmo::ship_design::ModuleRegistry 
         cost_energy: Amt::units(50),
         prerequisites: None,
         upgrade_to: Vec::new(),
+        build_time: 0,
     });
     modules.insert(ModuleDefinition {
         id: "afterburner".into(),
@@ -1142,6 +1143,7 @@ pub fn create_test_module_registry() -> macrocosmo::ship_design::ModuleRegistry 
         cost_energy: Amt::units(40),
         prerequisites: None,
         upgrade_to: Vec::new(),
+        build_time: 0,
     });
     modules.insert(ModuleDefinition {
         id: "survey_equipment".into(),
@@ -1159,6 +1161,7 @@ pub fn create_test_module_registry() -> macrocosmo::ship_design::ModuleRegistry 
         cost_energy: Amt::units(40),
         prerequisites: None,
         upgrade_to: Vec::new(),
+        build_time: 0,
     });
     modules.insert(ModuleDefinition {
         id: "colony_module".into(),
@@ -1176,6 +1179,7 @@ pub fn create_test_module_registry() -> macrocosmo::ship_design::ModuleRegistry 
         cost_energy: Amt::units(200),
         prerequisites: None,
         upgrade_to: Vec::new(),
+        build_time: 0,
     });
     modules.insert(ModuleDefinition {
         id: "cargo_bay".into(),
@@ -1193,6 +1197,7 @@ pub fn create_test_module_registry() -> macrocosmo::ship_design::ModuleRegistry 
         cost_energy: Amt::ZERO,
         prerequisites: None,
         upgrade_to: Vec::new(),
+        build_time: 0,
     });
     modules
 }

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -2243,6 +2243,7 @@ fn install_refit_fixture(app: &mut App) {
         cost_energy: Amt::units(energy),
         prerequisites: None,
         upgrade_to: Vec::new(),
+        build_time: 0,
     };
     modules.insert(mk("laser_mk1", 50, 20));
     modules.insert(mk("laser_mk2", 80, 30));


### PR DESCRIPTION
Closes #239.

## Summary

- Add `ModuleDefinition.build_time: i64` field, Lua-authored via `define_module { build_time = N }` (optional, defaults to 0).
- `design_derived.build_time` is now `hull.build_time + Σ module.build_time` (clamped to ≥ 1).
- `refit_cost` scales with the same formula (`(hull.build_time + Σ new_module.build_time) / 2`), closing the issue's motivation that wholesale module swaps were nearly free in time.
- 14 existing Lua modules tagged with build_time values in the 5-20 hd range.

## Test plan

New regressions in `macrocosmo/src/ship_design.rs`:

- [x] `test_design_derived_build_time_sums_hull_and_modules` — hull(10) + 2×module(5) → build_time = 20
- [x] `test_design_derived_build_time_clamped_to_one` — zero hull + no modules still yields 1 hd
- [x] `test_refit_cost_uses_module_build_time` — heavier new modules cost more refit time (10 vs 15)
- [x] `test_refit_cost_to_design_includes_module_build_time` — registry-routed refit sees module time
- [x] `test_preset_build_times_match_new_formula` — `design_derived` matches hand-computed `hull + Σ modules`
- [x] `test_heavier_loadout_costs_more_build_time` — identical hull, heavier modules → longer build time

Lua parser regression in `macrocosmo/src/scripting/ship_design_api.rs`:

- [x] `test_parse_modules_reads_build_time` — `build_time = 15` round-trips through `define_module`
- [x] Extended `test_parse_modules` — omitted `build_time` defaults to 0

Full workspace: `cargo test --workspace` → 0 failures.

## Balance numbers

Per-module build_time in `scripts/ships/modules.lua`. Deliberately coarse; finer tuning is tracked in #61.

| Module           | build_time (hd) | Bucket |
|------------------|-----------------|--------|
| cargo_bay        | 5               | light  |
| ion_thruster     | 6               | light  |
| afterburner      | 8               | light  |
| survey_equipment | 8               | light  |
| scout_module     | 8               | light  |
| fusion_reactor   | 10              | mid    |
| weapon_laser     | 10              | mid    |
| armor_plating    | 10              | mid    |
| weapon_missile   | 12              | mid    |
| shield_generator | 12              | mid    |
| ftl_drive        | 15              | heavy  |
| weapon_railgun   | 15              | heavy  |
| command_array    | 18              | heavy  |
| colony_module    | 20              | heavy  |

## Struct field added — callsites updated

`ModuleDefinition` gained one `i64` field. All existing literal initializers were updated mechanically with `build_time: 0` so behaviour is unchanged for anything that isn't the Lua-authored presets:

- `macrocosmo/src/ship/mod.rs` — 1 test fixture
- `macrocosmo/src/technology/unlocks.rs` — 2 test fixtures (`make_module` + tech indexing)
- `macrocosmo/tests/combat.rs` — 14 test fixtures
- `macrocosmo/tests/common/mod.rs` — 5 test fixtures in `create_test_module_registry`
- `macrocosmo/tests/ship.rs` — 1 closure-based fixture
- `macrocosmo/src/ship_design.rs` — 10 in-file test fixtures (including helpers)

## Merge order note

Open parallel PRs that construct `ModuleDefinition` literals directly will need `build_time: 0` appended to each (or a real hd value for module-authoring PRs). Known candidates:

- Combat scenario fixtures (if the in-flight scenario-test PR touches `ModuleDefinition { ... }` literals)
- `#295` S-1 Sovereignty — appears independent, should be unaffected
- `#288` α EventContext — independent
- `#247` save/load — module registry is not persisted, unaffected

Rebase either direction should be mechanical (struct field add is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)