### PR TITLE
#173: NPC empires spawn in player mode + pluggable mock AI hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,7 @@ define_ship_design { hull = hulls.corvette, modules = { ... } }
 9. **New game elements must be Lua-defined:** Rust provides the engine/framework, Lua defines specific content. No hardcoded enum variants for game content.
 10. **Use ModifiedValue for game-affecting numbers.** When touching a numeric value that could be affected by tech, modules, events, or modifiers, make it a `ModifiedValue` (or `ScopedModifiers`). Don't refactor untouched code, but apply this when adding/changing features.
 11. **Ship design fields are computed from hull + modules.** `ShipDesignDefinition` stats (hp, speed, ftl_range, build_cost, maintenance) must be calculated from hull + module definitions at registry time, not directly specified in Lua. `can_survey` = `survey_speed > 0`, `can_colonize` = `colonization_speed > 0` (no capability flags).
+12. **NPC empire AI (#173).** NPC empires spawn in both player and observer mode via `setup::run_all_factions_on_game_start` (ordered `.after(run_faction_on_game_start)`). The decision hook is `ai::npc_decision::npc_decision_tick`, registered under `AiTickSet::Reason`; today it invokes `NoOpPolicy` — future Lua / `macrocosmo-ai` policies plug in by replacing that call. The `macrocosmo-ai::mock` feature is **dev-dependency-only** (see `macrocosmo/Cargo.toml [dev-dependencies]`); production never activates it, and `ai-core-isolation.yml` CI enforces the `macrocosmo → macrocosmo-ai` direction. Real multi-tier planning (campaign / Nash / feasibility) lands under #189.
 
 ## Game Design Principles
 

--- a/macrocosmo/Cargo.toml
+++ b/macrocosmo/Cargo.toml
@@ -13,3 +13,11 @@ serde_json = "1"
 serde.workspace = true
 postcard.workspace = true
 macrocosmo-ai = { path = "../macrocosmo-ai", features = ["playthrough"] }
+
+[dev-dependencies]
+# #173: activate `mock` + `playthrough` features on the AI crate for
+# integration tests only. The production binary never sees the `mock`
+# feature — `ai-core-isolation.yml` CI enforces that the direction
+# remains `macrocosmo → macrocosmo-ai` and that no production code
+# depends on the mock module.
+macrocosmo-ai = { path = "../macrocosmo-ai", features = ["mock", "playthrough"] }

--- a/macrocosmo/scripts/factions/init.lua
+++ b/macrocosmo/scripts/factions/init.lua
@@ -62,4 +62,19 @@ define_faction {
     end,
 }
 
+-- #173: NPC empires. Defined without `on_game_start` so they do not compete
+-- with the player empire for the single capital star system. Homeworlds and
+-- starting fleets for NPC empires are a follow-up under #189.
+define_faction {
+    id = "vesk_hegemony",
+    name = "Vesk Hegemony",
+    faction_type = types.empire,
+}
+
+define_faction {
+    id = "aurelian_concord",
+    name = "Aurelian Concord",
+    faction_type = types.empire,
+}
+
 return {}

--- a/macrocosmo/src/ai/mod.rs
+++ b/macrocosmo/src/ai/mod.rs
@@ -31,6 +31,7 @@
 
 pub mod convert;
 pub mod emit;
+pub mod npc_decision;
 pub mod plugin;
 pub mod schema;
 

--- a/macrocosmo/src/ai/mod.rs
+++ b/macrocosmo/src/ai/mod.rs
@@ -21,6 +21,13 @@
 //!   — `SystemParam` helpers wrapping write / read / drain access to the
 //!   bus with automatic tick stamping from `GameClock`.
 //! - [`convert`] — `Entity`/`GameClock` ↔ `macrocosmo-ai` type helpers.
+//! - [`npc_decision`] — #173 hook point for per-faction NPC AI. Today the
+//!   production policy is a hand-written [`npc_decision::NoOpPolicy`];
+//!   future issues under #189 will swap in `macrocosmo-ai`-backed
+//!   policies without touching the tick-system wiring. The
+//!   `macrocosmo-ai::mock` feature is activated **only** as a
+//!   dev-dependency (`macrocosmo/Cargo.toml [dev-dependencies]`), never
+//!   in the production binary; `ai-core-isolation.yml` CI enforces this.
 //!
 //! Content (metrics/commands/evidence) is declared by downstream issues via
 //! [`schema::declare_all`]; this integration issue (#203) establishes the

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -1,0 +1,84 @@
+//! NPC decision tick — hook point for pluggable per-faction AI policies (#173).
+//!
+//! `AiPlugin` registers [`npc_decision_tick`] under [`AiTickSet::Reason`].
+//! The production policy today is [`NoOpPolicy`], which does nothing per
+//! tick. The trait exists so future issues under #189 can swap in
+//! `macrocosmo_ai`-backed policies (campaign / Nash / feasibility) without
+//! touching the system wiring.
+//!
+//! Scope note: this module intentionally carries **no** dependency on the
+//! optional `macrocosmo_ai::mock` feature. The dev-dependency in
+//! `macrocosmo/Cargo.toml` activates `mock` for the integration test
+//! binary only, so callers of the production game crate never pay for the
+//! feature.
+//!
+//! See `docs/plan-173-npc-empire-mock-ai.md` for the rollout plan.
+//!
+//! [`AiTickSet::Reason`]: super::AiTickSet::Reason
+
+use bevy::prelude::*;
+
+use crate::ai::plugin::AiBusResource;
+use crate::player::{Empire, Faction, PlayerEmpire};
+use crate::time_system::GameClock;
+
+/// Trait implemented by pluggable NPC decision policies. Stateless policies
+/// are encouraged; stateful policies can live in a `Resource` and be read
+/// from the tick system.
+///
+/// Phase 1 (#173): this trait is observed but unused — `npc_decision_tick`
+/// calls [`NoOpPolicy::tick`] directly. Future issues will route the call
+/// through a `Resource<Box<dyn NpcPolicy>>` so Lua-defined per-empire
+/// policies can be swapped in.
+pub trait NpcPolicy: Send + Sync + 'static {
+    /// Called once per `Update` tick per NPC empire. The return value is
+    /// intentionally `()` for now — a future revision will return
+    /// `Option<macrocosmo_ai::Command>` once intent-based commands exist.
+    fn tick(&mut self, faction: &str, now: i64);
+}
+
+/// Default policy: do nothing. Keeps the AI bus quiet so `playthrough`
+/// recordings remain deterministic and tests can assert "no commands
+/// emitted by NPCs" as a baseline.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct NoOpPolicy;
+
+impl NpcPolicy for NoOpPolicy {
+    fn tick(&mut self, _faction: &str, _now: i64) {
+        // intentional no-op (#173)
+    }
+}
+
+/// System run under [`AiTickSet::Reason`](super::AiTickSet::Reason):
+/// walk every NPC empire (`Empire` without `PlayerEmpire`) and invoke the
+/// currently-configured policy. Today the policy is [`NoOpPolicy`]; the
+/// call exists so that wiring regressions (NPCs not iterated, ordering
+/// broken) are caught by the integration tests in
+/// `tests/npc_empires_in_player_mode.rs`.
+///
+/// `_bus` is held to keep the parameter list forward-compatible with the
+/// future bus-emitting policy without a schema change.
+pub fn npc_decision_tick(
+    clock: Res<GameClock>,
+    _bus: ResMut<AiBusResource>,
+    npcs: Query<&Faction, (With<Empire>, Without<PlayerEmpire>)>,
+) {
+    let now = clock.elapsed;
+    let mut policy = NoOpPolicy;
+    for faction in &npcs {
+        policy.tick(&faction.id, now);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_op_policy_is_silent() {
+        let mut p = NoOpPolicy;
+        p.tick("vesk_hegemony", 0);
+        p.tick("aurelian_concord", 100);
+        // Reaching here without panic is the assertion.
+    }
+}

--- a/macrocosmo/src/ai/plugin.rs
+++ b/macrocosmo/src/ai/plugin.rs
@@ -85,6 +85,11 @@ impl Plugin for AiPlugin {
                 Update,
                 declare_foreign_slots_on_awareness.in_set(AiTickSet::MetricProduce),
             )
+            // #173: NPC decision tick — hand-written no-op default policy.
+            .add_systems(
+                Update,
+                super::npc_decision::npc_decision_tick.in_set(AiTickSet::Reason),
+            )
             .configure_sets(
                 Update,
                 (

--- a/macrocosmo/src/faction/mod.rs
+++ b/macrocosmo/src/faction/mod.rs
@@ -64,6 +64,19 @@ impl Plugin for FactionRelationsPlugin {
                 // reverse `.after(spawn_hostile_factions)` in galaxy/mod.rs.
                 spawn_hostile_factions.after(crate::player::spawn_player_empire),
             )
+            // #173: After NPC empires have been promoted to `Empire`
+            // entities by `run_all_factions_on_game_start`, seed their
+            // relations against the passive hostile factions and against
+            // each other. `spawn_hostile_factions` only seeds
+            // PlayerEmpire ↔ hostile pairs, so NPCs would otherwise see
+            // hostiles as Neutral / standing=0 and never engage under the
+            // aggressive ROE.
+            .add_systems(
+                Startup,
+                seed_npc_relations
+                    .after(spawn_hostile_factions)
+                    .after(crate::setup::run_all_factions_on_game_start),
+            )
             .add_systems(
                 Update,
                 tick_diplomatic_actions.after(crate::time_system::advance_game_time),
@@ -74,6 +87,49 @@ impl Plugin for FactionRelationsPlugin {
                     .after(crate::time_system::advance_game_time)
                     .after(tick_diplomatic_actions),
             );
+    }
+}
+
+/// Startup system (#173) that seeds NPC empire relations after
+/// `run_all_factions_on_game_start` has spawned NPC `Empire` entities.
+///
+/// Seeds two kinds of relations:
+/// 1. `NPC ↔ passive hostile` (space_creature, ancient_defense) with
+///    `Neutral` + `standing = -100`, mirroring
+///    [`spawn_hostile_factions`] for PlayerEmpires.
+/// 2. `NPC ↔ NPC` with `Neutral` + `standing = 0` (no pre-existing
+///    hostility — diplomacy can evolve through #172 actions).
+///
+/// The player empire is deliberately left alone here; its relations are
+/// seeded by [`spawn_hostile_factions`].
+pub fn seed_npc_relations(
+    mut relations: ResMut<FactionRelations>,
+    hostiles: Res<HostileFactions>,
+    npcs: Query<Entity, (With<crate::player::Empire>, Without<crate::player::PlayerEmpire>)>,
+) {
+    let npc_entities: Vec<Entity> = npcs.iter().collect();
+    if npc_entities.is_empty() {
+        return;
+    }
+
+    // 1. NPC ↔ passive hostiles.
+    for &npc in &npc_entities {
+        if let Some(sc) = hostiles.space_creature {
+            relations.set(npc, sc, FactionView::new(RelationState::Neutral, -100.0));
+            relations.set(sc, npc, FactionView::new(RelationState::Neutral, -100.0));
+        }
+        if let Some(ad) = hostiles.ancient_defense {
+            relations.set(npc, ad, FactionView::new(RelationState::Neutral, -100.0));
+            relations.set(ad, npc, FactionView::new(RelationState::Neutral, -100.0));
+        }
+    }
+
+    // 2. NPC ↔ NPC (other direction picked up on the symmetric iteration).
+    for (i, &a) in npc_entities.iter().enumerate() {
+        for &b in &npc_entities[i + 1..] {
+            relations.set(a, b, FactionView::new(RelationState::Neutral, 0.0));
+            relations.set(b, a, FactionView::new(RelationState::Neutral, 0.0));
+        }
     }
 }
 

--- a/macrocosmo/src/setup/mod.rs
+++ b/macrocosmo/src/setup/mod.rs
@@ -42,6 +42,12 @@ impl Plugin for GameSetupPlugin {
                 .after(crate::scripting::load_faction_registry)
                 .run_if(not_in_observer_mode),
         )
+        // #173: `run_all_factions_on_game_start` spawns NPC empires for every
+        // registered non-passive faction. Runs in BOTH player and observer
+        // modes so NPC empires exist in regular play. `.after(run_faction_on_game_start)`
+        // guarantees the player empire is fully set up before NPC spawns
+        // iterate the registry, and existing double-spawn guards
+        // (`existing_by_id` + passive-skip) prevent duplicates.
         .add_systems(
             Startup,
             run_all_factions_on_game_start
@@ -49,7 +55,7 @@ impl Plugin for GameSetupPlugin {
                 .after(crate::colony::spawn_capital_colony)
                 .after(crate::scripting::load_all_scripts)
                 .after(crate::scripting::load_faction_registry)
-                .run_if(in_observer_mode),
+                .after(run_faction_on_game_start),
         )
         .add_systems(
             Startup,
@@ -113,11 +119,12 @@ fn empire_bundle(name: String, faction_id: String, faction_name: String) -> impl
     )
 }
 
-/// Startup system for observer mode: iterate every registered NPC faction
-/// and spawn a full `Empire` entity for each, then run its `on_game_start`
-/// Lua callback. The `PlayerEmpire` marker is NEVER added. Hostile /
-/// passive factions (already spawned by `spawn_hostile_factions`) are
-/// skipped here.
+/// Startup system for both player and observer modes (#173): iterate every
+/// registered non-passive faction and spawn a full `Empire` entity for each
+/// missing one, then run its `on_game_start` Lua callback. The `PlayerEmpire`
+/// marker is NEVER added here — the player empire is spawned earlier by
+/// `spawn_player_empire` and skipped below. Hostile / passive factions
+/// (already spawned by `spawn_hostile_factions`) are skipped too.
 pub fn run_all_factions_on_game_start(world: &mut World) {
     // Snapshot the registry into a plain Vec so we can drop the borrow
     // before mutating the world.
@@ -130,18 +137,31 @@ pub fn run_all_factions_on_game_start(world: &mut World) {
     };
 
     if registry_ids.is_empty() {
-        warn!("Observer mode: FactionRegistry is empty; no NPC empires spawned");
+        warn!("Setup: FactionRegistry is empty; no NPC empires spawned");
         return;
     }
 
-    // Collect pre-existing Faction entities (e.g. spawned by faction plugin)
-    // so we don't double-spawn.
+    // Collect pre-existing bare Faction entities (e.g. spawned by the
+    // faction plugin as hostile) so we don't double-spawn.
     let existing_by_id: std::collections::HashMap<String, Entity> = {
         let mut q = world.query_filtered::<(Entity, &Faction), Without<Empire>>();
         q.iter(world).map(|(e, f)| (f.id.clone(), e)).collect()
     };
 
+    // #173: Collect pre-existing Empire entities (the player empire, or any
+    // Empire already promoted by a prior run) so we skip them.
+    let existing_empire_ids: std::collections::HashSet<String> = {
+        let mut q = world.query_filtered::<&Faction, With<Empire>>();
+        q.iter(world).map(|f| f.id.clone()).collect()
+    };
+
     for (faction_id, faction_name, has_callback) in &registry_ids {
+        // #173: Skip factions that already have an Empire (e.g. the player
+        // empire spawned by `spawn_player_empire`). Don't re-run their
+        // `on_game_start` — that is handled by `run_faction_on_game_start`.
+        if existing_empire_ids.contains(faction_id) {
+            continue;
+        }
         // If a bare Faction entity already exists (without Empire), upgrade
         // it to an Empire by inserting the bundle. Otherwise spawn fresh.
         if let Some(entity) = existing_by_id.get(faction_id) {
@@ -153,15 +173,15 @@ pub fn run_all_factions_on_game_start(world: &mut World) {
             if is_passive {
                 continue;
             }
-            // Upgrade: this branch is primarily defensive — in observer mode
-            // no prior Faction entity should already exist for these ids.
+            // Upgrade: defensive branch — normally no prior Faction entity
+            // exists for an empire id that isn't passive.
             world.entity_mut(*entity).insert(empire_bundle(
                 faction_name.clone(),
                 faction_id.clone(),
                 faction_name.clone(),
             ));
             info!(
-                "Observer mode: upgraded existing Faction '{}' to full Empire",
+                "Setup: upgraded existing Faction '{}' to full Empire",
                 faction_id
             );
         } else {
@@ -170,10 +190,7 @@ pub fn run_all_factions_on_game_start(world: &mut World) {
                 faction_id.clone(),
                 faction_name.clone(),
             ));
-            info!(
-                "Observer mode: spawned NPC Empire for faction '{}'",
-                faction_id
-            );
+            info!("Setup: spawned NPC Empire for faction '{}'", faction_id);
         }
 
         if *has_callback {

--- a/macrocosmo/tests/npc_empires_in_player_mode.rs
+++ b/macrocosmo/tests/npc_empires_in_player_mode.rs
@@ -1,0 +1,268 @@
+//! Integration tests for #173: NPC empires must spawn in player mode
+//! (`ObserverMode.enabled = false`) with healthy initial relations and
+//! without panicking during tick.
+//!
+//! These tests exercise the real `GameSetupPlugin` + `ScriptingPlugin` +
+//! `FactionRelationsPlugin` pipeline so the `.after(run_faction_on_game_start)`
+//! ordering, the `existing_empire_ids` filter, and `seed_npc_relations` are
+//! all covered.
+
+use bevy::prelude::*;
+
+use macrocosmo::ai::AiPlugin;
+use macrocosmo::faction::{
+    FactionRelations, FactionRelationsPlugin, HostileFactions, RelationState,
+};
+use macrocosmo::observer::{ObserverMode, ObserverPlugin, RngSeed};
+use macrocosmo::player::{Empire, Faction, PlayerEmpire};
+use macrocosmo::time_system::{GameClock, GameSpeed};
+
+/// Build a player-mode app that mirrors (a subset of) the production plugin
+/// list so NPC empire spawning goes through the real path:
+///
+/// - `observer_mode.enabled = false` (player mode)
+/// - `GalaxyPlugin` generates the star map + capital
+/// - `PlayerPlugin` spawns the player empire
+/// - `ColonyPlugin` spawns the capital colony
+/// - `ScriptingPlugin` + lifecycle loads the Lua definitions (including the
+///   humanity/vesk/aurelian factions)
+/// - `GameSetupPlugin` runs the faction `on_game_start` callbacks AND the
+///   NPC-empire spawn loop (#173)
+/// - `FactionRelationsPlugin` seeds hostile + NPC relations
+/// - `AiPlugin` wires the `npc_decision_tick` under `AiTickSet::Reason`
+///
+/// We deliberately skip `UiPlugin` (egui) and the visualization plugin —
+/// they require a windowing backend the headless test runner does not
+/// provide.
+fn player_mode_app() -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    // `PlayerPlugin` registers `log_player_info` which takes
+    // `Res<ButtonInput<KeyCode>>`. Headless MinimalPlugins don't provide
+    // it, so add InputPlugin to satisfy the parameter.
+    app.add_plugins(bevy::input::InputPlugin);
+
+    // Observer mode explicitly disabled — this is the regression guard.
+    app.insert_resource(ObserverMode {
+        enabled: false,
+        ..Default::default()
+    });
+    // Deterministic seed so the galaxy generator produces the same capital
+    // every run.
+    app.insert_resource(RngSeed(Some(0xC0FFEE)));
+    app.insert_resource(GameClock::new(0));
+    app.insert_resource(GameSpeed::default());
+
+    // Production plugins required to exercise the real startup ordering.
+    app.add_plugins((
+        macrocosmo::time_system::GameTimePlugin,
+        macrocosmo::galaxy::GalaxyPlugin,
+        macrocosmo::player::PlayerPlugin,
+        macrocosmo::communication::CommunicationPlugin,
+        macrocosmo::knowledge::KnowledgePlugin,
+        macrocosmo::ship::ShipPlugin,
+        macrocosmo::colony::ColonyPlugin,
+        macrocosmo::scripting::ScriptingPlugin,
+        macrocosmo::technology::TechnologyPlugin,
+        macrocosmo::event_system::EventSystemPlugin,
+        macrocosmo::events::EventsPlugin,
+        macrocosmo::species::SpeciesPlugin,
+        macrocosmo::ship_design::ShipDesignPlugin,
+    ));
+    app.add_plugins((
+        macrocosmo::deep_space::DeepSpacePlugin,
+        macrocosmo::setup::GameSetupPlugin,
+        macrocosmo::notifications::NotificationsPlugin,
+        FactionRelationsPlugin,
+        macrocosmo::choice::ChoicesPlugin,
+        AiPlugin,
+        ObserverPlugin,
+    ));
+    app
+}
+
+/// Collect the (entity, faction id) tuple for every NPC empire — i.e.
+/// every Empire entity that is not tagged `PlayerEmpire`.
+fn collect_npc_empires(app: &mut App) -> Vec<(Entity, String)> {
+    let mut q = app
+        .world_mut()
+        .query_filtered::<(Entity, &Faction), (With<Empire>, Without<PlayerEmpire>)>();
+    q.iter(app.world())
+        .map(|(e, f)| (e, f.id.clone()))
+        .collect()
+}
+
+#[test]
+fn npc_empires_spawn_in_player_mode() {
+    let mut app = player_mode_app();
+    // One Startup pass is enough — every Startup system runs before the
+    // first Update tick completes.
+    app.update();
+
+    let npcs = collect_npc_empires(&mut app);
+    assert!(
+        npcs.len() >= 2,
+        "expected >= 2 NPC empires to spawn in player mode; found {} ({:?})",
+        npcs.len(),
+        npcs.iter().map(|(_, id)| id).collect::<Vec<_>>()
+    );
+
+    // Sanity: the player empire also exists and is *not* counted above.
+    let mut player_q = app
+        .world_mut()
+        .query_filtered::<&Faction, With<PlayerEmpire>>();
+    let player_ids: Vec<String> = player_q.iter(app.world()).map(|f| f.id.clone()).collect();
+    assert_eq!(
+        player_ids.len(),
+        1,
+        "expected exactly one PlayerEmpire; found {}",
+        player_ids.len()
+    );
+    assert!(
+        !npcs.iter().any(|(_, id)| id == &player_ids[0]),
+        "PlayerEmpire id '{}' must not also appear as an NPC empire",
+        player_ids[0]
+    );
+}
+
+#[test]
+fn player_mode_ticks_without_panic() {
+    let mut app = player_mode_app();
+    // 20 ticks covers the `AiTickSet::Reason` schedule (where
+    // `npc_decision_tick` runs), diplomatic-action ticking, and other
+    // delta-based systems. If NPC spawn wiring breaks any of them (e.g.
+    // a query conflict, or Empire entities missing a component expected
+    // by a delta system), this panics. A longer horizon would exhaust
+    // the Lua auxiliary stack in `evaluate_fire_conditions` (a separate
+    // pre-existing issue unrelated to #173) so we keep it short.
+    for t in 1..=20 {
+        app.world_mut().resource_mut::<GameClock>().elapsed = t;
+        app.update();
+    }
+
+    // NPC empires should still be present at the end.
+    let npcs = collect_npc_empires(&mut app);
+    assert!(
+        npcs.len() >= 2,
+        "NPC empires should persist across ticks; got {}",
+        npcs.len()
+    );
+}
+
+#[test]
+fn npc_empires_are_valid_diplomatic_targets() {
+    let mut app = player_mode_app();
+    app.update();
+
+    let npcs = collect_npc_empires(&mut app);
+    assert!(!npcs.is_empty(), "need at least one NPC empire");
+
+    // For each NPC, we should be able to look up a Faction component by
+    // entity — that's exactly what the diplomatic-action registry does
+    // when resolving `target` to a live empire.
+    for (npc_entity, expected_id) in &npcs {
+        let faction = app
+            .world()
+            .get::<Faction>(*npc_entity)
+            .expect("NPC empire entity must carry a Faction component");
+        assert_eq!(&faction.id, expected_id);
+        // Also must have the Empire marker so diplomacy code treats it
+        // as a real empire, not a hostile entity-only faction.
+        assert!(
+            app.world().get::<Empire>(*npc_entity).is_some(),
+            "NPC '{}' must have Empire component to be a diplomatic target",
+            expected_id
+        );
+    }
+}
+
+#[test]
+fn npc_relations_with_hostiles_are_healthy() {
+    let mut app = player_mode_app();
+    app.update();
+
+    let npcs = collect_npc_empires(&mut app);
+    assert!(!npcs.is_empty(), "need at least one NPC empire");
+
+    let hostiles = *app.world().resource::<HostileFactions>();
+    let space_creature = hostiles
+        .space_creature
+        .expect("space_creature hostile faction should be spawned");
+    let ancient_defense = hostiles
+        .ancient_defense
+        .expect("ancient_defense hostile faction should be spawned");
+
+    let relations = app.world().resource::<FactionRelations>();
+
+    for (npc_entity, npc_id) in &npcs {
+        // NPC → hostile: must be Neutral + standing=-100 so
+        // `can_attack_aggressive()` returns true (negative standing).
+        let npc_to_sc = relations.get_or_default(*npc_entity, space_creature);
+        assert_eq!(
+            npc_to_sc.state,
+            RelationState::Neutral,
+            "{} → space_creature state should be Neutral",
+            npc_id
+        );
+        assert!(
+            npc_to_sc.standing < 0.0,
+            "{} → space_creature standing should be negative (got {})",
+            npc_id,
+            npc_to_sc.standing
+        );
+        assert!(
+            npc_to_sc.can_attack_aggressive(),
+            "{} should be willing to attack space_creature under aggressive ROE",
+            npc_id
+        );
+
+        let npc_to_ad = relations.get_or_default(*npc_entity, ancient_defense);
+        assert!(
+            npc_to_ad.can_attack_aggressive(),
+            "{} should be willing to attack ancient_defense under aggressive ROE",
+            npc_id
+        );
+
+        // Reverse direction — hostiles → NPC must also be set, so hostile
+        // defensive ROE engages the NPC when they share a system.
+        let sc_to_npc = relations.get_or_default(space_creature, *npc_entity);
+        assert!(
+            sc_to_npc.can_attack_aggressive(),
+            "space_creature → {} must be hostile (aggressive-ROE attack allowed)",
+            npc_id
+        );
+    }
+
+    // NPC ↔ NPC: seeded as Neutral/standing=0. Not aggressive by default.
+    if npcs.len() >= 2 {
+        let (a_entity, a_id) = &npcs[0];
+        let (b_entity, b_id) = &npcs[1];
+        let a_to_b = relations.get_or_default(*a_entity, *b_entity);
+        assert_eq!(
+            a_to_b.state,
+            RelationState::Neutral,
+            "{} → {} should be Neutral by default",
+            a_id,
+            b_id
+        );
+        assert!(
+            !a_to_b.can_attack_aggressive(),
+            "{} → {} must not be attackable under aggressive ROE at game start (standing={})",
+            a_id,
+            b_id,
+            a_to_b.standing
+        );
+    }
+}
+
+/// Smoke test: `macrocosmo-ai`'s `mock` feature is wired through the
+/// dev-dependency, proving tests can opt into the feature without leaking
+/// it into the production binary.
+#[test]
+fn mock_feature_reachable_via_dev_dependency() {
+    // `macrocosmo_ai::mock::preconfigured_bus` is only present when the
+    // `mock` feature is enabled. If this line fails to compile, the dev
+    // dep in `macrocosmo/Cargo.toml` has dropped the feature.
+    let bus = macrocosmo_ai::mock::preconfigured_bus();
+    assert!(bus.has_metric(&macrocosmo_ai::mock::metric_ids::fleet_readiness()));
+}


### PR DESCRIPTION
## Summary

- **Commit A** (`be4b0cb`): Drop `.run_if(in_observer_mode)` on `run_all_factions_on_game_start` + add `.after(run_faction_on_game_start)` ordering; add `vesk_hegemony` and `aurelian_concord` NPC empires to `scripts/factions/init.lua` (no `on_game_start` to avoid capital contention).
- **Commit B** (`20adc98`): New `src/ai/npc_decision.rs` with `NpcPolicy` trait + `NoOpPolicy` default, registered under `AiTickSet::Reason`. New `seed_npc_relations` startup system in `faction/mod.rs` seeds NPC ↔ hostile (Neutral/-100) and NPC ↔ NPC (Neutral/0) relations — mirrors the existing `spawn_hostile_factions` contract for player empires.
- **Commit C** (`da7f492`): New `tests/npc_empires_in_player_mode.rs` (5 tests) exercising the real plugin stack in player mode. Added `macrocosmo-ai` dev-dep with `mock` + `playthrough` features so the mock surface is usable in tests only; production `Cargo.toml` is unchanged.
- **Commit D** (`6728be4`): CLAUDE.md pitfall entry + `src/ai/mod.rs` module doc covering the NPC AI entry point and the dev-dep-only mock gating.

Closes #173. Unblocks #163 (observer-mode parity with player mode) and #292 (follow-on for real `macrocosmo-ai`-backed policies).

## Test plan

- [x] `cargo test --workspace --lib --bins` — 682 + 675 + 187 pass
- [x] `cargo test -p macrocosmo --test npc_empires_in_player_mode` — 5/5 pass:
  - [x] `npc_empires_spawn_in_player_mode` — ≥2 NPC empires exist with `ObserverMode.enabled = false`
  - [x] `player_mode_ticks_without_panic` — 20 Update ticks run clean under the full plugin stack
  - [x] `npc_empires_are_valid_diplomatic_targets` — each NPC has both `Faction` and `Empire` components
  - [x] `npc_relations_with_hostiles_are_healthy` — NPC ↔ hostile `can_attack_aggressive()` true in both directions; NPC ↔ NPC is Neutral/0 and non-aggressive
  - [x] `mock_feature_reachable_via_dev_dependency` — dev-only `macrocosmo-ai::mock` activates in tests
- [x] `cargo test -p macrocosmo --test {ai_integration,ai_foreign_slots,observer_mode,combat_scenarios,save_load,fixtures_smoke,...}` — all pass
- [x] `cargo test -p macrocosmo-ai` — pass
- [x] CI `ai-core-isolation.yml` unchanged; `macrocosmo → macrocosmo-ai` direction preserved (no production dependency on `mock`).

## Out of scope (#189 follow-ups)

- Real 3-tier planning (campaign planner, Nash solver, feasibility cache) wired through `NpcPolicy`
- Intent-based commands (NPCs emit ECS actions instead of silent no-ops)
- Per-empire policy assignment via Lua (`define_faction { policy = "aggressive" }`)
- NPC `on_game_start` Lua hooks (spawning homeworlds + starting fleets without contending with the player capital)
- `faction_type.default_state` seeding of initial relations (replacing hand-seed in `seed_npc_relations`)
- Extending `tick_diplomatic_actions` / `tick_custom_diplomatic_actions` to use NPC empires as targets

## Compatibility notes

- #247 save/load was merged to `main` and is already integrated here via rebase.
- `setup/mod.rs` change is narrow (plugin-build ordering + new `existing_empire_ids` filter); no save-file fixture regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)