### PR TITLE
fix: add build_time to combat_scenarios ModuleDefinition (main broken)

### DIFF
--- a/macrocosmo/tests/combat_scenarios.rs
+++ b/macrocosmo/tests/combat_scenarios.rs
@@ -87,6 +87,7 @@ fn install_scenario_weapon(app: &mut App) {
         }),
         cost_minerals: Amt::ZERO,
         cost_energy: Amt::ZERO,
+        build_time: 0,
         prerequisites: None,
         upgrade_to: Vec::new(),
     });


### PR DESCRIPTION
## Summary

Main is broken for the \`combat_scenarios\` test binary: \`ModuleDefinition\` literal in \`install_scenario_weapon\` is missing the \`build_time\` field that #316 added. Semantic merge conflict between #313 (scenarios added) and #316 (build_time field added) — #316 updated 24 literals but missed the newly-merged scenario file.

## Fix

Add \`build_time: 0\` to the single literal. No behavior change (scenarios don't build modules).

## Test plan

- \`cargo test --test combat_scenarios\` → 3 pass / 0 fail
- \`cargo check --tests --workspace\` → clean

## Pattern note

Same class as #308/#309: parallel PRs auto-merge OK but compile/runtime fails at the intersection. Mitigation per \`feedback_semantic_merge_conflict.md\`: always run \`cargo test --workspace\` after each merge.