### PR TITLE
#320: Fix mlua aux-stack leak from per-tick gamestate snapshots

### DIFF
--- a/macrocosmo/src/scripting/lifecycle.rs
+++ b/macrocosmo/src/scripting/lifecycle.rs
@@ -225,7 +225,16 @@ pub fn evaluate_fire_conditions(world: &mut World) {
                         continue;
                     }
                 }
-                if now - *last_fired >= *interval_hexadies {
+                if now - *last_fired >= *interval_hexadies && fire_condition.is_some() {
+                    // #320: Only queue suppression checks for periodics that
+                    // actually declare a fire_condition. Without one,
+                    // `evaluate_fire_conditions` would build a gamestate
+                    // snapshot just to answer "yes, fire" for every tick —
+                    // wasted Lua work (and aux-stack pressure) since the
+                    // actual fire is driven by `event_system::tick_events`
+                    // and `evaluate_fire_conditions` only ever *suppresses*
+                    // events that return false. Symmetric with the MTTH
+                    // branch below, which already filters None out.
                     out.push(PendingDecision {
                         kind: DecisionKind::Periodic,
                         event_id: id.clone(),

--- a/macrocosmo/src/scripting/lifecycle.rs
+++ b/macrocosmo/src/scripting/lifecycle.rs
@@ -317,6 +317,15 @@ pub fn evaluate_fire_conditions(world: &mut World) {
             });
             let _ = pd.kind; // retain the variant for diagnostic purposes; handled below via id
         }
+
+        // #320: Every per-tick gamestate build leaks ValueRef slots on the
+        // LuaJIT aux thread until Lua GC reclaims the snapshot tables that
+        // fire_conditions captured via `payload.gamestate`. Without an
+        // explicit collection LuaJIT's fixed LUAI_MAXCSTACK (~8000) is
+        // exhausted after ~80 ticks and all further Lua callbacks panic.
+        if let Err(e) = lua.gc_collect() {
+            warn!("evaluate_fire_conditions: lua.gc_collect failed: {e}");
+        }
     });
 
     // Apply decisions: for suppressed periodic events, bump last_fired; for
@@ -432,6 +441,14 @@ pub fn dispatch_event_handlers(world: &mut World) {
 
             // --- `on_trigger` callback on the event definition ---
             dispatch_on_trigger(lua, &fired.event_id, &payload_table);
+        }
+
+        // #320: Same aux-stack leak as `evaluate_fire_conditions`.
+        // Each fired event builds a fresh gamestate table via
+        // `attach_gamestate`; the snapshot lingers in Lua memory until GC
+        // reclaims it, pinning aux thread slots across ticks.
+        if let Err(e) = lua.gc_collect() {
+            warn!("dispatch_event_handlers: lua.gc_collect failed: {e}");
         }
     });
 }

