### PR TITLE
#334 Phase 1: event-driven MoveTo dispatch (CommandId + dispatcher + handler + 2-phase CommandLog)

### DIFF
--- a/macrocosmo/src/communication/mod.rs
+++ b/macrocosmo/src/communication/mod.rs
@@ -294,11 +294,81 @@ pub struct CommandLog {
     pub entries: Vec<CommandLogEntry>,
 }
 
+/// Terminal disposition of a locally-dispatched command (#334). The legacy
+/// `arrived` boolean is preserved for remote (`PendingCommand`) entries;
+/// `status` carries richer information for dispatcher/handler-driven
+/// commands. Defaults to `Pending` so save fixtures that predate this
+/// field decode unchanged.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum CommandLogStatus {
+    /// Legacy remote command awaiting light-speed arrival (kept as the
+    /// default so existing entries continue to display unchanged).
+    #[default]
+    Pending,
+    /// Dispatcher emitted a `CommandRequested`; handler has not yet
+    /// produced a terminal `CommandExecuted`.
+    Dispatched,
+    /// Handler emitted `CommandExecuted { result: Ok }`.
+    Executed,
+    /// Handler (or dispatcher-side validation) rejected the command.
+    Rejected { reason: String },
+    /// Handler emitted `CommandExecuted { result: Deferred }` — an async
+    /// follow-up will finalize via another `CommandExecuted`.
+    Deferred,
+}
+
 pub struct CommandLogEntry {
     pub description: String,
     pub sent_at: i64,
     pub arrives_at: i64,
+    /// Legacy UI flag — flipped to `true` when a remote `PendingCommand`
+    /// arrives at its target. For dispatcher/handler-driven commands
+    /// (#334) this is also set to `true` whenever `status` becomes
+    /// `Executed` / `Rejected` so bottom-bar rendering stays consistent
+    /// with the pre-refactor UX.
     pub arrived: bool,
+    /// #334: Stable identifier for dispatcher-allocated commands. `None`
+    /// for legacy remote-pending entries (pre-dispatcher code path).
+    pub command_id: Option<crate::ship::command_events::CommandId>,
+    /// #334: Per-entry lifecycle state.
+    pub status: CommandLogStatus,
+    /// #334: Timestamp the handler emitted its terminal `CommandExecuted`.
+    /// `None` for entries still in flight / legacy remote entries.
+    pub executed_at: Option<i64>,
+}
+
+impl CommandLogEntry {
+    /// Convenience constructor for legacy remote-pending entries.
+    pub fn new_pending(description: String, sent_at: i64, arrives_at: i64) -> Self {
+        Self {
+            description,
+            sent_at,
+            arrives_at,
+            arrived: false,
+            command_id: None,
+            status: CommandLogStatus::Pending,
+            executed_at: None,
+        }
+    }
+
+    /// #334: Dispatcher-side constructor (local command, zero light-speed
+    /// delay). `arrives_at == sent_at` so the UI "eta" renders as arrived
+    /// immediately while `status` tracks the true lifecycle.
+    pub fn new_dispatched(
+        description: String,
+        sent_at: i64,
+        command_id: crate::ship::command_events::CommandId,
+    ) -> Self {
+        Self {
+            description,
+            sent_at,
+            arrives_at: sent_at,
+            arrived: false,
+            command_id: Some(command_id),
+            status: CommandLogStatus::Dispatched,
+            executed_at: None,
+        }
+    }
 }
 
 pub fn dispatch_pending_colony_commands(
@@ -400,12 +470,11 @@ pub fn send_remote_command(
     let delay = physics::light_delay_hexadies(distance);
     let arrives_at = sent_at + delay;
 
-    command_log.entries.push(CommandLogEntry {
-        description: command.describe(),
+    command_log.entries.push(CommandLogEntry::new_pending(
+        command.describe(),
         sent_at,
         arrives_at,
-        arrived: false,
-    });
+    ));
 
     commands.spawn(PendingCommand {
         target_system,

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -3670,6 +3670,14 @@ pub struct SavedCommandLogEntry {
 }
 impl SavedCommandLogEntry {
     pub fn from_live(v: &CommandLogEntry) -> Self {
+        // #334 Phase 1: the new `command_id` / `status` / `executed_at`
+        // fields on `CommandLogEntry` are deliberately NOT persisted —
+        // they're frame-transient dispatcher bookkeeping. Saving and
+        // reloading a mid-dispatch entry in those new states would be
+        // misleading, and adding them here would bump SAVE_VERSION.
+        // Keeping only the four legacy fields preserves
+        // `tests/fixtures_smoke.rs` without regenerating
+        // `minimal_game.bin`.
         Self {
             description: v.description.clone(),
             sent_at: v.sent_at,
@@ -3678,11 +3686,18 @@ impl SavedCommandLogEntry {
         }
     }
     pub fn into_live(self) -> CommandLogEntry {
+        // #334: Reloaded entries default the new fields
+        // (`command_id = None`, `status = Pending`, `executed_at = None`)
+        // so every consumer that hasn't adopted the new lifecycle yet
+        // sees behavior identical to pre-refactor.
         CommandLogEntry {
             description: self.description,
             sent_at: self.sent_at,
             arrives_at: self.arrives_at,
             arrived: self.arrived,
+            command_id: None,
+            status: crate::communication::CommandLogStatus::Pending,
+            executed_at: None,
         }
     }
 }

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -329,10 +329,16 @@ pub struct SavedHostileHitpoints {
 
 impl SavedHostileHitpoints {
     pub fn from_live(v: &HostileHitpoints) -> Self {
-        Self { hp: v.hp, max_hp: v.max_hp }
+        Self {
+            hp: v.hp,
+            max_hp: v.max_hp,
+        }
     }
     pub fn into_live(self) -> HostileHitpoints {
-        HostileHitpoints { hp: self.hp, max_hp: self.max_hp }
+        HostileHitpoints {
+            hp: self.hp,
+            max_hp: self.max_hp,
+        }
     }
 }
 
@@ -344,10 +350,16 @@ pub struct SavedHostileStats {
 
 impl SavedHostileStats {
     pub fn from_live(v: &HostileStats) -> Self {
-        Self { strength: v.strength, evasion: v.evasion }
+        Self {
+            strength: v.strength,
+            evasion: v.evasion,
+        }
     }
     pub fn into_live(self) -> HostileStats {
-        HostileStats { strength: self.strength, evasion: self.evasion }
+        HostileStats {
+            strength: self.strength,
+            evasion: self.evasion,
+        }
     }
 }
 

--- a/macrocosmo/src/ship/bridges.rs
+++ b/macrocosmo/src/ship/bridges.rs
@@ -1,0 +1,217 @@
+//! #334 Phase 1: event-bus subscribers that translate `CommandExecuted`
+//! messages into side-effects for downstream consumers (`CommandLog`,
+//! future Lua `on_command_completed` hooks, AI debug telemetry).
+//!
+//! Phase 1 scope: `bridge_command_executed_to_log` — keeps the per-empire
+//! `CommandLog` UI component in sync with the dispatcher/handler pipeline
+//! by matching entries via `CommandId` and flipping `status` /
+//! `executed_at`. Phase 4 adds `bridge_command_executed_to_gamestate`.
+
+use bevy::prelude::*;
+
+use crate::communication::{CommandLog, CommandLogStatus};
+use crate::player::PlayerEmpire;
+use crate::ship::command_events::{CommandExecuted, CommandResult};
+
+/// Reads every `CommandExecuted` this frame and updates the matching
+/// `CommandLog` entry on the player empire. Entries are keyed by
+/// `CommandId`; unmatched `CommandExecuted` messages are silently ignored
+/// (NPC empires don't populate `CommandLog` yet — plan §5).
+pub fn bridge_command_executed_to_log(
+    mut executed: MessageReader<CommandExecuted>,
+    mut log_q: Query<&mut CommandLog, With<PlayerEmpire>>,
+) {
+    let Ok(mut log) = log_q.single_mut() else {
+        // Drain so messages don't pile up across frames when there's no
+        // player empire (observer mode, teardown).
+        for _ in executed.read() {}
+        return;
+    };
+    for event in executed.read() {
+        let Some(entry) = log
+            .entries
+            .iter_mut()
+            .find(|e| e.command_id == Some(event.command_id))
+        else {
+            // No matching dispatcher-side entry. Either the command was
+            // issued for an NPC empire, the entry predates dispatcher
+            // tracking, or save/load wiped it. Nothing to update.
+            continue;
+        };
+        entry.executed_at = Some(event.completed_at);
+        entry.status = match &event.result {
+            CommandResult::Ok => CommandLogStatus::Executed,
+            CommandResult::Rejected { reason } => CommandLogStatus::Rejected {
+                reason: reason.clone(),
+            },
+            CommandResult::Deferred => CommandLogStatus::Deferred,
+        };
+        // Keep the legacy `arrived` flag in sync for bottom-bar rendering
+        // (terminal dispositions — Ok / Rejected — flip it true so the UI
+        // shows "arrived"; Deferred stays false while the follow-up is
+        // pending).
+        entry.arrived = !matches!(entry.status, CommandLogStatus::Deferred);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::communication::CommandLogEntry;
+    use crate::ship::command_events::{CommandEventsPlugin, CommandId, CommandKind};
+    use bevy::MinimalPlugins;
+    use bevy::ecs::message::Messages;
+
+    fn make_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CommandEventsPlugin);
+        app.add_systems(Update, bridge_command_executed_to_log);
+        app
+    }
+
+    fn spawn_empire_with_log(world: &mut World, entries: Vec<CommandLogEntry>) -> Entity {
+        world
+            .spawn((PlayerEmpire, CommandLog { entries }))
+            .id()
+    }
+
+    #[test]
+    fn ok_terminal_flips_status_and_arrived() {
+        let mut app = make_app();
+        let cid = CommandId(42);
+        spawn_empire_with_log(
+            app.world_mut(),
+            vec![CommandLogEntry::new_dispatched("MoveTo X".into(), 10, cid)],
+        );
+        {
+            let mut msgs = app.world_mut().resource_mut::<Messages<CommandExecuted>>();
+            msgs.write(CommandExecuted {
+                command_id: cid,
+                kind: CommandKind::Move,
+                ship: Entity::from_raw_u32(1).unwrap(),
+                result: CommandResult::Ok,
+                completed_at: 20,
+            });
+        }
+        app.update();
+
+        let log = {
+            let mut q = app.world_mut().query_filtered::<&CommandLog, With<PlayerEmpire>>();
+            q.single(app.world()).unwrap().clone_entries()
+        };
+        assert_eq!(log[0].status, CommandLogStatus::Executed);
+        assert_eq!(log[0].executed_at, Some(20));
+        assert!(log[0].arrived);
+    }
+
+    // Little helper because CommandLog itself isn't Clone.
+    trait CloneEntries {
+        fn clone_entries(&self) -> Vec<CommandLogEntry>;
+    }
+    impl CloneEntries for CommandLog {
+        fn clone_entries(&self) -> Vec<CommandLogEntry> {
+            self.entries
+                .iter()
+                .map(|e| CommandLogEntry {
+                    description: e.description.clone(),
+                    sent_at: e.sent_at,
+                    arrives_at: e.arrives_at,
+                    arrived: e.arrived,
+                    command_id: e.command_id,
+                    status: e.status.clone(),
+                    executed_at: e.executed_at,
+                })
+                .collect()
+        }
+    }
+
+    #[test]
+    fn rejected_terminal_records_reason() {
+        let mut app = make_app();
+        let cid = CommandId(7);
+        spawn_empire_with_log(
+            app.world_mut(),
+            vec![CommandLogEntry::new_dispatched("MoveTo X".into(), 0, cid)],
+        );
+        {
+            let mut msgs = app.world_mut().resource_mut::<Messages<CommandExecuted>>();
+            msgs.write(CommandExecuted {
+                command_id: cid,
+                kind: CommandKind::Move,
+                ship: Entity::from_raw_u32(1).unwrap(),
+                result: CommandResult::Rejected {
+                    reason: "target despawned".into(),
+                },
+                completed_at: 5,
+            });
+        }
+        app.update();
+        let log = {
+            let mut q = app.world_mut().query_filtered::<&CommandLog, With<PlayerEmpire>>();
+            q.single(app.world()).unwrap().clone_entries()
+        };
+        assert_eq!(
+            log[0].status,
+            CommandLogStatus::Rejected {
+                reason: "target despawned".into()
+            }
+        );
+        assert!(log[0].arrived);
+    }
+
+    #[test]
+    fn deferred_leaves_arrived_false() {
+        let mut app = make_app();
+        let cid = CommandId(3);
+        spawn_empire_with_log(
+            app.world_mut(),
+            vec![CommandLogEntry::new_dispatched("MoveTo X".into(), 0, cid)],
+        );
+        {
+            let mut msgs = app.world_mut().resource_mut::<Messages<CommandExecuted>>();
+            msgs.write(CommandExecuted {
+                command_id: cid,
+                kind: CommandKind::Move,
+                ship: Entity::from_raw_u32(1).unwrap(),
+                result: CommandResult::Deferred,
+                completed_at: 2,
+            });
+        }
+        app.update();
+        let log = {
+            let mut q = app.world_mut().query_filtered::<&CommandLog, With<PlayerEmpire>>();
+            q.single(app.world()).unwrap().clone_entries()
+        };
+        assert_eq!(log[0].status, CommandLogStatus::Deferred);
+        assert!(!log[0].arrived);
+    }
+
+    #[test]
+    fn unmatched_command_id_is_ignored() {
+        let mut app = make_app();
+        let cid_kept = CommandId(1);
+        spawn_empire_with_log(
+            app.world_mut(),
+            vec![CommandLogEntry::new_dispatched("kept".into(), 0, cid_kept)],
+        );
+        {
+            let mut msgs = app.world_mut().resource_mut::<Messages<CommandExecuted>>();
+            // Message with an unmatched id — should be ignored, not panic.
+            msgs.write(CommandExecuted {
+                command_id: CommandId(999),
+                kind: CommandKind::Move,
+                ship: Entity::from_raw_u32(1).unwrap(),
+                result: CommandResult::Ok,
+                completed_at: 5,
+            });
+        }
+        app.update();
+        let log = {
+            let mut q = app.world_mut().query_filtered::<&CommandLog, With<PlayerEmpire>>();
+            q.single(app.world()).unwrap().clone_entries()
+        };
+        // The kept entry stays Dispatched.
+        assert_eq!(log[0].status, CommandLogStatus::Dispatched);
+    }
+}

--- a/macrocosmo/src/ship/bridges.rs
+++ b/macrocosmo/src/ship/bridges.rs
@@ -71,9 +71,7 @@ mod tests {
     }
 
     fn spawn_empire_with_log(world: &mut World, entries: Vec<CommandLogEntry>) -> Entity {
-        world
-            .spawn((PlayerEmpire, CommandLog { entries }))
-            .id()
+        world.spawn((PlayerEmpire, CommandLog { entries })).id()
     }
 
     #[test]
@@ -97,7 +95,9 @@ mod tests {
         app.update();
 
         let log = {
-            let mut q = app.world_mut().query_filtered::<&CommandLog, With<PlayerEmpire>>();
+            let mut q = app
+                .world_mut()
+                .query_filtered::<&CommandLog, With<PlayerEmpire>>();
             q.single(app.world()).unwrap().clone_entries()
         };
         assert_eq!(log[0].status, CommandLogStatus::Executed);
@@ -148,7 +148,9 @@ mod tests {
         }
         app.update();
         let log = {
-            let mut q = app.world_mut().query_filtered::<&CommandLog, With<PlayerEmpire>>();
+            let mut q = app
+                .world_mut()
+                .query_filtered::<&CommandLog, With<PlayerEmpire>>();
             q.single(app.world()).unwrap().clone_entries()
         };
         assert_eq!(
@@ -180,7 +182,9 @@ mod tests {
         }
         app.update();
         let log = {
-            let mut q = app.world_mut().query_filtered::<&CommandLog, With<PlayerEmpire>>();
+            let mut q = app
+                .world_mut()
+                .query_filtered::<&CommandLog, With<PlayerEmpire>>();
             q.single(app.world()).unwrap().clone_entries()
         };
         assert_eq!(log[0].status, CommandLogStatus::Deferred);
@@ -208,7 +212,9 @@ mod tests {
         }
         app.update();
         let log = {
-            let mut q = app.world_mut().query_filtered::<&CommandLog, With<PlayerEmpire>>();
+            let mut q = app
+                .world_mut()
+                .query_filtered::<&CommandLog, With<PlayerEmpire>>();
             q.single(app.world()).unwrap().clone_entries()
         };
         // The kept entry stays Dispatched.

--- a/macrocosmo/src/ship/command.rs
+++ b/macrocosmo/src/ship/command.rs
@@ -5,15 +5,13 @@ use crate::galaxy::StarSystem;
 use crate::ship_design::ShipDesignRegistry;
 use crate::time_system::GameClock;
 
-use super::movement::{
-    start_ftl_travel_full, start_sublight_travel_with_bonus, PortParams,
-};
+use super::movement::{PortParams, start_ftl_travel_full, start_sublight_travel_with_bonus};
+use super::routing;
 use super::survey::start_survey_with_bonus;
 use super::{
-    CommandQueue, QueuedCommand, PendingShipCommand, ShipCommand, RulesOfEngagement,
-    Ship, ShipState,
+    CommandQueue, PendingShipCommand, QueuedCommand, RulesOfEngagement, Ship, ShipCommand,
+    ShipState,
 };
-use super::routing;
 
 // --- Pending ship command processing (#33) ---
 
@@ -91,7 +89,8 @@ pub fn process_pending_ship_commands(
                     continue;
                 };
                 // Try FTL first, fall back to sublight
-                let port_params = system_buildings.get(docked_system)
+                let port_params = system_buildings
+                    .get(docked_system)
                     .map(|sb| PortParams::from_system_buildings(sb, &building_registry))
                     .unwrap_or(PortParams::NONE);
                 match start_ftl_travel_full(
@@ -132,10 +131,7 @@ pub fn process_pending_ship_commands(
                                 );
                             }
                             Err(e) => {
-                                info!(
-                                    "Remote move command rejected for {}: {}",
-                                    ship.name, e,
-                                );
+                                info!("Remote move command rejected for {}: {}", ship.name, e,);
                             }
                         }
                     }
@@ -147,7 +143,18 @@ pub fn process_pending_ship_commands(
                     commands.entity(cmd_entity).despawn();
                     continue;
                 };
-                match start_survey_with_bonus(&mut state, &ship, tgt, ship_pos, tgt_pos, clock.elapsed, global_params.survey_range_bonus, &design_registry, survey_range, survey_duration) {
+                match start_survey_with_bonus(
+                    &mut state,
+                    &ship,
+                    tgt,
+                    ship_pos,
+                    tgt_pos,
+                    clock.elapsed,
+                    global_params.survey_range_bonus,
+                    &design_registry,
+                    survey_range,
+                    survey_duration,
+                ) {
                     Ok(()) => {
                         info!(
                             "Remote survey command executed: {} surveying {}",
@@ -155,10 +162,7 @@ pub fn process_pending_ship_commands(
                         );
                     }
                     Err(e) => {
-                        info!(
-                            "Remote survey command for {} failed: {}",
-                            ship.name, e,
-                        );
+                        info!("Remote survey command for {} failed: {}", ship.name, e,);
                     }
                 }
             }
@@ -216,7 +220,17 @@ pub fn process_command_queue(
     empire_params_q: Query<&crate::technology::GlobalParams, With<crate::player::PlayerEmpire>>,
     balance: Res<crate::technology::GameBalance>,
     empire_knowledge_q: Query<&crate::knowledge::KnowledgeStore, With<crate::player::PlayerEmpire>>,
-    mut ships: Query<(Entity, &Ship, &mut ShipState, &mut CommandQueue, &Position, Option<&RulesOfEngagement>), Without<routing::PendingRoute>>,
+    mut ships: Query<
+        (
+            Entity,
+            &Ship,
+            &mut ShipState,
+            &mut CommandQueue,
+            &Position,
+            Option<&RulesOfEngagement>,
+        ),
+        Without<routing::PendingRoute>,
+    >,
     systems: Query<(Entity, &StarSystem, &Position), Without<Ship>>,
     _system_buildings: Query<&crate::colony::SystemBuildings>,
     _planets: Query<&crate::galaxy::Planet>,
@@ -288,8 +302,7 @@ pub fn process_command_queue(
                 else {
                     unreachable!("outer match guarantees Scout variant");
                 };
-                let Ok((_target_entity, _target_star, _target_pos)) =
-                    systems.get(target_system)
+                let Ok((_target_entity, _target_star, _target_pos)) = systems.get(target_system)
                 else {
                     warn!("Queued Scout target no longer exists");
                     queue.sync_prediction(ship_pos.as_array(), docked_system);
@@ -298,19 +311,13 @@ pub fn process_command_queue(
                 // Non-FTL ships are disallowed from Scout — scouts must
                 // leap to the target. Reject early with a warning.
                 if ship.ftl_range <= 0.0 {
-                    warn!(
-                        "Scout rejected: ship {} has no FTL capability",
-                        ship.name
-                    );
+                    warn!("Scout rejected: ship {} has no FTL capability", ship.name);
                     queue.sync_prediction(ship_pos.as_array(), docked_system);
                     continue;
                 }
                 // Must carry the scout module.
                 if !super::scout::ship_has_scout_module(ship) {
-                    warn!(
-                        "Scout rejected: ship {} lacks a scout module",
-                        ship.name
-                    );
+                    warn!("Scout rejected: ship {} lacks a scout module", ship.name);
                     queue.sync_prediction(ship_pos.as_array(), docked_system);
                     continue;
                 }
@@ -359,7 +366,8 @@ pub fn process_command_queue(
                 let next = queue.commands.remove(0);
                 match next {
                     QueuedCommand::Survey { system: target } => {
-                        let Ok((_target_entity, target_star, target_pos)) = systems.get(target) else {
+                        let Ok((_target_entity, target_star, target_pos)) = systems.get(target)
+                        else {
                             warn!("Queued Survey target no longer exists");
                             queue.sync_prediction(ship_pos.as_array(), docked_system);
                             continue;
@@ -367,9 +375,16 @@ pub fn process_command_queue(
                         // #101: If not docked at the target system, auto-insert a move command.
                         // #185: Loitering ships also need to move first.
                         if docked_system != Some(target) {
-                            queue.commands.insert(0, QueuedCommand::Survey { system: target });
-                            queue.commands.insert(0, QueuedCommand::MoveTo { system: target });
-                            info!("Queue: Ship {} not at target, auto-inserting move before survey of {}", ship.name, target_star.name);
+                            queue
+                                .commands
+                                .insert(0, QueuedCommand::Survey { system: target });
+                            queue
+                                .commands
+                                .insert(0, QueuedCommand::MoveTo { system: target });
+                            info!(
+                                "Queue: Ship {} not at target, auto-inserting move before survey of {}",
+                                ship.name, target_star.name
+                            );
                             continue;
                         }
                         let origin = Position::from(ship_pos.as_array());
@@ -386,10 +401,7 @@ pub fn process_command_queue(
                             survey_duration_base,
                         ) {
                             Ok(()) => {
-                                info!(
-                                    "Queue: Ship {} surveying {}",
-                                    ship.name, target_star.name
-                                );
+                                info!("Queue: Ship {} surveying {}", ship.name, target_star.name);
                             }
                             Err(e) => {
                                 warn!("Queue: Survey failed for {}: {}", ship.name, e);
@@ -397,34 +409,50 @@ pub fn process_command_queue(
                         }
                         queue.sync_prediction(ship_pos.as_array(), docked_system);
                     }
-                    QueuedCommand::Colonize { system: target, planet } => {
-                        let Ok((_target_entity, target_star, _target_pos)) = systems.get(target) else {
+                    QueuedCommand::Colonize {
+                        system: target,
+                        planet,
+                    } => {
+                        let Ok((_target_entity, target_star, _target_pos)) = systems.get(target)
+                        else {
                             warn!("Queued Colonize target no longer exists");
                             queue.sync_prediction(ship_pos.as_array(), docked_system);
                             continue;
                         };
                         if docked_system != Some(target) {
-                            queue.commands.insert(0, QueuedCommand::Colonize { system: target, planet });
-                            queue.commands.insert(0, QueuedCommand::MoveTo { system: target });
-                            info!("Queue: Ship {} not at target, auto-inserting move before colonize of {}", ship.name, target_star.name);
+                            queue.commands.insert(
+                                0,
+                                QueuedCommand::Colonize {
+                                    system: target,
+                                    planet,
+                                },
+                            );
+                            queue
+                                .commands
+                                .insert(0, QueuedCommand::MoveTo { system: target });
+                            info!(
+                                "Queue: Ship {} not at target, auto-inserting move before colonize of {}",
+                                ship.name, target_star.name
+                            );
                             continue;
                         }
                         if !design_registry.can_colonize(&ship.design_id) {
-                            warn!("Queue: Ship {} cannot colonize (not a colony ship)", ship.name);
+                            warn!(
+                                "Queue: Ship {} cannot colonize (not a colony ship)",
+                                ship.name
+                            );
                             queue.sync_prediction(ship_pos.as_array(), docked_system);
                             continue;
                         }
-                        let docked_sys = docked_system.expect("survey/colonize already required docked");
+                        let docked_sys =
+                            docked_system.expect("survey/colonize already required docked");
                         *state = ShipState::Settling {
                             system: docked_sys,
                             planet,
                             started_at: clock.elapsed,
                             completes_at: clock.elapsed + settling_duration,
                         };
-                        info!(
-                            "Queue: Ship {} colonizing {}",
-                            ship.name, target_star.name
-                        );
+                        info!("Queue: Ship {} colonizing {}", ship.name, target_star.name);
                         queue.sync_prediction(ship_pos.as_array(), docked_system);
                     }
                     QueuedCommand::MoveToCoordinates { .. } | QueuedCommand::MoveTo { .. } => {} // handled above

--- a/macrocosmo/src/ship/command.rs
+++ b/macrocosmo/src/ship/command.rs
@@ -203,48 +203,47 @@ pub fn process_pending_ship_commands(
 /// #46: Checks for port facility at origin system
 /// #108: Unified MoveTo with auto-route planning (FTL chain > FTL direct > SubLight)
 /// #128: Async A* mixed route planning (FTL/sublight)
+#[allow(clippy::too_many_arguments)]
 pub fn process_command_queue(
-    mut commands: Commands,
+    // #334 Phase 1: `Commands` / KnowledgeStore / FactionRelations /
+    // port-params / FTL blocker params are preserved at the SystemParam
+    // surface for Phase 2/3 migrations (Survey / Colonize / Scout handlers
+    // continue to need some of them) even though this tick the MoveTo
+    // path no longer consults them. Underscored locals silence the
+    // "unused" warnings without touching the signature.
+    mut _commands: Commands,
     clock: Res<GameClock>,
     empire_params_q: Query<&crate::technology::GlobalParams, With<crate::player::PlayerEmpire>>,
     balance: Res<crate::technology::GameBalance>,
-    // #187: Player empire's KnowledgeStore used for Retreat-route avoidance.
     empire_knowledge_q: Query<&crate::knowledge::KnowledgeStore, With<crate::player::PlayerEmpire>>,
     mut ships: Query<(Entity, &Ship, &mut ShipState, &mut CommandQueue, &Position, Option<&RulesOfEngagement>), Without<routing::PendingRoute>>,
     systems: Query<(Entity, &StarSystem, &Position), Without<Ship>>,
-    system_buildings: Query<&crate::colony::SystemBuildings>,
+    _system_buildings: Query<&crate::colony::SystemBuildings>,
     _planets: Query<&crate::galaxy::Planet>,
-    // #187/#293: Hostile garrisons + faction ownership keyed by star system.
     hostiles_q: Query<
         (&crate::galaxy::AtSystem, &crate::faction::FactionOwner),
         With<crate::galaxy::Hostile>,
     >,
-    relations: Res<crate::faction::FactionRelations>,
-    mut pending_count: ResMut<routing::RouteCalculationsPending>,
+    _relations: Res<crate::faction::FactionRelations>,
+    mut _pending_count: ResMut<routing::RouteCalculationsPending>,
     design_registry: Res<ShipDesignRegistry>,
-    building_registry: Res<crate::colony::BuildingRegistry>,
-    // #145: Forbidden regions that block FTL travel.
+    _building_registry: Res<crate::colony::BuildingRegistry>,
     regions: Query<&crate::galaxy::ForbiddenRegion>,
 ) {
     let Ok(global_params) = empire_params_q.single() else {
         return;
     };
-    let base_ftl_speed = balance.initial_ftl_speed_c();
-    // #145: snapshot FTL-blocking regions once per tick; cheap since the
-    // region set is small (single-digit count) at MVP scope.
-    let ftl_blockers = routing::collect_ftl_blockers(&regions);
+    let _base_ftl_speed = balance.initial_ftl_speed_c();
+    let _ftl_blockers = routing::collect_ftl_blockers(&regions);
     let settling_duration = balance.settling_duration();
     let survey_range_base = balance.survey_range_ly();
     let survey_duration_base = balance.survey_duration();
-    let empire_knowledge = empire_knowledge_q.single().ok();
-    // #187/#293: Build the hostile system → hostile faction map once per tick.
-    let hostile_faction_map: std::collections::HashMap<Entity, Entity> = hostiles_q
+    let _empire_knowledge = empire_knowledge_q.single().ok();
+    let _hostile_faction_map: std::collections::HashMap<Entity, Entity> = hostiles_q
         .iter()
         .map(|(at_system, owner)| (at_system.0, owner.0))
         .collect();
-    for (entity, ship, mut state, mut queue, ship_pos, roe) in ships.iter_mut() {
-        // #187: ROE defaults to Defensive when absent (matches Ship::default spawn).
-        let roe = roe.copied().unwrap_or_default();
+    for (_entity, ship, mut state, mut queue, ship_pos, _roe) in ships.iter_mut() {
         // #185: Process queue when ship is Docked OR Loitering (current command finished).
         let docked_system: Option<Entity> = match *state {
             ShipState::Docked { system } => Some(system),
@@ -260,145 +259,21 @@ pub fn process_command_queue(
         let next = &queue.commands[0];
 
         match next {
-            QueuedCommand::MoveTo { system: target } => {
-                let target = *target;
-                let Ok((_target_entity, _target_star, target_pos)) = systems.get(target) else {
-                    warn!("Queued MoveTo target no longer exists");
-                    queue.commands.remove(0);
-                    queue.sync_prediction(ship_pos.as_array(), docked_system);
-                    continue;
-                };
-
-                // Already at target (only possible when docked)?
-                if docked_system == Some(target) {
-                    queue.commands.remove(0);
-                    queue.sync_prediction(ship_pos.as_array(), docked_system);
-                    continue;
-                }
-
-                // #296 (S-3): Immobile ships (Cores) can never satisfy a
-                // MoveTo. Drop the command with an info-level log; the UI
-                // guard should already prevent these from being queued, but
-                // belt-and-braces.
-                if ship.is_immobile() {
-                    info!(
-                        "Queue: dropping MoveTo on immobile ship {} (no propulsion)",
-                        ship.name
-                    );
-                    queue.commands.remove(0);
-                    queue.sync_prediction(ship_pos.as_array(), docked_system);
-                    continue;
-                }
-
-                // For loitering ships, fall back to a direct sublight move (no FTL chain
-                // planning from deep space).
-                if docked_system.is_none() {
-                    queue.commands.remove(0);
-                    // #296: immobile ships can't move sublight either —
-                    // consume the command with a warning.
-                    if let Err(e) = start_sublight_travel_with_bonus(
-                        &mut state,
-                        ship_pos,
-                        ship,
-                        Position::from(target_pos.as_array()),
-                        Some(target),
-                        clock.elapsed,
-                        global_params.sublight_speed_bonus,
-                    ) {
-                        warn!(
-                            "Queue: Loitering ship {} cannot sublight to target: {}",
-                            ship.name, e
-                        );
-                    } else {
-                        queue.sync_prediction(target_pos.as_array(), Some(target));
-                        info!("Queue: Loitering ship {} sublight to target", ship.name);
-                    }
-                    continue;
-                }
-
-                // Docked: use the system's position as origin for FTL route planning.
-                let docked_sys_for_origin = docked_system.expect("docked branch");
-                let Ok((_, _, origin_pos)) = systems.get(docked_sys_for_origin) else {
-                    warn!("Queue: Origin system no longer exists");
-                    queue.commands.remove(0);
-                    queue.sync_prediction(ship_pos.as_array(), docked_system);
-                    continue;
-                };
-                let origin_pos_arr = origin_pos.as_array();
-
-                // From here we know docked_system.is_some(); only docked ships use the
-                // FTL route planner.
-                let docked_sys = docked_system.expect("loitering branch handled above");
-                let port_params = system_buildings.get(docked_sys)
-                    .map(|sb| PortParams::from_system_buildings(sb, &building_registry))
-                    .unwrap_or(PortParams::NONE);
-                let effective_ftl_range = if ship.ftl_range > 0.0 {
-                    ship.ftl_range + global_params.ftl_range_bonus + port_params.ftl_range_bonus
-                } else {
-                    0.0
-                };
-                let effective_ftl_speed = base_ftl_speed * global_params.ftl_speed_multiplier;
-                let effective_sublight_speed = ship.sublight_speed + global_params.sublight_speed_bonus;
-
-                // Spawn async route computation task.
-                // #187: Feed per-ship ROE + KnowledgeStore-derived hostile info.
-                let ship_faction = match ship.owner {
-                    super::Owner::Empire(f) => Some(f),
-                    super::Owner::Neutral => None,
-                };
-                let snapshots = routing::collect_route_snapshots(
-                    &systems,
-                    empire_knowledge,
-                    &relations,
-                    ship_faction,
-                    &hostile_faction_map,
+            // #334 Phase 1: MoveTo / MoveToCoordinates are handled by
+            // `super::dispatcher::dispatch_queued_commands` +
+            // `super::handlers::move_handler::{handle_move_requested,
+            // handle_move_to_coordinates_requested}`. The dispatcher pops
+            // these variants before this system runs so they should never
+            // reach here; the arms are kept exhaustive for the compiler.
+            QueuedCommand::MoveTo { .. } | QueuedCommand::MoveToCoordinates { .. } => {
+                // Unreachable under the Phase 1 schedule (dispatcher runs
+                // `.before(process_command_queue)`). If we ever observe
+                // this in practice, drop the head to avoid a stall.
+                warn!(
+                    "Queue: MoveTo/MoveToCoordinates reached legacy path (dispatcher ordering bug?) — dropping head"
                 );
-                let task = routing::spawn_route_task_full(
-                    origin_pos_arr,
-                    target,
-                    effective_ftl_range,
-                    effective_sublight_speed,
-                    effective_ftl_speed,
-                    snapshots,
-                    roe,
-                    ftl_blockers.clone(),
-                );
-                commands.entity(entity).insert(routing::PendingRoute {
-                    task,
-                    target_system: target,
-                });
-                pending_count.count += 1;
-                info!("Queue: Ship {} spawned async route to target", ship.name);
-                // Do NOT consume the MoveTo — poll_pending_routes will handle it.
-            }
-            QueuedCommand::MoveToCoordinates { target } => {
-                // #185: Move sublight to deep-space coordinates and loiter on arrival.
-                let target_arr = *target;
                 queue.commands.remove(0);
-                // #296: immobile ships cannot leave their docking system.
-                match start_sublight_travel_with_bonus(
-                    &mut state,
-                    ship_pos,
-                    ship,
-                    Position::from(target_arr),
-                    None, // no target system → arrival transitions to Loitering
-                    clock.elapsed,
-                    global_params.sublight_speed_bonus,
-                ) {
-                    Ok(()) => {
-                        queue.sync_prediction(target_arr, None);
-                        info!(
-                            "Queue: Ship {} sublight to deep-space coordinates ({:.2},{:.2},{:.2})",
-                            ship.name, target_arr[0], target_arr[1], target_arr[2]
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            "Queue: Ship {} cannot MoveToCoordinates: {}",
-                            ship.name, e
-                        );
-                    }
-                }
+                queue.sync_prediction(ship_pos.as_array(), docked_system);
             }
             QueuedCommand::Scout { .. } => {
                 // #217: Consume and dispatch synchronously. If not at the

--- a/macrocosmo/src/ship/command_events.rs
+++ b/macrocosmo/src/ship/command_events.rs
@@ -294,9 +294,7 @@ mod tests {
 
         // Write 100 distinct MoveRequested messages in ascending id order.
         {
-            let mut messages = app
-                .world_mut()
-                .resource_mut::<Messages<MoveRequested>>();
+            let mut messages = app.world_mut().resource_mut::<Messages<MoveRequested>>();
             for i in 1..=100u64 {
                 messages.write(MoveRequested {
                     command_id: CommandId(i),

--- a/macrocosmo/src/ship/command_events.rs
+++ b/macrocosmo/src/ship/command_events.rs
@@ -1,0 +1,326 @@
+//! #334: Event-driven command dispatch — message types, `CommandId`, and
+//! the [`CommandEventsPlugin`] that registers them with Bevy.
+//!
+//! This module is the **skeleton** for the command dispatch refactor. Phase 1
+//! only wires `MoveRequested` + `MoveToCoordinatesRequested` through the new
+//! dispatcher / handler path; the other request types are pre-declared so
+//! follow-up phases (Phase 2/3/4) only add handlers, not new message types.
+//!
+//! Bevy 0.18 renamed `Event` → `Message` (`MessageReader`, `MessageWriter`,
+//! `App::add_message`). This module uses the new terminology throughout.
+//!
+//! See `docs/plan-334-command-dispatch-event-driven.md` §2.1 for the full
+//! design rationale (per-variant types vs. single enum).
+
+use bevy::prelude::*;
+
+use super::{Owner, ReportMode};
+use crate::amount::Amt;
+
+// ---------------------------------------------------------------------------
+// CommandId + allocator
+// ---------------------------------------------------------------------------
+
+/// Stable command identifier — allocated by the dispatcher, stitched into
+/// `CommandRequested` messages and the terminal `CommandExecuted` so
+/// `CommandLog` and (future) #268 relay dedup can match them without string
+/// keys. Monotonic per-game-session.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CommandId(pub u64);
+
+impl CommandId {
+    pub const ZERO: CommandId = CommandId(0);
+}
+
+/// Monotonic counter resource that hands out fresh [`CommandId`]s. Reset to
+/// zero on a fresh game (implicit via `Default`); persistence of this
+/// counter is intentionally *not* a save-format concern — command ids do
+/// not need to survive save/load (in-flight messages are frame-transient).
+#[derive(Resource, Debug, Default)]
+pub struct NextCommandId(pub u64);
+
+impl NextCommandId {
+    /// Allocate a fresh [`CommandId`]. Returns strictly-monotonic values;
+    /// the first call returns `CommandId(1)` so `CommandId(0)` can be used
+    /// as a reserved / sentinel value if ever needed.
+    pub fn allocate(&mut self) -> CommandId {
+        self.0 = self.0.saturating_add(1);
+        CommandId(self.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CommandKind + CommandResult (post-execution signal)
+// ---------------------------------------------------------------------------
+
+/// Discriminator carried on [`CommandExecuted`] so subscribers that only
+/// care "command X finished" don't have to match on each variant's tuple.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CommandKind {
+    Move,
+    MoveToCoordinates,
+    Survey,
+    Colonize,
+    Scout,
+    LoadDeliverable,
+    DeployDeliverable,
+    CoreDeploy,
+    TransferToStructure,
+    LoadFromScrapyard,
+    Attack,
+}
+
+/// Terminal disposition of a dispatched command.
+#[derive(Debug, Clone)]
+pub enum CommandResult {
+    /// Handler completed the semantic mutation successfully.
+    Ok,
+    /// Handler detected a late condition (race, state change, target
+    /// despawn) and rolled back. `reason` is a short log-friendly key.
+    Rejected { reason: String },
+    /// Handler split the command — e.g. the async route planner spawned a
+    /// `PendingRoute` and will finalize later, or an auto-inserted MoveTo
+    /// prefix was queued. A follow-up `CommandExecuted` (with `Ok` or
+    /// `Rejected`) will arrive later.
+    Deferred,
+}
+
+// ---------------------------------------------------------------------------
+// CommandRequested messages — one per QueuedCommand variant
+// ---------------------------------------------------------------------------
+
+/// Request to move a ship to a target star system (#108 MoveTo — FTL chain
+/// -> hybrid FTL+sublight -> sublight fallback). Emitted by the dispatcher
+/// after it validates that the ship exists, is Docked or Loitering, is not
+/// immobile, and that the target system exists.
+#[derive(Message, Debug, Clone)]
+pub struct MoveRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub target: Entity,
+    pub issued_at: i64,
+}
+
+/// Request to sublight-travel to an arbitrary deep-space coordinate (#185).
+#[derive(Message, Debug, Clone)]
+pub struct MoveToCoordinatesRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub target: [f64; 3],
+    pub issued_at: i64,
+}
+
+/// Skeleton for Phase 2 migration of Survey. No handler yet.
+#[derive(Message, Debug, Clone)]
+pub struct SurveyRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub target_system: Entity,
+    pub issued_at: i64,
+}
+
+/// Skeleton for Phase 2 migration of Colonize.
+#[derive(Message, Debug, Clone)]
+pub struct ColonizeRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub target_system: Entity,
+    pub planet: Option<Entity>,
+    pub issued_at: i64,
+}
+
+/// Skeleton for Phase 3 migration of Scout.
+#[derive(Message, Debug, Clone)]
+pub struct ScoutRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub target_system: Entity,
+    pub observation_duration: i64,
+    pub report_mode: ReportMode,
+    pub issued_at: i64,
+}
+
+/// Skeleton for Phase 2 migration of LoadDeliverable.
+#[derive(Message, Debug, Clone)]
+pub struct LoadDeliverableRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub system: Entity,
+    pub stockpile_index: usize,
+    pub issued_at: i64,
+}
+
+/// Skeleton for Phase 2 migration of DeployDeliverable.
+#[derive(Message, Debug, Clone)]
+pub struct DeployDeliverableRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub position: [f64; 3],
+    pub item_index: usize,
+    pub issued_at: i64,
+}
+
+/// Skeleton for Phase 2 — replaces `PendingCoreDeploys` resource plumbing.
+#[derive(Message, Debug, Clone)]
+pub struct CoreDeployRequested {
+    pub command_id: CommandId,
+    pub deployer: Entity,
+    pub target_system: Entity,
+    pub deploy_pos: [f64; 3],
+    pub faction_owner: Option<Entity>,
+    pub owner: Owner,
+    pub design_id: String,
+    pub submitted_at: i64,
+}
+
+/// Skeleton for Phase 2 migration of TransferToStructure.
+#[derive(Message, Debug, Clone)]
+pub struct TransferToStructureRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub structure: Entity,
+    pub minerals: Amt,
+    pub energy: Amt,
+    pub issued_at: i64,
+}
+
+/// Skeleton for Phase 2 migration of LoadFromScrapyard.
+#[derive(Message, Debug, Clone)]
+pub struct LoadFromScrapyardRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub structure: Entity,
+    pub issued_at: i64,
+}
+
+/// Skeleton for #219 / #220 (defensive platform combat). No handler yet —
+/// pre-declared so the plugin registers it and future work only adds the
+/// handler system.
+#[derive(Message, Debug, Clone)]
+pub struct AttackRequested {
+    pub command_id: CommandId,
+    pub attacker: Entity,
+    pub target: Entity,
+    pub issued_at: i64,
+}
+
+// ---------------------------------------------------------------------------
+// CommandExecuted — single tagged message consumed by log / gamestate bridge
+// ---------------------------------------------------------------------------
+
+/// Emitted by handlers (and the async `poll_pending_routes` system for
+/// deferred routes) when a command reaches a terminal state. Consumed by:
+/// - `bridge_command_executed_to_log` — updates [`crate::communication::CommandLog`].
+/// - (Phase 4) `bridge_command_executed_to_gamestate` — enqueues Lua
+///   `on_command_completed` hook payloads.
+#[derive(Message, Debug, Clone)]
+pub struct CommandExecuted {
+    pub command_id: CommandId,
+    pub kind: CommandKind,
+    pub ship: Entity,
+    pub result: CommandResult,
+    pub completed_at: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+/// Registers the `NextCommandId` resource and every `CommandRequested` /
+/// `CommandExecuted` message type. Keeps `main.rs` free of per-variant
+/// `add_message` noise as later phases add handlers.
+pub struct CommandEventsPlugin;
+
+impl Plugin for CommandEventsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<NextCommandId>();
+        // Per-variant request messages — all registered up front so handlers
+        // added in later phases only need to write a new system.
+        app.add_message::<MoveRequested>();
+        app.add_message::<MoveToCoordinatesRequested>();
+        app.add_message::<SurveyRequested>();
+        app.add_message::<ColonizeRequested>();
+        app.add_message::<ScoutRequested>();
+        app.add_message::<LoadDeliverableRequested>();
+        app.add_message::<DeployDeliverableRequested>();
+        app.add_message::<CoreDeployRequested>();
+        app.add_message::<TransferToStructureRequested>();
+        app.add_message::<LoadFromScrapyardRequested>();
+        app.add_message::<AttackRequested>();
+        // Single tagged "command finished" message.
+        app.add_message::<CommandExecuted>();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::message::Messages;
+
+    #[test]
+    fn command_id_allocator_is_monotonic() {
+        let mut next = NextCommandId::default();
+        let a = next.allocate();
+        let b = next.allocate();
+        let c = next.allocate();
+        assert_eq!(a.0, 1);
+        assert_eq!(b.0, 2);
+        assert_eq!(c.0, 3);
+        assert!(a < b && b < c);
+    }
+
+    #[test]
+    fn command_id_allocator_starts_at_one_not_zero() {
+        // CommandId(0) is reserved as ZERO sentinel.
+        let mut next = NextCommandId::default();
+        assert_ne!(next.allocate(), CommandId::ZERO);
+    }
+
+    /// §6 open-question guard: confirm the `MessageReader` iteration order
+    /// matches the `MessageWriter::write` order so downstream handlers can
+    /// rely on FIFO delivery. Locking this assumption here keeps future
+    /// Bevy upgrades honest.
+    #[test]
+    fn test_message_reader_preserves_emit_order() {
+        let mut app = App::new();
+        app.add_plugins(CommandEventsPlugin);
+
+        let dummy_ship = Entity::from_raw_u32(1).unwrap();
+        let dummy_target = Entity::from_raw_u32(2).unwrap();
+
+        // Write 100 distinct MoveRequested messages in ascending id order.
+        {
+            let mut messages = app
+                .world_mut()
+                .resource_mut::<Messages<MoveRequested>>();
+            for i in 1..=100u64 {
+                messages.write(MoveRequested {
+                    command_id: CommandId(i),
+                    ship: dummy_ship,
+                    target: dummy_target,
+                    issued_at: i as i64,
+                });
+            }
+        }
+
+        // Collect ids in `read()` order and verify strict ascending.
+        let messages = app.world().resource::<Messages<MoveRequested>>();
+        let mut cursor = messages.get_cursor();
+        let ids: Vec<u64> = cursor.read(messages).map(|m| m.command_id.0).collect();
+        assert_eq!(ids.len(), 100);
+        for (expected, got) in (1..=100u64).zip(ids.iter().copied()) {
+            assert_eq!(expected, got, "MessageReader must preserve FIFO emit order");
+        }
+    }
+
+    #[test]
+    fn plugin_registers_next_command_id_resource() {
+        let mut app = App::new();
+        app.add_plugins(CommandEventsPlugin);
+        assert!(app.world().get_resource::<NextCommandId>().is_some());
+    }
+}

--- a/macrocosmo/src/ship/dispatcher.rs
+++ b/macrocosmo/src/ship/dispatcher.rs
@@ -1,0 +1,431 @@
+//! #334 Phase 1: command-queue dispatcher.
+//!
+//! Iterates every ship's `CommandQueue`, peeks the head command, performs
+//! **lightweight validation only** (ship is Docked/Loitering, target exists,
+//! ship not immobile), and for the Phase-1 migrated variants
+//! (`MoveTo` / `MoveToCoordinates`) emits the corresponding
+//! [`CommandRequested`](super::command_events) message and pops the queue.
+//!
+//! Non-migrated variants are left at the head of the queue untouched so the
+//! legacy `process_command_queue` / `process_deliverable_commands` systems
+//! can consume them via their original path. As Phase 2/3 land, variants
+//! move out of those legacy paths and into this dispatcher's emit arms.
+//!
+//! **No state mutation beyond `CommandQueue::commands.remove(0)` and
+//! message emit** — all semantic effects (starting FTL travel, spawning
+//! route tasks, flipping `ShipState`) happen in the downstream handler
+//! systems that read the message. This keeps the dispatcher's query set
+//! tiny (well below Bevy's 16-param cap) and frees each handler to hold
+//! only the queries *it* needs (plan §2.2, §2.3).
+
+use bevy::prelude::*;
+
+use super::command_events::{
+    CommandId, MoveRequested, MoveToCoordinatesRequested, NextCommandId,
+};
+use super::routing::PendingRoute;
+use super::{CommandQueue, QueuedCommand, Ship, ShipState};
+use crate::components::Position;
+use crate::galaxy::StarSystem;
+use crate::time_system::GameClock;
+
+/// Lightweight dispatcher: validates + emits `CommandRequested` messages.
+///
+/// Phase 1 scope: `MoveTo` and `MoveToCoordinates`. Other variants fall
+/// through untouched; the legacy `process_command_queue` consumes them.
+#[allow(clippy::too_many_arguments)]
+pub fn dispatch_queued_commands(
+    clock: Res<GameClock>,
+    mut next_id: ResMut<NextCommandId>,
+    // Ships not already mid-route. `PendingRoute` means a MoveTo is already
+    // being resolved asynchronously; skip those to preserve the 1-in-flight
+    // invariant from the legacy code (`Without<PendingRoute>` in
+    // process_command_queue).
+    mut ships: Query<
+        (Entity, &Ship, &ShipState, &Position, &mut CommandQueue),
+        Without<PendingRoute>,
+    >,
+    // Read-only target lookup. Name not used here but the filter ensures we
+    // only match star-system entities.
+    systems: Query<Entity, With<StarSystem>>,
+    // Typed message writers — one per Phase-1 request variant.
+    mut move_req: MessageWriter<MoveRequested>,
+    mut move_xy_req: MessageWriter<MoveToCoordinatesRequested>,
+) {
+    for (ship_entity, ship, state, ship_pos, mut queue) in ships.iter_mut() {
+        // Only ships in a state that can accept a new command get dispatched.
+        // The legacy code consumed queue items for ships that were Docked or
+        // Loitering; mid-travel / mid-survey / mid-settling ships have to
+        // finish the current action first. Preserve that exactly.
+        let (is_docked, docked_system): (bool, Option<Entity>) = match *state {
+            ShipState::Docked { system } => (true, Some(system)),
+            ShipState::Loitering { .. } => (false, None),
+            _ => continue,
+        };
+
+        if queue.commands.is_empty() {
+            continue;
+        }
+
+        // Peek the head command. We only mutate the queue if this command
+        // is a Phase-1 migrated variant AND passes dispatcher validation.
+        match &queue.commands[0] {
+            QueuedCommand::MoveTo { system: target } => {
+                let target = *target;
+
+                // Target system must still exist.
+                if systems.get(target).is_err() {
+                    warn!(
+                        "dispatch: MoveTo target {:?} no longer exists (ship {})",
+                        target, ship.name
+                    );
+                    queue.commands.remove(0);
+                    queue.sync_prediction(ship_pos.as_array(), docked_system);
+                    continue;
+                }
+
+                // Already at target — drop the no-op.
+                if is_docked && docked_system == Some(target) {
+                    queue.commands.remove(0);
+                    queue.sync_prediction(ship_pos.as_array(), docked_system);
+                    continue;
+                }
+
+                // Immobile ships (Cores, etc.) can never satisfy a MoveTo.
+                // Drop with info-level log; UI guard should already prevent
+                // this but belt-and-braces per plan §3.1.
+                if ship.is_immobile() {
+                    info!(
+                        "dispatch: dropping MoveTo on immobile ship {} (no propulsion)",
+                        ship.name
+                    );
+                    queue.commands.remove(0);
+                    queue.sync_prediction(ship_pos.as_array(), docked_system);
+                    continue;
+                }
+
+                // Validation passed → emit and pop.
+                let command_id: CommandId = next_id.allocate();
+                queue.commands.remove(0);
+                move_req.write(MoveRequested {
+                    command_id,
+                    ship: ship_entity,
+                    target,
+                    issued_at: clock.elapsed,
+                });
+                info!(
+                    "dispatch: ship {} MoveRequested -> {:?} (cmd {})",
+                    ship.name, target, command_id.0
+                );
+            }
+            QueuedCommand::MoveToCoordinates { target } => {
+                let target_arr = *target;
+                // Immobile ships cannot MoveToCoordinates either.
+                if ship.is_immobile() {
+                    info!(
+                        "dispatch: dropping MoveToCoordinates on immobile ship {}",
+                        ship.name
+                    );
+                    queue.commands.remove(0);
+                    queue.sync_prediction(ship_pos.as_array(), docked_system);
+                    continue;
+                }
+
+                let command_id = next_id.allocate();
+                queue.commands.remove(0);
+                move_xy_req.write(MoveToCoordinatesRequested {
+                    command_id,
+                    ship: ship_entity,
+                    target: target_arr,
+                    issued_at: clock.elapsed,
+                });
+                info!(
+                    "dispatch: ship {} MoveToCoordinatesRequested -> ({:.2},{:.2},{:.2}) (cmd {})",
+                    ship.name,
+                    target_arr[0],
+                    target_arr[1],
+                    target_arr[2],
+                    command_id.0
+                );
+            }
+            // Non-migrated variants: leave the head untouched so the legacy
+            // `process_command_queue` / `process_deliverable_commands`
+            // systems consume them this same tick (they run .after(dispatcher)).
+            QueuedCommand::Survey { .. }
+            | QueuedCommand::Colonize { .. }
+            | QueuedCommand::Scout { .. }
+            | QueuedCommand::LoadDeliverable { .. }
+            | QueuedCommand::DeployDeliverable { .. }
+            | QueuedCommand::TransferToStructure { .. }
+            | QueuedCommand::LoadFromScrapyard { .. } => {
+                // Phase 2/3 will migrate these. For now, do nothing — the
+                // legacy systems pick them up.
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::amount::Amt;
+    use crate::ship::command_events::CommandEventsPlugin;
+    use crate::ship::{Owner, ShipHitpoints, ShipModifiers, ShipStats};
+    use bevy::MinimalPlugins;
+    use bevy::ecs::message::Messages;
+
+    fn dummy_home_port(world: &mut World) -> Entity {
+        // Spawn a harmless placeholder entity just so `Ship.home_port`
+        // references a valid Entity id. The dispatcher never resolves it.
+        world.spawn_empty().id()
+    }
+
+    fn spawn_test_ship(
+        world: &mut World,
+        pos: [f64; 3],
+        docked_system: Option<Entity>,
+        sublight_speed: f64,
+        ftl_range: f64,
+    ) -> Entity {
+        let home_port = dummy_home_port(world);
+        let state = match docked_system {
+            Some(system) => ShipState::Docked { system },
+            None => ShipState::Loitering { position: pos },
+        };
+        world
+            .spawn((
+                Ship {
+                    name: "T".into(),
+                    design_id: "test".into(),
+                    hull_id: "hull".into(),
+                    modules: vec![],
+                    owner: Owner::Neutral,
+                    sublight_speed,
+                    ftl_range,
+                    player_aboard: false,
+                    home_port,
+                    design_revision: 0,
+                    fleet: None,
+                },
+                state,
+                Position::from(pos),
+                CommandQueue::default(),
+                crate::ship::Cargo::default(),
+                ShipHitpoints {
+                    hull: 10.0,
+                    hull_max: 10.0,
+                    armor: 0.0,
+                    armor_max: 0.0,
+                    shield: 0.0,
+                    shield_max: 0.0,
+                    shield_regen: 0.0,
+                },
+                ShipModifiers::default(),
+                ShipStats::default(),
+            ))
+            .id()
+    }
+
+    fn spawn_test_system(world: &mut World, pos: [f64; 3]) -> Entity {
+        world
+            .spawn((
+                StarSystem {
+                    name: "S".into(),
+                    surveyed: true,
+                    is_capital: false,
+                    star_type: "g2v".into(),
+                },
+                Position::from(pos),
+            ))
+            .id()
+    }
+
+    fn make_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(GameClock::new(0));
+        app.add_plugins(CommandEventsPlugin);
+        app.add_systems(Update, dispatch_queued_commands);
+        app
+    }
+
+    #[test]
+    fn dispatches_move_to_emits_request_and_pops_queue() {
+        let mut app = make_app();
+        let target = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
+        let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
+        let ship = spawn_test_ship(
+            app.world_mut(),
+            [0.0, 0.0, 0.0],
+            Some(origin),
+            0.5,
+            10.0,
+        );
+        {
+            let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+            q.commands.push(QueuedCommand::MoveTo { system: target });
+        }
+        app.update();
+
+        // Message emitted with matching ship + target
+        let messages = app.world().resource::<Messages<MoveRequested>>();
+        let mut cursor = messages.get_cursor();
+        let all: Vec<&MoveRequested> = cursor.read(messages).collect();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].ship, ship);
+        assert_eq!(all[0].target, target);
+        assert_ne!(all[0].command_id, CommandId::ZERO);
+
+        // Queue is now empty — command popped.
+        let q = app.world().get::<CommandQueue>(ship).unwrap();
+        assert!(q.commands.is_empty());
+    }
+
+    #[test]
+    fn dispatcher_rejects_move_to_for_immobile_ship() {
+        let mut app = make_app();
+        let target = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
+        let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
+        // Immobile: 0 sublight, 0 ftl_range.
+        let ship = spawn_test_ship(
+            app.world_mut(),
+            [0.0, 0.0, 0.0],
+            Some(origin),
+            0.0,
+            0.0,
+        );
+        {
+            let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+            q.commands.push(QueuedCommand::MoveTo { system: target });
+        }
+        app.update();
+
+        // No message, queue cleared.
+        let messages = app.world().resource::<Messages<MoveRequested>>();
+        let mut cursor = messages.get_cursor();
+        assert_eq!(cursor.read(messages).count(), 0);
+        let q = app.world().get::<CommandQueue>(ship).unwrap();
+        assert!(q.commands.is_empty());
+    }
+
+    #[test]
+    fn dispatcher_drops_already_at_target() {
+        let mut app = make_app();
+        let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
+        let ship =
+            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        {
+            let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+            q.commands.push(QueuedCommand::MoveTo { system: origin });
+        }
+        app.update();
+
+        // Already at target → queue cleared, no message.
+        let messages = app.world().resource::<Messages<MoveRequested>>();
+        let mut cursor = messages.get_cursor();
+        assert_eq!(cursor.read(messages).count(), 0);
+        let q = app.world().get::<CommandQueue>(ship).unwrap();
+        assert!(q.commands.is_empty());
+    }
+
+    #[test]
+    fn dispatcher_drops_nonexistent_target() {
+        let mut app = make_app();
+        let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
+        let phantom = Entity::from_raw_u32(9999).unwrap();
+        let ship =
+            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        {
+            let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+            q.commands.push(QueuedCommand::MoveTo { system: phantom });
+        }
+        app.update();
+
+        let messages = app.world().resource::<Messages<MoveRequested>>();
+        let mut cursor = messages.get_cursor();
+        assert_eq!(cursor.read(messages).count(), 0);
+        let q = app.world().get::<CommandQueue>(ship).unwrap();
+        assert!(q.commands.is_empty());
+    }
+
+    #[test]
+    fn dispatches_move_to_coordinates_and_pops() {
+        let mut app = make_app();
+        let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
+        let ship =
+            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        {
+            let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+            q.commands
+                .push(QueuedCommand::MoveToCoordinates { target: [3.0, 4.0, 0.0] });
+        }
+        app.update();
+
+        let messages = app
+            .world()
+            .resource::<Messages<MoveToCoordinatesRequested>>();
+        let mut cursor = messages.get_cursor();
+        let all: Vec<&MoveToCoordinatesRequested> = cursor.read(messages).collect();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].target, [3.0, 4.0, 0.0]);
+        let q = app.world().get::<CommandQueue>(ship).unwrap();
+        assert!(q.commands.is_empty());
+    }
+
+    #[test]
+    fn dispatcher_leaves_non_migrated_variants_untouched() {
+        let mut app = make_app();
+        let target = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
+        let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
+        let ship =
+            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        {
+            let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
+            q.commands.push(QueuedCommand::Survey { system: target });
+            q.commands
+                .push(QueuedCommand::TransferToStructure {
+                    structure: target,
+                    minerals: Amt(0),
+                    energy: Amt(0),
+                });
+        }
+        app.update();
+
+        // No MoveRequested emitted, queue head is still Survey.
+        let messages = app.world().resource::<Messages<MoveRequested>>();
+        let mut cursor = messages.get_cursor();
+        assert_eq!(cursor.read(messages).count(), 0);
+        let q = app.world().get::<CommandQueue>(ship).unwrap();
+        assert_eq!(q.commands.len(), 2);
+        assert!(matches!(q.commands[0], QueuedCommand::Survey { .. }));
+    }
+
+    #[test]
+    fn dispatcher_fifo_across_multiple_ships() {
+        // Plan §6: verify per-ship FIFO + cross-ship emit order.
+        let mut app = make_app();
+        let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
+        let t1 = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
+        let t2 = spawn_test_system(app.world_mut(), [6.0, 0.0, 0.0]);
+        let ship_a =
+            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        let ship_b =
+            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        {
+            let mut q = app.world_mut().get_mut::<CommandQueue>(ship_a).unwrap();
+            q.commands.push(QueuedCommand::MoveTo { system: t1 });
+        }
+        {
+            let mut q = app.world_mut().get_mut::<CommandQueue>(ship_b).unwrap();
+            q.commands.push(QueuedCommand::MoveTo { system: t2 });
+        }
+        app.update();
+
+        let messages = app.world().resource::<Messages<MoveRequested>>();
+        let mut cursor = messages.get_cursor();
+        let all: Vec<&MoveRequested> = cursor.read(messages).collect();
+        assert_eq!(all.len(), 2);
+        // Command ids must be strictly monotonic.
+        assert!(all[0].command_id < all[1].command_id);
+    }
+}

--- a/macrocosmo/src/ship/dispatcher.rs
+++ b/macrocosmo/src/ship/dispatcher.rs
@@ -25,8 +25,10 @@ use super::command_events::{
 };
 use super::routing::PendingRoute;
 use super::{CommandQueue, QueuedCommand, Ship, ShipState};
+use crate::communication::{CommandLog, CommandLogEntry};
 use crate::components::Position;
 use crate::galaxy::StarSystem;
+use crate::player::PlayerEmpire;
 use crate::time_system::GameClock;
 
 /// Lightweight dispatcher: validates + emits `CommandRequested` messages.
@@ -51,7 +53,13 @@ pub fn dispatch_queued_commands(
     // Typed message writers — one per Phase-1 request variant.
     mut move_req: MessageWriter<MoveRequested>,
     mut move_xy_req: MessageWriter<MoveToCoordinatesRequested>,
+    // #334 Phase 1: append a `Dispatched` entry to the player empire's
+    // CommandLog on each successful validation. The bridge system
+    // `bridge_command_executed_to_log` finalizes via `CommandId` match.
+    // Optional — observer-mode apps without a `PlayerEmpire` skip logging.
+    mut command_log_q: Query<&mut CommandLog, With<PlayerEmpire>>,
 ) {
+    let mut command_log = command_log_q.single_mut().ok();
     for (ship_entity, ship, state, ship_pos, mut queue) in ships.iter_mut() {
         // Only ships in a state that can accept a new command get dispatched.
         // The legacy code consumed queue items for ships that were Docked or
@@ -113,6 +121,13 @@ pub fn dispatch_queued_commands(
                     target,
                     issued_at: clock.elapsed,
                 });
+                if let Some(log) = command_log.as_mut() {
+                    log.entries.push(CommandLogEntry::new_dispatched(
+                        format!("{} → MoveTo {:?}", ship.name, target),
+                        clock.elapsed,
+                        command_id,
+                    ));
+                }
                 info!(
                     "dispatch: ship {} MoveRequested -> {:?} (cmd {})",
                     ship.name, target, command_id.0
@@ -139,6 +154,16 @@ pub fn dispatch_queued_commands(
                     target: target_arr,
                     issued_at: clock.elapsed,
                 });
+                if let Some(log) = command_log.as_mut() {
+                    log.entries.push(CommandLogEntry::new_dispatched(
+                        format!(
+                            "{} → MoveToCoordinates ({:.2},{:.2},{:.2})",
+                            ship.name, target_arr[0], target_arr[1], target_arr[2]
+                        ),
+                        clock.elapsed,
+                        command_id,
+                    ));
+                }
                 info!(
                     "dispatch: ship {} MoveToCoordinatesRequested -> ({:.2},{:.2},{:.2}) (cmd {})",
                     ship.name,

--- a/macrocosmo/src/ship/dispatcher.rs
+++ b/macrocosmo/src/ship/dispatcher.rs
@@ -20,9 +20,7 @@
 
 use bevy::prelude::*;
 
-use super::command_events::{
-    CommandId, MoveRequested, MoveToCoordinatesRequested, NextCommandId,
-};
+use super::command_events::{CommandId, MoveRequested, MoveToCoordinatesRequested, NextCommandId};
 use super::routing::PendingRoute;
 use super::{CommandQueue, QueuedCommand, Ship, ShipState};
 use crate::communication::{CommandLog, CommandLogEntry};
@@ -166,11 +164,7 @@ pub fn dispatch_queued_commands(
                 }
                 info!(
                     "dispatch: ship {} MoveToCoordinatesRequested -> ({:.2},{:.2},{:.2}) (cmd {})",
-                    ship.name,
-                    target_arr[0],
-                    target_arr[1],
-                    target_arr[2],
-                    command_id.0
+                    ship.name, target_arr[0], target_arr[1], target_arr[2], command_id.0
                 );
             }
             // Non-migrated variants: leave the head untouched so the legacy
@@ -279,13 +273,7 @@ mod tests {
         let mut app = make_app();
         let target = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
         let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
-        let ship = spawn_test_ship(
-            app.world_mut(),
-            [0.0, 0.0, 0.0],
-            Some(origin),
-            0.5,
-            10.0,
-        );
+        let ship = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
         {
             let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
             q.commands.push(QueuedCommand::MoveTo { system: target });
@@ -312,13 +300,7 @@ mod tests {
         let target = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
         let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
         // Immobile: 0 sublight, 0 ftl_range.
-        let ship = spawn_test_ship(
-            app.world_mut(),
-            [0.0, 0.0, 0.0],
-            Some(origin),
-            0.0,
-            0.0,
-        );
+        let ship = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.0, 0.0);
         {
             let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
             q.commands.push(QueuedCommand::MoveTo { system: target });
@@ -337,8 +319,7 @@ mod tests {
     fn dispatcher_drops_already_at_target() {
         let mut app = make_app();
         let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
-        let ship =
-            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        let ship = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
         {
             let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
             q.commands.push(QueuedCommand::MoveTo { system: origin });
@@ -358,8 +339,7 @@ mod tests {
         let mut app = make_app();
         let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
         let phantom = Entity::from_raw_u32(9999).unwrap();
-        let ship =
-            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        let ship = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
         {
             let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
             q.commands.push(QueuedCommand::MoveTo { system: phantom });
@@ -377,12 +357,12 @@ mod tests {
     fn dispatches_move_to_coordinates_and_pops() {
         let mut app = make_app();
         let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
-        let ship =
-            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        let ship = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
         {
             let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
-            q.commands
-                .push(QueuedCommand::MoveToCoordinates { target: [3.0, 4.0, 0.0] });
+            q.commands.push(QueuedCommand::MoveToCoordinates {
+                target: [3.0, 4.0, 0.0],
+            });
         }
         app.update();
 
@@ -402,17 +382,15 @@ mod tests {
         let mut app = make_app();
         let target = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
         let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
-        let ship =
-            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        let ship = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
         {
             let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
             q.commands.push(QueuedCommand::Survey { system: target });
-            q.commands
-                .push(QueuedCommand::TransferToStructure {
-                    structure: target,
-                    minerals: Amt(0),
-                    energy: Amt(0),
-                });
+            q.commands.push(QueuedCommand::TransferToStructure {
+                structure: target,
+                minerals: Amt(0),
+                energy: Amt(0),
+            });
         }
         app.update();
 
@@ -432,10 +410,8 @@ mod tests {
         let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
         let t1 = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
         let t2 = spawn_test_system(app.world_mut(), [6.0, 0.0, 0.0]);
-        let ship_a =
-            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
-        let ship_b =
-            spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        let ship_a = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
+        let ship_b = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
         {
             let mut q = app.world_mut().get_mut::<CommandQueue>(ship_a).unwrap();
             q.commands.push(QueuedCommand::MoveTo { system: t1 });

--- a/macrocosmo/src/ship/handlers/mod.rs
+++ b/macrocosmo/src/ship/handlers/mod.rs
@@ -1,0 +1,14 @@
+//! #334 Phase 1: per-variant command handlers.
+//!
+//! Each handler reads a single typed [`MessageReader<XRequested>`](bevy::prelude::MessageReader)
+//! and holds only the queries / resources it needs. Together with
+//! `super::dispatcher::dispatch_queued_commands`, this replaces the fat
+//! `process_command_queue` + `process_deliverable_commands` loops with a
+//! narrow dispatcher and focused handlers.
+//!
+//! Phase 1 scope: `handle_move_requested` + `handle_move_to_coordinates_requested`.
+//! Phases 2/3/4 migrate the remaining variants into this module.
+
+pub mod move_handler;
+
+pub use move_handler::{handle_move_requested, handle_move_to_coordinates_requested};

--- a/macrocosmo/src/ship/handlers/move_handler.rs
+++ b/macrocosmo/src/ship/handlers/move_handler.rs
@@ -1,0 +1,318 @@
+//! #334 Phase 1: MoveTo / MoveToCoordinates handler systems.
+//!
+//! `handle_move_requested` consumes `MoveRequested` messages and executes
+//! the same FTL-chain routing logic as the legacy `process_command_queue`
+//! MoveTo arm (see `docs/plan-334-command-dispatch-event-driven.md` §2.3).
+//! The async route task is spawned via [`routing::spawn_route_task_full`];
+//! `poll_pending_routes` finalizes the terminal `CommandExecuted` when the
+//! route resolves.
+//!
+//! `handle_move_to_coordinates_requested` consumes `MoveToCoordinatesRequested`
+//! and runs a synchronous sublight-to-deep-space move, emitting a terminal
+//! `CommandExecuted` immediately on success/failure.
+
+use bevy::prelude::*;
+
+use crate::components::Position;
+use crate::galaxy::StarSystem;
+use crate::ship_design::ShipDesignRegistry;
+use crate::time_system::GameClock;
+
+use crate::ship::command_events::{
+    CommandExecuted, CommandKind, CommandResult,
+    MoveRequested, MoveToCoordinatesRequested,
+};
+use crate::ship::movement::{start_sublight_travel_with_bonus, PortParams};
+use crate::ship::routing;
+use crate::ship::{CommandQueue, RulesOfEngagement, Ship, ShipState};
+
+/// Handles `MoveRequested`. Runs **before** the legacy `process_command_queue`
+/// (see `ShipPlugin` schedule) so that spawning `PendingRoute` correctly
+/// excludes the ship from the legacy system's `Without<PendingRoute>`
+/// filter for this tick.
+///
+/// On success (async route spawned): emits nothing — `poll_pending_routes`
+/// will emit the terminal `CommandExecuted { result: Ok/Rejected }` when
+/// the route resolves. (Plan §3.3 `Deferred` semantics are carried
+/// implicitly by the presence of `PendingRoute`.)
+///
+/// On sync failure (e.g. target despawned between dispatcher and handler,
+/// or Loitering sublight-fallback fails): emits `CommandExecuted` with
+/// `CommandResult::Rejected`.
+#[allow(clippy::too_many_arguments)]
+pub fn handle_move_requested(
+    mut commands: Commands,
+    clock: Res<GameClock>,
+    mut reqs: MessageReader<MoveRequested>,
+    empire_params_q: Query<&crate::technology::GlobalParams, With<crate::player::PlayerEmpire>>,
+    balance: Res<crate::technology::GameBalance>,
+    empire_knowledge_q: Query<&crate::knowledge::KnowledgeStore, With<crate::player::PlayerEmpire>>,
+    // Same shape as the legacy `process_command_queue` ship query, minus
+    // `&mut CommandQueue` (we don't touch the queue from the handler — the
+    // dispatcher already popped the MoveTo).
+    mut ships: Query<
+        (&Ship, &mut ShipState, &Position, Option<&RulesOfEngagement>),
+        Without<routing::PendingRoute>,
+    >,
+    systems: Query<(Entity, &StarSystem, &Position), Without<Ship>>,
+    system_buildings: Query<&crate::colony::SystemBuildings>,
+    hostiles_q: Query<
+        (&crate::galaxy::AtSystem, &crate::faction::FactionOwner),
+        With<crate::galaxy::Hostile>,
+    >,
+    relations: Res<crate::faction::FactionRelations>,
+    mut pending_count: ResMut<routing::RouteCalculationsPending>,
+    design_registry: Res<ShipDesignRegistry>,
+    building_registry: Res<crate::colony::BuildingRegistry>,
+    regions: Query<&crate::galaxy::ForbiddenRegion>,
+    mut executed: MessageWriter<CommandExecuted>,
+) {
+    // Early exit when no MoveRequested messages this tick.
+    let Some(global_params) = empire_params_q.single().ok() else {
+        // No empire → drain without action (avoids eating messages) but
+        // also don't emit terminals since there's nobody to hear them.
+        for _ in reqs.read() {}
+        return;
+    };
+    let _ = &design_registry; // kept for symmetry with legacy; future uses
+    let base_ftl_speed = balance.initial_ftl_speed_c();
+    let ftl_blockers = routing::collect_ftl_blockers(&regions);
+    let empire_knowledge = empire_knowledge_q.single().ok();
+    let hostile_faction_map: std::collections::HashMap<Entity, Entity> = hostiles_q
+        .iter()
+        .map(|(at_system, owner)| (at_system.0, owner.0))
+        .collect();
+
+    for req in reqs.read() {
+        let ship_entity = req.ship;
+        let target = req.target;
+
+        let Ok((ship, mut state, ship_pos, roe)) = ships.get_mut(ship_entity) else {
+            // Ship despawned or already has PendingRoute (another
+            // dispatcher tick raced us). Reject.
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Move,
+                ship: ship_entity,
+                result: CommandResult::Rejected {
+                    reason: "ship unavailable for move".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+        let roe = roe.copied().unwrap_or_default();
+
+        // The dispatcher already validated that the target exists; re-check
+        // here to guard against a same-tick despawn race (plan §3.2).
+        let Ok((_, _target_star, target_pos)) = systems.get(target) else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Move,
+                ship: ship_entity,
+                result: CommandResult::Rejected {
+                    reason: "target system despawned".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        // Determine whether the ship is Docked or Loitering; other states
+        // should never arrive here (dispatcher guards them) but we reject
+        // gracefully if so.
+        let docked_system: Option<Entity> = match *state {
+            ShipState::Docked { system } => Some(system),
+            ShipState::Loitering { .. } => None,
+            _ => {
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::Move,
+                    ship: ship_entity,
+                    result: CommandResult::Rejected {
+                        reason: "ship not idle".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
+                continue;
+            }
+        };
+
+        // Loitering ship: direct sublight, no FTL route planner.
+        if docked_system.is_none() {
+            match start_sublight_travel_with_bonus(
+                &mut state,
+                ship_pos,
+                ship,
+                Position::from(target_pos.as_array()),
+                Some(target),
+                clock.elapsed,
+                global_params.sublight_speed_bonus,
+            ) {
+                Ok(()) => {
+                    info!(
+                        "handle_move: Loitering ship {} sublight to target (cmd {})",
+                        ship.name, req.command_id.0
+                    );
+                    executed.write(CommandExecuted {
+                        command_id: req.command_id,
+                        kind: CommandKind::Move,
+                        ship: ship_entity,
+                        result: CommandResult::Ok,
+                        completed_at: clock.elapsed,
+                    });
+                }
+                Err(e) => {
+                    warn!(
+                        "handle_move: Loitering ship {} cannot sublight to target: {}",
+                        ship.name, e
+                    );
+                    executed.write(CommandExecuted {
+                        command_id: req.command_id,
+                        kind: CommandKind::Move,
+                        ship: ship_entity,
+                        result: CommandResult::Rejected {
+                            reason: format!("sublight start failed: {}", e),
+                        },
+                        completed_at: clock.elapsed,
+                    });
+                }
+            }
+            continue;
+        }
+
+        // Docked: spawn async route planner (FTL chain / hybrid / sublight).
+        let docked_sys = docked_system.expect("docked branch");
+        let Ok((_, _, origin_pos)) = systems.get(docked_sys) else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Move,
+                ship: ship_entity,
+                result: CommandResult::Rejected {
+                    reason: "origin system lost".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+        let origin_pos_arr = origin_pos.as_array();
+        let port_params = system_buildings
+            .get(docked_sys)
+            .map(|sb| PortParams::from_system_buildings(sb, &building_registry))
+            .unwrap_or(PortParams::NONE);
+        let effective_ftl_range = if ship.ftl_range > 0.0 {
+            ship.ftl_range + global_params.ftl_range_bonus + port_params.ftl_range_bonus
+        } else {
+            0.0
+        };
+        let effective_ftl_speed = base_ftl_speed * global_params.ftl_speed_multiplier;
+        let effective_sublight_speed = ship.sublight_speed + global_params.sublight_speed_bonus;
+
+        let ship_faction = match ship.owner {
+            crate::ship::Owner::Empire(f) => Some(f),
+            crate::ship::Owner::Neutral => None,
+        };
+        let snapshots = routing::collect_route_snapshots(
+            &systems,
+            empire_knowledge,
+            &relations,
+            ship_faction,
+            &hostile_faction_map,
+        );
+        let task = routing::spawn_route_task_full(
+            origin_pos_arr,
+            target,
+            effective_ftl_range,
+            effective_sublight_speed,
+            effective_ftl_speed,
+            snapshots,
+            roe,
+            ftl_blockers.clone(),
+        );
+        commands.entity(ship_entity).insert(routing::PendingRoute {
+            task,
+            target_system: target,
+            command_id: Some(req.command_id),
+        });
+        pending_count.count += 1;
+        info!(
+            "handle_move: ship {} spawned async route to target (cmd {})",
+            ship.name, req.command_id.0
+        );
+        // Terminal `CommandExecuted` (Ok or Rejected) is emitted later by
+        // `poll_pending_routes` once the async task resolves.
+    }
+}
+
+/// Handles `MoveToCoordinatesRequested` — synchronous sublight to a deep-space coord.
+#[allow(clippy::too_many_arguments)]
+pub fn handle_move_to_coordinates_requested(
+    clock: Res<GameClock>,
+    mut reqs: MessageReader<MoveToCoordinatesRequested>,
+    empire_params_q: Query<&crate::technology::GlobalParams, With<crate::player::PlayerEmpire>>,
+    mut ships: Query<
+        (&Ship, &mut ShipState, &Position, &mut CommandQueue),
+        Without<routing::PendingRoute>,
+    >,
+    mut executed: MessageWriter<CommandExecuted>,
+) {
+    let Ok(global_params) = empire_params_q.single() else {
+        for _ in reqs.read() {}
+        return;
+    };
+
+    for req in reqs.read() {
+        let Ok((ship, mut state, ship_pos, mut queue)) = ships.get_mut(req.ship) else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::MoveToCoordinates,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "ship unavailable".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        match start_sublight_travel_with_bonus(
+            &mut state,
+            ship_pos,
+            ship,
+            Position::from(req.target),
+            None,
+            clock.elapsed,
+            global_params.sublight_speed_bonus,
+        ) {
+            Ok(()) => {
+                queue.sync_prediction(req.target, None);
+                info!(
+                    "handle_move_xy: ship {} sublight to ({:.2},{:.2},{:.2}) (cmd {})",
+                    ship.name, req.target[0], req.target[1], req.target[2], req.command_id.0,
+                );
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::MoveToCoordinates,
+                    ship: req.ship,
+                    result: CommandResult::Ok,
+                    completed_at: clock.elapsed,
+                });
+            }
+            Err(e) => {
+                warn!(
+                    "handle_move_xy: ship {} cannot MoveToCoordinates: {}",
+                    ship.name, e
+                );
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::MoveToCoordinates,
+                    ship: req.ship,
+                    result: CommandResult::Rejected {
+                        reason: format!("sublight start failed: {}", e),
+                    },
+                    completed_at: clock.elapsed,
+                });
+            }
+        }
+    }
+}

--- a/macrocosmo/src/ship/handlers/move_handler.rs
+++ b/macrocosmo/src/ship/handlers/move_handler.rs
@@ -19,10 +19,9 @@ use crate::ship_design::ShipDesignRegistry;
 use crate::time_system::GameClock;
 
 use crate::ship::command_events::{
-    CommandExecuted, CommandKind, CommandResult,
-    MoveRequested, MoveToCoordinatesRequested,
+    CommandExecuted, CommandKind, CommandResult, MoveRequested, MoveToCoordinatesRequested,
 };
-use crate::ship::movement::{start_sublight_travel_with_bonus, PortParams};
+use crate::ship::movement::{PortParams, start_sublight_travel_with_bonus};
 use crate::ship::routing;
 use crate::ship::{CommandQueue, RulesOfEngagement, Ship, ShipState};
 

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -17,6 +17,8 @@ pub mod core_deliverable;
 pub mod command_events;
 // #334 Phase 1: queue dispatcher — validates + emits CommandRequested messages.
 pub mod dispatcher;
+// #334 Phase 1: per-variant handlers (MoveTo + MoveToCoordinates this phase).
+pub mod handlers;
 
 pub use fleet::*;
 pub use exploration::*;
@@ -254,6 +256,28 @@ impl Plugin for ShipPlugin {
                 .after(process_command_queue),
         ).after(crate::time_system::advance_game_time)
          .before(crate::colony::advance_production_tick));
+        // #334 Phase 1: dispatcher + MoveTo/MoveToCoordinates handlers.
+        // Kept in their own `add_systems` call (instead of joining the
+        // main Ship tuple above) to stay under Bevy 0.18's 20-arm
+        // `IntoScheduleConfigs` limit without resorting to a nested tuple
+        // (which for this schedule was observed to elide the systems
+        // from the scheduler entirely).
+        app.add_systems(
+            Update,
+            (
+                dispatcher::dispatch_queued_commands,
+                handlers::handle_move_requested,
+                handlers::handle_move_to_coordinates_requested,
+            )
+                .chain()
+                .after(deliverable_ops::process_deliverable_commands)
+                .after(sublight_movement_system)
+                .after(process_ftl_travel)
+                .after(process_surveys)
+                .before(process_command_queue)
+                .after(crate::time_system::advance_game_time)
+                .before(crate::colony::advance_production_tick),
+        );
         // #128: Poll route tasks after Commands from process_command_queue are flushed.
         app.add_systems(Update, (
             bevy::ecs::schedule::ApplyDeferred,

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -13,6 +13,8 @@ pub mod pursuit;
 pub mod deliverable_ops;
 pub mod scout;
 pub mod core_deliverable;
+// #334 Phase 1: event-driven command dispatch — message types and allocator.
+pub mod command_events;
 
 pub use fleet::*;
 pub use exploration::*;
@@ -175,6 +177,9 @@ impl Plugin for ShipPlugin {
         app.init_resource::<routing::RouteCalculationsPending>();
         // #296 (S-3): Per-tick queue for Infrastructure Core deploy tickets.
         app.init_resource::<core_deliverable::PendingCoreDeploys>();
+        // #334 Phase 1: register command-dispatch message types + allocator
+        // before any dispatcher/handler system that references them.
+        app.add_plugins(command_events::CommandEventsPlugin);
         app.add_systems(Update, (
             sync_ship_module_modifiers,
             sync_ship_hitpoints.after(sync_ship_module_modifiers),

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -19,6 +19,8 @@ pub mod command_events;
 pub mod dispatcher;
 // #334 Phase 1: per-variant handlers (MoveTo + MoveToCoordinates this phase).
 pub mod handlers;
+// #334 Phase 1: CommandExecuted → CommandLog / gamestate bridge systems.
+pub mod bridges;
 
 pub use fleet::*;
 pub use exploration::*;
@@ -275,6 +277,19 @@ impl Plugin for ShipPlugin {
                 .after(process_ftl_travel)
                 .after(process_surveys)
                 .before(process_command_queue)
+                .after(crate::time_system::advance_game_time)
+                .before(crate::colony::advance_production_tick),
+        );
+        // #334 Phase 1: CommandExecuted → CommandLog bridge. Runs after the
+        // route poller (which emits terminal CommandExecuted for deferred
+        // MoveTo) and after process_command_queue so synchronous handler
+        // emissions are visible in the same frame.
+        app.add_systems(
+            Update,
+            bridges::bridge_command_executed_to_log
+                .after(routing::poll_pending_routes)
+                .after(handlers::handle_move_requested)
+                .after(handlers::handle_move_to_coordinates_requested)
                 .after(crate::time_system::advance_game_time)
                 .before(crate::colony::advance_production_tick),
         );

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -1,18 +1,18 @@
-pub mod routing;
-pub mod fleet;
+pub mod combat;
+pub mod command;
+pub mod core_deliverable;
+pub mod courier_route;
+pub mod deliverable_ops;
 pub mod exploration;
+pub mod fleet;
 pub mod hitpoints;
 pub mod modifiers;
+pub mod movement;
+pub mod pursuit;
+pub mod routing;
+pub mod scout;
 pub mod settlement;
 pub mod survey;
-pub mod combat;
-pub mod movement;
-pub mod command;
-pub mod courier_route;
-pub mod pursuit;
-pub mod deliverable_ops;
-pub mod scout;
-pub mod core_deliverable;
 // #334 Phase 1: event-driven command dispatch — message types and allocator.
 pub mod command_events;
 // #334 Phase 1: queue dispatcher — validates + emits CommandRequested messages.
@@ -22,18 +22,21 @@ pub mod handlers;
 // #334 Phase 1: CommandExecuted → CommandLog / gamestate bridge systems.
 pub mod bridges;
 
-pub use fleet::*;
+pub use combat::*;
+pub use command::*;
+pub use core_deliverable::{
+    CoreDeployTicket, CoreShip, PendingCoreDeploys, resolve_core_deploys,
+    spawn_core_ship_from_deliverable,
+};
+pub use courier_route::*;
 pub use exploration::*;
+pub use fleet::*;
 pub use hitpoints::*;
 pub use modifiers::*;
+pub use movement::*;
+pub use pursuit::*;
 pub use settlement::*;
 pub use survey::*;
-pub use combat::*;
-pub use movement::*;
-pub use command::*;
-pub use courier_route::*;
-pub use pursuit::*;
-pub use core_deliverable::{CoreShip, PendingCoreDeploys, CoreDeployTicket, resolve_core_deploys, spawn_core_ship_from_deliverable};
 
 use bevy::prelude::*;
 
@@ -55,7 +58,11 @@ pub struct CommandQueue {
 
 impl CommandQueue {
     /// Push a command and update predicted position
-    pub fn push(&mut self, cmd: QueuedCommand, system_positions: &impl Fn(Entity) -> Option<[f64; 3]>) {
+    pub fn push(
+        &mut self,
+        cmd: QueuedCommand,
+        system_positions: &impl Fn(Entity) -> Option<[f64; 3]>,
+    ) {
         match &cmd {
             QueuedCommand::MoveTo { system }
             | QueuedCommand::Survey { system }
@@ -87,8 +94,8 @@ impl CommandQueue {
                 self.predicted_system = None;
             }
             // #223: In-place resource actions — no predicted movement change.
-            QueuedCommand::TransferToStructure { .. }
-            | QueuedCommand::LoadFromScrapyard { .. } => {}
+            QueuedCommand::TransferToStructure { .. } | QueuedCommand::LoadFromScrapyard { .. } => {
+            }
         }
         self.commands.push(cmd);
     }
@@ -123,11 +130,20 @@ pub enum ReportMode {
 
 #[derive(Clone, Debug)]
 pub enum QueuedCommand {
-    MoveTo { system: Entity },
-    Survey { system: Entity },
-    Colonize { system: Entity, planet: Option<Entity> },
+    MoveTo {
+        system: Entity,
+    },
+    Survey {
+        system: Entity,
+    },
+    Colonize {
+        system: Entity,
+        planet: Option<Entity>,
+    },
     /// #185: Travel sublight to an arbitrary point in deep space and loiter there.
-    MoveToCoordinates { target: [f64; 3] },
+    MoveToCoordinates {
+        target: [f64; 3],
+    },
     /// #217: Dispatch the ship to `target_system`, observe the area within
     /// the scout's sensor range for `observation_duration` hexadies, then
     /// report back via `report_mode`. The ship MUST have a scout module
@@ -170,7 +186,9 @@ pub enum QueuedCommand {
     },
     /// #223: Drain a co-located `Scrapyard`'s remaining resources into the
     /// ship's Cargo (clamped by cargo capacity).
-    LoadFromScrapyard { structure: Entity },
+    LoadFromScrapyard {
+        structure: Entity,
+    },
 }
 
 /// Initial FTL speed as a multiple of light speed
@@ -186,78 +204,82 @@ impl Plugin for ShipPlugin {
         // #334 Phase 1: register command-dispatch message types + allocator
         // before any dispatcher/handler system that references them.
         app.add_plugins(command_events::CommandEventsPlugin);
-        app.add_systems(Update, (
-            sync_ship_module_modifiers,
-            sync_ship_hitpoints.after(sync_ship_module_modifiers),
-            tick_shield_regen,
-            sublight_movement_system,
-            process_ftl_travel,
-            deliver_survey_results.after(process_ftl_travel),
-            process_surveys,
-            process_settling,
-            process_refitting,
-            process_pending_ship_commands,
-            // #223: Deliverable ops run BEFORE the FTL router so any
-            // injected MoveTo/MoveToCoordinates is dispatched this tick.
-            deliverable_ops::process_deliverable_commands
-                .after(sublight_movement_system)
-                .after(process_ftl_travel)
-                .after(process_surveys),
-            // #296 (S-3): Resolve Core deploy tickets into actual CoreShip
-            // entities, grouping same-tick duplicates and tie-breaking via
-            // GameRng. Runs after the deliverable command processor (which
-            // enqueues tickets) and before the command queue, so newly
-            // spawned Cores are visible on the next frame.
-            core_deliverable::resolve_core_deploys
-                .after(deliverable_ops::process_deliverable_commands),
-            process_command_queue
-                .after(sublight_movement_system)
-                .after(process_ftl_travel)
-                .after(process_surveys)
-                .after(deliverable_ops::process_deliverable_commands),
-            resolve_combat,
-            tick_ship_repair,
-            // #117: Courier automation — runs before process_command_queue
-            // so that any MoveTo it queues this frame is dispatched in the
-            // same frame.
-            tick_courier_routes
-                .before(process_command_queue)
-                .after(sublight_movement_system)
-                .after(process_ftl_travel),
-            // #186 Phase 1: Aggressive ROE detection of hostile deep-space
-            // contacts. Runs after movement so ship positions are current.
-            pursuit::detect_hostiles_system
-                .after(sublight_movement_system)
-                .after(process_ftl_travel)
-                .after(process_command_queue),
-            // #217: Scout observation ticker — transitions a Scouting ship
-            // into Docked + attaches a ScoutReport when the timer expires.
-            // Runs after FTL/sublight movement so a ship that finished
-            // travel and transitioned into Scouting this tick doesn't
-            // double-process.
-            scout::tick_scout_observation
-                .after(process_ftl_travel)
-                .after(sublight_movement_system)
-                .after(process_command_queue),
-            // #217: Scout report delivery — writes to KnowledgeStore on
-            // FTL comm success, or auto-queues return home. Runs after the
-            // observation ticker so a ship that completed observation this
-            // frame can still have its report routed this frame.
-            scout::process_scout_report
-                .after(scout::tick_scout_observation)
-                .after(process_command_queue),
-            // #287 (γ-1): Reconcile FleetMembers against live Ship entities
-            // and despawn fleets that have lost their last member. Runs
-            // after every system that may despawn a ship this frame
-            // (combat, settlement, refit consumption, command processing)
-            // so the cleanup is visible next tick at the latest.
-            fleet::prune_empty_fleets
-                .after(resolve_combat)
-                .after(process_settling)
-                .after(process_refitting)
-                .after(process_command_queue),
-        ).after(crate::time_system::advance_game_time)
-         .before(crate::colony::advance_production_tick));
+        app.add_systems(
+            Update,
+            (
+                sync_ship_module_modifiers,
+                sync_ship_hitpoints.after(sync_ship_module_modifiers),
+                tick_shield_regen,
+                sublight_movement_system,
+                process_ftl_travel,
+                deliver_survey_results.after(process_ftl_travel),
+                process_surveys,
+                process_settling,
+                process_refitting,
+                process_pending_ship_commands,
+                // #223: Deliverable ops run BEFORE the FTL router so any
+                // injected MoveTo/MoveToCoordinates is dispatched this tick.
+                deliverable_ops::process_deliverable_commands
+                    .after(sublight_movement_system)
+                    .after(process_ftl_travel)
+                    .after(process_surveys),
+                // #296 (S-3): Resolve Core deploy tickets into actual CoreShip
+                // entities, grouping same-tick duplicates and tie-breaking via
+                // GameRng. Runs after the deliverable command processor (which
+                // enqueues tickets) and before the command queue, so newly
+                // spawned Cores are visible on the next frame.
+                core_deliverable::resolve_core_deploys
+                    .after(deliverable_ops::process_deliverable_commands),
+                process_command_queue
+                    .after(sublight_movement_system)
+                    .after(process_ftl_travel)
+                    .after(process_surveys)
+                    .after(deliverable_ops::process_deliverable_commands),
+                resolve_combat,
+                tick_ship_repair,
+                // #117: Courier automation — runs before process_command_queue
+                // so that any MoveTo it queues this frame is dispatched in the
+                // same frame.
+                tick_courier_routes
+                    .before(process_command_queue)
+                    .after(sublight_movement_system)
+                    .after(process_ftl_travel),
+                // #186 Phase 1: Aggressive ROE detection of hostile deep-space
+                // contacts. Runs after movement so ship positions are current.
+                pursuit::detect_hostiles_system
+                    .after(sublight_movement_system)
+                    .after(process_ftl_travel)
+                    .after(process_command_queue),
+                // #217: Scout observation ticker — transitions a Scouting ship
+                // into Docked + attaches a ScoutReport when the timer expires.
+                // Runs after FTL/sublight movement so a ship that finished
+                // travel and transitioned into Scouting this tick doesn't
+                // double-process.
+                scout::tick_scout_observation
+                    .after(process_ftl_travel)
+                    .after(sublight_movement_system)
+                    .after(process_command_queue),
+                // #217: Scout report delivery — writes to KnowledgeStore on
+                // FTL comm success, or auto-queues return home. Runs after the
+                // observation ticker so a ship that completed observation this
+                // frame can still have its report routed this frame.
+                scout::process_scout_report
+                    .after(scout::tick_scout_observation)
+                    .after(process_command_queue),
+                // #287 (γ-1): Reconcile FleetMembers against live Ship entities
+                // and despawn fleets that have lost their last member. Runs
+                // after every system that may despawn a ship this frame
+                // (combat, settlement, refit consumption, command processing)
+                // so the cleanup is visible next tick at the latest.
+                fleet::prune_empty_fleets
+                    .after(resolve_combat)
+                    .after(process_settling)
+                    .after(process_refitting)
+                    .after(process_command_queue),
+            )
+                .after(crate::time_system::advance_game_time)
+                .before(crate::colony::advance_production_tick),
+        );
         // #334 Phase 1: dispatcher + MoveTo/MoveToCoordinates handlers.
         // Kept in their own `add_systems` call (instead of joining the
         // main Ship tuple above) to stay under Bevy 0.18's 20-arm
@@ -294,13 +316,17 @@ impl Plugin for ShipPlugin {
                 .before(crate::colony::advance_production_tick),
         );
         // #128: Poll route tasks after Commands from process_command_queue are flushed.
-        app.add_systems(Update, (
-            bevy::ecs::schedule::ApplyDeferred,
-            routing::poll_pending_routes,
-        ).chain()
-         .after(process_command_queue)
-         .after(crate::time_system::advance_game_time)
-         .before(crate::colony::advance_production_tick));
+        app.add_systems(
+            Update,
+            (
+                bevy::ecs::schedule::ApplyDeferred,
+                routing::poll_pending_routes,
+            )
+                .chain()
+                .after(process_command_queue)
+                .after(crate::time_system::advance_game_time)
+                .before(crate::colony::advance_production_tick),
+        );
     }
 }
 
@@ -347,10 +373,16 @@ pub struct PendingShipCommand {
 /// The kinds of commands that can be issued to a ship.
 #[derive(Clone, Debug)]
 pub enum ShipCommand {
-    MoveTo { destination: Entity },
-    Survey { target: Entity },
+    MoveTo {
+        destination: Entity,
+    },
+    Survey {
+        target: Entity,
+    },
     Colonize,
-    SetROE { roe: RulesOfEngagement },
+    SetROE {
+        roe: RulesOfEngagement,
+    },
     /// Enqueue a command into the ship's CommandQueue (for in-transit ships).
     EnqueueCommand(QueuedCommand),
 }
@@ -466,7 +498,9 @@ impl Ship {
 
 #[derive(Component)]
 pub enum ShipState {
-    Docked { system: Entity },
+    Docked {
+        system: Entity,
+    },
     SubLight {
         origin: [f64; 3],
         destination: [f64; 3],
@@ -578,12 +612,7 @@ impl Cargo {
     /// Check if the cargo can accept another item with `cargo_size` against
     /// the ship's effective capacity `cap`. Uses the same mass accounting as
     /// `total_mass_with`.
-    pub fn can_accept_item_size(
-        &self,
-        added_size: u32,
-        cap: Amt,
-        mass_per_slot_raw: u64,
-    ) -> bool {
+    pub fn can_accept_item_size(&self, added_size: u32, cap: Amt, mass_per_slot_raw: u64) -> bool {
         // Without a registry lookup we can't compute item mass for existing
         // items, so callers must provide it via `total_mass_with` externally.
         // This helper only checks the additive delta; callers sum the existing
@@ -634,14 +663,19 @@ pub fn spawn_ship(
 ) -> Entity {
     let design = design_registry.get(design_id);
     let hull_hp = design.map(|d| d.hp).unwrap_or(50.0);
-    let hull_id = design.map(|d| d.hull_id.as_str()).unwrap_or("corvette").to_string();
+    let hull_id = design
+        .map(|d| d.hull_id.as_str())
+        .unwrap_or("corvette")
+        .to_string();
     let sublight_speed = design.map(|d| d.sublight_speed).unwrap_or(0.75);
     let ftl_range = design.map(|d| d.ftl_range).unwrap_or(10.0);
     // #123: Newly built ships are spawned in sync with the current design revision.
     let design_revision = design.map(|d| d.revision).unwrap_or(0);
     // Equip ships from the design's slot assignments so they start out matching
     // the design exactly (no spurious "needs refit" right after construction).
-    let modules = design.map(crate::ship_design::design_equipped_modules).unwrap_or_default();
+    let modules = design
+        .map(crate::ship_design::design_equipped_modules)
+        .unwrap_or_default();
     // #287 (γ-1): Reserve both entity ids up front so Ship <-> Fleet
     // can be wired in a single Commands batch (no follow-up backref
     // system needed). Every `spawn_ship` call produces a matching
@@ -705,8 +739,8 @@ pub fn spawn_ship(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::ecs::world::World;
     use crate::ship_design::{ShipDesignDefinition, ShipDesignRegistry};
+    use bevy::ecs::world::World;
 
     // --- #223: Cargo item mass accounting ---
 
@@ -716,8 +750,12 @@ mod tests {
             minerals: Amt::units(50),
             energy: Amt::units(30),
             items: vec![
-                CargoItem::Deliverable { definition_id: "sensor_buoy".into() },
-                CargoItem::Deliverable { definition_id: "interdictor".into() },
+                CargoItem::Deliverable {
+                    definition_id: "sensor_buoy".into(),
+                },
+                CargoItem::Deliverable {
+                    definition_id: "interdictor".into(),
+                },
             ],
         };
         // sensor_buoy size=1, interdictor size=3 → 4 slots total.
@@ -739,7 +777,9 @@ mod tests {
         let cargo = Cargo {
             minerals: Amt::ZERO,
             energy: Amt::ZERO,
-            items: vec![CargoItem::Deliverable { definition_id: "big".into() }],
+            items: vec![CargoItem::Deliverable {
+                definition_id: "big".into(),
+            }],
         };
         let lookup = |id: &str| -> Option<u32> {
             match id {
@@ -874,8 +914,16 @@ mod tests {
         let mut ship = make_ship("colony_ship_mk1");
         ship.sublight_speed = 0.0;
         ship.ftl_range = 0.0;
-        let origin = Position { x: 0.0, y: 0.0, z: 0.0 };
-        let dest = Position { x: 1.0, y: 0.0, z: 0.0 };
+        let origin = Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let dest = Position {
+            x: 1.0,
+            y: 0.0,
+            z: 0.0,
+        };
         let mut state = ShipState::Docked { system };
         let result = start_sublight_travel(&mut state, &origin, &ship, dest, Some(system), 0);
         assert_eq!(result, Err("ship is immobile"));
@@ -888,13 +936,25 @@ mod tests {
         let mut world = World::new();
         let system = world.spawn_empty().id();
         let ship = make_ship("colony_ship_mk1"); // 0.5c
-        let origin = Position { x: 0.0, y: 0.0, z: 0.0 };
-        let dest = Position { x: 1.0, y: 0.0, z: 0.0 }; // 1 LY away
+        let origin = Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let dest = Position {
+            x: 1.0,
+            y: 0.0,
+            z: 0.0,
+        }; // 1 LY away
         let mut state = ShipState::Docked { system };
         start_sublight_travel(&mut state, &origin, &ship, dest, Some(system), 100)
             .expect("mobile ship should travel");
         match state {
-            ShipState::SubLight { arrival_at, departed_at, .. } => {
+            ShipState::SubLight {
+                arrival_at,
+                departed_at,
+                ..
+            } => {
                 assert_eq!(departed_at, 100);
                 assert_eq!(arrival_at, 220);
             }
@@ -912,8 +972,16 @@ mod tests {
         let mut ship = make_ship("courier_mk1");
         ship.ftl_range = 0.0;
         let mut state = ShipState::Docked { system: origin };
-        let origin_pos = Position { x: 0.0, y: 0.0, z: 0.0 };
-        let dest_pos = Position { x: 1.0, y: 0.0, z: 0.0 };
+        let origin_pos = Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let dest_pos = Position {
+            x: 1.0,
+            y: 0.0,
+            z: 0.0,
+        };
         let result = start_ftl_travel(&mut state, &ship, origin, dest, &origin_pos, &dest_pos, 0);
         assert_eq!(result, Err("Ship has no FTL capability"));
     }
@@ -925,8 +993,16 @@ mod tests {
         let dest = world.spawn_empty().id();
         let ship = make_ship("colony_ship_mk1");
         let mut state = ShipState::Docked { system: origin };
-        let origin_pos = Position { x: 0.0, y: 0.0, z: 0.0 };
-        let dest_pos = Position { x: 50.0, y: 0.0, z: 0.0 };
+        let origin_pos = Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let dest_pos = Position {
+            x: 50.0,
+            y: 0.0,
+            z: 0.0,
+        };
         let result = start_ftl_travel(&mut state, &ship, origin, dest, &origin_pos, &dest_pos, 0);
         assert_eq!(result, Err("Destination is beyond FTL range"));
     }
@@ -938,8 +1014,16 @@ mod tests {
         let dest = world.spawn_empty().id();
         let ship = make_ship("colony_ship_mk1");
         let mut state = ShipState::Docked { system: origin };
-        let origin_pos = Position { x: 0.0, y: 0.0, z: 0.0 };
-        let dest_pos = Position { x: 10.0, y: 0.0, z: 0.0 };
+        let origin_pos = Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let dest_pos = Position {
+            x: 10.0,
+            y: 0.0,
+            z: 0.0,
+        };
         let result = start_ftl_travel(&mut state, &ship, origin, dest, &origin_pos, &dest_pos, 0);
         assert!(result.is_ok());
         match state {
@@ -956,12 +1040,31 @@ mod tests {
         let origin = world.spawn_empty().id();
         let dest = world.spawn_empty().id();
         let ship = make_ship("colony_ship_mk1");
-        let origin_pos = Position { x: 0.0, y: 0.0, z: 0.0 };
-        let dest_pos = Position { x: 10.0, y: 0.0, z: 0.0 };
+        let origin_pos = Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let dest_pos = Position {
+            x: 10.0,
+            y: 0.0,
+            z: 0.0,
+        };
 
         // Without port
         let mut state_no_port = ShipState::Docked { system: origin };
-        let _ = start_ftl_travel_with_bonus(&mut state_no_port, &ship, origin, dest, &origin_pos, &dest_pos, 0, 0.0, 1.0, PortParams::NONE);
+        let _ = start_ftl_travel_with_bonus(
+            &mut state_no_port,
+            &ship,
+            origin,
+            dest,
+            &origin_pos,
+            &dest_pos,
+            0,
+            0.0,
+            1.0,
+            PortParams::NONE,
+        );
         let time_no_port = match state_no_port {
             ShipState::InFTL { arrival_at, .. } => arrival_at,
             _ => panic!("Expected InFTL state"),
@@ -969,15 +1072,33 @@ mod tests {
 
         // With port (using Lua-defined values)
         let mut state_port = ShipState::Docked { system: origin };
-        let port_params = PortParams { has_port: true, ftl_range_bonus: 10.0, travel_time_factor: 0.8 };
-        let _ = start_ftl_travel_with_bonus(&mut state_port, &ship, origin, dest, &origin_pos, &dest_pos, 0, 0.0, 1.0, port_params);
+        let port_params = PortParams {
+            has_port: true,
+            ftl_range_bonus: 10.0,
+            travel_time_factor: 0.8,
+        };
+        let _ = start_ftl_travel_with_bonus(
+            &mut state_port,
+            &ship,
+            origin,
+            dest,
+            &origin_pos,
+            &dest_pos,
+            0,
+            0.0,
+            1.0,
+            port_params,
+        );
         let time_port = match state_port {
             ShipState::InFTL { arrival_at, .. } => arrival_at,
             _ => panic!("Expected InFTL state"),
         };
 
         // Port should reduce travel time by 20%
-        assert!(time_port < time_no_port, "Port should reduce FTL travel time");
+        assert!(
+            time_port < time_no_port,
+            "Port should reduce FTL travel time"
+        );
         let expected = (time_no_port as f64 * 0.8).ceil() as i64;
         assert_eq!(time_port, expected);
     }
@@ -989,18 +1110,52 @@ mod tests {
         let dest = world.spawn_empty().id();
         let ship = make_ship("colony_ship_mk1"); // ftl_range = 15.0
 
-        let origin_pos = Position { x: 0.0, y: 0.0, z: 0.0 };
-        let dest_pos = Position { x: 20.0, y: 0.0, z: 0.0 }; // 20 ly, beyond base 15 ly range
+        let origin_pos = Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        };
+        let dest_pos = Position {
+            x: 20.0,
+            y: 0.0,
+            z: 0.0,
+        }; // 20 ly, beyond base 15 ly range
 
         // Without port: should fail
         let mut state = ShipState::Docked { system: origin };
-        let result = start_ftl_travel_with_bonus(&mut state, &ship, origin, dest, &origin_pos, &dest_pos, 0, 0.0, 1.0, PortParams::NONE);
+        let result = start_ftl_travel_with_bonus(
+            &mut state,
+            &ship,
+            origin,
+            dest,
+            &origin_pos,
+            &dest_pos,
+            0,
+            0.0,
+            1.0,
+            PortParams::NONE,
+        );
         assert_eq!(result, Err("Destination is beyond FTL range"));
 
         // With port: +10 ly range, so 25 ly total, should succeed
         let mut state = ShipState::Docked { system: origin };
-        let port_params = PortParams { has_port: true, ftl_range_bonus: 10.0, travel_time_factor: 0.8 };
-        let result = start_ftl_travel_with_bonus(&mut state, &ship, origin, dest, &origin_pos, &dest_pos, 0, 0.0, 1.0, port_params);
+        let port_params = PortParams {
+            has_port: true,
+            ftl_range_bonus: 10.0,
+            travel_time_factor: 0.8,
+        };
+        let result = start_ftl_travel_with_bonus(
+            &mut state,
+            &ship,
+            origin,
+            dest,
+            &origin_pos,
+            &dest_pos,
+            0,
+            0.0,
+            1.0,
+            port_params,
+        );
         assert!(result.is_ok(), "Port should extend FTL range by 10 ly");
     }
 
@@ -1019,9 +1174,18 @@ mod tests {
     fn build_cost_returns_expected_values() {
         // #236: derived build cost = hull + Σ module costs
         let registry = test_design_registry();
-        assert_eq!(registry.build_cost("explorer_mk1"), (Amt::units(360), Amt::units(190)));
-        assert_eq!(registry.build_cost("colony_ship_mk1"), (Amt::units(800), Amt::units(450)));
-        assert_eq!(registry.build_cost("courier_mk1"), (Amt::units(290), Amt::units(140)));
+        assert_eq!(
+            registry.build_cost("explorer_mk1"),
+            (Amt::units(360), Amt::units(190))
+        );
+        assert_eq!(
+            registry.build_cost("colony_ship_mk1"),
+            (Amt::units(800), Amt::units(450))
+        );
+        assert_eq!(
+            registry.build_cost("courier_mk1"),
+            (Amt::units(290), Amt::units(140))
+        );
     }
 
     #[test]
@@ -1053,9 +1217,10 @@ mod tests {
             upgrade_to: Vec::new(),
             build_time: 0,
         });
-        let modules = vec![
-            EquippedModule { slot_type: "weapon".into(), module_id: "test_weapon".into() },
-        ];
+        let modules = vec![EquippedModule {
+            slot_type: "weapon".into(),
+            module_id: "test_weapon".into(),
+        }];
         let (bm, be) = design_reg.build_cost("explorer_mk1");
         let (rm, re) = design_reg.scrap_refund("explorer_mk1", &modules, &module_registry);
         // Refund = 50% of (hull cost + module cost)
@@ -1074,9 +1239,7 @@ mod tests {
         let system_b = world.spawn_empty().id();
         // Ship is docked at system_a, survey targets system_b
         let mut queue = CommandQueue {
-            commands: vec![QueuedCommand::Survey {
-                system: system_b,
-            }],
+            commands: vec![QueuedCommand::Survey { system: system_b }],
             ..Default::default()
         };
         let state = ShipState::Docked { system: system_a };
@@ -1092,8 +1255,12 @@ mod tests {
             QueuedCommand::Survey { system: target } => {
                 assert_ne!(docked_system, target);
                 // Auto-insert: move to target, then re-queue survey
-                queue.commands.insert(0, QueuedCommand::Survey { system: target });
-                queue.commands.insert(0, QueuedCommand::MoveTo { system: target });
+                queue
+                    .commands
+                    .insert(0, QueuedCommand::Survey { system: target });
+                queue
+                    .commands
+                    .insert(0, QueuedCommand::MoveTo { system: target });
             }
             _ => panic!("Expected Survey command"),
         }
@@ -1124,11 +1291,22 @@ mod tests {
         };
         let next = queue.commands.remove(0);
         match next {
-            QueuedCommand::Colonize { system: target, planet } => {
+            QueuedCommand::Colonize {
+                system: target,
+                planet,
+            } => {
                 assert_ne!(docked_system, target);
                 // Auto-insert: move to target, then re-queue colonize
-                queue.commands.insert(0, QueuedCommand::Colonize { system: target, planet });
-                queue.commands.insert(0, QueuedCommand::MoveTo { system: target });
+                queue.commands.insert(
+                    0,
+                    QueuedCommand::Colonize {
+                        system: target,
+                        planet,
+                    },
+                );
+                queue
+                    .commands
+                    .insert(0, QueuedCommand::MoveTo { system: target });
             }
             _ => panic!("Expected Colonize command"),
         }

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -15,6 +15,8 @@ pub mod scout;
 pub mod core_deliverable;
 // #334 Phase 1: event-driven command dispatch — message types and allocator.
 pub mod command_events;
+// #334 Phase 1: queue dispatcher — validates + emits CommandRequested messages.
+pub mod dispatcher;
 
 pub use fleet::*;
 pub use exploration::*;

--- a/macrocosmo/src/ship/routing.rs
+++ b/macrocosmo/src/ship/routing.rs
@@ -14,8 +14,8 @@
 
 use bevy::prelude::*;
 use bevy::tasks::{AsyncComputeTaskPool, Task, block_on, poll_once};
-use std::collections::BinaryHeap;
 use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 
 use crate::components::Position;
 use crate::galaxy::region::RegionBlockSnapshot;
@@ -24,9 +24,8 @@ use crate::physics::distance_ly_arr;
 use crate::time_system::HEXADIES_PER_YEAR;
 
 use super::{
-    CommandQueue, Ship, ShipState, QueuedCommand, RulesOfEngagement,
+    CommandQueue, PortParams, QueuedCommand, RulesOfEngagement, Ship, ShipState,
     start_sublight_travel_with_bonus,
-    PortParams,
 };
 
 /// Maximum sublight edge distance in light-years (caps edge count in A*).
@@ -58,7 +57,10 @@ pub enum RouteSegment {
     /// FTL jump to a star system.
     FTL { to: Entity },
     /// Sub-light travel to a position, optionally associated with a star system.
-    SubLight { to_pos: [f64; 3], to_system: Option<Entity> },
+    SubLight {
+        to_pos: [f64; 3],
+        to_system: Option<Entity>,
+    },
 }
 
 /// A complete planned route consisting of ordered segments.
@@ -117,7 +119,10 @@ impl PartialOrd for AStarNode {
 impl Ord for AStarNode {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reverse ordering for min-heap behavior with BinaryHeap (max-heap).
-        other.f_cost.partial_cmp(&self.f_cost).unwrap_or(Ordering::Equal)
+        other
+            .f_cost
+            .partial_cmp(&self.f_cost)
+            .unwrap_or(Ordering::Equal)
     }
 }
 
@@ -211,7 +216,11 @@ pub fn plan_route_full(
     let n = systems.len();
 
     // Heuristic: straight-line distance / max_speed (admissible lower bound).
-    let max_speed = if ftl_speed > 0.0 { ftl_speed } else { sublight_speed };
+    let max_speed = if ftl_speed > 0.0 {
+        ftl_speed
+    } else {
+        sublight_speed
+    };
     if max_speed <= 0.0 {
         return None;
     }
@@ -221,9 +230,9 @@ pub fn plan_route_full(
 
     // Find which system index the ship starts at (if any). We treat origin as
     // a virtual node with index `n` that has edges to reachable systems.
-    let origin_at_system: Option<usize> = systems.iter().position(|s| {
-        distance_ly_arr(origin_pos, s.pos) < 1e-9
-    });
+    let origin_at_system: Option<usize> = systems
+        .iter()
+        .position(|s| distance_ly_arr(origin_pos, s.pos) < 1e-9);
 
     // If the ship is already at the destination, return empty route.
     if origin_at_system == Some(destination_index) {
@@ -307,9 +316,8 @@ pub fn plan_route_full(
             // known-hostile system. The destination is exempted — the player
             // explicitly requested it — so MoveTo into a hostile system still
             // succeeds.
-            let apply_hostile_penalty = roe == RulesOfEngagement::Retreat
-                && target.hostile_known
-                && j != destination_index;
+            let apply_hostile_penalty =
+                roe == RulesOfEngagement::Retreat && target.hostile_known && j != destination_index;
 
             for (kind, base_cost) in edges {
                 let cost = if apply_hostile_penalty {
@@ -391,18 +399,20 @@ pub fn collect_route_snapshots(
             // and whether the ship's faction actually treats that hostile as
             // an enemy. Unknown / un-owned hostiles are ignored (light-speed delay).
             let hostile_known = match (ship_faction, knowledge) {
-                (Some(from), Some(store)) => store
-                    .get(entity)
-                    .map(|k| k.data.has_hostile)
-                    .unwrap_or(false)
-                    && hostile_faction_map
-                        .get(&entity)
-                        .map(|&hostile| {
-                            relations
-                                .get_or_default(from, hostile)
-                                .can_attack_aggressive()
-                        })
-                        .unwrap_or(false),
+                (Some(from), Some(store)) => {
+                    store
+                        .get(entity)
+                        .map(|k| k.data.has_hostile)
+                        .unwrap_or(false)
+                        && hostile_faction_map
+                            .get(&entity)
+                            .map(|&hostile| {
+                                relations
+                                    .get_or_default(from, hostile)
+                                    .can_attack_aggressive()
+                            })
+                            .unwrap_or(false)
+                }
                 _ => false,
             };
             RouteSystemSnapshot {
@@ -494,9 +504,7 @@ pub fn spawn_route_task_full(
 /// #145: Build a list of [`RegionBlockSnapshot`] from all forbidden regions
 /// that carry the `blocks_ftl` capability. Pure ECS-to-snapshot conversion;
 /// safe to call from sync systems and hand off to async tasks.
-pub fn collect_ftl_blockers(
-    regions: &Query<&ForbiddenRegion>,
-) -> Vec<RegionBlockSnapshot> {
+pub fn collect_ftl_blockers(regions: &Query<&ForbiddenRegion>) -> Vec<RegionBlockSnapshot> {
     regions
         .iter()
         .filter(|r| r.has_capability("blocks_ftl"))
@@ -516,13 +524,10 @@ pub fn poll_pending_routes(
     clock: Res<crate::time_system::GameClock>,
     empire_params_q: Query<&crate::technology::GlobalParams, With<crate::player::PlayerEmpire>>,
     balance: Res<crate::technology::GameBalance>,
-    mut ships: Query<(
-        Entity,
-        &Ship,
-        &mut ShipState,
-        &mut CommandQueue,
-        &Position,
-    ), With<PendingRoute>>,
+    mut ships: Query<
+        (Entity, &Ship, &mut ShipState, &mut CommandQueue, &Position),
+        With<PendingRoute>,
+    >,
     mut pending_q: Query<&mut PendingRoute>,
     systems: Query<(Entity, &StarSystem, &Position), Without<Ship>>,
     system_buildings: Query<&crate::colony::SystemBuildings>,
@@ -580,9 +585,13 @@ pub fn poll_pending_routes(
         };
 
         // Ensure ship is still docked (may have changed state while waiting).
-        let ShipState::Docked { system: docked_system } = *state else {
+        let ShipState::Docked {
+            system: docked_system,
+        } = *state
+        else {
             // Ship moved; discard the route, remove the MoveTo from queue head if still there.
-            if matches!(queue.commands.first(), Some(QueuedCommand::MoveTo { system }) if *system == target_system) {
+            if matches!(queue.commands.first(), Some(QueuedCommand::MoveTo { system }) if *system == target_system)
+            {
                 queue.commands.remove(0);
             }
             queue.sync_prediction(ship_pos.as_array(), None);
@@ -601,7 +610,8 @@ pub fn poll_pending_routes(
         };
 
         // Consume the MoveTo from the queue head.
-        if matches!(queue.commands.first(), Some(QueuedCommand::MoveTo { system }) if *system == target_system) {
+        if matches!(queue.commands.first(), Some(QueuedCommand::MoveTo { system }) if *system == target_system)
+        {
             queue.commands.remove(0);
         }
 
@@ -677,15 +687,28 @@ pub fn poll_pending_routes(
         for seg in remaining.iter().rev() {
             match seg {
                 RouteSegment::FTL { to } => {
-                    queue.commands.insert(0, QueuedCommand::MoveTo { system: *to });
+                    queue
+                        .commands
+                        .insert(0, QueuedCommand::MoveTo { system: *to });
                 }
-                RouteSegment::SubLight { to_system: Some(sys), .. } => {
-                    queue.commands.insert(0, QueuedCommand::MoveTo { system: *sys });
+                RouteSegment::SubLight {
+                    to_system: Some(sys),
+                    ..
+                } => {
+                    queue
+                        .commands
+                        .insert(0, QueuedCommand::MoveTo { system: *sys });
                 }
-                RouteSegment::SubLight { to_pos, to_system: None } => {
+                RouteSegment::SubLight {
+                    to_pos,
+                    to_system: None,
+                } => {
                     // Sublight to a non-system position — unusual, but handle gracefully.
                     // For now this shouldn't happen since all snapshots are systems.
-                    warn!("Route segment to non-system position {:?}, skipping", to_pos);
+                    warn!(
+                        "Route segment to non-system position {:?}, skipping",
+                        to_pos
+                    );
                 }
             }
         }
@@ -698,7 +721,10 @@ pub fn poll_pending_routes(
         match first {
             RouteSegment::FTL { to } => {
                 let Ok((_, first_star, first_pos)) = systems.get(*to) else {
-                    warn!("Route planner: FTL target no longer exists for {}", ship.name);
+                    warn!(
+                        "Route planner: FTL target no longer exists for {}",
+                        ship.name
+                    );
                     queue.sync_prediction(ship_pos.as_array(), Some(docked_system));
                     if let Some(cid) = maybe_cmd_id {
                         executed.write(CommandExecuted {
@@ -728,7 +754,8 @@ pub fn poll_pending_routes(
                     }
                     continue;
                 };
-                let port_params = system_buildings.get(docked_system)
+                let port_params = system_buildings
+                    .get(docked_system)
                     .map(|sb| PortParams::from_system_buildings(sb, &building_registry))
                     .unwrap_or(PortParams::NONE);
                 match crate::ship::movement::start_ftl_travel_full(
@@ -747,12 +774,17 @@ pub fn poll_pending_routes(
                     Ok(()) => {
                         info!(
                             "Route planner: {} FTL jumping to {} ({} segments remaining)",
-                            ship.name, first_star.name, remaining.len()
+                            ship.name,
+                            first_star.name,
+                            remaining.len()
                         );
                         segment_ok = true;
                     }
                     Err(e) => {
-                        warn!("Route planner: FTL hop failed for {}: {}, falling back to sublight", ship.name, e);
+                        warn!(
+                            "Route planner: FTL hop failed for {}: {}, falling back to sublight",
+                            ship.name, e
+                        );
                         // Fall back to sublight for this segment.
                         if let Err(e2) = start_sublight_travel_with_bonus(
                             &mut state,
@@ -808,7 +840,9 @@ pub fn poll_pending_routes(
                 } else {
                     info!(
                         "Route planner: {} sublight to {:?} ({} segments remaining)",
-                        ship.name, to_system, remaining.len()
+                        ship.name,
+                        to_system,
+                        remaining.len()
                     );
                     segment_ok = true;
                 }
@@ -824,7 +858,9 @@ pub fn poll_pending_routes(
                 result: if segment_ok {
                     CommandResult::Ok
                 } else {
-                    CommandResult::Rejected { reason: segment_reason }
+                    CommandResult::Rejected {
+                        reason: segment_reason,
+                    }
                 },
                 completed_at: clock.elapsed,
             });
@@ -842,8 +878,19 @@ mod tests {
         Entity::from_bits(n + 1)
     }
 
-    fn make_snapshot(index: usize, entity: Entity, pos: [f64; 3], surveyed: bool) -> RouteSystemSnapshot {
-        RouteSystemSnapshot { index, entity, pos, surveyed, hostile_known: false }
+    fn make_snapshot(
+        index: usize,
+        entity: Entity,
+        pos: [f64; 3],
+        surveyed: bool,
+    ) -> RouteSystemSnapshot {
+        RouteSystemSnapshot {
+            index,
+            entity,
+            pos,
+            surveyed,
+            hostile_known: false,
+        }
     }
 
     fn make_snapshot_hostile(
@@ -853,7 +900,13 @@ mod tests {
         surveyed: bool,
         hostile_known: bool,
     ) -> RouteSystemSnapshot {
-        RouteSystemSnapshot { index, entity, pos, surveyed, hostile_known }
+        RouteSystemSnapshot {
+            index,
+            entity,
+            pos,
+            surveyed,
+            hostile_known,
+        }
     }
 
     #[test]
@@ -897,14 +950,16 @@ mod tests {
         let systems = vec![
             make_snapshot(0, e0, [0.0, 0.0, 0.0], true),
             make_snapshot(1, e1, [5.0, 0.0, 0.0], false), // unsurveyed — can't FTL here
-            make_snapshot(2, e2, [10.0, 0.0, 0.0], true),  // surveyed — FTL from e1
+            make_snapshot(2, e2, [10.0, 0.0, 0.0], true), // surveyed — FTL from e1
         ];
         let result = plan_route([0.0, 0.0, 0.0], 2, 6.0, 0.5, 10.0, &systems);
         assert!(result.is_some());
         let route = result.unwrap();
         assert_eq!(route.segments.len(), 2);
         // First hop: sublight to e1 (unsurveyed, can't FTL).
-        assert!(matches!(route.segments[0], RouteSegment::SubLight { to_system: Some(sys), .. } if sys == e1));
+        assert!(
+            matches!(route.segments[0], RouteSegment::SubLight { to_system: Some(sys), .. } if sys == e1)
+        );
         // Second hop: FTL to e2.
         assert!(matches!(route.segments[1], RouteSegment::FTL { to } if to == e2));
     }
@@ -924,7 +979,9 @@ mod tests {
         let route = result.unwrap();
         assert_eq!(route.segments.len(), 2);
         assert!(matches!(route.segments[0], RouteSegment::FTL { to } if to == e1));
-        assert!(matches!(route.segments[1], RouteSegment::SubLight { to_system: Some(sys), .. } if sys == e2));
+        assert!(
+            matches!(route.segments[1], RouteSegment::SubLight { to_system: Some(sys), .. } if sys == e2)
+        );
     }
 
     #[test]
@@ -942,9 +999,7 @@ mod tests {
     #[test]
     fn already_at_destination() {
         let e0 = test_entity(0);
-        let systems = vec![
-            make_snapshot(0, e0, [0.0, 0.0, 0.0], true),
-        ];
+        let systems = vec![make_snapshot(0, e0, [0.0, 0.0, 0.0], true)];
         let result = plan_route([0.0, 0.0, 0.0], 0, 6.0, 0.5, 10.0, &systems);
         assert!(result.is_some());
         assert!(result.unwrap().segments.is_empty());

--- a/macrocosmo/src/ship/routing.rs
+++ b/macrocosmo/src/ship/routing.rs
@@ -72,6 +72,14 @@ pub struct PlannedRoute {
 pub struct PendingRoute {
     pub task: Task<Option<PlannedRoute>>,
     pub target_system: Entity,
+    /// #334: `CommandId` of the dispatched `MoveRequested` that spawned
+    /// this async route. Threaded here so that when `poll_pending_routes`
+    /// reaches a terminal state (Ok / Rejected) it can emit the matching
+    /// [`crate::ship::command_events::CommandExecuted`] for `CommandLog`
+    /// and future gamestate bridges to key by. `None` only for legacy
+    /// in-flight ships that predate the dispatcher refactor (should
+    /// never occur post-Phase 1, but kept optional for safety).
+    pub command_id: Option<super::command_events::CommandId>,
 }
 
 /// Resource: count of pending route computations. When > 0, game time is paused.
@@ -520,7 +528,13 @@ pub fn poll_pending_routes(
     system_buildings: Query<&crate::colony::SystemBuildings>,
     mut pending_count: ResMut<RouteCalculationsPending>,
     building_registry: Res<crate::colony::BuildingRegistry>,
+    // #334 Phase 1: emit the terminal CommandExecuted for the MoveRequested
+    // that spawned this async route. `CommandId` is threaded via
+    // `PendingRoute.command_id`; `None` is tolerated for in-flight ships
+    // that predate the refactor (emission is skipped in that case).
+    mut executed: MessageWriter<super::command_events::CommandExecuted>,
 ) {
+    use super::command_events::{CommandExecuted, CommandKind, CommandResult};
     let Ok(global_params) = empire_params_q.single() else {
         return;
     };
@@ -542,12 +556,26 @@ pub fn poll_pending_routes(
         };
 
         let target_system = pending.target_system;
+        // #334: preserve the CommandId for terminal `CommandExecuted` below.
+        let maybe_cmd_id = pending.command_id;
 
         // Remove PendingRoute component and decrement counter.
         commands.entity(ship_entity).remove::<PendingRoute>();
         pending_count.count = pending_count.count.saturating_sub(1);
 
         let Ok((_, ship, mut state, mut queue, ship_pos)) = ships.get_mut(ship_entity) else {
+            // Ship despawned while waiting — emit Rejected.
+            if let Some(cid) = maybe_cmd_id {
+                executed.write(CommandExecuted {
+                    command_id: cid,
+                    kind: CommandKind::Move,
+                    ship: ship_entity,
+                    result: CommandResult::Rejected {
+                        reason: "ship despawned".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
+            }
             continue;
         };
 
@@ -558,6 +586,17 @@ pub fn poll_pending_routes(
                 queue.commands.remove(0);
             }
             queue.sync_prediction(ship_pos.as_array(), None);
+            if let Some(cid) = maybe_cmd_id {
+                executed.write(CommandExecuted {
+                    command_id: cid,
+                    kind: CommandKind::Move,
+                    ship: ship_entity,
+                    result: CommandResult::Rejected {
+                        reason: "ship no longer docked".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
+            }
             continue;
         };
 
@@ -568,38 +607,65 @@ pub fn poll_pending_routes(
 
         let Some(route) = route_option else {
             // No route found — fall back to direct sublight.
+            let mut fallback_ok = false;
             if let Ok((_, _target_star, target_pos)) = systems.get(target_system) {
-                let Ok((_, _, origin_pos)) = systems.get(docked_system) else {
-                    queue.sync_prediction(ship_pos.as_array(), Some(docked_system));
-                    continue;
-                };
-                if let Err(e) = start_sublight_travel_with_bonus(
-                    &mut state,
-                    origin_pos,
-                    ship,
-                    *target_pos,
-                    Some(target_system),
-                    clock.elapsed,
-                    global_params.sublight_speed_bonus,
-                ) {
-                    // #296: immobile ships never reach the planner (UI guard
-                    // + command_queue), but defend-in-depth keeps the system
-                    // tolerant.
-                    warn!(
-                        "Route planner: sublight fallback failed for {}: {}",
-                        ship.name, e
-                    );
-                } else {
-                    info!("Route planner: no route found for {}, falling back to sublight", ship.name);
+                if let Ok((_, _, origin_pos)) = systems.get(docked_system) {
+                    if let Err(e) = start_sublight_travel_with_bonus(
+                        &mut state,
+                        origin_pos,
+                        ship,
+                        *target_pos,
+                        Some(target_system),
+                        clock.elapsed,
+                        global_params.sublight_speed_bonus,
+                    ) {
+                        // #296: immobile ships never reach the planner (UI guard
+                        // + command_queue), but defend-in-depth keeps the system
+                        // tolerant.
+                        warn!(
+                            "Route planner: sublight fallback failed for {}: {}",
+                            ship.name, e
+                        );
+                    } else {
+                        info!(
+                            "Route planner: no route found for {}, falling back to sublight",
+                            ship.name
+                        );
+                        fallback_ok = true;
+                    }
                 }
             }
             queue.sync_prediction(ship_pos.as_array(), Some(docked_system));
+            if let Some(cid) = maybe_cmd_id {
+                executed.write(CommandExecuted {
+                    command_id: cid,
+                    kind: CommandKind::Move,
+                    ship: ship_entity,
+                    result: if fallback_ok {
+                        CommandResult::Ok
+                    } else {
+                        CommandResult::Rejected {
+                            reason: "no route + sublight fallback failed".to_string(),
+                        }
+                    },
+                    completed_at: clock.elapsed,
+                });
+            }
             continue;
         };
 
         if route.segments.is_empty() {
             // Already at destination.
             queue.sync_prediction(ship_pos.as_array(), Some(docked_system));
+            if let Some(cid) = maybe_cmd_id {
+                executed.write(CommandExecuted {
+                    command_id: cid,
+                    kind: CommandKind::Move,
+                    ship: ship_entity,
+                    result: CommandResult::Ok,
+                    completed_at: clock.elapsed,
+                });
+            }
             continue;
         }
 
@@ -624,16 +690,42 @@ pub fn poll_pending_routes(
             }
         }
 
-        // Execute the first segment.
+        // Execute the first segment. On success emit `Ok`; on failure
+        // (both FTL and sublight-fallback fail, or sublight segment fails)
+        // emit `Rejected`.
+        let mut segment_ok = false;
+        let mut segment_reason = String::new();
         match first {
             RouteSegment::FTL { to } => {
                 let Ok((_, first_star, first_pos)) = systems.get(*to) else {
                     warn!("Route planner: FTL target no longer exists for {}", ship.name);
                     queue.sync_prediction(ship_pos.as_array(), Some(docked_system));
+                    if let Some(cid) = maybe_cmd_id {
+                        executed.write(CommandExecuted {
+                            command_id: cid,
+                            kind: CommandKind::Move,
+                            ship: ship_entity,
+                            result: CommandResult::Rejected {
+                                reason: "FTL target despawned".to_string(),
+                            },
+                            completed_at: clock.elapsed,
+                        });
+                    }
                     continue;
                 };
                 let Ok((_, _, origin_pos)) = systems.get(docked_system) else {
                     queue.sync_prediction(ship_pos.as_array(), Some(docked_system));
+                    if let Some(cid) = maybe_cmd_id {
+                        executed.write(CommandExecuted {
+                            command_id: cid,
+                            kind: CommandKind::Move,
+                            ship: ship_entity,
+                            result: CommandResult::Rejected {
+                                reason: "origin system lost".to_string(),
+                            },
+                            completed_at: clock.elapsed,
+                        });
+                    }
                     continue;
                 };
                 let port_params = system_buildings.get(docked_system)
@@ -657,6 +749,7 @@ pub fn poll_pending_routes(
                             "Route planner: {} FTL jumping to {} ({} segments remaining)",
                             ship.name, first_star.name, remaining.len()
                         );
+                        segment_ok = true;
                     }
                     Err(e) => {
                         warn!("Route planner: FTL hop failed for {}: {}, falling back to sublight", ship.name, e);
@@ -674,6 +767,9 @@ pub fn poll_pending_routes(
                                 "Route planner: sublight fallback also failed for {}: {}",
                                 ship.name, e2
                             );
+                            segment_reason = format!("FTL + sublight both failed: {}", e2);
+                        } else {
+                            segment_ok = true;
                         }
                     }
                 }
@@ -681,6 +777,17 @@ pub fn poll_pending_routes(
             RouteSegment::SubLight { to_pos, to_system } => {
                 let Ok((_, _, origin_pos)) = systems.get(docked_system) else {
                     queue.sync_prediction(ship_pos.as_array(), Some(docked_system));
+                    if let Some(cid) = maybe_cmd_id {
+                        executed.write(CommandExecuted {
+                            command_id: cid,
+                            kind: CommandKind::Move,
+                            ship: ship_entity,
+                            result: CommandResult::Rejected {
+                                reason: "origin system lost".to_string(),
+                            },
+                            completed_at: clock.elapsed,
+                        });
+                    }
                     continue;
                 };
                 let dest_pos = Position::from(*to_pos);
@@ -697,13 +804,30 @@ pub fn poll_pending_routes(
                         "Route planner: sublight segment rejected for {}: {}",
                         ship.name, e
                     );
+                    segment_reason = format!("sublight segment rejected: {}", e);
                 } else {
                     info!(
                         "Route planner: {} sublight to {:?} ({} segments remaining)",
                         ship.name, to_system, remaining.len()
                     );
+                    segment_ok = true;
                 }
             }
+        }
+
+        // Emit terminal CommandExecuted keyed by the original MoveRequested.
+        if let Some(cid) = maybe_cmd_id {
+            executed.write(CommandExecuted {
+                command_id: cid,
+                kind: CommandKind::Move,
+                ship: ship_entity,
+                result: if segment_ok {
+                    CommandResult::Ok
+                } else {
+                    CommandResult::Rejected { reason: segment_reason }
+                },
+                completed_at: clock.elapsed,
+            });
         }
     }
 }

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -476,6 +476,16 @@ pub fn test_app() -> App {
             .after(macrocosmo::time_system::advance_game_time)
             .before(advance_production_tick),
     );
+    // #334 Phase 1: CommandExecuted → CommandLog bridge.
+    app.add_systems(
+        Update,
+        macrocosmo::ship::bridges::bridge_command_executed_to_log
+            .after(macrocosmo::ship::routing::poll_pending_routes)
+            .after(macrocosmo::ship::handlers::handle_move_requested)
+            .after(macrocosmo::ship::handlers::handle_move_to_coordinates_requested)
+            .after(macrocosmo::time_system::advance_game_time)
+            .before(advance_production_tick),
+    );
     app.add_systems(
         Update,
         (
@@ -698,6 +708,14 @@ pub fn full_test_app() -> App {
         )
             .chain()
             .after(process_command_queue),
+    );
+    // #334 Phase 1: CommandExecuted → CommandLog bridge.
+    app.add_systems(
+        Update,
+        macrocosmo::ship::bridges::bridge_command_executed_to_log
+            .after(macrocosmo::ship::routing::poll_pending_routes)
+            .after(macrocosmo::ship::handlers::handle_move_requested)
+            .after(macrocosmo::ship::handlers::handle_move_to_coordinates_requested),
     );
 
     // --- Colony systems (from ColonyPlugin) ---

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -405,7 +405,13 @@ pub fn test_app() -> App {
     // resolve_core_deploys can run without a Resource-missing panic.
     app.init_resource::<macrocosmo::ship::PendingCoreDeploys>();
     app.init_resource::<macrocosmo::scripting::GameRng>();
+    // #334 Phase 1: command-dispatch message types + allocator.
+    app.add_plugins(macrocosmo::ship::command_events::CommandEventsPlugin);
     app.add_systems(Update, macrocosmo::time_system::advance_game_time);
+    // #334 Phase 1: primary ship pipeline, split into two `add_systems`
+    // calls so we stay under the 20-arm IntoScheduleConfigs limit. The
+    // second call `.after(process_command_queue)` preserves the original
+    // ordering of scout / combat / repair / pursuit / fleet cleanup.
     app.add_systems(
         Update,
         (
@@ -426,10 +432,25 @@ pub fn test_app() -> App {
             // #296 (S-3): Drain Core deploy tickets enqueued by the
             // deliverable processor. Mirrors ShipPlugin ordering.
             macrocosmo::ship::resolve_core_deploys,
+            // #334 Phase 1: dispatcher + MoveTo/MoveToCoordinates handlers
+            // run before process_command_queue so the PendingRoute filter
+            // on the legacy system excludes ships whose MoveTo was just
+            // dispatched this tick.
+            macrocosmo::ship::dispatcher::dispatch_queued_commands,
+            macrocosmo::ship::handlers::handle_move_requested,
+            macrocosmo::ship::handlers::handle_move_to_coordinates_requested,
             process_command_queue,
+        )
+            .chain()
+            .after(macrocosmo::time_system::advance_game_time)
+            .before(advance_production_tick),
+    );
+    app.add_systems(
+        Update,
+        (
             // #217: Scout observation + report. Chained after
-            // process_command_queue so a Scout that began transitioning to
-            // Scouting this tick doesn't get double-processed.
+            // process_command_queue so a Scout that began transitioning
+            // to Scouting this tick doesn't get double-processed.
             macrocosmo::ship::scout::tick_scout_observation,
             macrocosmo::ship::scout::process_scout_report,
             resolve_combat,
@@ -439,6 +460,7 @@ pub fn test_app() -> App {
             macrocosmo::ship::fleet::prune_empty_fleets,
         )
             .chain()
+            .after(process_command_queue)
             .after(macrocosmo::time_system::advance_game_time)
             .before(advance_production_tick),
     );
@@ -494,7 +516,21 @@ pub fn test_app() -> App {
             .after(macrocosmo::time_system::advance_game_time)
             .after(tick_timed_effects),
     );
-    app.add_systems(Update, propagate_knowledge);
+    // #334 Phase 1: pin propagate_knowledge to run BEFORE the colony tick
+    // chain (tick_building_queue / tick_population_growth / …) so
+    // knowledge snapshots capture the pre-tick state — tests in
+    // `tests/knowledge.rs` assert on queued-but-not-yet-completed build
+    // orders and on the pristine population count. Before the dispatcher
+    // refactor this was a lucky side-effect of the ship schedule's
+    // topological order.
+    app.add_systems(
+        Update,
+        propagate_knowledge
+            .before(tick_building_queue)
+            .before(tick_population_growth)
+            .before(tick_production)
+            .before(tick_maintenance),
+    );
     app.add_systems(Update, macrocosmo::knowledge::snapshot_production_knowledge);
     // #118: Sensor Buoy detection
     app.init_resource::<macrocosmo::deep_space::StructureRegistry>();
@@ -602,6 +638,8 @@ pub fn full_test_app() -> App {
     // #296 (S-3): Core deploy queue + RNG (mirrors ShipPlugin / ScriptingPlugin).
     app.init_resource::<macrocosmo::ship::PendingCoreDeploys>();
     app.init_resource::<macrocosmo::scripting::GameRng>();
+    // #334 Phase 1: command-dispatch message types + allocator.
+    app.add_plugins(macrocosmo::ship::command_events::CommandEventsPlugin);
 
     // --- #233 Notification pipeline resources ---
     app.init_resource::<macrocosmo::knowledge::PendingFactQueue>();
@@ -613,6 +651,7 @@ pub fn full_test_app() -> App {
     app.insert_resource(macrocosmo::notifications::NotificationQueue::new());
 
     // --- Ship systems (from ShipPlugin) ---
+    // #334 Phase 1: split into two calls to stay under the 20-arm limit.
     app.add_systems(
         Update,
         (
@@ -630,7 +669,16 @@ pub fn full_test_app() -> App {
             macrocosmo::ship::deliverable_ops::process_deliverable_commands,
             // #296 (S-3): Drain Core deploy tickets enqueued above.
             macrocosmo::ship::resolve_core_deploys,
+            // #334 Phase 1: event-driven MoveTo path alongside legacy queue.
+            macrocosmo::ship::dispatcher::dispatch_queued_commands,
+            macrocosmo::ship::handlers::handle_move_requested,
+            macrocosmo::ship::handlers::handle_move_to_coordinates_requested,
             process_command_queue,
+        ),
+    );
+    app.add_systems(
+        Update,
+        (
             // #217: Scout observation + delivery.
             macrocosmo::ship::scout::tick_scout_observation,
             macrocosmo::ship::scout::process_scout_report,

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -12,8 +12,8 @@ use bevy::prelude::*;
 use macrocosmo::amount::Amt;
 use macrocosmo::colony::{BuildKind, BuildQueue, BuildingQueue, SystemBuildingQueue};
 use macrocosmo::communication::{
-    self, BuildingKind, BuildingScope, ColonyCommand, CommandLog, PendingColonyDispatch,
-    PendingColonyDispatches, PendingCommand, RemoteCommand, MAX_DISPATCH_RETRY_FRAMES,
+    self, BuildingKind, BuildingScope, ColonyCommand, CommandLog, MAX_DISPATCH_RETRY_FRAMES,
+    PendingColonyDispatch, PendingColonyDispatches, PendingCommand, RemoteCommand,
 };
 use macrocosmo::components::Position;
 use macrocosmo::player::{Player, PlayerEmpire, StationedAt};

--- a/macrocosmo/tests/remote_colony_commands.rs
+++ b/macrocosmo/tests/remote_colony_commands.rs
@@ -73,12 +73,11 @@ fn spawn_pending_remote_command(
     let empire = empire_entity(app.world_mut());
     if let Some(mut log) = app.world_mut().get_mut::<CommandLog>(empire) {
         log.entries
-            .push(macrocosmo::communication::CommandLogEntry {
-                description: "test".to_string(),
+            .push(macrocosmo::communication::CommandLogEntry::new_pending(
+                "test".to_string(),
                 sent_at,
                 arrives_at,
-                arrived: false,
-            });
+            ));
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of [#334 command-dispatch refactor (Option C: event-driven split)](../blob/main/docs/plan-334-command-dispatch-event-driven.md).

Migrates **only** `QueuedCommand::MoveTo` and `QueuedCommand::MoveToCoordinates` from `process_command_queue` to the new dispatcher + per-variant handler pipeline. DeployDeliverable, LoadDeliverable, TransferToStructure, LoadFromScrapyard, Survey, Colonize, Scout remain on the legacy `process_command_queue` / `process_deliverable_commands` path — **Phase 2/3 land in follow-up PRs** (see plan §7).

## Scope

- **New module `ship/command_events.rs`** — `CommandId` + `NextCommandId` resource, `CommandKind` / `CommandResult`, per-variant `*Requested` messages (every `QueuedCommand` variant is pre-declared as a skeleton; only `MoveRequested` / `MoveToCoordinatesRequested` are wired in Phase 1). Single tagged `CommandExecuted` for post-completion subscribers. `CommandEventsPlugin` registers them all. (plan §2.1)
- **New module `ship/dispatcher.rs`** — `dispatch_queued_commands`: lightweight validator that peeks each ship's `CommandQueue` head, validates (ship exists / Docked-or-Loitering / target exists / not immobile), and for the two Phase-1 variants allocates a `CommandId`, emits the typed request message, and pops the queue. Non-migrated variants are left untouched so the legacy system consumes them this same tick. (plan §2.2, §3.1)
- **New module `ship/handlers/{mod,move_handler}.rs`** — `handle_move_requested` (spawns async `PendingRoute` for docked ships, sync sublight for Loitering) and `handle_move_to_coordinates_requested` (sync sublight to deep-space coord). Both emit terminal `CommandExecuted` with `Ok / Rejected / Deferred` results. (plan §2.3, §3.2)
- **`routing::PendingRoute` gains `command_id: Option<CommandId>`** threaded from dispatcher through handler through `poll_pending_routes`, so the terminal `CommandExecuted` on route resolution (including sublight fallback, route-not-found fallback, despawn races) is keyed correctly. Legacy-path routes pass `None` and skip the terminal event. (plan §3.3)
- **Legacy `process_command_queue` MoveTo / MoveToCoordinates arms deleted** — replaced with a `warn!`-and-drop safety net that should be unreachable under the Phase-1 schedule. (plan §7 Phase 1 checklist)
- **New module `ship/bridges.rs` + `bridge_command_executed_to_log`** — reads `MessageReader<CommandExecuted>` and updates the matching `CommandLog` entry by `CommandId`. Sets `status` (Executed / Rejected / Deferred), `executed_at`, and the legacy `arrived` flag for bottom-bar UI compatibility. (plan §4)
- **`CommandLog` schema extended** with `command_id: Option<CommandId>`, `status: CommandLogStatus`, `executed_at: Option<i64>`. The legacy `arrived` field is preserved. Two constructors: `new_pending` (remote flow, unchanged semantics) and `new_dispatched` (dispatcher-side entry). Save fixtures unchanged — `SavedCommandLogEntry` still persists only the four legacy fields.

## Out of Scope for This PR

Phase 2/3/4 will land separately:

- **Phase 2**: DeployDeliverable (+ Core branch), LoadDeliverable, TransferToStructure, LoadFromScrapyard, Colonize, Survey. `PendingCoreDeploys` resource replaced by `CoreDeployRequested` message.
- **Phase 3**: Scout migration + deletion of `process_command_queue` / `process_deliverable_commands` / `AttackRequested` skeleton for #219/#220.
- **Phase 4**: Lua `on_command_completed` hook via `bridge_command_executed_to_gamestate` (queue-only, no sync callback).

## Deviations from plan

- **Plan suggests wiring dispatcher in Commit 2**; this PR wires it in Commit 3 alongside the handler + legacy arm deletion so every intermediate commit leaves the tree green (MoveTo behaviour preserved throughout).
- **Plan §2.4 schedule example** placed the dispatcher + handlers inside the main `ShipPlugin` system tuple. Bevy 0.18's `IntoScheduleConfigs` has a 20-arm limit; the PR puts dispatcher/handlers in a separate `add_systems` call with explicit `.before(process_command_queue)` / `.after(deliverable_ops)` ordering. Initial nested-tuple attempt caused Bevy to elide the systems from scheduler (root cause not fully pinned; separate-call approach is simpler and unambiguous).
- **`tests/common/mod.rs` `propagate_knowledge` pinning**: needed `.before(tick_building_queue / tick_population_growth / tick_production / tick_maintenance)` after splitting the ship chain — this was an implicit topological ordering baseline tests depended on before the refactor.

## Tests

- **Lib (702 pass)** — 4 new `command_events` tests (`CommandId` monotonicity, `NextCommandId::allocate` non-zero, plugin registers resource, `test_message_reader_preserves_emit_order` locking the plan §6 FIFO assumption) + 7 new `dispatcher` tests (MoveTo emit+pop, immobile reject, already-at-target drop, despawned target drop, MoveToCoordinates emit+pop, non-migrated pass-through, per-ship FIFO) + 4 new `bridges` tests (Ok/Rejected/Deferred/unmatched-id).
- **Integration (1105 pass across all test files)** — `tests/fixtures_smoke::load_minimal_game_fixture_smoke` green (save format unchanged); `tests/smoke::all_systems_no_query_conflict` green (no B0001 introduced); existing MoveTo / delivery pipeline / Core deploy / settlement / scout tests unchanged.
- **`cargo check --workspace --tests`** clean.
- **`rustfmt --edition 2024 --check`** clean on all files this PR touched.

Total: **1807 tests pass, 0 failures.**

## Plan references

- Plan: [`docs/plan-334-command-dispatch-event-driven.md`](../blob/main/docs/plan-334-command-dispatch-event-driven.md)
- Phase 1 checklist: §7 Phase 1 + Appendix B

## Test plan

- [x] `cargo test --workspace` all pass
- [x] `cargo check --workspace --tests` clean
- [x] `rustfmt --edition 2024 --check` on touched files
- [x] `all_systems_no_query_conflict` passes (no B0001)
- [x] `load_minimal_game_fixture_smoke` passes (save format stable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)