### PR TITLE
#284: Add profile cargo feature (bevy trace_tracy) + prof_span! hot-path annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd310426290cec560221f9750c2f4484be4a8eeea7de3483c423329b465c40e"
 dependencies = [
  "bevy_internal",
+ "tracing",
 ]
 
 [[package]]
@@ -482,6 +483,7 @@ dependencies = [
  "downcast-rs 2.0.2",
  "log",
  "thiserror 2.0.18",
+ "tracing",
  "variadics_please",
  "wasm-bindgen",
  "web-sys",
@@ -715,6 +717,7 @@ dependencies = [
  "slotmap",
  "smallvec",
  "thiserror 2.0.18",
+ "tracing",
  "variadics_please",
 ]
 
@@ -1076,9 +1079,11 @@ dependencies = [
  "bevy_platform",
  "bevy_utils",
  "tracing",
+ "tracing-error",
  "tracing-log",
  "tracing-oslog",
  "tracing-subscriber",
+ "tracing-tracy",
  "tracing-wasm",
 ]
 
@@ -1345,10 +1350,12 @@ dependencies = [
  "naga",
  "nonmax",
  "offset-allocator",
+ "profiling",
  "send_wrapper",
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
+ "tracy-client",
  "variadics_please",
  "wasm-bindgen",
  "web-sys",
@@ -2754,6 +2761,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,6 +3545,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lua-src"
@@ -4477,6 +4512,20 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+ "tracing",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pxfm"
@@ -5315,6 +5364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5356,6 +5415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tracy"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
 name = "tracing-wasm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5364,6 +5434,27 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f6fc3baeac5d86ab90c772e9e30620fc653bf1864295029921a15ef478e6a5"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
+dependencies = [
+ "cc",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,172 @@
+# Profiling Macrocosmo with Tracy (#284)
+
+Macrocosmo integrates with [Tracy](https://github.com/wolfpld/tracy) via Bevy's
+first-party `trace_tracy` feature. Enabling the `profile` cargo feature
+pass-throughs `bevy/trace_tracy` (CPU spans + a `RenderQueue` GPU row) and
+`bevy/debug` (human-readable system names in the timeline). A handful of
+self-written hot-path systems also emit spans via the `prof_span!` macro —
+these compile to **nothing** on default builds.
+
+The default build therefore carries zero binary-size or startup overhead; you
+only pay for profiling when you explicitly opt in.
+
+## What gets captured
+
+With `--features profile` on a `--release` build Tracy shows:
+
+- **Bevy systems** — every scheduled system becomes a span, named via
+  `bevy/debug` (human-readable names instead of numeric ids).
+- **Self-written spans** — the macro `crate::prof_span!("...")` adds targeted
+  spans on hot paths:
+  - Lua callback dispatch: `EventBus::fire`, `run_lifecycle_hooks`,
+    `drain_script_events`.
+  - Knowledge propagation: `build_system_snapshot`, `propagate_knowledge`,
+    `relay_knowledge_propagate_system`.
+  - UI six-system chain: `compute_ui_state`, `draw_top_bar`,
+    `draw_outline_and_tooltips`, `draw_main_panels`, `draw_overlays`,
+    `draw_bottom_bar`.
+  - Galaxy rendering: `update_star_colors`, `sync_territory_material`.
+- **`RenderQueue` row** — Bevy's built-in GPU timing row (queue submission
+  latencies per-frame). Use mean-time-per-call (MTPC) / distribution rather
+  than frame-by-frame spikes, since the dynamic game clock introduces jitter.
+
+Not captured (see non-goals below): memory allocations, FPS overlay, custom
+render-pass GPU spans.
+
+## Prerequisites
+
+1. **Tracy client version must match the server (profiler UI)**. Check
+   which tracy client version Bevy 0.18 pulls in:
+
+   ```bash
+   cargo tree -p macrocosmo --features profile | grep tracy
+   ```
+
+   Cross-reference against the
+   [rust_tracy_client version support table](https://github.com/nagisa/rust_tracy_client?tab=readme-ov-file#version-support-table)
+   to find the matching Tracy release. At the time of writing Bevy 0.18 uses
+   `tracy-client 0.18.x`, which maps to Tracy **0.11.x**.
+
+2. Install the matching Tracy binaries. On macOS you can build from source
+   (`brew install tracy` sometimes lags behind):
+
+   ```bash
+   git clone --depth 1 --branch v0.11.1 https://github.com/wolfpld/tracy
+   cd tracy/profiler/build/unix && make release
+   cd ../../../capture/build/unix && make release
+   ```
+
+   You'll want two binaries: `tracy-profiler` (GUI) and `tracy-capture`
+   (headless recorder).
+
+## Always use `--release`
+
+Bevy's profiling docs are emphatic about this:
+
+> There is little point to profiling unoptimized code — numbers look nothing
+> like a release build.
+
+Run:
+
+```bash
+cargo run --release --features profile
+```
+
+Never profile a `dev` build; the numbers are meaningless.
+
+## Workflow A — Live connection (quickest)
+
+1. Start the profiler GUI **first** so it's waiting for a connection:
+
+   ```bash
+   tracy-profiler
+   ```
+
+   Click **Connect** in the GUI.
+
+2. Launch the game:
+
+   ```bash
+   cargo run --release --features profile
+   ```
+
+3. Play through the scenario you want to measure. The GUI fills in
+   real-time.
+
+4. On exit (or at any time) click **File → Save Trace** in the GUI to keep
+   the recording.
+
+## Workflow B — Recording (recommended, lower overhead)
+
+The live connection adds frame-by-frame network chatter. For longer sessions
+or more reliable numbers, record first and inspect later.
+
+1. Start the headless capture tool:
+
+   ```bash
+   tracy-capture -o trace.tracy
+   ```
+
+   It will wait for the app to start.
+
+2. Run the game:
+
+   ```bash
+   cargo run --release --features profile
+   ```
+
+3. When the scenario is done, stop the game. `tracy-capture` writes
+   `trace.tracy`.
+
+4. Open the trace in the GUI:
+
+   ```bash
+   tracy-profiler trace.tracy
+   ```
+
+## Reading the results
+
+- **Self-written spans** — filter the `Find zone` panel by e.g.
+  `propagate_knowledge` to isolate your target. Use the `Statistics` tab for
+  MTPC + total time.
+- **Bevy systems** — with `bevy/debug` enabled each scheduled system appears
+  by its function path, so `bevy_ecs::...::run_system` rows become readable.
+- **GPU timing** — open the `RenderQueue` row near the bottom. Look at the
+  distribution (mean, p95) rather than individual frames — the game clock is
+  dynamic and frame duration is not a useful axis on its own.
+
+## Adding new spans
+
+Use the `prof_span!` macro (re-exported at crate root) at the top of any
+function you want to measure:
+
+```rust
+pub fn my_hot_system(/* params */) {
+    crate::prof_span!("my_hot_system");
+    // ... work ...
+}
+```
+
+Guidelines:
+
+- Only spans on **hot paths** — per-tick / per-frame systems, Lua callback
+  dispatch, Bevy systems that touch thousands of entities. Avoid spamming
+  cold startup code.
+- Keep names stable across builds; Tracy treats them as string identifiers.
+- The macro is cfg-gated, so default builds emit nothing — do not add
+  `#[cfg(feature = "profile")]` around the call site yourself.
+
+## Non-goals (not implemented, see #284)
+
+- `bevy/trace_tracy_memory` — allocation tracking. Non-trivial overhead and
+  not needed for the current bottleneck hunt. File a follow-up if you need
+  it.
+- `bevy_dev_tools::FpsOverlayPlugin` — an in-game FPS counter independent of
+  Tracy. Tracked separately.
+- Chrome tracing (`bevy/trace_chrome`) / `perf` / flame graphs — Tracy
+  supersedes these for the use cases we have today.
+- Custom GPU spans via `RenderDiagnosticsPlugin` — we don't yet have custom
+  render passes worth labelling.
+- Automated benchmarks (`criterion`) / CI regression gates — out of scope.
+- Compile-time profiling (`cargo --timings`, `cargo-bloat`) — revisit when
+  build times become a concrete problem.

--- a/macrocosmo/Cargo.toml
+++ b/macrocosmo/Cargo.toml
@@ -14,6 +14,20 @@ serde.workspace = true
 postcard.workspace = true
 macrocosmo-ai = { path = "../macrocosmo-ai", features = ["playthrough"] }
 
+[features]
+# Default build carries no profiling overhead.
+default = []
+
+# #284: development-only profiling feature. Enables:
+#   - `bevy/trace_tracy` — Tracy profiler integration (CPU spans + GPU
+#     `RenderQueue` row). The `prof_span!` macro expands to
+#     `info_span!(...).entered()` only when this feature is on; otherwise
+#     it is a no-op so default builds carry zero overhead.
+#   - `bevy/debug` — human-readable system names in Tracy for Bevy's
+#     built-in schedules (`Update`, `EguiPrimaryContextPass`, etc.).
+# See `docs/profiling.md` for the workflow.
+profile = ["bevy/trace_tracy", "bevy/debug"]
+
 [dev-dependencies]
 # #173: activate `mock` + `playthrough` features on the AI crate for
 # integration tests only. The production binary never sees the `mock`

--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -905,6 +905,7 @@ pub fn relay_knowledge_propagate_system(
     faction_relations: Res<crate::faction::FactionRelations>,
     building_registry: Res<crate::colony::BuildingRegistry>,
 ) {
+    crate::prof_span!("relay_knowledge_propagate_system");
     // Build region blockers (pairs segment check); only regions carrying the
     // `blocks_ftl_comm` capability matter here.
     let comm_blockers: Vec<crate::galaxy::RegionBlockSnapshot> = ftl_comm_blocking_regions

--- a/macrocosmo/src/event_system.rs
+++ b/macrocosmo/src/event_system.rs
@@ -375,6 +375,7 @@ impl EventBus {
     /// but do not abort processing of remaining handlers.
     pub fn fire(lua: &Lua, ctx: &dyn EventContext) -> usize {
         let event_id = ctx.event_id();
+        crate::prof_span!("EventBus::fire");
 
         // Build payload table via the trait — includes `event_id` per the
         // EventContext contract.

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -363,6 +363,7 @@ pub fn build_system_snapshot(
     hostile_map: &HashMap<Entity, f64>,
     building_registry: &crate::colony::BuildingRegistry,
 ) -> SystemSnapshot {
+    crate::prof_span!("build_system_snapshot");
     let is_colonized = colonies
         .iter()
         .any(|(_, c, _, _, _, _, _)| c.system(planets) == Some(entity));
@@ -543,6 +544,7 @@ pub fn propagate_knowledge(
     ships: Query<(Entity, &Ship, &ShipState, &crate::ship::ShipHitpoints)>,
     building_registry: Res<crate::colony::BuildingRegistry>,
 ) {
+    crate::prof_span!("propagate_knowledge");
     let Ok(mut store) = empire_q.single_mut() else {
         return;
     };

--- a/macrocosmo/src/lib.rs
+++ b/macrocosmo/src/lib.rs
@@ -19,6 +19,7 @@ pub mod observer;
 pub mod persistence;
 pub mod physics;
 pub mod player;
+pub mod profiling;
 pub mod scripting;
 pub mod setup;
 pub mod species;

--- a/macrocosmo/src/main.rs
+++ b/macrocosmo/src/main.rs
@@ -18,6 +18,7 @@ mod notifications;
 mod observer;
 mod physics;
 mod player;
+mod profiling;
 mod scripting;
 mod setup;
 mod species;

--- a/macrocosmo/src/profiling.rs
+++ b/macrocosmo/src/profiling.rs
@@ -1,0 +1,45 @@
+//! # Profiling support (#284)
+//!
+//! Zero-overhead span helper for [Tracy](https://github.com/wolfpld/tracy)
+//! profiling. Activated via the `profile` cargo feature, which also
+//! pass-throughs `bevy/trace_tracy` and `bevy/debug`.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use crate::prof_span;
+//!
+//! fn my_hot_system(...) {
+//!     prof_span!("my_hot_system");
+//!     // ... work ...
+//! }
+//! ```
+//!
+//! With the default build (`profile` feature off), the macro expands to
+//! **nothing** — no `tracing` calls, no local guard, zero runtime and binary
+//! overhead. See `docs/profiling.md` for the full workflow.
+
+/// Open an `info_span!` in the current scope when the `profile` feature is
+/// enabled; no-op otherwise. Accepts the same argument shapes as
+/// `tracing::info_span!` (at minimum a static name, optionally key/value
+/// fields).
+///
+/// The generated guard lives until the surrounding scope ends, so simply
+/// call this as the first statement of a function to measure the whole
+/// body.
+#[cfg(feature = "profile")]
+#[macro_export]
+macro_rules! prof_span {
+    ($name:expr $(, $($arg:tt)*)?) => {
+        let __prof_span = ::bevy::prelude::info_span!($name $(, $($arg)*)?);
+        let __prof_guard = __prof_span.entered();
+    };
+}
+
+/// No-op variant of [`prof_span!`] used when the `profile` feature is
+/// disabled. Expands to nothing so default builds carry zero overhead.
+#[cfg(not(feature = "profile"))]
+#[macro_export]
+macro_rules! prof_span {
+    ($name:expr $(, $($arg:tt)*)?) => {};
+}

--- a/macrocosmo/src/scripting/lifecycle.rs
+++ b/macrocosmo/src/scripting/lifecycle.rs
@@ -70,6 +70,7 @@ pub fn run_lifecycle_hooks(
     engine: Res<ScriptEngine>,
     mut empire_query: Query<(&mut GameFlags, &mut ScopedFlags), With<PlayerEmpire>>,
 ) {
+    crate::prof_span!("run_lifecycle_hooks");
     let lua = engine.lua();
 
     // Run on_scripts_loaded hooks
@@ -119,6 +120,7 @@ pub fn drain_script_events(
     if len == 0 {
         return;
     }
+    crate::prof_span!("drain_script_events");
 
     for i in 1..=len {
         let Ok(entry) = events.get::<mlua::Table>(i) else {

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -200,6 +200,7 @@ fn compute_ui_state(
     empire_q: Query<(&KnowledgeStore, &AuthorityParams), With<PlayerEmpire>>,
     planets: Query<&Planet>,
 ) {
+    crate::prof_span!("compute_ui_state");
     let player_info = player_q
         .iter()
         .next()
@@ -323,6 +324,7 @@ fn draw_top_bar_system(
     mut observer_view: ResMut<crate::observer::ObserverView>,
     factions_q: Query<(Entity, &crate::player::Faction), With<crate::player::Empire>>,
 ) {
+    crate::prof_span!("draw_top_bar");
     let Ok(ctx) = contexts.ctx_mut() else {
         return;
     };
@@ -518,6 +520,7 @@ fn draw_outline_and_tooltips_system(
     windows: Query<&Window>,
     camera_q: Query<(&Camera, &GlobalTransform), With<Camera2d>>,
 ) {
+    crate::prof_span!("draw_outline_and_tooltips");
     let Ok(ctx) = contexts.ctx_mut() else {
         return;
     };
@@ -605,6 +608,7 @@ fn draw_main_panels_system(
     mut deliverables_res: MainPanelDeliverableRes,
     mut game_events: MessageWriter<GameEvent>,
 ) {
+    crate::prof_span!("draw_main_panels");
     let Ok(ctx) = contexts.ctx_mut() else {
         return;
     };
@@ -1099,6 +1103,7 @@ fn draw_overlays_system(
     effects_preview: Res<crate::technology::TechEffectsPreview>,
     unlock_index: Res<crate::technology::TechUnlockIndex>,
 ) {
+    crate::prof_span!("draw_overlays");
     let Ok(ctx) = contexts.ctx_mut() else {
         return;
     };
@@ -1188,6 +1193,7 @@ fn draw_bottom_bar_system(
     clock: Res<GameClock>,
     empire_q: Query<&CommandLog, With<PlayerEmpire>>,
 ) {
+    crate::prof_span!("draw_bottom_bar");
     let Ok(ctx) = contexts.ctx_mut() else {
         return;
     };

--- a/macrocosmo/src/visualization/stars.rs
+++ b/macrocosmo/src/visualization/stars.rs
@@ -142,6 +142,7 @@ pub fn update_star_colors(
     camera_q: Query<&Projection, With<Camera2d>>,
     player_q: Query<&StationedAt, With<Player>>,
 ) {
+    crate::prof_span!("update_star_colors");
     let Ok(knowledge) = empire_q.single() else {
         return;
     };

--- a/macrocosmo/src/visualization/territory.rs
+++ b/macrocosmo/src/visualization/territory.rs
@@ -236,6 +236,7 @@ fn sync_territory_material(
     mut materials: ResMut<Assets<TerritoryMaterial>>,
     material_handles: Query<&MeshMaterial2d<TerritoryMaterial>>,
 ) {
+    crate::prof_span!("sync_territory_material");
     // For now only the player empire owns colonies. If this changes, expand
     // into a (empire_entity -> empire_id) mapping below.
     let Ok((player_entity, knowledge)) = empire_q.single() else {


### PR DESCRIPTION
## Summary

- Adds `profile` cargo feature to `macrocosmo` crate (default off) that passes through to `bevy/trace_tracy` + `bevy/debug` for Tracy-compatible CPU/GPU spans and human-readable Bevy system names.
- Introduces `prof_span!` macro in `macrocosmo/src/profiling.rs` that is cfg-gated to a single `;` under default build — true zero overhead when the feature is off.
- Wires spans into 13 per-frame / per-tick hot paths:
  - **Lua callbacks**: `EventBus::fire`, `run_lifecycle_hooks`, `drain_script_events`
  - **Knowledge propagation**: `build_system_snapshot`, `propagate_knowledge`, `relay_knowledge_propagate_system`
  - **UI 6-system chain**: `compute_ui_state`, `draw_top_bar`, `draw_outline_and_tooltips`, `draw_main_panels`, `draw_overlays`, `draw_bottom_bar`
  - **Galaxy rendering**: `update_star_colors`, `sync_territory_material`
- `docs/profiling.md` documents the Tracy version-check workflow (`cargo tree` vs the rust_tracy_client support table), the mandatory `--release` flag, live vs. recording capture, and non-goals (`trace_tracy_memory`, `FpsOverlayPlugin`, Chrome tracing, custom GPU spans).

Closes #284.

## Test plan

- [x] `cargo check --workspace` (default) — clean
- [x] `cargo check --workspace --features profile` — clean
- [x] `cargo check --workspace --tests` (both configs) — clean
- [x] `cargo test --workspace --lib` — 869 passed; 0 failed
- [ ] Manual: `cargo run --release --features profile` alongside `tracy-profiler` to confirm Bevy systems + `RenderQueue` row + custom spans appear in the GUI

## Non-goals (deferred)

- `bevy/trace_tracy_memory` (memory tracking, extra overhead)
- `FpsOverlayPlugin` (in-game counter without Tracy)
- Chrome tracing / `perf` flame graphs / criterion / CI regression
- Custom `RenderDiagnosticsPlugin` GPU spans
- Compile-time profiling (`cargo --timings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)