--- a/macrocosmo/tests/stress_lua_scheduling.rs
+++ b/macrocosmo/tests/stress_lua_scheduling.rs
@@ -1,0 +1,173 @@
+//! #320 regression: LuaJIT aux-stack leak under sustained per-tick Lua
+//! scheduling.
+//!
+//! Before the fix, `evaluate_fire_conditions` and `dispatch_event_handlers`
+//! each built fresh gamestate tables every tick without ever triggering a
+//! Lua GC. The `ValueRef` slots those tables held on LuaJIT's auxiliary
+//! thread (`LUAI_MAXCSTACK`, ~8000) accumulated until the aux thread was
+//! exhausted and further Lua callbacks panicked — typically after ~80
+//! ticks with a gamestate snapshot that touches ~100 refs per build.
+//!
+//! This test stresses both paths simultaneously for 1000 ticks. Before the
+//! fix it panics within the first couple of hundred iterations; with the
+//! fix it finishes cleanly and Lua's reported memory footprint stays
+//! bounded.
+
+use bevy::prelude::*;
+use macrocosmo::condition::ScopedFlags;
+use macrocosmo::event_system::{
+    EventDefinition, EventSystem, EventTrigger, FiredEvent, LuaFunctionRef,
+};
+use macrocosmo::player::{Empire, PlayerEmpire};
+use macrocosmo::scripting::ScriptEngine;
+use macrocosmo::scripting::lifecycle::{dispatch_event_handlers, evaluate_fire_conditions};
+use macrocosmo::technology::{GameFlags, TechId, TechTree};
+use macrocosmo::time_system::GameClock;
+
+const STRESS_TICKS: i64 = 1000;
+
+/// Upper bound on Lua memory growth across the whole stress run.
+///
+/// LuaJIT accounts its own heap separately from process RSS; 32 MiB is a
+/// conservative ceiling well above the ~1 MiB baseline observed on a
+/// healthy build but far below what an unbounded aux-stack leak would
+/// reach after 1000 ticks with ~100 refs/tick worth of snapshot tables.
+const LUA_MEMORY_CEILING_BYTES: usize = 32 * 1024 * 1024;
+
+fn build_stress_world() -> World {
+    let mut world = World::new();
+    world.insert_resource(GameClock::new(0));
+    world.insert_resource(EventSystem::default());
+    world.insert_resource(ScriptEngine::new().expect("ScriptEngine init"));
+
+    let mut tree = TechTree::default();
+    tree.researched.insert(TechId("tech_a".to_string()));
+    let mut flags = GameFlags::default();
+    flags.set("fa");
+    world.spawn((
+        Empire {
+            name: "StressEmpire".into(),
+        },
+        PlayerEmpire,
+        tree,
+        flags,
+        ScopedFlags::default(),
+    ));
+
+    world
+}
+
+/// Seed a periodic event with a Lua fire_condition and a bus handler that
+/// both observe `evt.gamestate`. Both paths therefore have to build a
+/// snapshot table whenever the event is due/fires.
+fn seed_events(world: &mut World) {
+    let fref = {
+        let engine = world.resource::<ScriptEngine>();
+        let lua = engine.lua();
+        // `on` handler for the fired event: reads gamestate to force a
+        // snapshot build inside dispatch_event_handlers.
+        lua.load(
+            r#"
+            _hits = 0
+            on("stress_periodic", function(evt)
+                _hits = _hits + 1
+                -- Touch gamestate so the snapshot is actually used.
+                local _ = evt.gamestate.clock.now
+                local _ = evt.gamestate.player_empire.name
+            end)
+            "#,
+        )
+        .exec()
+        .expect("install bus handler");
+
+        // fire_condition: always returns true, but walks gamestate fields
+        // so evaluate_fire_conditions has to materialise the snapshot.
+        let f: mlua::Function = lua
+            .load(
+                r#"return function(evt)
+                    local _ = evt.gamestate.player_empire.techs.tech_a
+                    return true
+                end"#,
+            )
+            .eval()
+            .expect("compile fire_condition");
+        LuaFunctionRef::from_function(lua, f).expect("wrap fire_condition")
+    };
+
+    let mut es = world.resource_mut::<EventSystem>();
+    es.register(EventDefinition {
+        id: "stress_periodic".to_string(),
+        name: "Stress Periodic".to_string(),
+        description: "Periodic event with Lua fire_condition, fires every tick.".to_string(),
+        trigger: EventTrigger::Periodic {
+            interval_hexadies: 1,
+            last_fired: 0,
+            fire_condition: Some(fref),
+            max_times: None,
+            times_triggered: 0,
+        },
+    });
+}
+
+/// Simulate a single tick: advance clock, inject a fired event (to drive
+/// dispatch_event_handlers), then run the two Lua-heavy systems in the
+/// same order as the main schedule.
+fn run_tick(world: &mut World, now: i64) {
+    world.resource_mut::<GameClock>().elapsed = now;
+
+    // Drive the dispatcher every tick by pushing one FiredEvent per tick.
+    // In production tick_events would do this; we skip the rest of the
+    // event_system pipeline to keep the test focused on the Lua leak.
+    world
+        .resource_mut::<EventSystem>()
+        .fired_log
+        .push(FiredEvent {
+            event_id: "stress_periodic".to_string(),
+            target: None,
+            fired_at: now,
+            payload: None,
+        });
+
+    evaluate_fire_conditions(world);
+    dispatch_event_handlers(world);
+}
+
+#[test]
+fn stress_lua_scheduling_does_not_exhaust_aux_stack() {
+    let mut world = build_stress_world();
+    seed_events(&mut world);
+
+    // Baseline Lua footprint *after* snapshot plumbing is installed.
+    let baseline_memory = world.resource::<ScriptEngine>().lua().used_memory();
+
+    for tick in 1..=STRESS_TICKS {
+        run_tick(&mut world, tick);
+    }
+
+    // Hit counter confirms the bus handler actually ran every tick — a
+    // silent early-exit would make the test useless as a regression.
+    let engine = world.resource::<ScriptEngine>();
+    let hits: i64 = engine
+        .lua()
+        .globals()
+        .get("_hits")
+        .expect("_hits global readable");
+    assert_eq!(
+        hits, STRESS_TICKS,
+        "dispatcher must invoke the bus handler once per tick"
+    );
+
+    let final_memory = engine.lua().used_memory();
+    eprintln!(
+        "stress_lua_scheduling: baseline={} bytes, final={} bytes (ceiling {})",
+        baseline_memory, final_memory, LUA_MEMORY_CEILING_BYTES
+    );
+    assert!(
+        final_memory < LUA_MEMORY_CEILING_BYTES,
+        "Lua heap grew beyond {} bytes (baseline {}, final {}); \
+         #320 aux-stack leak likely regressed",
+        LUA_MEMORY_CEILING_BYTES,
+        baseline_memory,
+        final_memory,
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #320. Release blocker: after ~80 ticks Lua callbacks panic with
`cannot create a Lua reference, out of auxiliary stack space`.

Primary fix: force `lua.gc_collect()` at the end of each `resource_scope`
closure that builds gamestate snapshots — `evaluate_fire_conditions` and
`dispatch_event_handlers`. Without it, the snapshot tables captured via
`payload.gamestate` keep their ValueRef slots on LuaJIT's fixed-size aux
thread (`LUAI_MAXCSTACK` ≈ 8000) until Lua-side GC naturally reclaims
them, which under continuous scheduling never happens within the budget.

Secondary: skip the whole snapshot-build for periodic events that have
no `fire_condition`, mirroring the existing MTTH branch. Trims redundant
Lua work on the hot path.

## Second leak source

The issue only called out `evaluate_fire_conditions`, but
`dispatch_event_handlers` (lifecycle.rs:417 pre-fix) exhibits the same
leak per fired event: each iteration calls `attach_gamestate` to build
a fresh snapshot. Leaving it unpatched would keep the release blocker
open, so this PR closes both paths.

## Commit B specification check

Adopted. Verified against `src/event_system.rs`: the periodic fire
itself is driven independently by `event_system::tick_events` (line 457),
which pushes a `FiredEvent` regardless of what `evaluate_fire_conditions`
does. The latter only *suppresses* events whose fire_condition returns
false (bumps `last_fired` to `now`). A periodic with `fire_condition =
None` therefore has nothing to decide — skipping it in the snapshot loop
cannot cause a missed fire.

## Test plan

- [x] `cargo test --workspace` — 1960 tests pass across 49 binaries
- [x] New `tests/stress_lua_scheduling.rs` — 1000 ticks, both leak sites
      exercised on every tick; was verified to fail on a pre-fix checkout
      with the exact error reported in #320 (`used 7996 slots`)
- [x] `lua.used_memory()` after stress run: baseline ≈ 58 KB, final ≈ 74 KB,
      ceiling 32 MiB — memory growth bounded
- [x] All pre-existing scripting / event_system unit tests still pass
- [x] `cargo fmt` applied only to `macrocosmo/src/scripting/lifecycle.rs`
      and `macrocosmo/tests/stress_lua_scheduling.rs` via `rustfmt --edition 2024`
      (workspace-wide `cargo fmt` avoided per CLAUDE.md workaround)

## Follow-up

Tracked in the plan document `docs/plan-320-mlua-aux-stack-leak.md`
section 7:

1. Per-tick gamestate cache (`CachedGamestate { tick, RegistryKey }`) —
   performance optimisation, build once per tick instead of once per
   fire_condition / fired event. Separate issue; invalidation policy
   needs design discussion (stale-mid-tick tolerance).
2. Swap `gc_collect` (full cycle) for `gc_step_kbytes(256)` if the full
   GC shows up on frame-time profiles.
3. Gradual migration of `attach_gamestate` to `lua.scope` auto-drop.

No changes to the `#263` snapshot-per-event contract — GC is drop-phase
cleanup only, the shape Lua handlers see is unchanged.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)