### PR TITLE
#334 Phase 2: event-driven Deliverable / Core / Colonize / Survey handlers

### DIFF
--- a/macrocosmo/src/ship/command.rs
+++ b/macrocosmo/src/ship/command.rs
@@ -209,12 +209,11 @@ pub fn process_pending_ship_commands(
 /// #128: Async A* mixed route planning (FTL/sublight)
 #[allow(clippy::too_many_arguments)]
 pub fn process_command_queue(
-    // #334 Phase 1: `Commands` / KnowledgeStore / FactionRelations /
-    // port-params / FTL blocker params are preserved at the SystemParam
-    // surface for Phase 2/3 migrations (Survey / Colonize / Scout handlers
-    // continue to need some of them) even though this tick the MoveTo
-    // path no longer consults them. Underscored locals silence the
-    // "unused" warnings without touching the signature.
+    // #334 Phase 2 (Commits 1–4): most variants migrated to the
+    // dispatcher + handler pipeline. Only `Scout` is still handled here
+    // pending Phase 3. The bulk of the SystemParam surface is therefore
+    // underscored — the shape is preserved to minimise diff noise when
+    // Scout migrates; the final shape lands under Phase 3.
     mut _commands: Commands,
     clock: Res<GameClock>,
     empire_params_q: Query<&crate::technology::GlobalParams, With<crate::player::PlayerEmpire>>,
@@ -358,17 +357,13 @@ pub fn process_command_queue(
                 );
                 queue.sync_prediction(ship_pos.as_array(), Some(target_system));
             }
-            // #334 Phase 2 (Commit 4): Survey / Colonize migrated to
-            // `handlers::settlement_handler`. Exhaustive match requires the
-            // arms stay listed; they're unreachable under Phase 2 schedule
-            // but we silently skip (same guard as MoveTo/MoveToCoordinates
-            // above) to let any handler-injected retry survive the tick.
-            QueuedCommand::Survey { .. }
-            | QueuedCommand::Colonize { .. }
-            | QueuedCommand::LoadDeliverable { .. }
-            | QueuedCommand::DeployDeliverable { .. }
-            | QueuedCommand::TransferToStructure { .. }
-            | QueuedCommand::LoadFromScrapyard { .. } => {
+            // #334 Phase 2 (Commits 1–4): Survey / Colonize / LoadDeliverable
+            // / DeployDeliverable / TransferToStructure / LoadFromScrapyard
+            // are handled by the dispatcher + handler pipeline. Phase 3 will
+            // migrate the remaining `Scout` variant. Everything else is a
+            // no-op here so any handler-injected retry survives the tick
+            // (same guard as MoveTo / MoveToCoordinates above).
+            _ => {
                 // no-op; handled by dispatcher + handler pipeline. Leave
                 // at the queue head so the next-tick dispatcher picks up
                 // any retry re-injected by a handler this tick.

--- a/macrocosmo/src/ship/command.rs
+++ b/macrocosmo/src/ship/command.rs
@@ -244,19 +244,20 @@ pub fn process_command_queue(
     _building_registry: Res<crate::colony::BuildingRegistry>,
     regions: Query<&crate::galaxy::ForbiddenRegion>,
 ) {
-    let Ok(global_params) = empire_params_q.single() else {
+    let Ok(_global_params) = empire_params_q.single() else {
         return;
     };
     let _base_ftl_speed = balance.initial_ftl_speed_c();
     let _ftl_blockers = routing::collect_ftl_blockers(&regions);
-    let settling_duration = balance.settling_duration();
-    let survey_range_base = balance.survey_range_ly();
-    let survey_duration_base = balance.survey_duration();
+    let _settling_duration = balance.settling_duration();
+    let _survey_range_base = balance.survey_range_ly();
+    let _survey_duration_base = balance.survey_duration();
     let _empire_knowledge = empire_knowledge_q.single().ok();
     let _hostile_faction_map: std::collections::HashMap<Entity, Entity> = hostiles_q
         .iter()
         .map(|(at_system, owner)| (at_system.0, owner.0))
         .collect();
+    let _ = &design_registry;
     for (_entity, ship, mut state, mut queue, ship_pos, _roe) in ships.iter_mut() {
         // #185: Process queue when ship is Docked OR Loitering (current command finished).
         let docked_system: Option<Entity> = match *state {
@@ -357,124 +358,20 @@ pub fn process_command_queue(
                 );
                 queue.sync_prediction(ship_pos.as_array(), Some(target_system));
             }
-            QueuedCommand::Survey { .. } | QueuedCommand::Colonize { .. } => {
-                // Consume the command and process synchronously.
-                let next = queue.commands.remove(0);
-                match next {
-                    QueuedCommand::Survey { system: target } => {
-                        let Ok((_target_entity, target_star, target_pos)) = systems.get(target)
-                        else {
-                            warn!("Queued Survey target no longer exists");
-                            queue.sync_prediction(ship_pos.as_array(), docked_system);
-                            continue;
-                        };
-                        // #101: If not docked at the target system, auto-insert a move command.
-                        // #185: Loitering ships also need to move first.
-                        if docked_system != Some(target) {
-                            queue
-                                .commands
-                                .insert(0, QueuedCommand::Survey { system: target });
-                            queue
-                                .commands
-                                .insert(0, QueuedCommand::MoveTo { system: target });
-                            info!(
-                                "Queue: Ship {} not at target, auto-inserting move before survey of {}",
-                                ship.name, target_star.name
-                            );
-                            continue;
-                        }
-                        let origin = Position::from(ship_pos.as_array());
-                        match start_survey_with_bonus(
-                            &mut state,
-                            ship,
-                            target,
-                            &origin,
-                            target_pos,
-                            clock.elapsed,
-                            global_params.survey_range_bonus,
-                            &design_registry,
-                            survey_range_base,
-                            survey_duration_base,
-                        ) {
-                            Ok(()) => {
-                                info!("Queue: Ship {} surveying {}", ship.name, target_star.name);
-                            }
-                            Err(e) => {
-                                warn!("Queue: Survey failed for {}: {}", ship.name, e);
-                            }
-                        }
-                        queue.sync_prediction(ship_pos.as_array(), docked_system);
-                    }
-                    QueuedCommand::Colonize {
-                        system: target,
-                        planet,
-                    } => {
-                        let Ok((_target_entity, target_star, _target_pos)) = systems.get(target)
-                        else {
-                            warn!("Queued Colonize target no longer exists");
-                            queue.sync_prediction(ship_pos.as_array(), docked_system);
-                            continue;
-                        };
-                        if docked_system != Some(target) {
-                            queue.commands.insert(
-                                0,
-                                QueuedCommand::Colonize {
-                                    system: target,
-                                    planet,
-                                },
-                            );
-                            queue
-                                .commands
-                                .insert(0, QueuedCommand::MoveTo { system: target });
-                            info!(
-                                "Queue: Ship {} not at target, auto-inserting move before colonize of {}",
-                                ship.name, target_star.name
-                            );
-                            continue;
-                        }
-                        if !design_registry.can_colonize(&ship.design_id) {
-                            warn!(
-                                "Queue: Ship {} cannot colonize (not a colony ship)",
-                                ship.name
-                            );
-                            queue.sync_prediction(ship_pos.as_array(), docked_system);
-                            continue;
-                        }
-                        let docked_sys =
-                            docked_system.expect("survey/colonize already required docked");
-                        *state = ShipState::Settling {
-                            system: docked_sys,
-                            planet,
-                            started_at: clock.elapsed,
-                            completes_at: clock.elapsed + settling_duration,
-                        };
-                        info!("Queue: Ship {} colonizing {}", ship.name, target_star.name);
-                        queue.sync_prediction(ship_pos.as_array(), docked_system);
-                    }
-                    QueuedCommand::MoveToCoordinates { .. } | QueuedCommand::MoveTo { .. } => {} // handled above
-                    // #217: Scout is handled by its own outer arm.
-                    QueuedCommand::Scout { .. } => {}
-                    // #223: Deliverable-side commands are handled by
-                    // `super::deliverable_ops::process_deliverable_commands`.
-                    // This arm is unreachable via the outer match, but the
-                    // exhaustive compiler still needs the variants enumerated.
-                    QueuedCommand::LoadDeliverable { .. }
-                    | QueuedCommand::DeployDeliverable { .. }
-                    | QueuedCommand::TransferToStructure { .. }
-                    | QueuedCommand::LoadFromScrapyard { .. } => {
-                        // handled by deliverable_ops
-                    }
-                }
-            }
-            // #223: Deliverable-side commands are processed by
-            // `super::deliverable_ops::process_deliverable_commands`, which
-            // runs as its own system. We skip them here and leave them at
-            // the head of the queue.
-            QueuedCommand::LoadDeliverable { .. }
+            // #334 Phase 2 (Commit 4): Survey / Colonize migrated to
+            // `handlers::settlement_handler`. Exhaustive match requires the
+            // arms stay listed; they're unreachable under Phase 2 schedule
+            // but we silently skip (same guard as MoveTo/MoveToCoordinates
+            // above) to let any handler-injected retry survive the tick.
+            QueuedCommand::Survey { .. }
+            | QueuedCommand::Colonize { .. }
+            | QueuedCommand::LoadDeliverable { .. }
             | QueuedCommand::DeployDeliverable { .. }
             | QueuedCommand::TransferToStructure { .. }
             | QueuedCommand::LoadFromScrapyard { .. } => {
-                // no-op; the deliverable ops system consumes these.
+                // no-op; handled by dispatcher + handler pipeline. Leave
+                // at the queue head so the next-tick dispatcher picks up
+                // any retry re-injected by a handler this tick.
             }
         }
     }

--- a/macrocosmo/src/ship/command.rs
+++ b/macrocosmo/src/ship/command.rs
@@ -276,18 +276,14 @@ pub fn process_command_queue(
             // #334 Phase 1: MoveTo / MoveToCoordinates are handled by
             // `super::dispatcher::dispatch_queued_commands` +
             // `super::handlers::move_handler::{handle_move_requested,
-            // handle_move_to_coordinates_requested}`. The dispatcher pops
-            // these variants before this system runs so they should never
-            // reach here; the arms are kept exhaustive for the compiler.
+            // handle_move_to_coordinates_requested}`. The dispatcher
+            // normally pops these before we run, but Phase 2 handlers
+            // (e.g. `handle_deploy_deliverable_requested`) can auto-inject
+            // a MoveTo/MoveToCoordinates at the queue head in the SAME
+            // tick as the dispatcher runs. Leave it untouched here so the
+            // next-tick dispatcher picks it up.
             QueuedCommand::MoveTo { .. } | QueuedCommand::MoveToCoordinates { .. } => {
-                // Unreachable under the Phase 1 schedule (dispatcher runs
-                // `.before(process_command_queue)`). If we ever observe
-                // this in practice, drop the head to avoid a stall.
-                warn!(
-                    "Queue: MoveTo/MoveToCoordinates reached legacy path (dispatcher ordering bug?) — dropping head"
-                );
-                queue.commands.remove(0);
-                queue.sync_prediction(ship_pos.as_array(), docked_system);
+                // Skip — dispatcher will process next tick.
             }
             QueuedCommand::Scout { .. } => {
                 // #217: Consume and dispatch synchronously. If not at the

--- a/macrocosmo/src/ship/core_deliverable.rs
+++ b/macrocosmo/src/ship/core_deliverable.rs
@@ -29,7 +29,9 @@ use bevy::prelude::*;
 
 use crate::components::Position;
 use crate::galaxy::{AtSystem, StarSystem};
-use crate::ship::command_events::{CommandExecuted, CommandKind, CommandResult, CoreDeployRequested};
+use crate::ship::command_events::{
+    CommandExecuted, CommandKind, CommandResult, CoreDeployRequested,
+};
 use crate::ship::{Owner, Ship, spawn_ship};
 use crate::ship_design::ShipDesignRegistry;
 use crate::time_system::GameClock;

--- a/macrocosmo/src/ship/core_deliverable.rs
+++ b/macrocosmo/src/ship/core_deliverable.rs
@@ -11,20 +11,28 @@
 //!   fleet entities. `faction::system_owner` filters on this marker so that
 //!   transient ships (colony ships, couriers, cruisers) never confer
 //!   sovereignty.
-//! * [`PendingCoreDeploys`] — per-tick queue of deploy tickets produced by
-//!   `deliverable_ops::process_deliverable_commands`. Tickets are resolved in
-//!   [`resolve_core_deploys`] with deterministic tie-breaking when multiple
-//!   deploys target the same system on the same tick.
+//! * [`handle_core_deploy_requested`] — consumes
+//!   [`CoreDeployRequested`](crate::ship::command_events::CoreDeployRequested)
+//!   messages emitted by `handle_deploy_deliverable_requested`. Tickets are
+//!   resolved with deterministic tie-breaking when multiple deploys target
+//!   the same system on the same tick.
 //! * [`spawn_core_ship_from_deliverable`] — helper that wraps the normal
 //!   `spawn_ship` path, additionally attaching [`CoreShip`] and
 //!   [`AtSystem`](crate::galaxy::AtSystem) so sovereignty follows the ship.
+//!
+//! #334 Phase 2 (Commit 2): the intermediate `PendingCoreDeploys` resource +
+//! `CoreDeployTicket` struct were retired in favour of the per-frame
+//! `MessageReader<CoreDeployRequested>` stream. Tie-break + already-has-core
+//! semantics are unchanged.
 
 use bevy::prelude::*;
 
 use crate::components::Position;
 use crate::galaxy::{AtSystem, StarSystem};
+use crate::ship::command_events::{CommandExecuted, CommandKind, CommandResult, CoreDeployRequested};
 use crate::ship::{Owner, Ship, spawn_ship};
 use crate::ship_design::ShipDesignRegistry;
+use crate::time_system::GameClock;
 
 /// Zero-sized marker distinguishing Core ships (infrastructure_core
 /// deployments) from ordinary fleet ships.
@@ -35,46 +43,6 @@ use crate::ship_design::ShipDesignRegistry;
 /// sovereignty is bound to a persistent, non-moving presence.
 #[derive(Component, Default, Clone, Copy, Debug)]
 pub struct CoreShip;
-
-/// One pending Core deploy request, produced when a ship processes a
-/// `DeployDeliverable` command whose target definition carries
-/// `spawns_as_ship = Some(_)`.
-///
-/// The `submitted_at` field is captured from `GameClock.elapsed` at the moment
-/// the ticket was created; `resolve_core_deploys` uses it only for logging.
-#[derive(Debug, Clone)]
-pub struct CoreDeployTicket {
-    /// The ship entity that executed the deploy command.
-    pub deployer: Entity,
-    /// The target star system the Core should be spawned into.
-    pub target_system: Entity,
-    /// The deploy position in galactic coordinates (inner-orbit offset from
-    /// the target system's position).
-    pub deploy_pos: [f64; 3],
-    /// Faction owning the Core ship. `None` for `Owner::Neutral` — such
-    /// deploys self-destruct in `resolve_core_deploys` to preserve the
-    /// invariant that every Core ship has a diplomatic identity.
-    pub faction_owner: Option<Entity>,
-    /// The `Owner` value to plumb through `spawn_ship`.
-    pub owner: Owner,
-    /// The `ShipDesignDefinition.id` used to spawn the Core ship. Must point
-    /// at a design with `sublight_speed = 0` and `ftl_range = 0`.
-    pub design_id: String,
-    /// Index in the deployer's `Cargo.items` of the consumed deliverable.
-    /// Retained for traceability / future logging — cargo removal happens in
-    /// `process_deliverable_commands` when the ticket is pushed, not here.
-    pub cargo_item_index: usize,
-    /// `GameClock.elapsed` hexadies when the ticket was enqueued.
-    pub submitted_at: i64,
-}
-
-/// Per-tick queue of Core deploy tickets. Drained by [`resolve_core_deploys`]
-/// each tick; grouping by `target_system` yields the tie-break set when
-/// multiple deploys land on the same system in the same frame.
-#[derive(Resource, Default, Debug)]
-pub struct PendingCoreDeploys {
-    pub tickets: Vec<CoreDeployTicket>,
-}
 
 /// Spawn a Core ship at `position` in `system`, attaching [`CoreShip`] and
 /// [`AtSystem`] alongside the standard ship components.
@@ -107,24 +75,32 @@ pub fn spawn_core_ship_from_deliverable(
     entity
 }
 
-/// Resolve `PendingCoreDeploys.tickets` into actual Core ships.
+/// Resolve incoming [`CoreDeployRequested`] messages into actual Core ships.
 ///
 /// Ordering:
-/// 1. Group tickets by `target_system`.
-/// 2. If any existing `CoreShip` is already present in that system, DROP all
-///    tickets for that system (the deliverable self-destructs, matching the
-///    "already has a Core" validation in the plan).
-/// 3. If multiple tickets target the same system in the same tick, pick a
-///    winner deterministically via `GameRng` and discard the rest.
-/// 4. Tickets with `Owner::Neutral` / no `faction_owner` are dropped (Core
-///    ships require a diplomatic identity — see [`CoreDeployTicket::owner`]).
-/// 5. Spawn the winner via [`spawn_core_ship_from_deliverable`].
+/// 1. Group requests by `target_system`.
+/// 2. If any existing `CoreShip` is already present in that system, REJECT
+///    all requests for that system (the deliverable self-destructs, matching
+///    the "already has a Core" validation in the plan). A terminal
+///    `CommandExecuted { result: Rejected }` is emitted for each.
+/// 3. If multiple requests target the same system in the same tick, pick a
+///    winner deterministically via `GameRng`; the losers receive
+///    `CommandExecuted { result: Rejected { reason: "lost tie-break" } }`.
+/// 4. Requests with `Owner::Neutral` / no `faction_owner` are rejected (Core
+///    ships require a diplomatic identity).
+/// 5. Spawn the winner via [`spawn_core_ship_from_deliverable`] and emit a
+///    terminal `CommandExecuted { result: Ok }` keyed by `command_id`.
 ///
-/// Runs `.after(process_deliverable_commands)` so tickets enqueued this tick
-/// resolve in the same frame.
-pub fn resolve_core_deploys(
+/// Runs `.after(handle_deploy_deliverable_requested)` so messages enqueued
+/// this tick resolve in the same frame. Replaces the legacy
+/// `resolve_core_deploys` + `PendingCoreDeploys` intermediate resource
+/// (#334 Phase 2 Commit 2).
+#[allow(clippy::too_many_arguments)]
+pub fn handle_core_deploy_requested(
     mut commands: Commands,
-    mut pending: ResMut<PendingCoreDeploys>,
+    clock: Res<GameClock>,
+    mut reqs: MessageReader<CoreDeployRequested>,
+    mut executed: MessageWriter<CommandExecuted>,
     rng: Res<crate::scripting::GameRng>,
     design_registry: Res<ShipDesignRegistry>,
     existing_cores: Query<&AtSystem, With<CoreShip>>,
@@ -133,7 +109,10 @@ pub fn resolve_core_deploys(
     use rand::Rng;
     use std::collections::HashMap;
 
-    if pending.tickets.is_empty() {
+    // Drain incoming messages into an owned vec so we can group / mutate
+    // freely without fighting the reader borrow.
+    let incoming: Vec<CoreDeployRequested> = reqs.read().cloned().collect();
+    if incoming.is_empty() {
         return;
     }
 
@@ -145,45 +124,102 @@ pub fn resolve_core_deploys(
     }
 
     // Group tickets by target_system.
-    let mut by_system: HashMap<Entity, Vec<CoreDeployTicket>> = HashMap::new();
-    for t in pending.tickets.drain(..) {
-        by_system.entry(t.target_system).or_default().push(t);
+    let mut by_system: HashMap<Entity, Vec<CoreDeployRequested>> = HashMap::new();
+    for r in incoming {
+        by_system.entry(r.target_system).or_default().push(r);
     }
 
     for (system, mut group) in by_system.into_iter() {
         // System must still exist.
         if star_systems.get(system).is_err() {
-            for t in &group {
+            for r in &group {
                 warn!(
-                    "Core deploy discarded: target system {:?} no longer exists (ticket from {:?})",
-                    system, t.deployer
+                    "Core deploy discarded: target system {:?} no longer exists (deployer {:?})",
+                    system, r.deployer
                 );
+                executed.write(CommandExecuted {
+                    command_id: r.command_id,
+                    kind: CommandKind::CoreDeploy,
+                    ship: r.deployer,
+                    result: CommandResult::Rejected {
+                        reason: "target system despawned".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
             }
             continue;
         }
         if owned.contains(&system) {
-            for t in &group {
+            for r in &group {
                 info!(
-                    "Core deploy discarded: system {:?} already has a Core ship (ticket from {:?})",
-                    system, t.deployer
+                    "Core deploy discarded: system {:?} already has a Core ship (deployer {:?})",
+                    system, r.deployer
                 );
+                executed.write(CommandExecuted {
+                    command_id: r.command_id,
+                    kind: CommandKind::CoreDeploy,
+                    ship: r.deployer,
+                    result: CommandResult::Rejected {
+                        reason: "system already has Core".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
             }
             continue;
         }
-        // Filter out neutral / owner-less tickets.
-        group.retain(|t| t.faction_owner.is_some() && matches!(t.owner, Owner::Empire(_)));
-        if group.is_empty() {
+        // Separate neutral / owner-less requests from empire-owned ones and
+        // emit terminal rejections for the neutrals (Core ships require a
+        // diplomatic identity — legacy dropped these silently; we now log
+        // Rejected explicitly so CommandLog reflects the outcome).
+        let mut retained: Vec<CoreDeployRequested> = Vec::with_capacity(group.len());
+        for r in group.drain(..) {
+            if r.faction_owner.is_some() && matches!(r.owner, Owner::Empire(_)) {
+                retained.push(r);
+            } else {
+                executed.write(CommandExecuted {
+                    command_id: r.command_id,
+                    kind: CommandKind::CoreDeploy,
+                    ship: r.deployer,
+                    result: CommandResult::Rejected {
+                        reason: "neutral owner".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
+            }
+        }
+        if retained.is_empty() {
             continue;
         }
-        let winner = if group.len() == 1 {
-            group.remove(0)
+        // Tie-break via GameRng when multiple empire-owned requests collide.
+        let winner_idx = if retained.len() == 1 {
+            0
         } else {
             let handle = rng.handle();
             let mut guard = handle.lock().unwrap();
-            let idx = guard.random_range(0..group.len());
+            let idx = guard.random_range(0..retained.len());
             drop(guard);
-            group.swap_remove(idx)
+            idx
         };
+        // Emit Rejected for losers before consuming the winner.
+        for (i, r) in retained.iter().enumerate() {
+            if i == winner_idx {
+                continue;
+            }
+            info!(
+                "Core deploy lost tie-break in system {:?} (deployer {:?})",
+                system, r.deployer
+            );
+            executed.write(CommandExecuted {
+                command_id: r.command_id,
+                kind: CommandKind::CoreDeploy,
+                ship: r.deployer,
+                result: CommandResult::Rejected {
+                    reason: "lost tie-break".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+        }
+        let winner = retained.swap_remove(winner_idx);
         let name = format!(
             "Infrastructure Core ({:?})",
             winner.faction_owner.unwrap_or(Entity::PLACEHOLDER)
@@ -202,6 +238,13 @@ pub fn resolve_core_deploys(
             "Spawned Core ship {:?} in system {:?} (deployer {:?}, submitted at {} hd)",
             entity, system, winner.deployer, winner.submitted_at
         );
+        executed.write(CommandExecuted {
+            command_id: winner.command_id,
+            kind: CommandKind::CoreDeploy,
+            ship: winner.deployer,
+            result: CommandResult::Ok,
+            completed_at: clock.elapsed,
+        });
     }
 }
 

--- a/macrocosmo/src/ship/deliverable_ops.rs
+++ b/macrocosmo/src/ship/deliverable_ops.rs
@@ -24,10 +24,7 @@ pub const DEPLOY_POSITION_EPSILON: f64 = 0.01;
 /// #223: Dismantle a deep-space structure. Removes any existing
 /// `ConstructionPlatform` (lost investment) and installs a `Scrapyard` whose
 /// `remaining = lifetime_cost * scrap_refund`.
-pub fn dismantle_structure(
-    world: &mut World,
-    structure: Entity,
-) -> Result<(), &'static str> {
+pub fn dismantle_structure(world: &mut World, structure: Entity) -> Result<(), &'static str> {
     // Gather what we need without the registry mutably borrowed.
     let (def_id, lifetime) = {
         let Some(ds) = world.get::<DeepSpaceStructure>(structure) else {

--- a/macrocosmo/src/ship/deliverable_ops.rs
+++ b/macrocosmo/src/ship/deliverable_ops.rs
@@ -1,176 +1,25 @@
-//! #223: Deliverable-side command processing.
+//! #223: Deliverable-side helpers.
 //!
-//! Separate from `process_command_queue` (which handles FTL/sublight routing)
-//! because deliverable operations are synchronous, in-place, and don't involve
-//! route planning. Runs BEFORE `process_command_queue` so that any `MoveTo`
-//! auto-queued by this module is dispatched on the same tick.
+//! #334 Phase 2: the per-tick `process_deliverable_commands` loop has been
+//! retired. All four deliverable command variants (`LoadDeliverable`,
+//! `DeployDeliverable`, `TransferToStructure`, `LoadFromScrapyard`) are now
+//! processed by the event-driven `handlers::deliverable_handler` pipeline.
 //!
-//! Commands handled (after #334 Phase 2 migration):
-//!   - `TransferToStructure { structure, minerals, energy }` (migrates in Commit 3)
-//!   - `LoadFromScrapyard { structure }` (migrates in Commit 3)
-//!
-//! `LoadDeliverable` and `DeployDeliverable` are now handled by the
-//! event-driven `handlers::deliverable_handler` pipeline (Commit 1 of Phase 2).
-//!
-//! See `src/ship/mod.rs` for the variant docs.
+//! This module retains:
+//! - [`DEPLOY_POSITION_EPSILON`] shared constant for co-location checks;
+//! - [`dismantle_structure`] helper used by build-queue teardown.
 
 use bevy::prelude::*;
 
 use crate::amount::Amt;
-use crate::components::Position;
 use crate::deep_space::{
     ConstructionPlatform, DeepSpaceStructure, LifetimeCost, ResourceCost, Scrapyard,
     StructureRegistry,
 };
-use crate::ship::{Cargo, CommandQueue, QueuedCommand, Ship, ShipModifiers, ShipState};
 
 /// Maximum position delta (in light-years) for a ship to be considered
 /// "co-located" with a deep-space structure or deploy coordinate.
 pub const DEPLOY_POSITION_EPSILON: f64 = 0.01;
-
-/// Process deliverable-side commands at the head of each ship's queue.
-///
-/// Runs in the `Update` schedule, ordered `.after(advance_game_time)` and
-/// `.before(process_command_queue)` so any auto-queued movement reaches the
-/// FTL planner on the same tick.
-#[allow(clippy::too_many_arguments)]
-pub fn process_deliverable_commands(
-    balance: Res<crate::technology::GameBalance>,
-    registry: Res<StructureRegistry>,
-    mut ships: Query<(
-        Entity,
-        &Ship,
-        &ShipState,
-        &Position,
-        &mut CommandQueue,
-        &mut Cargo,
-        &ShipModifiers,
-    )>,
-    mut platforms: Query<(&Position, &mut ConstructionPlatform), Without<Ship>>,
-    mut scrapyards: Query<(&Position, &mut Scrapyard), Without<Ship>>,
-    structures: Query<(&DeepSpaceStructure, &Position), Without<Ship>>,
-) {
-    let mass_per_slot_raw = balance.mass_per_item_slot().0;
-    let _ = structures; // reserved for future reads
-
-    for (_ship_entity, ship, _state, ship_pos, mut queue, mut cargo, ship_mods) in
-        ships.iter_mut()
-    {
-        if queue.commands.is_empty() {
-            continue;
-        }
-        // Peek at head.
-        let head = queue.commands[0].clone();
-        match head {
-            QueuedCommand::TransferToStructure {
-                structure,
-                minerals,
-                energy,
-            } => {
-                // Ship must be at the structure's position.
-                let Ok((struct_pos, mut platform)) = platforms.get_mut(structure) else {
-                    warn!(
-                        "TransferToStructure: target {:?} is not a ConstructionPlatform",
-                        structure
-                    );
-                    queue.commands.remove(0);
-                    continue;
-                };
-                if ship_pos.distance_to(struct_pos) > DEPLOY_POSITION_EPSILON {
-                    queue.commands.insert(
-                        0,
-                        QueuedCommand::MoveToCoordinates {
-                            target: struct_pos.as_array(),
-                        },
-                    );
-                    continue;
-                }
-                // Clamp transfers by what the ship actually carries.
-                let m = cargo.minerals.min(minerals);
-                let e = cargo.energy.min(energy);
-                if m == Amt::ZERO && e == Amt::ZERO {
-                    queue.commands.remove(0);
-                    continue;
-                }
-                cargo.minerals = cargo.minerals.sub(m);
-                cargo.energy = cargo.energy.sub(e);
-                platform.accumulated.minerals = platform.accumulated.minerals.add(m);
-                platform.accumulated.energy = platform.accumulated.energy.add(e);
-                queue.commands.remove(0);
-                info!(
-                    "Ship {} transferred {}m/{}e to platform {:?}",
-                    ship.name,
-                    m.to_f64(),
-                    e.to_f64(),
-                    structure
-                );
-            }
-            QueuedCommand::LoadFromScrapyard { structure } => {
-                let Ok((scrap_pos, mut scrap)) = scrapyards.get_mut(structure) else {
-                    warn!(
-                        "LoadFromScrapyard: target {:?} has no Scrapyard",
-                        structure
-                    );
-                    queue.commands.remove(0);
-                    continue;
-                };
-                if ship_pos.distance_to(scrap_pos) > DEPLOY_POSITION_EPSILON {
-                    queue.commands.insert(
-                        0,
-                        QueuedCommand::MoveToCoordinates {
-                            target: scrap_pos.as_array(),
-                        },
-                    );
-                    continue;
-                }
-                // Drain as much as the ship can hold. Resources are weightless
-                // relative to the item-mass model (cargo_capacity bounds the
-                // TOTAL mass including resources), so use the same accounting.
-                let cap = ship_mods.cargo_capacity.final_value();
-                let lookup = |id: &str| -> Option<u32> {
-                    registry
-                        .get(id)
-                        .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
-                };
-                let current_mass =
-                    cargo.total_mass_with(&lookup, mass_per_slot_raw);
-                let headroom = if current_mass >= cap {
-                    Amt::ZERO
-                } else {
-                    Amt(cap.0 - current_mass.0)
-                };
-                // Split headroom between minerals and energy proportionally.
-                let to_take_m = scrap.remaining.minerals.min(headroom);
-                let headroom_after_m = Amt(headroom.0.saturating_sub(to_take_m.0));
-                let to_take_e = scrap.remaining.energy.min(headroom_after_m);
-
-                if to_take_m == Amt::ZERO && to_take_e == Amt::ZERO {
-                    // No space. Drop the command so the user can retry.
-                    queue.commands.remove(0);
-                    continue;
-                }
-
-                cargo.minerals = cargo.minerals.add(to_take_m);
-                cargo.energy = cargo.energy.add(to_take_e);
-                scrap.remaining.minerals = scrap.remaining.minerals.sub(to_take_m);
-                scrap.remaining.energy = scrap.remaining.energy.sub(to_take_e);
-                queue.commands.remove(0);
-                info!(
-                    "Ship {} salvaged {}m/{}e from scrapyard {:?}",
-                    ship.name,
-                    to_take_m.to_f64(),
-                    to_take_e.to_f64(),
-                    structure
-                );
-            }
-            // Other commands are handled by the dispatcher + handler path
-            // (`handlers::deliverable_handler`, `move_handler`) or by the
-            // legacy `process_command_queue` (Survey / Colonize / Scout,
-            // migrating in later Phase 2 commits).
-            _ => {}
-        }
-    }
-}
 
 /// #223: Dismantle a deep-space structure. Removes any existing
 /// `ConstructionPlatform` (lost investment) and installs a `Scrapyard` whose

--- a/macrocosmo/src/ship/deliverable_ops.rs
+++ b/macrocosmo/src/ship/deliverable_ops.rs
@@ -5,31 +5,24 @@
 //! route planning. Runs BEFORE `process_command_queue` so that any `MoveTo`
 //! auto-queued by this module is dispatched on the same tick.
 //!
-//! Commands handled:
-//!   - `LoadDeliverable { system, stockpile_index }`
-//!   - `DeployDeliverable { position, item_index }`
-//!   - `TransferToStructure { structure, minerals, energy }`
-//!   - `LoadFromScrapyard { structure }`
+//! Commands handled (after #334 Phase 2 migration):
+//!   - `TransferToStructure { structure, minerals, energy }` (migrates in Commit 3)
+//!   - `LoadFromScrapyard { structure }` (migrates in Commit 3)
+//!
+//! `LoadDeliverable` and `DeployDeliverable` are now handled by the
+//! event-driven `handlers::deliverable_handler` pipeline (Commit 1 of Phase 2).
 //!
 //! See `src/ship/mod.rs` for the variant docs.
 
 use bevy::prelude::*;
 
 use crate::amount::Amt;
-use crate::colony::DeliverableStockpile;
 use crate::components::Position;
 use crate::deep_space::{
-    spawn_deliverable_entity, ConstructionPlatform, DeepSpaceStructure, LifetimeCost, ResourceCost,
-    Scrapyard, StructureRegistry,
+    ConstructionPlatform, DeepSpaceStructure, LifetimeCost, ResourceCost, Scrapyard,
+    StructureRegistry,
 };
-use crate::knowledge::{
- FactSysParam, KnowledgeFact, PlayerVantage,
-};
-use crate::player::{AboardShip, Player, StationedAt};
-use crate::ship::{
-    Cargo, CargoItem, CommandQueue, QueuedCommand, Ship, ShipModifiers, ShipState,
-    core_deliverable::{CoreDeployTicket, PendingCoreDeploys},
-};
+use crate::ship::{Cargo, CommandQueue, QueuedCommand, Ship, ShipModifiers, ShipState};
 
 /// Maximum position delta (in light-years) for a ship to be considered
 /// "co-located" with a deep-space structure or deploy coordinate.
@@ -42,11 +35,8 @@ pub const DEPLOY_POSITION_EPSILON: f64 = 0.01;
 /// FTL planner on the same tick.
 #[allow(clippy::too_many_arguments)]
 pub fn process_deliverable_commands(
-    mut commands: Commands,
-    clock: Res<crate::time_system::GameClock>,
     balance: Res<crate::technology::GameBalance>,
     registry: Res<StructureRegistry>,
-    mut events: MessageWriter<crate::events::GameEvent>,
     mut ships: Query<(
         Entity,
         &Ship,
@@ -56,39 +46,14 @@ pub fn process_deliverable_commands(
         &mut Cargo,
         &ShipModifiers,
     )>,
-    mut stockpiles: Query<&mut DeliverableStockpile>,
     mut platforms: Query<(&Position, &mut ConstructionPlatform), Without<Ship>>,
     mut scrapyards: Query<(&Position, &mut Scrapyard), Without<Ship>>,
     structures: Query<(&DeepSpaceStructure, &Position), Without<Ship>>,
-    player_q: Query<&StationedAt, Without<Ship>>,
-    player_aboard_q: Query<&AboardShip, With<Player>>,
-    // #296 (S-3): (entity, position) for all star systems — used both by the
-    // existing player-vantage lookup and by the new Core-deploy proximity
-    // match. A single tuple-style Query keeps the total param count under
-    // Bevy's 16-arg limit.
-    star_systems: Query<(Entity, &Position), (Without<Ship>, With<crate::galaxy::StarSystem>)>,
-    // #296 (S-3): Existing Core ships keyed by AtSystem for the
-    // "already-has-core" validation branch. Query is `With<CoreShip>` so it
-    // stays disjoint from any writable Ship query.
-    existing_cores: Query<&crate::galaxy::AtSystem, With<crate::ship::CoreShip>>,
-    // #296 (S-3): Pending ticket queue — resolved downstream by
-    // `resolve_core_deploys` with tie-break + Core-ship spawn.
-    mut pending_cores: ResMut<PendingCoreDeploys>,
-    mut fact_sys: FactSysParam,
 ) {
     let mass_per_slot_raw = balance.mass_per_item_slot().0;
-    // #249: Snapshot player vantage once per tick.
-    let player_system = player_q.iter().next().map(|s| s.system);
-    let player_pos: Option<[f64; 3]> = player_system
-        .and_then(|s| star_systems.get(s).ok())
-        .map(|(_, p)| p.as_array());
-    let player_aboard = player_aboard_q.iter().next().is_some();
-    let vantage = player_pos.map(|pos| PlayerVantage {
-        player_pos: pos,
-        player_aboard,
-    });
+    let _ = structures; // reserved for future reads
 
-    for (_ship_entity, ship, state, ship_pos, mut queue, mut cargo, ship_mods) in
+    for (_ship_entity, ship, _state, ship_pos, mut queue, mut cargo, ship_mods) in
         ships.iter_mut()
     {
         if queue.commands.is_empty() {
@@ -97,231 +62,6 @@ pub fn process_deliverable_commands(
         // Peek at head.
         let head = queue.commands[0].clone();
         match head {
-            QueuedCommand::LoadDeliverable { system, stockpile_index } => {
-                // Ship must be docked at the system.
-                let docked_system = match state {
-                    ShipState::Docked { system: s } => Some(*s),
-                    _ => None,
-                };
-                if docked_system != Some(system) {
-                    // Inject a MoveTo to that system before this command.
-                    // The existing command is kept; insert the move at position 0.
-                    queue.commands.insert(0, QueuedCommand::MoveTo { system });
-                    continue;
-                }
-                // Find the stockpile.
-                let Ok(mut stockpile) = stockpiles.get_mut(system) else {
-                    warn!("LoadDeliverable: system has no DeliverableStockpile");
-                    queue.commands.remove(0);
-                    continue;
-                };
-                let Some(item) = stockpile.items.get(stockpile_index).cloned() else {
-                    warn!(
-                        "LoadDeliverable: index {} out of range (len={})",
-                        stockpile_index,
-                        stockpile.items.len()
-                    );
-                    queue.commands.remove(0);
-                    continue;
-                };
-                // Check cargo capacity.
-                let size = registry
-                    .get(item.definition_id())
-                    .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
-                    .unwrap_or(1);
-                let cap = ship_mods.cargo_capacity.final_value();
-                let lookup = |id: &str| -> Option<u32> {
-                    registry
-                        .get(id)
-                        .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
-                };
-                if !cargo.can_fit(size, cap, &lookup, mass_per_slot_raw) {
-                    warn!(
-                        "LoadDeliverable: ship {} has insufficient cargo capacity for {}",
-                        ship.name,
-                        item.definition_id()
-                    );
-                    queue.commands.remove(0);
-                    continue;
-                }
-                // Load it.
-                stockpile.items.remove(stockpile_index);
-                cargo.items.push(item.clone());
-                queue.commands.remove(0);
-                info!(
-                    "Ship {} loaded {} from system stockpile",
-                    ship.name,
-                    item.definition_id()
-                );
-                // #249: Dual-write Load event as a StructureBuilt fact.
-                let event_id = fact_sys.allocate_event_id();
-                let desc = format!("{} loaded {}", ship.name, item.definition_id());
-                events.write(crate::events::GameEvent {
-                    id: event_id,
-                    timestamp: clock.elapsed,
-                    kind: crate::events::GameEventKind::ShipBuilt,
-                    description: desc.clone(),
-                    related_system: Some(system),
-                });
-                let origin_pos: Option<[f64; 3]> =
-                    star_systems.get(system).ok().map(|(_, p)| p.as_array());
-                if let (Some(v), Some(op)) = (vantage, origin_pos) {
-                    let fact = KnowledgeFact::StructureBuilt {
-                        event_id: Some(event_id),
-                        system: Some(system),
-                        kind: "cargo_load".into(),
-                        name: item.definition_id().to_string(),
-                        destroyed: false,
-                        detail: desc,
-                    };
-                    fact_sys.record(fact, op, clock.elapsed, &v);
-                }
-            }
-            QueuedCommand::DeployDeliverable { position, item_index } => {
-                // Ship must not be in FTL or surveying. Loitering/Docked OK.
-                let allowed = matches!(
-                    state,
-                    ShipState::Docked { .. } | ShipState::Loitering { .. }
-                );
-                if !allowed {
-                    // Wait until movement completes.
-                    continue;
-                }
-                // Check that ship is at position.
-                let here = ship_pos.as_array();
-                let d = (here[0] - position[0]).powi(2)
-                    + (here[1] - position[1]).powi(2)
-                    + (here[2] - position[2]).powi(2);
-                if d.sqrt() > DEPLOY_POSITION_EPSILON {
-                    queue
-                        .commands
-                        .insert(0, QueuedCommand::MoveToCoordinates { target: position });
-                    continue;
-                }
-                // Execute deployment.
-                let Some(item) = cargo.items.get(item_index).cloned() else {
-                    warn!("DeployDeliverable: item_index out of range");
-                    queue.commands.remove(0);
-                    continue;
-                };
-                let def_id = item.definition_id().to_string();
-                let Some(def) = registry.get(&def_id) else {
-                    warn!("DeployDeliverable: unknown definition {}", def_id);
-                    queue.commands.remove(0);
-                    continue;
-                };
-                // #296 (S-3): Deliverables whose metadata carries
-                // `spawns_as_ship = Some(_)` are Core ships. Route them
-                // through PendingCoreDeploys instead of the deep-space
-                // structure spawn path. The ticket queue enforces validation
-                // (existing Core, tie-break) in a dedicated resolver.
-                if let Some(design_id) = def
-                    .deliverable
-                    .as_ref()
-                    .and_then(|m| m.spawns_as_ship.as_ref())
-                {
-                    // Identify target system by proximity. Deploy must be
-                    // inside a known system; a deep-space deploy makes the
-                    // ticket self-destruct (consume cargo + remove command).
-                    let mut target: Option<(Entity, Position)> = None;
-                    let mut best_d: f64 = f64::INFINITY;
-                    for (sys_entity, sys_pos) in star_systems.iter() {
-                        let dx = position[0] - sys_pos.x;
-                        let dy = position[1] - sys_pos.y;
-                        let dz = position[2] - sys_pos.z;
-                        let d = (dx * dx + dy * dy + dz * dz).sqrt();
-                        if d <= crate::galaxy::SYSTEM_RADIUS_LY && d < best_d {
-                            best_d = d;
-                            target = Some((sys_entity, *sys_pos));
-                        }
-                    }
-                    let Some((target_system, sys_pos)) = target else {
-                        warn!(
-                            "Core deploy self-destruct: ship {} deployed {} in deep space",
-                            ship.name, def_id
-                        );
-                        cargo.items.remove(item_index);
-                        queue.commands.remove(0);
-                        continue;
-                    };
-                    // Early validation: already owned → self-destruct.
-                    let has_core = existing_cores
-                        .iter()
-                        .any(|at| at.0 == target_system);
-                    if has_core {
-                        info!(
-                            "Core deploy self-destruct: system {:?} already has a Core (ship {})",
-                            target_system, ship.name
-                        );
-                        cargo.items.remove(item_index);
-                        queue.commands.remove(0);
-                        continue;
-                    }
-                    let faction_owner = match ship.owner {
-                        crate::ship::Owner::Empire(f) => Some(f),
-                        crate::ship::Owner::Neutral => None,
-                    };
-                    let deploy_pos = [
-                        sys_pos.x + crate::galaxy::INNER_ORBIT_OFFSET_LY,
-                        sys_pos.y,
-                        sys_pos.z,
-                    ];
-                    pending_cores.tickets.push(CoreDeployTicket {
-                        deployer: _ship_entity,
-                        target_system,
-                        deploy_pos,
-                        faction_owner,
-                        owner: ship.owner,
-                        design_id: design_id.clone(),
-                        cargo_item_index: item_index,
-                        submitted_at: clock.elapsed,
-                    });
-                    cargo.items.remove(item_index);
-                    queue.commands.remove(0);
-                    info!(
-                        "Ship {} enqueued Core deploy in system {:?} (definition={})",
-                        ship.name, target_system, def_id
-                    );
-                    continue;
-                }
-                let spawned = spawn_deliverable_entity(
-                    &mut commands,
-                    &def_id,
-                    position,
-                    ship.owner,
-                    &registry,
-                );
-                if spawned.is_none() {
-                    warn!("DeployDeliverable: spawn failed for {}", def_id);
-                    queue.commands.remove(0);
-                    continue;
-                }
-                cargo.items.remove(item_index);
-                queue.commands.remove(0);
-                info!("Ship {} deployed {} at {:?}", ship.name, def_id, position);
-                // #249: Dual-write Deploy event.
-                let event_id = fact_sys.allocate_event_id();
-                let desc = format!("{} deployed {}", ship.name, def_id);
-                events.write(crate::events::GameEvent {
-                    id: event_id,
-                    timestamp: clock.elapsed,
-                    kind: crate::events::GameEventKind::ShipBuilt,
-                    description: desc.clone(),
-                    related_system: None,
-                });
-                let origin_pos = position;
-                if let Some(v) = vantage {
-                    let fact = KnowledgeFact::StructureBuilt {
-                        event_id: Some(event_id),
-                        system: None,
-                        kind: "deployed_deliverable".into(),
-                        name: def_id.clone(),
-                        destroyed: false,
-                        detail: desc,
-                    };
-                    fact_sys.record(fact, origin_pos, clock.elapsed, &v);
-                }
-            }
             QueuedCommand::TransferToStructure {
                 structure,
                 minerals,
@@ -423,13 +163,13 @@ pub fn process_deliverable_commands(
                     structure
                 );
             }
-            // Other commands are handled by process_command_queue.
+            // Other commands are handled by the dispatcher + handler path
+            // (`handlers::deliverable_handler`, `move_handler`) or by the
+            // legacy `process_command_queue` (Survey / Colonize / Scout,
+            // migrating in later Phase 2 commits).
             _ => {}
         }
     }
-
-    // Suppress unused warning for this query — it's kept for future use.
-    let _ = structures;
 }
 
 /// #223: Dismantle a deep-space structure. Removes any existing

--- a/macrocosmo/src/ship/dispatcher.rs
+++ b/macrocosmo/src/ship/dispatcher.rs
@@ -21,8 +21,9 @@
 use bevy::prelude::*;
 
 use super::command_events::{
-    CommandId, DeployDeliverableRequested, LoadDeliverableRequested, LoadFromScrapyardRequested,
-    MoveRequested, MoveToCoordinatesRequested, NextCommandId, TransferToStructureRequested,
+    ColonizeRequested, CommandId, DeployDeliverableRequested, LoadDeliverableRequested,
+    LoadFromScrapyardRequested, MoveRequested, MoveToCoordinatesRequested, NextCommandId,
+    SurveyRequested, TransferToStructureRequested,
 };
 use super::routing::PendingRoute;
 use super::{CommandQueue, QueuedCommand, Ship, ShipState};
@@ -58,6 +59,8 @@ pub fn dispatch_queued_commands(
     mut deploy_req: MessageWriter<DeployDeliverableRequested>,
     mut transfer_req: MessageWriter<TransferToStructureRequested>,
     mut scrap_req: MessageWriter<LoadFromScrapyardRequested>,
+    mut survey_req: MessageWriter<SurveyRequested>,
+    mut colonize_req: MessageWriter<ColonizeRequested>,
     // #334 Phase 1: append a `Dispatched` entry to the player empire's
     // CommandLog on each successful validation. The bridge system
     // `bridge_command_executed_to_log` finalizes via `CommandId` match.
@@ -289,13 +292,60 @@ pub fn dispatch_queued_commands(
                     ship.name, structure, command_id.0
                 );
             }
+            QueuedCommand::Survey { system: target } => {
+                let target = *target;
+                let command_id = next_id.allocate();
+                queue.commands.remove(0);
+                survey_req.write(SurveyRequested {
+                    command_id,
+                    ship: ship_entity,
+                    target_system: target,
+                    issued_at: clock.elapsed,
+                });
+                if let Some(log) = command_log.as_mut() {
+                    log.entries.push(CommandLogEntry::new_dispatched(
+                        format!("{} → Survey {:?}", ship.name, target),
+                        clock.elapsed,
+                        command_id,
+                    ));
+                }
+                info!(
+                    "dispatch: ship {} SurveyRequested -> {:?} (cmd {})",
+                    ship.name, target, command_id.0
+                );
+            }
+            QueuedCommand::Colonize {
+                system: target,
+                planet,
+            } => {
+                let target = *target;
+                let planet = *planet;
+                let command_id = next_id.allocate();
+                queue.commands.remove(0);
+                colonize_req.write(ColonizeRequested {
+                    command_id,
+                    ship: ship_entity,
+                    target_system: target,
+                    planet,
+                    issued_at: clock.elapsed,
+                });
+                if let Some(log) = command_log.as_mut() {
+                    log.entries.push(CommandLogEntry::new_dispatched(
+                        format!("{} → Colonize {:?}", ship.name, target),
+                        clock.elapsed,
+                        command_id,
+                    ));
+                }
+                info!(
+                    "dispatch: ship {} ColonizeRequested -> {:?} (cmd {})",
+                    ship.name, target, command_id.0
+                );
+            }
             // Non-migrated variants: leave the head untouched so the legacy
             // `process_command_queue` system consumes them this same tick.
-            QueuedCommand::Survey { .. }
-            | QueuedCommand::Colonize { .. }
-            | QueuedCommand::Scout { .. } => {
-                // Commit 4 (Survey/Colonize) / Phase 3 (Scout) will migrate
-                // these. For now, do nothing — the legacy systems pick them up.
+            QueuedCommand::Scout { .. } => {
+                // Phase 3 will migrate Scout. For now the legacy system
+                // picks it up.
             }
         }
     }
@@ -496,28 +546,31 @@ mod tests {
 
     #[test]
     fn dispatcher_leaves_non_migrated_variants_untouched() {
+        // #334 Phase 2 (Commit 4): Survey/Colonize are now migrated. Scout
+        // remains the only non-migrated variant — verify the dispatcher
+        // doesn't consume it.
+        use crate::ship::ReportMode;
         let mut app = make_app();
         let target = spawn_test_system(app.world_mut(), [5.0, 0.0, 0.0]);
         let origin = spawn_test_system(app.world_mut(), [0.0, 0.0, 0.0]);
         let ship = spawn_test_ship(app.world_mut(), [0.0, 0.0, 0.0], Some(origin), 0.5, 10.0);
         {
             let mut q = app.world_mut().get_mut::<CommandQueue>(ship).unwrap();
-            q.commands.push(QueuedCommand::Survey { system: target });
-            q.commands.push(QueuedCommand::TransferToStructure {
-                structure: target,
-                minerals: Amt(0),
-                energy: Amt(0),
+            q.commands.push(QueuedCommand::Scout {
+                target_system: target,
+                observation_duration: 10,
+                report_mode: ReportMode::Return,
             });
         }
         app.update();
 
-        // No MoveRequested emitted, queue head is still Survey.
+        // No MoveRequested emitted, queue head is still Scout.
         let messages = app.world().resource::<Messages<MoveRequested>>();
         let mut cursor = messages.get_cursor();
         assert_eq!(cursor.read(messages).count(), 0);
         let q = app.world().get::<CommandQueue>(ship).unwrap();
-        assert_eq!(q.commands.len(), 2);
-        assert!(matches!(q.commands[0], QueuedCommand::Survey { .. }));
+        assert_eq!(q.commands.len(), 1);
+        assert!(matches!(q.commands[0], QueuedCommand::Scout { .. }));
     }
 
     #[test]

--- a/macrocosmo/src/ship/dispatcher.rs
+++ b/macrocosmo/src/ship/dispatcher.rs
@@ -20,7 +20,10 @@
 
 use bevy::prelude::*;
 
-use super::command_events::{CommandId, MoveRequested, MoveToCoordinatesRequested, NextCommandId};
+use super::command_events::{
+    CommandId, DeployDeliverableRequested, LoadDeliverableRequested, MoveRequested,
+    MoveToCoordinatesRequested, NextCommandId,
+};
 use super::routing::PendingRoute;
 use super::{CommandQueue, QueuedCommand, Ship, ShipState};
 use crate::communication::{CommandLog, CommandLogEntry};
@@ -48,9 +51,11 @@ pub fn dispatch_queued_commands(
     // Read-only target lookup. Name not used here but the filter ensures we
     // only match star-system entities.
     systems: Query<Entity, With<StarSystem>>,
-    // Typed message writers — one per Phase-1 request variant.
+    // Typed message writers — one per Phase-1/2 request variant.
     mut move_req: MessageWriter<MoveRequested>,
     mut move_xy_req: MessageWriter<MoveToCoordinatesRequested>,
+    mut load_req: MessageWriter<LoadDeliverableRequested>,
+    mut deploy_req: MessageWriter<DeployDeliverableRequested>,
     // #334 Phase 1: append a `Dispatched` entry to the player empire's
     // CommandLog on each successful validation. The bridge system
     // `bridge_command_executed_to_log` finalizes via `CommandId` match.
@@ -167,18 +172,73 @@ pub fn dispatch_queued_commands(
                     ship.name, target_arr[0], target_arr[1], target_arr[2], command_id.0
                 );
             }
+            QueuedCommand::LoadDeliverable {
+                system,
+                stockpile_index,
+            } => {
+                let system = *system;
+                let stockpile_index = *stockpile_index;
+                let command_id = next_id.allocate();
+                queue.commands.remove(0);
+                load_req.write(LoadDeliverableRequested {
+                    command_id,
+                    ship: ship_entity,
+                    system,
+                    stockpile_index,
+                    issued_at: clock.elapsed,
+                });
+                if let Some(log) = command_log.as_mut() {
+                    log.entries.push(CommandLogEntry::new_dispatched(
+                        format!("{} → LoadDeliverable [{}]", ship.name, stockpile_index),
+                        clock.elapsed,
+                        command_id,
+                    ));
+                }
+                info!(
+                    "dispatch: ship {} LoadDeliverableRequested system={:?} idx={} (cmd {})",
+                    ship.name, system, stockpile_index, command_id.0
+                );
+            }
+            QueuedCommand::DeployDeliverable {
+                position,
+                item_index,
+            } => {
+                let position = *position;
+                let item_index = *item_index;
+                let command_id = next_id.allocate();
+                queue.commands.remove(0);
+                deploy_req.write(DeployDeliverableRequested {
+                    command_id,
+                    ship: ship_entity,
+                    position,
+                    item_index,
+                    issued_at: clock.elapsed,
+                });
+                if let Some(log) = command_log.as_mut() {
+                    log.entries.push(CommandLogEntry::new_dispatched(
+                        format!(
+                            "{} → DeployDeliverable [{}] at ({:.2},{:.2},{:.2})",
+                            ship.name, item_index, position[0], position[1], position[2]
+                        ),
+                        clock.elapsed,
+                        command_id,
+                    ));
+                }
+                info!(
+                    "dispatch: ship {} DeployDeliverableRequested idx={} (cmd {})",
+                    ship.name, item_index, command_id.0
+                );
+            }
             // Non-migrated variants: leave the head untouched so the legacy
             // `process_command_queue` / `process_deliverable_commands`
             // systems consume them this same tick (they run .after(dispatcher)).
             QueuedCommand::Survey { .. }
             | QueuedCommand::Colonize { .. }
             | QueuedCommand::Scout { .. }
-            | QueuedCommand::LoadDeliverable { .. }
-            | QueuedCommand::DeployDeliverable { .. }
             | QueuedCommand::TransferToStructure { .. }
             | QueuedCommand::LoadFromScrapyard { .. } => {
-                // Phase 2/3 will migrate these. For now, do nothing — the
-                // legacy systems pick them up.
+                // Phase 2 (later commits) / 3 will migrate these. For now,
+                // do nothing — the legacy systems pick them up.
             }
         }
     }

--- a/macrocosmo/src/ship/dispatcher.rs
+++ b/macrocosmo/src/ship/dispatcher.rs
@@ -21,8 +21,8 @@
 use bevy::prelude::*;
 
 use super::command_events::{
-    CommandId, DeployDeliverableRequested, LoadDeliverableRequested, MoveRequested,
-    MoveToCoordinatesRequested, NextCommandId,
+    CommandId, DeployDeliverableRequested, LoadDeliverableRequested, LoadFromScrapyardRequested,
+    MoveRequested, MoveToCoordinatesRequested, NextCommandId, TransferToStructureRequested,
 };
 use super::routing::PendingRoute;
 use super::{CommandQueue, QueuedCommand, Ship, ShipState};
@@ -56,6 +56,8 @@ pub fn dispatch_queued_commands(
     mut move_xy_req: MessageWriter<MoveToCoordinatesRequested>,
     mut load_req: MessageWriter<LoadDeliverableRequested>,
     mut deploy_req: MessageWriter<DeployDeliverableRequested>,
+    mut transfer_req: MessageWriter<TransferToStructureRequested>,
+    mut scrap_req: MessageWriter<LoadFromScrapyardRequested>,
     // #334 Phase 1: append a `Dispatched` entry to the player empire's
     // CommandLog on each successful validation. The bridge system
     // `bridge_command_executed_to_log` finalizes via `CommandId` match.
@@ -229,16 +231,71 @@ pub fn dispatch_queued_commands(
                     ship.name, item_index, command_id.0
                 );
             }
+            QueuedCommand::TransferToStructure {
+                structure,
+                minerals,
+                energy,
+            } => {
+                let structure = *structure;
+                let minerals = *minerals;
+                let energy = *energy;
+                let command_id = next_id.allocate();
+                queue.commands.remove(0);
+                transfer_req.write(TransferToStructureRequested {
+                    command_id,
+                    ship: ship_entity,
+                    structure,
+                    minerals,
+                    energy,
+                    issued_at: clock.elapsed,
+                });
+                if let Some(log) = command_log.as_mut() {
+                    log.entries.push(CommandLogEntry::new_dispatched(
+                        format!(
+                            "{} → TransferToStructure {:?} ({}m/{}e)",
+                            ship.name,
+                            structure,
+                            minerals.to_f64(),
+                            energy.to_f64()
+                        ),
+                        clock.elapsed,
+                        command_id,
+                    ));
+                }
+                info!(
+                    "dispatch: ship {} TransferToStructureRequested -> {:?} (cmd {})",
+                    ship.name, structure, command_id.0
+                );
+            }
+            QueuedCommand::LoadFromScrapyard { structure } => {
+                let structure = *structure;
+                let command_id = next_id.allocate();
+                queue.commands.remove(0);
+                scrap_req.write(LoadFromScrapyardRequested {
+                    command_id,
+                    ship: ship_entity,
+                    structure,
+                    issued_at: clock.elapsed,
+                });
+                if let Some(log) = command_log.as_mut() {
+                    log.entries.push(CommandLogEntry::new_dispatched(
+                        format!("{} → LoadFromScrapyard {:?}", ship.name, structure),
+                        clock.elapsed,
+                        command_id,
+                    ));
+                }
+                info!(
+                    "dispatch: ship {} LoadFromScrapyardRequested -> {:?} (cmd {})",
+                    ship.name, structure, command_id.0
+                );
+            }
             // Non-migrated variants: leave the head untouched so the legacy
-            // `process_command_queue` / `process_deliverable_commands`
-            // systems consume them this same tick (they run .after(dispatcher)).
+            // `process_command_queue` system consumes them this same tick.
             QueuedCommand::Survey { .. }
             | QueuedCommand::Colonize { .. }
-            | QueuedCommand::Scout { .. }
-            | QueuedCommand::TransferToStructure { .. }
-            | QueuedCommand::LoadFromScrapyard { .. } => {
-                // Phase 2 (later commits) / 3 will migrate these. For now,
-                // do nothing — the legacy systems pick them up.
+            | QueuedCommand::Scout { .. } => {
+                // Commit 4 (Survey/Colonize) / Phase 3 (Scout) will migrate
+                // these. For now, do nothing — the legacy systems pick them up.
             }
         }
     }

--- a/macrocosmo/src/ship/handlers/deliverable_handler.rs
+++ b/macrocosmo/src/ship/handlers/deliverable_handler.rs
@@ -1,0 +1,514 @@
+//! #334 Phase 2: `LoadDeliverable` / `DeployDeliverable` handlers.
+//!
+//! Extracted verbatim from `deliverable_ops::process_deliverable_commands`
+//! — same validation, same mutation, same `FactSysParam` dual-writes. The
+//! only change is that these systems are **message-driven**: the dispatcher
+//! emits [`LoadDeliverableRequested`] / [`DeployDeliverableRequested`]
+//! instead of the legacy loop pulling the queue head.
+//!
+//! Core-branch of `DeployDeliverable` continues to push a
+//! [`CoreDeployTicket`] into [`PendingCoreDeploys`] for Commit 1; Commit 2
+//! switches this to emit a [`CoreDeployRequested`] message and drops the
+//! intermediate resource entirely.
+
+use bevy::prelude::*;
+
+use crate::colony::DeliverableStockpile;
+use crate::components::Position;
+use crate::deep_space::{ConstructionPlatform, DeepSpaceStructure, Scrapyard, StructureRegistry, spawn_deliverable_entity};
+use crate::knowledge::{FactSysParam, KnowledgeFact, PlayerVantage};
+use crate::player::{AboardShip, Player, StationedAt};
+use crate::ship::command_events::{
+    CommandExecuted, CommandKind, CommandResult, DeployDeliverableRequested,
+    LoadDeliverableRequested,
+};
+use crate::ship::core_deliverable::{CoreDeployTicket, PendingCoreDeploys};
+use crate::ship::deliverable_ops::DEPLOY_POSITION_EPSILON;
+use crate::ship::{Cargo, CommandQueue, QueuedCommand, Ship, ShipModifiers, ShipState};
+use crate::time_system::GameClock;
+
+// ---------------------------------------------------------------------------
+// LoadDeliverable
+// ---------------------------------------------------------------------------
+
+/// Handles `LoadDeliverableRequested`. Mirrors the `LoadDeliverable` arm of
+/// the legacy `process_deliverable_commands`: validates that the ship is
+/// docked at the target system (auto-queues a `MoveTo` otherwise), pulls the
+/// stockpile item if cargo capacity permits, and dual-writes a
+/// `StructureBuilt` knowledge fact.
+#[allow(clippy::too_many_arguments)]
+pub fn handle_load_deliverable_requested(
+    clock: Res<GameClock>,
+    balance: Res<crate::technology::GameBalance>,
+    registry: Res<StructureRegistry>,
+    mut reqs: MessageReader<LoadDeliverableRequested>,
+    mut events: MessageWriter<crate::events::GameEvent>,
+    mut executed: MessageWriter<CommandExecuted>,
+    mut ships: Query<(
+        &Ship,
+        &ShipState,
+        &Position,
+        &mut CommandQueue,
+        &mut Cargo,
+        &ShipModifiers,
+    )>,
+    mut stockpiles: Query<&mut DeliverableStockpile>,
+    star_systems: Query<(Entity, &Position), (Without<Ship>, With<crate::galaxy::StarSystem>)>,
+    player_q: Query<&StationedAt, Without<Ship>>,
+    player_aboard_q: Query<&AboardShip, With<Player>>,
+    mut fact_sys: FactSysParam,
+) {
+    let mass_per_slot_raw = balance.mass_per_item_slot().0;
+    let player_system = player_q.iter().next().map(|s| s.system);
+    let player_pos: Option<[f64; 3]> = player_system
+        .and_then(|s| star_systems.get(s).ok())
+        .map(|(_, p)| p.as_array());
+    let player_aboard = player_aboard_q.iter().next().is_some();
+    let vantage = player_pos.map(|pos| PlayerVantage {
+        player_pos: pos,
+        player_aboard,
+    });
+
+    for req in reqs.read() {
+        let Ok((ship, state, _ship_pos, mut queue, mut cargo, ship_mods)) = ships.get_mut(req.ship)
+        else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadDeliverable,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "ship unavailable".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        // Ship must be docked at the target system.
+        let docked_system = match state {
+            ShipState::Docked { system } => Some(*system),
+            _ => None,
+        };
+        if docked_system != Some(req.system) {
+            // Auto-insert a MoveTo. The command queue ordering is preserved
+            // because the caller (dispatcher) already popped the original
+            // LoadDeliverable; we re-inject it here so the legacy queue
+            // sees it again after the ship arrives.
+            queue
+                .commands
+                .insert(0, QueuedCommand::LoadDeliverable {
+                    system: req.system,
+                    stockpile_index: req.stockpile_index,
+                });
+            queue
+                .commands
+                .insert(0, QueuedCommand::MoveTo { system: req.system });
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadDeliverable,
+                ship: req.ship,
+                result: CommandResult::Deferred,
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        let Ok(mut stockpile) = stockpiles.get_mut(req.system) else {
+            warn!("LoadDeliverable: system has no DeliverableStockpile");
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadDeliverable,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "no stockpile".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+        let Some(item) = stockpile.items.get(req.stockpile_index).cloned() else {
+            warn!(
+                "LoadDeliverable: index {} out of range (len={})",
+                req.stockpile_index,
+                stockpile.items.len()
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadDeliverable,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "stockpile index out of range".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        let size = registry
+            .get(item.definition_id())
+            .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
+            .unwrap_or(1);
+        let cap = ship_mods.cargo_capacity.final_value();
+        let lookup = |id: &str| -> Option<u32> {
+            registry
+                .get(id)
+                .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
+        };
+        if !cargo.can_fit(size, cap, &lookup, mass_per_slot_raw) {
+            warn!(
+                "LoadDeliverable: ship {} has insufficient cargo capacity for {}",
+                ship.name,
+                item.definition_id()
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadDeliverable,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "insufficient cargo".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        stockpile.items.remove(req.stockpile_index);
+        cargo.items.push(item.clone());
+        info!(
+            "Ship {} loaded {} from system stockpile",
+            ship.name,
+            item.definition_id()
+        );
+
+        // Dual-write knowledge fact.
+        let event_id = fact_sys.allocate_event_id();
+        let desc = format!("{} loaded {}", ship.name, item.definition_id());
+        events.write(crate::events::GameEvent {
+            id: event_id,
+            timestamp: clock.elapsed,
+            kind: crate::events::GameEventKind::ShipBuilt,
+            description: desc.clone(),
+            related_system: Some(req.system),
+        });
+        let origin_pos: Option<[f64; 3]> =
+            star_systems.get(req.system).ok().map(|(_, p)| p.as_array());
+        if let (Some(v), Some(op)) = (vantage, origin_pos) {
+            let fact = KnowledgeFact::StructureBuilt {
+                event_id: Some(event_id),
+                system: Some(req.system),
+                kind: "cargo_load".into(),
+                name: item.definition_id().to_string(),
+                destroyed: false,
+                detail: desc,
+            };
+            fact_sys.record(fact, op, clock.elapsed, &v);
+        }
+
+        executed.write(CommandExecuted {
+            command_id: req.command_id,
+            kind: CommandKind::LoadDeliverable,
+            ship: req.ship,
+            result: CommandResult::Ok,
+            completed_at: clock.elapsed,
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DeployDeliverable (structure-spawn + Core-branch)
+// ---------------------------------------------------------------------------
+
+/// Handles `DeployDeliverableRequested`. Preserves both branches:
+/// - Non-Core: spawns the deep-space structure via
+///   [`spawn_deliverable_entity`] and dual-writes the Deploy event.
+/// - Core (`spawns_as_ship = Some(_)`): pushes a [`CoreDeployTicket`] onto
+///   [`PendingCoreDeploys`]; actual spawn resolution still runs in
+///   `resolve_core_deploys` for Commit 1. Commit 2 of #334 Phase 2 switches
+///   this path to emit a [`CoreDeployRequested`] message and deletes the
+///   intermediate resource.
+#[allow(clippy::too_many_arguments)]
+pub fn handle_deploy_deliverable_requested(
+    mut commands: Commands,
+    clock: Res<GameClock>,
+    registry: Res<StructureRegistry>,
+    mut reqs: MessageReader<DeployDeliverableRequested>,
+    mut events: MessageWriter<crate::events::GameEvent>,
+    mut executed: MessageWriter<CommandExecuted>,
+    mut ships: Query<(Entity, &Ship, &ShipState, &Position, &mut CommandQueue, &mut Cargo)>,
+    existing_cores: Query<&crate::galaxy::AtSystem, With<crate::ship::CoreShip>>,
+    star_systems: Query<(Entity, &Position), (Without<Ship>, With<crate::galaxy::StarSystem>)>,
+    player_q: Query<&StationedAt, Without<Ship>>,
+    player_aboard_q: Query<&AboardShip, With<Player>>,
+    mut pending_cores: ResMut<PendingCoreDeploys>,
+    mut fact_sys: FactSysParam,
+) {
+    let player_system = player_q.iter().next().map(|s| s.system);
+    let player_pos: Option<[f64; 3]> = player_system
+        .and_then(|s| star_systems.get(s).ok())
+        .map(|(_, p)| p.as_array());
+    let player_aboard = player_aboard_q.iter().next().is_some();
+    let vantage = player_pos.map(|pos| PlayerVantage {
+        player_pos: pos,
+        player_aboard,
+    });
+
+    for req in reqs.read() {
+        let Ok((ship_entity, ship, state, ship_pos, mut queue, mut cargo)) =
+            ships.get_mut(req.ship)
+        else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::DeployDeliverable,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "ship unavailable".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        // Ship must not be in FTL or surveying. Loitering/Docked OK.
+        let allowed = matches!(
+            state,
+            ShipState::Docked { .. } | ShipState::Loitering { .. }
+        );
+        if !allowed {
+            // Wait until movement completes — re-inject the original command
+            // into the queue head so it retries next tick when the ship is
+            // idle.
+            queue.commands.insert(
+                0,
+                QueuedCommand::DeployDeliverable {
+                    position: req.position,
+                    item_index: req.item_index,
+                },
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::DeployDeliverable,
+                ship: req.ship,
+                result: CommandResult::Deferred,
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        // Check that ship is at position.
+        let here = ship_pos.as_array();
+        let d = (here[0] - req.position[0]).powi(2)
+            + (here[1] - req.position[1]).powi(2)
+            + (here[2] - req.position[2]).powi(2);
+        if d.sqrt() > DEPLOY_POSITION_EPSILON {
+            queue.commands.insert(
+                0,
+                QueuedCommand::DeployDeliverable {
+                    position: req.position,
+                    item_index: req.item_index,
+                },
+            );
+            queue.commands.insert(
+                0,
+                QueuedCommand::MoveToCoordinates {
+                    target: req.position,
+                },
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::DeployDeliverable,
+                ship: req.ship,
+                result: CommandResult::Deferred,
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        // Execute deployment.
+        let Some(item) = cargo.items.get(req.item_index).cloned() else {
+            warn!("DeployDeliverable: item_index out of range");
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::DeployDeliverable,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "cargo index out of range".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+        let def_id = item.definition_id().to_string();
+        let Some(def) = registry.get(&def_id) else {
+            warn!("DeployDeliverable: unknown definition {}", def_id);
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::DeployDeliverable,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "unknown definition".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        // Core branch: deliverables with `spawns_as_ship = Some(_)` route
+        // through the Core deploy pipeline.
+        if let Some(design_id) = def
+            .deliverable
+            .as_ref()
+            .and_then(|m| m.spawns_as_ship.as_ref())
+        {
+            let mut target: Option<(Entity, Position)> = None;
+            let mut best_d: f64 = f64::INFINITY;
+            for (sys_entity, sys_pos) in star_systems.iter() {
+                let dx = req.position[0] - sys_pos.x;
+                let dy = req.position[1] - sys_pos.y;
+                let dz = req.position[2] - sys_pos.z;
+                let d = (dx * dx + dy * dy + dz * dz).sqrt();
+                if d <= crate::galaxy::SYSTEM_RADIUS_LY && d < best_d {
+                    best_d = d;
+                    target = Some((sys_entity, *sys_pos));
+                }
+            }
+            let Some((target_system, sys_pos)) = target else {
+                warn!(
+                    "Core deploy self-destruct: ship {} deployed {} in deep space",
+                    ship.name, def_id
+                );
+                cargo.items.remove(req.item_index);
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::DeployDeliverable,
+                    ship: req.ship,
+                    result: CommandResult::Rejected {
+                        reason: "deep-space Core self-destruct".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
+                continue;
+            };
+            // Early validation: already owned → self-destruct.
+            let has_core = existing_cores.iter().any(|at| at.0 == target_system);
+            if has_core {
+                info!(
+                    "Core deploy self-destruct: system {:?} already has a Core (ship {})",
+                    target_system, ship.name
+                );
+                cargo.items.remove(req.item_index);
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::DeployDeliverable,
+                    ship: req.ship,
+                    result: CommandResult::Rejected {
+                        reason: "system already has Core".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
+                continue;
+            }
+            let faction_owner = match ship.owner {
+                crate::ship::Owner::Empire(f) => Some(f),
+                crate::ship::Owner::Neutral => None,
+            };
+            let deploy_pos = [
+                sys_pos.x + crate::galaxy::INNER_ORBIT_OFFSET_LY,
+                sys_pos.y,
+                sys_pos.z,
+            ];
+            pending_cores.tickets.push(CoreDeployTicket {
+                deployer: ship_entity,
+                target_system,
+                deploy_pos,
+                faction_owner,
+                owner: ship.owner,
+                design_id: design_id.clone(),
+                cargo_item_index: req.item_index,
+                submitted_at: clock.elapsed,
+            });
+            cargo.items.remove(req.item_index);
+            info!(
+                "Ship {} enqueued Core deploy in system {:?} (definition={})",
+                ship.name, target_system, def_id
+            );
+            // Core deploys finalize in `resolve_core_deploys`; this handler
+            // only enqueues the ticket. Mark as Deferred so CommandLog
+            // reflects the in-flight resolution. Commit 2 will flip this to
+            // a terminal result emitted by the (renamed)
+            // `handle_core_deploy_requested`.
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::DeployDeliverable,
+                ship: req.ship,
+                result: CommandResult::Deferred,
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        // Structure-spawn branch.
+        let spawned = spawn_deliverable_entity(
+            &mut commands,
+            &def_id,
+            req.position,
+            ship.owner,
+            &registry,
+        );
+        if spawned.is_none() {
+            warn!("DeployDeliverable: spawn failed for {}", def_id);
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::DeployDeliverable,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "spawn failed".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+        cargo.items.remove(req.item_index);
+        info!("Ship {} deployed {} at {:?}", ship.name, def_id, req.position);
+
+        // Dual-write Deploy event.
+        let event_id = fact_sys.allocate_event_id();
+        let desc = format!("{} deployed {}", ship.name, def_id);
+        events.write(crate::events::GameEvent {
+            id: event_id,
+            timestamp: clock.elapsed,
+            kind: crate::events::GameEventKind::ShipBuilt,
+            description: desc.clone(),
+            related_system: None,
+        });
+        let origin_pos = req.position;
+        if let Some(v) = vantage {
+            let fact = KnowledgeFact::StructureBuilt {
+                event_id: Some(event_id),
+                system: None,
+                kind: "deployed_deliverable".into(),
+                name: def_id.clone(),
+                destroyed: false,
+                detail: desc,
+            };
+            fact_sys.record(fact, origin_pos, clock.elapsed, &v);
+        }
+
+        executed.write(CommandExecuted {
+            command_id: req.command_id,
+            kind: CommandKind::DeployDeliverable,
+            ship: req.ship,
+            result: CommandResult::Ok,
+            completed_at: clock.elapsed,
+        });
+
+        // Silence unused imports warnings in case `DeepSpaceStructure` /
+        // `ConstructionPlatform` / `Scrapyard` aren't referenced by a
+        // specific build path — they're retained to match the legacy query
+        // graph for future reads.
+        let _ = (
+            std::marker::PhantomData::<DeepSpaceStructure>,
+            std::marker::PhantomData::<ConstructionPlatform>,
+            std::marker::PhantomData::<Scrapyard>,
+        );
+    }
+}

--- a/macrocosmo/src/ship/handlers/deliverable_handler.rs
+++ b/macrocosmo/src/ship/handlers/deliverable_handler.rs
@@ -97,12 +97,13 @@ pub fn handle_load_deliverable_requested(
             // because the caller (dispatcher) already popped the original
             // LoadDeliverable; we re-inject it here so the legacy queue
             // sees it again after the ship arrives.
-            queue
-                .commands
-                .insert(0, QueuedCommand::LoadDeliverable {
+            queue.commands.insert(
+                0,
+                QueuedCommand::LoadDeliverable {
                     system: req.system,
                     stockpile_index: req.stockpile_index,
-                });
+                },
+            );
             queue
                 .commands
                 .insert(0, QueuedCommand::MoveTo { system: req.system });
@@ -238,7 +239,14 @@ pub fn handle_deploy_deliverable_requested(
     mut events: MessageWriter<crate::events::GameEvent>,
     mut executed: MessageWriter<CommandExecuted>,
     mut core_out: MessageWriter<CoreDeployRequested>,
-    mut ships: Query<(Entity, &Ship, &ShipState, &Position, &mut CommandQueue, &mut Cargo)>,
+    mut ships: Query<(
+        Entity,
+        &Ship,
+        &ShipState,
+        &Position,
+        &mut CommandQueue,
+        &mut Cargo,
+    )>,
     existing_cores: Query<&crate::galaxy::AtSystem, With<crate::ship::CoreShip>>,
     star_systems: Query<(Entity, &Position), (Without<Ship>, With<crate::galaxy::StarSystem>)>,
     player_q: Query<&StationedAt, Without<Ship>>,
@@ -450,13 +458,8 @@ pub fn handle_deploy_deliverable_requested(
         }
 
         // Structure-spawn branch.
-        let spawned = spawn_deliverable_entity(
-            &mut commands,
-            &def_id,
-            req.position,
-            ship.owner,
-            &registry,
-        );
+        let spawned =
+            spawn_deliverable_entity(&mut commands, &def_id, req.position, ship.owner, &registry);
         if spawned.is_none() {
             warn!("DeployDeliverable: spawn failed for {}", def_id);
             executed.write(CommandExecuted {
@@ -471,7 +474,10 @@ pub fn handle_deploy_deliverable_requested(
             continue;
         }
         cargo.items.remove(req.item_index);
-        info!("Ship {} deployed {} at {:?}", ship.name, def_id, req.position);
+        info!(
+            "Ship {} deployed {} at {:?}",
+            ship.name, def_id, req.position
+        );
 
         // Dual-write Deploy event.
         let event_id = fact_sys.allocate_event_id();
@@ -634,7 +640,13 @@ pub fn handle_load_from_scrapyard_requested(
     registry: Res<StructureRegistry>,
     mut reqs: MessageReader<LoadFromScrapyardRequested>,
     mut executed: MessageWriter<CommandExecuted>,
-    mut ships: Query<(&Ship, &Position, &mut CommandQueue, &mut Cargo, &ShipModifiers)>,
+    mut ships: Query<(
+        &Ship,
+        &Position,
+        &mut CommandQueue,
+        &mut Cargo,
+        &ShipModifiers,
+    )>,
     mut scrapyards: Query<(&Position, &mut Scrapyard), Without<Ship>>,
 ) {
     let mass_per_slot_raw = balance.mass_per_item_slot().0;
@@ -671,9 +683,12 @@ pub fn handle_load_from_scrapyard_requested(
         };
 
         if ship_pos.distance_to(scrap_pos) > DEPLOY_POSITION_EPSILON {
-            queue
-                .commands
-                .insert(0, QueuedCommand::LoadFromScrapyard { structure: req.structure });
+            queue.commands.insert(
+                0,
+                QueuedCommand::LoadFromScrapyard {
+                    structure: req.structure,
+                },
+            );
             queue.commands.insert(
                 0,
                 QueuedCommand::MoveToCoordinates {

--- a/macrocosmo/src/ship/handlers/deliverable_handler.rs
+++ b/macrocosmo/src/ship/handlers/deliverable_handler.rs
@@ -1,25 +1,30 @@
-//! #334 Phase 2: `LoadDeliverable` / `DeployDeliverable` handlers.
+//! #334 Phase 2: deliverable command handlers.
 //!
 //! Extracted verbatim from `deliverable_ops::process_deliverable_commands`
 //! — same validation, same mutation, same `FactSysParam` dual-writes. The
 //! only change is that these systems are **message-driven**: the dispatcher
-//! emits [`LoadDeliverableRequested`] / [`DeployDeliverableRequested`]
-//! instead of the legacy loop pulling the queue head.
+//! emits per-variant `*Requested` messages instead of the legacy loop
+//! pulling the queue head.
 //!
-//! Core-branch of `DeployDeliverable` emits a [`CoreDeployRequested`]
-//! message (Commit 2) — the legacy `PendingCoreDeploys` + `CoreDeployTicket`
-//! intermediate resource is retired.
+//! Commit 1: `handle_load_deliverable_requested`, `handle_deploy_deliverable_requested`.
+//! Commit 2: Core-branch of Deploy emits a [`CoreDeployRequested`] message
+//! consumed by `core_deliverable::handle_core_deploy_requested`.
+//! Commit 3: `handle_transfer_to_structure_requested`, `handle_load_from_scrapyard_requested`.
 
 use bevy::prelude::*;
 
+use crate::amount::Amt;
 use crate::colony::DeliverableStockpile;
 use crate::components::Position;
-use crate::deep_space::{ConstructionPlatform, DeepSpaceStructure, Scrapyard, StructureRegistry, spawn_deliverable_entity};
+use crate::deep_space::{
+    ConstructionPlatform, DeepSpaceStructure, Scrapyard, StructureRegistry,
+    spawn_deliverable_entity,
+};
 use crate::knowledge::{FactSysParam, KnowledgeFact, PlayerVantage};
 use crate::player::{AboardShip, Player, StationedAt};
 use crate::ship::command_events::{
     CommandExecuted, CommandKind, CommandResult, CoreDeployRequested, DeployDeliverableRequested,
-    LoadDeliverableRequested,
+    LoadDeliverableRequested, LoadFromScrapyardRequested, TransferToStructureRequested,
 };
 use crate::ship::deliverable_ops::DEPLOY_POSITION_EPSILON;
 use crate::ship::{Cargo, CommandQueue, QueuedCommand, Ship, ShipModifiers, ShipState};
@@ -499,14 +504,238 @@ pub fn handle_deploy_deliverable_requested(
             completed_at: clock.elapsed,
         });
 
-        // Silence unused imports warnings in case `DeepSpaceStructure` /
-        // `ConstructionPlatform` / `Scrapyard` aren't referenced by a
-        // specific build path — they're retained to match the legacy query
-        // graph for future reads.
-        let _ = (
-            std::marker::PhantomData::<DeepSpaceStructure>,
-            std::marker::PhantomData::<ConstructionPlatform>,
-            std::marker::PhantomData::<Scrapyard>,
+        // Silence unused imports warnings in case `DeepSpaceStructure`
+        // isn't referenced by a specific build path — it's retained to
+        // match the legacy query graph for future reads. (ConstructionPlatform
+        // and Scrapyard are used by the transfer / scrapyard handlers below.)
+        let _ = std::marker::PhantomData::<DeepSpaceStructure>;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TransferToStructure
+// ---------------------------------------------------------------------------
+
+/// Handles `TransferToStructureRequested`. Auto-injects a MoveToCoordinates
+/// when the ship isn't at the platform's position (plan §3.3), then drains
+/// the ship's minerals/energy into the platform's accumulated pool clamped
+/// by what the ship actually carries.
+#[allow(clippy::too_many_arguments)]
+pub fn handle_transfer_to_structure_requested(
+    clock: Res<GameClock>,
+    mut reqs: MessageReader<TransferToStructureRequested>,
+    mut executed: MessageWriter<CommandExecuted>,
+    mut ships: Query<(&Ship, &Position, &mut CommandQueue, &mut Cargo)>,
+    mut platforms: Query<(&Position, &mut ConstructionPlatform), Without<Ship>>,
+) {
+    for req in reqs.read() {
+        let Ok((ship, ship_pos, mut queue, mut cargo)) = ships.get_mut(req.ship) else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::TransferToStructure,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "ship unavailable".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        let Ok((struct_pos, mut platform)) = platforms.get_mut(req.structure) else {
+            warn!(
+                "TransferToStructure: target {:?} is not a ConstructionPlatform",
+                req.structure
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::TransferToStructure,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "target not a platform".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        if ship_pos.distance_to(struct_pos) > DEPLOY_POSITION_EPSILON {
+            queue.commands.insert(
+                0,
+                QueuedCommand::TransferToStructure {
+                    structure: req.structure,
+                    minerals: req.minerals,
+                    energy: req.energy,
+                },
+            );
+            queue.commands.insert(
+                0,
+                QueuedCommand::MoveToCoordinates {
+                    target: struct_pos.as_array(),
+                },
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::TransferToStructure,
+                ship: req.ship,
+                result: CommandResult::Deferred,
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        let m = cargo.minerals.min(req.minerals);
+        let e = cargo.energy.min(req.energy);
+        if m == Amt::ZERO && e == Amt::ZERO {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::TransferToStructure,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "nothing to transfer".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+        cargo.minerals = cargo.minerals.sub(m);
+        cargo.energy = cargo.energy.sub(e);
+        platform.accumulated.minerals = platform.accumulated.minerals.add(m);
+        platform.accumulated.energy = platform.accumulated.energy.add(e);
+        info!(
+            "Ship {} transferred {}m/{}e to platform {:?}",
+            ship.name,
+            m.to_f64(),
+            e.to_f64(),
+            req.structure
         );
+        executed.write(CommandExecuted {
+            command_id: req.command_id,
+            kind: CommandKind::TransferToStructure,
+            ship: req.ship,
+            result: CommandResult::Ok,
+            completed_at: clock.elapsed,
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LoadFromScrapyard
+// ---------------------------------------------------------------------------
+
+/// Handles `LoadFromScrapyardRequested`. Auto-injects MoveToCoordinates
+/// when not co-located. Drains as much as the ship can hold; minerals are
+/// taken first, then energy fills remaining headroom (same algorithm as
+/// the legacy code).
+#[allow(clippy::too_many_arguments)]
+pub fn handle_load_from_scrapyard_requested(
+    clock: Res<GameClock>,
+    balance: Res<crate::technology::GameBalance>,
+    registry: Res<StructureRegistry>,
+    mut reqs: MessageReader<LoadFromScrapyardRequested>,
+    mut executed: MessageWriter<CommandExecuted>,
+    mut ships: Query<(&Ship, &Position, &mut CommandQueue, &mut Cargo, &ShipModifiers)>,
+    mut scrapyards: Query<(&Position, &mut Scrapyard), Without<Ship>>,
+) {
+    let mass_per_slot_raw = balance.mass_per_item_slot().0;
+
+    for req in reqs.read() {
+        let Ok((ship, ship_pos, mut queue, mut cargo, ship_mods)) = ships.get_mut(req.ship) else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadFromScrapyard,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "ship unavailable".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        let Ok((scrap_pos, mut scrap)) = scrapyards.get_mut(req.structure) else {
+            warn!(
+                "LoadFromScrapyard: target {:?} has no Scrapyard",
+                req.structure
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadFromScrapyard,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "target not a scrapyard".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        if ship_pos.distance_to(scrap_pos) > DEPLOY_POSITION_EPSILON {
+            queue
+                .commands
+                .insert(0, QueuedCommand::LoadFromScrapyard { structure: req.structure });
+            queue.commands.insert(
+                0,
+                QueuedCommand::MoveToCoordinates {
+                    target: scrap_pos.as_array(),
+                },
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadFromScrapyard,
+                ship: req.ship,
+                result: CommandResult::Deferred,
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        let cap = ship_mods.cargo_capacity.final_value();
+        let lookup = |id: &str| -> Option<u32> {
+            registry
+                .get(id)
+                .and_then(|d| d.deliverable.as_ref().map(|m| m.cargo_size))
+        };
+        let current_mass = cargo.total_mass_with(&lookup, mass_per_slot_raw);
+        let headroom = if current_mass >= cap {
+            Amt::ZERO
+        } else {
+            Amt(cap.0 - current_mass.0)
+        };
+        let to_take_m = scrap.remaining.minerals.min(headroom);
+        let headroom_after_m = Amt(headroom.0.saturating_sub(to_take_m.0));
+        let to_take_e = scrap.remaining.energy.min(headroom_after_m);
+
+        if to_take_m == Amt::ZERO && to_take_e == Amt::ZERO {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::LoadFromScrapyard,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "no cargo space".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        cargo.minerals = cargo.minerals.add(to_take_m);
+        cargo.energy = cargo.energy.add(to_take_e);
+        scrap.remaining.minerals = scrap.remaining.minerals.sub(to_take_m);
+        scrap.remaining.energy = scrap.remaining.energy.sub(to_take_e);
+        info!(
+            "Ship {} salvaged {}m/{}e from scrapyard {:?}",
+            ship.name,
+            to_take_m.to_f64(),
+            to_take_e.to_f64(),
+            req.structure
+        );
+        executed.write(CommandExecuted {
+            command_id: req.command_id,
+            kind: CommandKind::LoadFromScrapyard,
+            ship: req.ship,
+            result: CommandResult::Ok,
+            completed_at: clock.elapsed,
+        });
     }
 }

--- a/macrocosmo/src/ship/handlers/deliverable_handler.rs
+++ b/macrocosmo/src/ship/handlers/deliverable_handler.rs
@@ -6,10 +6,9 @@
 //! emits [`LoadDeliverableRequested`] / [`DeployDeliverableRequested`]
 //! instead of the legacy loop pulling the queue head.
 //!
-//! Core-branch of `DeployDeliverable` continues to push a
-//! [`CoreDeployTicket`] into [`PendingCoreDeploys`] for Commit 1; Commit 2
-//! switches this to emit a [`CoreDeployRequested`] message and drops the
-//! intermediate resource entirely.
+//! Core-branch of `DeployDeliverable` emits a [`CoreDeployRequested`]
+//! message (Commit 2) — the legacy `PendingCoreDeploys` + `CoreDeployTicket`
+//! intermediate resource is retired.
 
 use bevy::prelude::*;
 
@@ -19,10 +18,9 @@ use crate::deep_space::{ConstructionPlatform, DeepSpaceStructure, Scrapyard, Str
 use crate::knowledge::{FactSysParam, KnowledgeFact, PlayerVantage};
 use crate::player::{AboardShip, Player, StationedAt};
 use crate::ship::command_events::{
-    CommandExecuted, CommandKind, CommandResult, DeployDeliverableRequested,
+    CommandExecuted, CommandKind, CommandResult, CoreDeployRequested, DeployDeliverableRequested,
     LoadDeliverableRequested,
 };
-use crate::ship::core_deliverable::{CoreDeployTicket, PendingCoreDeploys};
 use crate::ship::deliverable_ops::DEPLOY_POSITION_EPSILON;
 use crate::ship::{Cargo, CommandQueue, QueuedCommand, Ship, ShipModifiers, ShipState};
 use crate::time_system::GameClock;
@@ -221,11 +219,11 @@ pub fn handle_load_deliverable_requested(
 /// Handles `DeployDeliverableRequested`. Preserves both branches:
 /// - Non-Core: spawns the deep-space structure via
 ///   [`spawn_deliverable_entity`] and dual-writes the Deploy event.
-/// - Core (`spawns_as_ship = Some(_)`): pushes a [`CoreDeployTicket`] onto
-///   [`PendingCoreDeploys`]; actual spawn resolution still runs in
-///   `resolve_core_deploys` for Commit 1. Commit 2 of #334 Phase 2 switches
-///   this path to emit a [`CoreDeployRequested`] message and deletes the
-///   intermediate resource.
+/// - Core (`spawns_as_ship = Some(_)`): emits a [`CoreDeployRequested`]
+///   message consumed by `handle_core_deploy_requested` (tie-break + spawn).
+///   The Deploy handler emits a `Deferred` `CommandExecuted` so the
+///   two-phase CommandLog status lands; the Core handler emits the terminal
+///   `Ok` / `Rejected` keyed by the original `command_id`.
 #[allow(clippy::too_many_arguments)]
 pub fn handle_deploy_deliverable_requested(
     mut commands: Commands,
@@ -234,12 +232,12 @@ pub fn handle_deploy_deliverable_requested(
     mut reqs: MessageReader<DeployDeliverableRequested>,
     mut events: MessageWriter<crate::events::GameEvent>,
     mut executed: MessageWriter<CommandExecuted>,
+    mut core_out: MessageWriter<CoreDeployRequested>,
     mut ships: Query<(Entity, &Ship, &ShipState, &Position, &mut CommandQueue, &mut Cargo)>,
     existing_cores: Query<&crate::galaxy::AtSystem, With<crate::ship::CoreShip>>,
     star_systems: Query<(Entity, &Position), (Without<Ship>, With<crate::galaxy::StarSystem>)>,
     player_q: Query<&StationedAt, Without<Ship>>,
     player_aboard_q: Query<&AboardShip, With<Player>>,
-    mut pending_cores: ResMut<PendingCoreDeploys>,
     mut fact_sys: FactSysParam,
 ) {
     let player_system = player_q.iter().next().map(|s| s.system);
@@ -416,26 +414,26 @@ pub fn handle_deploy_deliverable_requested(
                 sys_pos.y,
                 sys_pos.z,
             ];
-            pending_cores.tickets.push(CoreDeployTicket {
+            core_out.write(CoreDeployRequested {
+                command_id: req.command_id,
                 deployer: ship_entity,
                 target_system,
                 deploy_pos,
                 faction_owner,
                 owner: ship.owner,
                 design_id: design_id.clone(),
-                cargo_item_index: req.item_index,
                 submitted_at: clock.elapsed,
             });
             cargo.items.remove(req.item_index);
             info!(
-                "Ship {} enqueued Core deploy in system {:?} (definition={})",
-                ship.name, target_system, def_id
+                "Ship {} emitted CoreDeployRequested for system {:?} (definition={}, cmd {})",
+                ship.name, target_system, def_id, req.command_id.0
             );
-            // Core deploys finalize in `resolve_core_deploys`; this handler
-            // only enqueues the ticket. Mark as Deferred so CommandLog
-            // reflects the in-flight resolution. Commit 2 will flip this to
-            // a terminal result emitted by the (renamed)
-            // `handle_core_deploy_requested`.
+            // `handle_core_deploy_requested` emits the terminal
+            // `CommandExecuted` (Ok / Rejected) this same tick via the
+            // `.after(handle_deploy_deliverable_requested)` edge. We emit
+            // `Deferred` here so CommandLog acquires an intermediate state
+            // — the bridge then overwrites it when the core handler fires.
             executed.write(CommandExecuted {
                 command_id: req.command_id,
                 kind: CommandKind::DeployDeliverable,

--- a/macrocosmo/src/ship/handlers/mod.rs
+++ b/macrocosmo/src/ship/handlers/mod.rs
@@ -11,9 +11,11 @@
 
 pub mod deliverable_handler;
 pub mod move_handler;
+pub mod settlement_handler;
 
 pub use deliverable_handler::{
     handle_deploy_deliverable_requested, handle_load_deliverable_requested,
     handle_load_from_scrapyard_requested, handle_transfer_to_structure_requested,
 };
 pub use move_handler::{handle_move_requested, handle_move_to_coordinates_requested};
+pub use settlement_handler::{handle_colonize_requested, handle_survey_requested};

--- a/macrocosmo/src/ship/handlers/mod.rs
+++ b/macrocosmo/src/ship/handlers/mod.rs
@@ -9,6 +9,10 @@
 //! Phase 1 scope: `handle_move_requested` + `handle_move_to_coordinates_requested`.
 //! Phases 2/3/4 migrate the remaining variants into this module.
 
+pub mod deliverable_handler;
 pub mod move_handler;
 
+pub use deliverable_handler::{
+    handle_deploy_deliverable_requested, handle_load_deliverable_requested,
+};
 pub use move_handler::{handle_move_requested, handle_move_to_coordinates_requested};

--- a/macrocosmo/src/ship/handlers/mod.rs
+++ b/macrocosmo/src/ship/handlers/mod.rs
@@ -14,5 +14,6 @@ pub mod move_handler;
 
 pub use deliverable_handler::{
     handle_deploy_deliverable_requested, handle_load_deliverable_requested,
+    handle_load_from_scrapyard_requested, handle_transfer_to_structure_requested,
 };
 pub use move_handler::{handle_move_requested, handle_move_to_coordinates_requested};

--- a/macrocosmo/src/ship/handlers/settlement_handler.rs
+++ b/macrocosmo/src/ship/handlers/settlement_handler.rs
@@ -1,0 +1,268 @@
+//! #334 Phase 2 (Commit 4): `Survey` / `Colonize` handlers.
+//!
+//! Extracted from the `Survey` / `Colonize` arms of
+//! `command::process_command_queue`. Semantics are preserved verbatim:
+//! - If the ship is not at the target system, auto-insert a `MoveTo` ahead
+//!   of the command (Deferred).
+//! - If at target, call `start_survey_with_bonus` / transition into
+//!   `ShipState::Settling` (Ok) or reject with a warning (Rejected).
+//!
+//! The settlement tick system (`process_settling`) and the survey tick
+//! system (`process_surveys`) remain unchanged — this handler only
+//! INITIATES the action; lifecycle progression runs elsewhere.
+
+use bevy::prelude::*;
+
+use crate::components::Position;
+use crate::ship_design::ShipDesignRegistry;
+use crate::time_system::GameClock;
+
+use crate::ship::command_events::{
+    ColonizeRequested, CommandExecuted, CommandKind, CommandResult, SurveyRequested,
+};
+use crate::ship::survey::start_survey_with_bonus;
+use crate::ship::{CommandQueue, QueuedCommand, Ship, ShipState};
+
+#[allow(clippy::too_many_arguments)]
+pub fn handle_survey_requested(
+    clock: Res<GameClock>,
+    balance: Res<crate::technology::GameBalance>,
+    empire_params_q: Query<&crate::technology::GlobalParams, With<crate::player::PlayerEmpire>>,
+    mut reqs: MessageReader<SurveyRequested>,
+    mut executed: MessageWriter<CommandExecuted>,
+    mut ships: Query<(&Ship, &mut ShipState, &Position, &mut CommandQueue)>,
+    systems: Query<(&crate::galaxy::StarSystem, &Position), Without<Ship>>,
+    design_registry: Res<ShipDesignRegistry>,
+) {
+    let Ok(global_params) = empire_params_q.single() else {
+        for _ in reqs.read() {}
+        return;
+    };
+    let survey_range_base = balance.survey_range_ly();
+    let survey_duration_base = balance.survey_duration();
+
+    for req in reqs.read() {
+        let Ok((ship, mut state, ship_pos, mut queue)) = ships.get_mut(req.ship) else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Survey,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "ship unavailable".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        let docked_system: Option<Entity> = match *state {
+            ShipState::Docked { system } => Some(system),
+            ShipState::Loitering { .. } => None,
+            _ => {
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::Survey,
+                    ship: req.ship,
+                    result: CommandResult::Rejected {
+                        reason: "ship not idle".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
+                continue;
+            }
+        };
+
+        let Ok((target_star, target_pos)) = systems.get(req.target_system) else {
+            warn!("Queued Survey target no longer exists");
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Survey,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "target system despawned".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        // Auto-insert a MoveTo if not at target. Re-queue Survey after it.
+        if docked_system != Some(req.target_system) {
+            queue
+                .commands
+                .insert(0, QueuedCommand::Survey { system: req.target_system });
+            queue
+                .commands
+                .insert(0, QueuedCommand::MoveTo { system: req.target_system });
+            info!(
+                "Queue: Ship {} not at target, auto-inserting move before survey of {}",
+                ship.name, target_star.name
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Survey,
+                ship: req.ship,
+                result: CommandResult::Deferred,
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        let origin = Position::from(ship_pos.as_array());
+        match start_survey_with_bonus(
+            &mut state,
+            ship,
+            req.target_system,
+            &origin,
+            target_pos,
+            clock.elapsed,
+            global_params.survey_range_bonus,
+            &design_registry,
+            survey_range_base,
+            survey_duration_base,
+        ) {
+            Ok(()) => {
+                info!("Queue: Ship {} surveying {}", ship.name, target_star.name);
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::Survey,
+                    ship: req.ship,
+                    result: CommandResult::Ok,
+                    completed_at: clock.elapsed,
+                });
+            }
+            Err(e) => {
+                warn!("Queue: Survey failed for {}: {}", ship.name, e);
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::Survey,
+                    ship: req.ship,
+                    result: CommandResult::Rejected {
+                        reason: format!("survey start failed: {}", e),
+                    },
+                    completed_at: clock.elapsed,
+                });
+            }
+        }
+        queue.sync_prediction(ship_pos.as_array(), docked_system);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn handle_colonize_requested(
+    clock: Res<GameClock>,
+    balance: Res<crate::technology::GameBalance>,
+    mut reqs: MessageReader<ColonizeRequested>,
+    mut executed: MessageWriter<CommandExecuted>,
+    mut ships: Query<(&Ship, &mut ShipState, &Position, &mut CommandQueue)>,
+    systems: Query<(&crate::galaxy::StarSystem, &Position), Without<Ship>>,
+    design_registry: Res<ShipDesignRegistry>,
+) {
+    let settling_duration = balance.settling_duration();
+
+    for req in reqs.read() {
+        let Ok((ship, mut state, ship_pos, mut queue)) = ships.get_mut(req.ship) else {
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Colonize,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "ship unavailable".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        let docked_system: Option<Entity> = match *state {
+            ShipState::Docked { system } => Some(system),
+            ShipState::Loitering { .. } => None,
+            _ => {
+                executed.write(CommandExecuted {
+                    command_id: req.command_id,
+                    kind: CommandKind::Colonize,
+                    ship: req.ship,
+                    result: CommandResult::Rejected {
+                        reason: "ship not idle".to_string(),
+                    },
+                    completed_at: clock.elapsed,
+                });
+                continue;
+            }
+        };
+
+        let Ok((target_star, _target_pos)) = systems.get(req.target_system) else {
+            warn!("Queued Colonize target no longer exists");
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Colonize,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "target system despawned".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            continue;
+        };
+
+        if docked_system != Some(req.target_system) {
+            queue.commands.insert(
+                0,
+                QueuedCommand::Colonize {
+                    system: req.target_system,
+                    planet: req.planet,
+                },
+            );
+            queue
+                .commands
+                .insert(0, QueuedCommand::MoveTo { system: req.target_system });
+            info!(
+                "Queue: Ship {} not at target, auto-inserting move before colonize of {}",
+                ship.name, target_star.name
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Colonize,
+                ship: req.ship,
+                result: CommandResult::Deferred,
+                completed_at: clock.elapsed,
+            });
+            continue;
+        }
+
+        if !design_registry.can_colonize(&ship.design_id) {
+            warn!(
+                "Queue: Ship {} cannot colonize (not a colony ship)",
+                ship.name
+            );
+            executed.write(CommandExecuted {
+                command_id: req.command_id,
+                kind: CommandKind::Colonize,
+                ship: req.ship,
+                result: CommandResult::Rejected {
+                    reason: "not a colony ship".to_string(),
+                },
+                completed_at: clock.elapsed,
+            });
+            queue.sync_prediction(ship_pos.as_array(), docked_system);
+            continue;
+        }
+
+        let docked_sys = docked_system.expect("colonize already required docked");
+        *state = ShipState::Settling {
+            system: docked_sys,
+            planet: req.planet,
+            started_at: clock.elapsed,
+            completes_at: clock.elapsed + settling_duration,
+        };
+        info!("Queue: Ship {} colonizing {}", ship.name, target_star.name);
+        executed.write(CommandExecuted {
+            command_id: req.command_id,
+            kind: CommandKind::Colonize,
+            ship: req.ship,
+            result: CommandResult::Ok,
+            completed_at: clock.elapsed,
+        });
+        queue.sync_prediction(ship_pos.as_array(), docked_system);
+    }
+}

--- a/macrocosmo/src/ship/handlers/settlement_handler.rs
+++ b/macrocosmo/src/ship/handlers/settlement_handler.rs
@@ -88,12 +88,18 @@ pub fn handle_survey_requested(
 
         // Auto-insert a MoveTo if not at target. Re-queue Survey after it.
         if docked_system != Some(req.target_system) {
-            queue
-                .commands
-                .insert(0, QueuedCommand::Survey { system: req.target_system });
-            queue
-                .commands
-                .insert(0, QueuedCommand::MoveTo { system: req.target_system });
+            queue.commands.insert(
+                0,
+                QueuedCommand::Survey {
+                    system: req.target_system,
+                },
+            );
+            queue.commands.insert(
+                0,
+                QueuedCommand::MoveTo {
+                    system: req.target_system,
+                },
+            );
             info!(
                 "Queue: Ship {} not at target, auto-inserting move before survey of {}",
                 ship.name, target_star.name
@@ -213,9 +219,12 @@ pub fn handle_colonize_requested(
                     planet: req.planet,
                 },
             );
-            queue
-                .commands
-                .insert(0, QueuedCommand::MoveTo { system: req.target_system });
+            queue.commands.insert(
+                0,
+                QueuedCommand::MoveTo {
+                    system: req.target_system,
+                },
+            );
             info!(
                 "Queue: Ship {} not at target, auto-inserting move before colonize of {}",
                 ship.name, target_star.name

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -295,6 +295,9 @@ impl Plugin for ShipPlugin {
                 // handlers.
                 handlers::handle_transfer_to_structure_requested,
                 handlers::handle_load_from_scrapyard_requested,
+                // #334 Phase 2 (Commit 4): Survey / Colonize handlers.
+                handlers::handle_survey_requested,
+                handlers::handle_colonize_requested,
             )
                 .chain()
                 .after(sublight_movement_system)
@@ -321,6 +324,8 @@ impl Plugin for ShipPlugin {
                 .after(handlers::handle_deploy_deliverable_requested)
                 .after(handlers::handle_transfer_to_structure_requested)
                 .after(handlers::handle_load_from_scrapyard_requested)
+                .after(handlers::handle_survey_requested)
+                .after(handlers::handle_colonize_requested)
                 .after(core_deliverable::handle_core_deploy_requested)
                 .after(crate::time_system::advance_game_time)
                 .before(crate::colony::advance_production_tick),

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -225,9 +225,12 @@ impl Plugin for ShipPlugin {
                     .after(process_surveys),
                 // #296 (S-3): Resolve Core deploy tickets into actual CoreShip
                 // entities, grouping same-tick duplicates and tie-breaking via
-                // GameRng. Runs after the deliverable command processor (which
-                // enqueues tickets) and before the command queue, so newly
-                // spawned Cores are visible on the next frame.
+                // GameRng. #334 Phase 2: tickets are now pushed by
+                // `handlers::handle_deploy_deliverable_requested`, so this
+                // system is ordered with `.after(handle_deploy_deliverable_requested)`
+                // in the separate dispatcher `add_systems` call below — here
+                // we only keep the legacy `.after(process_deliverable_commands)`
+                // edge as an additional guard.
                 core_deliverable::resolve_core_deploys
                     .after(deliverable_ops::process_deliverable_commands),
                 process_command_queue
@@ -292,6 +295,13 @@ impl Plugin for ShipPlugin {
                 dispatcher::dispatch_queued_commands,
                 handlers::handle_move_requested,
                 handlers::handle_move_to_coordinates_requested,
+                // #334 Phase 2 (Commit 1): LoadDeliverable / DeployDeliverable
+                // handlers run after the dispatcher so same-tick messages are
+                // picked up. Core-branch of Deploy continues to push into
+                // PendingCoreDeploys; `resolve_core_deploys` still drains the
+                // resource below (Commit 2 switches to a message-driven flow).
+                handlers::handle_load_deliverable_requested,
+                handlers::handle_deploy_deliverable_requested,
             )
                 .chain()
                 .after(deliverable_ops::process_deliverable_commands)
@@ -299,6 +309,9 @@ impl Plugin for ShipPlugin {
                 .after(process_ftl_travel)
                 .after(process_surveys)
                 .before(process_command_queue)
+                // Core deploy ticket resolution must run after the deploy
+                // handler that populates the queue this tick.
+                .before(core_deliverable::resolve_core_deploys)
                 .after(crate::time_system::advance_game_time)
                 .before(crate::colony::advance_production_tick),
         );

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -217,26 +217,17 @@ impl Plugin for ShipPlugin {
                 process_settling,
                 process_refitting,
                 process_pending_ship_commands,
-                // #223: Deliverable ops run BEFORE the FTL router so any
-                // injected MoveTo/MoveToCoordinates is dispatched this tick.
-                deliverable_ops::process_deliverable_commands
-                    .after(sublight_movement_system)
-                    .after(process_ftl_travel)
-                    .after(process_surveys),
-                // #296 (S-3): Resolve Core deploy requests into actual CoreShip
-                // entities, grouping same-tick duplicates and tie-breaking via
-                // GameRng. #334 Phase 2 (Commit 2): renamed from
-                // `resolve_core_deploys` and migrated to `MessageReader<CoreDeployRequested>`.
-                // The per-tick ordering with `handle_deploy_deliverable_requested`
-                // (which emits the messages) is declared in the separate
-                // dispatcher `add_systems` call below.
-                core_deliverable::handle_core_deploy_requested
-                    .after(deliverable_ops::process_deliverable_commands),
+                // #296 (S-3) / #334 Phase 2 Commit 2: Resolve Core deploy
+                // requests into actual CoreShip entities, grouping same-tick
+                // duplicates and tie-breaking via GameRng. Per-tick ordering
+                // with `handle_deploy_deliverable_requested` (which emits the
+                // messages) is declared in the dispatcher `add_systems` call
+                // below.
+                core_deliverable::handle_core_deploy_requested,
                 process_command_queue
                     .after(sublight_movement_system)
                     .after(process_ftl_travel)
-                    .after(process_surveys)
-                    .after(deliverable_ops::process_deliverable_commands),
+                    .after(process_surveys),
                 resolve_combat,
                 tick_ship_repair,
                 // #117: Courier automation — runs before process_command_queue
@@ -300,9 +291,12 @@ impl Plugin for ShipPlugin {
                 // message that `handle_core_deploy_requested` drains.
                 handlers::handle_load_deliverable_requested,
                 handlers::handle_deploy_deliverable_requested,
+                // #334 Phase 2 (Commit 3): Transfer / LoadFromScrapyard
+                // handlers.
+                handlers::handle_transfer_to_structure_requested,
+                handlers::handle_load_from_scrapyard_requested,
             )
                 .chain()
-                .after(deliverable_ops::process_deliverable_commands)
                 .after(sublight_movement_system)
                 .after(process_ftl_travel)
                 .after(process_surveys)
@@ -325,6 +319,8 @@ impl Plugin for ShipPlugin {
                 .after(handlers::handle_move_to_coordinates_requested)
                 .after(handlers::handle_load_deliverable_requested)
                 .after(handlers::handle_deploy_deliverable_requested)
+                .after(handlers::handle_transfer_to_structure_requested)
+                .after(handlers::handle_load_from_scrapyard_requested)
                 .after(core_deliverable::handle_core_deploy_requested)
                 .after(crate::time_system::advance_game_time)
                 .before(crate::colony::advance_production_tick),

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -25,8 +25,7 @@ pub mod bridges;
 pub use combat::*;
 pub use command::*;
 pub use core_deliverable::{
-    CoreDeployTicket, CoreShip, PendingCoreDeploys, resolve_core_deploys,
-    spawn_core_ship_from_deliverable,
+    CoreShip, handle_core_deploy_requested, spawn_core_ship_from_deliverable,
 };
 pub use courier_route::*;
 pub use exploration::*;
@@ -199,8 +198,9 @@ pub struct ShipPlugin;
 impl Plugin for ShipPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<routing::RouteCalculationsPending>();
-        // #296 (S-3): Per-tick queue for Infrastructure Core deploy tickets.
-        app.init_resource::<core_deliverable::PendingCoreDeploys>();
+        // #334 Phase 2 (Commit 2): `PendingCoreDeploys` was retired in favour
+        // of the `CoreDeployRequested` message bus registered via
+        // `CommandEventsPlugin`.
         // #334 Phase 1: register command-dispatch message types + allocator
         // before any dispatcher/handler system that references them.
         app.add_plugins(command_events::CommandEventsPlugin);
@@ -223,15 +223,14 @@ impl Plugin for ShipPlugin {
                     .after(sublight_movement_system)
                     .after(process_ftl_travel)
                     .after(process_surveys),
-                // #296 (S-3): Resolve Core deploy tickets into actual CoreShip
+                // #296 (S-3): Resolve Core deploy requests into actual CoreShip
                 // entities, grouping same-tick duplicates and tie-breaking via
-                // GameRng. #334 Phase 2: tickets are now pushed by
-                // `handlers::handle_deploy_deliverable_requested`, so this
-                // system is ordered with `.after(handle_deploy_deliverable_requested)`
-                // in the separate dispatcher `add_systems` call below — here
-                // we only keep the legacy `.after(process_deliverable_commands)`
-                // edge as an additional guard.
-                core_deliverable::resolve_core_deploys
+                // GameRng. #334 Phase 2 (Commit 2): renamed from
+                // `resolve_core_deploys` and migrated to `MessageReader<CoreDeployRequested>`.
+                // The per-tick ordering with `handle_deploy_deliverable_requested`
+                // (which emits the messages) is declared in the separate
+                // dispatcher `add_systems` call below.
+                core_deliverable::handle_core_deploy_requested
                     .after(deliverable_ops::process_deliverable_commands),
                 process_command_queue
                     .after(sublight_movement_system)
@@ -295,11 +294,10 @@ impl Plugin for ShipPlugin {
                 dispatcher::dispatch_queued_commands,
                 handlers::handle_move_requested,
                 handlers::handle_move_to_coordinates_requested,
-                // #334 Phase 2 (Commit 1): LoadDeliverable / DeployDeliverable
+                // #334 Phase 2 (Commit 1/2): LoadDeliverable / DeployDeliverable
                 // handlers run after the dispatcher so same-tick messages are
-                // picked up. Core-branch of Deploy continues to push into
-                // PendingCoreDeploys; `resolve_core_deploys` still drains the
-                // resource below (Commit 2 switches to a message-driven flow).
+                // picked up. Core-branch of Deploy emits a `CoreDeployRequested`
+                // message that `handle_core_deploy_requested` drains.
                 handlers::handle_load_deliverable_requested,
                 handlers::handle_deploy_deliverable_requested,
             )
@@ -309,9 +307,9 @@ impl Plugin for ShipPlugin {
                 .after(process_ftl_travel)
                 .after(process_surveys)
                 .before(process_command_queue)
-                // Core deploy ticket resolution must run after the deploy
-                // handler that populates the queue this tick.
-                .before(core_deliverable::resolve_core_deploys)
+                // Core deploy resolution must run after the deploy handler
+                // that emits `CoreDeployRequested` this tick.
+                .before(core_deliverable::handle_core_deploy_requested)
                 .after(crate::time_system::advance_game_time)
                 .before(crate::colony::advance_production_tick),
         );
@@ -325,6 +323,9 @@ impl Plugin for ShipPlugin {
                 .after(routing::poll_pending_routes)
                 .after(handlers::handle_move_requested)
                 .after(handlers::handle_move_to_coordinates_requested)
+                .after(handlers::handle_load_deliverable_requested)
+                .after(handlers::handle_deploy_deliverable_requested)
+                .after(core_deliverable::handle_core_deploy_requested)
                 .after(crate::time_system::advance_game_time)
                 .before(crate::colony::advance_production_tick),
         );

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -425,9 +425,6 @@ pub fn test_app() -> App {
             process_refitting,
             process_pending_ship_commands,
             tick_courier_routes,
-            // #223: Deliverable ops run before process_command_queue so any
-            // injected MoveTo reaches the router in the same frame.
-            macrocosmo::ship::deliverable_ops::process_deliverable_commands,
             // #334 Phase 1: dispatcher + MoveTo/MoveToCoordinates handlers
             // run before process_command_queue so the PendingRoute filter
             // on the legacy system excludes ships whose MoveTo was just
@@ -438,6 +435,9 @@ pub fn test_app() -> App {
             // #334 Phase 2 (Commit 1): deliverable handlers.
             macrocosmo::ship::handlers::handle_load_deliverable_requested,
             macrocosmo::ship::handlers::handle_deploy_deliverable_requested,
+            // #334 Phase 2 (Commit 3): transfer / scrapyard handlers.
+            macrocosmo::ship::handlers::handle_transfer_to_structure_requested,
+            macrocosmo::ship::handlers::handle_load_from_scrapyard_requested,
             // #334 Phase 2 (Commit 2): Core deploy message handler, replaces
             // the legacy `resolve_core_deploys` + `PendingCoreDeploys` path.
             macrocosmo::ship::handle_core_deploy_requested,
@@ -679,7 +679,6 @@ pub fn full_test_app() -> App {
             process_refitting,
             process_pending_ship_commands,
             tick_courier_routes,
-            macrocosmo::ship::deliverable_ops::process_deliverable_commands,
             // #334 Phase 1: event-driven MoveTo path alongside legacy queue.
             macrocosmo::ship::dispatcher::dispatch_queued_commands,
             macrocosmo::ship::handlers::handle_move_requested,
@@ -687,6 +686,9 @@ pub fn full_test_app() -> App {
             // #334 Phase 2 (Commit 1): deliverable handlers.
             macrocosmo::ship::handlers::handle_load_deliverable_requested,
             macrocosmo::ship::handlers::handle_deploy_deliverable_requested,
+            // #334 Phase 2 (Commit 3): transfer / scrapyard handlers.
+            macrocosmo::ship::handlers::handle_transfer_to_structure_requested,
+            macrocosmo::ship::handlers::handle_load_from_scrapyard_requested,
             // #334 Phase 2 (Commit 2): Core deploy message handler, replaces
             // the legacy `resolve_core_deploys` + `PendingCoreDeploys` path.
             macrocosmo::ship::handle_core_deploy_requested,

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -425,11 +425,18 @@ pub fn test_app() -> App {
             process_refitting,
             process_pending_ship_commands,
             tick_courier_routes,
-            // #334 Phase 1: dispatcher + MoveTo/MoveToCoordinates handlers
-            // run before process_command_queue so the PendingRoute filter
-            // on the legacy system excludes ships whose MoveTo was just
-            // dispatched this tick.
+            // #334 Phase 1/2: dispatcher runs first in this chain so its
+            // messages are visible to handlers that run immediately after
+            // via the second add_systems block below.
             macrocosmo::ship::dispatcher::dispatch_queued_commands,
+        )
+            .chain()
+            .after(macrocosmo::time_system::advance_game_time)
+            .before(advance_production_tick),
+    );
+    app.add_systems(
+        Update,
+        (
             macrocosmo::ship::handlers::handle_move_requested,
             macrocosmo::ship::handlers::handle_move_to_coordinates_requested,
             // #334 Phase 2 (Commit 1): deliverable handlers.
@@ -438,12 +445,16 @@ pub fn test_app() -> App {
             // #334 Phase 2 (Commit 3): transfer / scrapyard handlers.
             macrocosmo::ship::handlers::handle_transfer_to_structure_requested,
             macrocosmo::ship::handlers::handle_load_from_scrapyard_requested,
+            // #334 Phase 2 (Commit 4): survey / colonize handlers.
+            macrocosmo::ship::handlers::handle_survey_requested,
+            macrocosmo::ship::handlers::handle_colonize_requested,
             // #334 Phase 2 (Commit 2): Core deploy message handler, replaces
             // the legacy `resolve_core_deploys` + `PendingCoreDeploys` path.
             macrocosmo::ship::handle_core_deploy_requested,
             process_command_queue,
         )
             .chain()
+            .after(macrocosmo::ship::dispatcher::dispatch_queued_commands)
             .after(macrocosmo::time_system::advance_game_time)
             .before(advance_production_tick),
     );
@@ -679,8 +690,14 @@ pub fn full_test_app() -> App {
             process_refitting,
             process_pending_ship_commands,
             tick_courier_routes,
-            // #334 Phase 1: event-driven MoveTo path alongside legacy queue.
+            // #334 Phase 1/2: dispatcher runs first; handlers are registered
+            // separately below to stay under the 20-arm IntoScheduleConfigs limit.
             macrocosmo::ship::dispatcher::dispatch_queued_commands,
+        ),
+    );
+    app.add_systems(
+        Update,
+        (
             macrocosmo::ship::handlers::handle_move_requested,
             macrocosmo::ship::handlers::handle_move_to_coordinates_requested,
             // #334 Phase 2 (Commit 1): deliverable handlers.
@@ -689,11 +706,16 @@ pub fn full_test_app() -> App {
             // #334 Phase 2 (Commit 3): transfer / scrapyard handlers.
             macrocosmo::ship::handlers::handle_transfer_to_structure_requested,
             macrocosmo::ship::handlers::handle_load_from_scrapyard_requested,
+            // #334 Phase 2 (Commit 4): survey / colonize handlers.
+            macrocosmo::ship::handlers::handle_survey_requested,
+            macrocosmo::ship::handlers::handle_colonize_requested,
             // #334 Phase 2 (Commit 2): Core deploy message handler, replaces
             // the legacy `resolve_core_deploys` + `PendingCoreDeploys` path.
             macrocosmo::ship::handle_core_deploy_requested,
             process_command_queue,
-        ),
+        )
+            .chain()
+            .after(macrocosmo::ship::dispatcher::dispatch_queued_commands),
     );
     app.add_systems(
         Update,

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -401,9 +401,8 @@ pub fn test_app() -> App {
     // advance_game_time is a no-op in tests (we manually set clock.elapsed)
     // but must be registered because other systems use .after(advance_game_time)
     app.init_resource::<macrocosmo::ship::routing::RouteCalculationsPending>();
-    // #296 (S-3): Test apps must initialise these so deliverable_ops /
-    // resolve_core_deploys can run without a Resource-missing panic.
-    app.init_resource::<macrocosmo::ship::PendingCoreDeploys>();
+    // #334 Phase 2 (Commit 2): `PendingCoreDeploys` resource retired —
+    // `CoreDeployRequested` messages flow through `CommandEventsPlugin`.
     app.init_resource::<macrocosmo::scripting::GameRng>();
     // #334 Phase 1: command-dispatch message types + allocator.
     app.add_plugins(macrocosmo::ship::command_events::CommandEventsPlugin);
@@ -429,9 +428,6 @@ pub fn test_app() -> App {
             // #223: Deliverable ops run before process_command_queue so any
             // injected MoveTo reaches the router in the same frame.
             macrocosmo::ship::deliverable_ops::process_deliverable_commands,
-            // #296 (S-3): Drain Core deploy tickets enqueued by the
-            // deliverable processor. Mirrors ShipPlugin ordering.
-            macrocosmo::ship::resolve_core_deploys,
             // #334 Phase 1: dispatcher + MoveTo/MoveToCoordinates handlers
             // run before process_command_queue so the PendingRoute filter
             // on the legacy system excludes ships whose MoveTo was just
@@ -442,6 +438,9 @@ pub fn test_app() -> App {
             // #334 Phase 2 (Commit 1): deliverable handlers.
             macrocosmo::ship::handlers::handle_load_deliverable_requested,
             macrocosmo::ship::handlers::handle_deploy_deliverable_requested,
+            // #334 Phase 2 (Commit 2): Core deploy message handler, replaces
+            // the legacy `resolve_core_deploys` + `PendingCoreDeploys` path.
+            macrocosmo::ship::handle_core_deploy_requested,
             process_command_queue,
         )
             .chain()
@@ -648,8 +647,9 @@ pub fn full_test_app() -> App {
 
     // --- Routing resource ---
     app.init_resource::<macrocosmo::ship::routing::RouteCalculationsPending>();
-    // #296 (S-3): Core deploy queue + RNG (mirrors ShipPlugin / ScriptingPlugin).
-    app.init_resource::<macrocosmo::ship::PendingCoreDeploys>();
+    // #296 (S-3) / #334 Phase 2 (Commit 2): the `PendingCoreDeploys` resource
+    // was retired in favour of `CoreDeployRequested` messages — only the RNG
+    // stays.
     app.init_resource::<macrocosmo::scripting::GameRng>();
     // #334 Phase 1: command-dispatch message types + allocator.
     app.add_plugins(macrocosmo::ship::command_events::CommandEventsPlugin);
@@ -680,8 +680,6 @@ pub fn full_test_app() -> App {
             process_pending_ship_commands,
             tick_courier_routes,
             macrocosmo::ship::deliverable_ops::process_deliverable_commands,
-            // #296 (S-3): Drain Core deploy tickets enqueued above.
-            macrocosmo::ship::resolve_core_deploys,
             // #334 Phase 1: event-driven MoveTo path alongside legacy queue.
             macrocosmo::ship::dispatcher::dispatch_queued_commands,
             macrocosmo::ship::handlers::handle_move_requested,
@@ -689,6 +687,9 @@ pub fn full_test_app() -> App {
             // #334 Phase 2 (Commit 1): deliverable handlers.
             macrocosmo::ship::handlers::handle_load_deliverable_requested,
             macrocosmo::ship::handlers::handle_deploy_deliverable_requested,
+            // #334 Phase 2 (Commit 2): Core deploy message handler, replaces
+            // the legacy `resolve_core_deploys` + `PendingCoreDeploys` path.
+            macrocosmo::ship::handle_core_deploy_requested,
             process_command_queue,
         ),
     );

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -439,6 +439,9 @@ pub fn test_app() -> App {
             macrocosmo::ship::dispatcher::dispatch_queued_commands,
             macrocosmo::ship::handlers::handle_move_requested,
             macrocosmo::ship::handlers::handle_move_to_coordinates_requested,
+            // #334 Phase 2 (Commit 1): deliverable handlers.
+            macrocosmo::ship::handlers::handle_load_deliverable_requested,
+            macrocosmo::ship::handlers::handle_deploy_deliverable_requested,
             process_command_queue,
         )
             .chain()
@@ -683,6 +686,9 @@ pub fn full_test_app() -> App {
             macrocosmo::ship::dispatcher::dispatch_queued_commands,
             macrocosmo::ship::handlers::handle_move_requested,
             macrocosmo::ship::handlers::handle_move_to_coordinates_requested,
+            // #334 Phase 2 (Commit 1): deliverable handlers.
+            macrocosmo::ship::handlers::handle_load_deliverable_requested,
+            macrocosmo::ship::handlers::handle_deploy_deliverable_requested,
             process_command_queue,
         ),
     );

--- a/macrocosmo/tests/infrastructure_core.rs
+++ b/macrocosmo/tests/infrastructure_core.rs
@@ -15,9 +15,8 @@ use macrocosmo::faction::FactionOwner;
 use macrocosmo::galaxy::{
     AtSystem, INNER_ORBIT_OFFSET_LY, Sovereignty, system_inner_orbit_position,
 };
-use macrocosmo::ship::core_deliverable::{
-    CoreDeployTicket, PendingCoreDeploys, resolve_core_deploys,
-};
+use macrocosmo::ship::command_events::{CommandId, CoreDeployRequested};
+use macrocosmo::ship::core_deliverable::handle_core_deploy_requested;
 use macrocosmo::ship::{CoreShip, Owner};
 use macrocosmo::ship_design::ShipDesignRegistry;
 
@@ -145,31 +144,32 @@ fn pending_core_deploys_resolves_single_ticket() {
         });
     }
 
-    // Enqueue a ticket directly.
+    // Enqueue a CoreDeployRequested message directly.
     let deployer = app.world_mut().spawn_empty().id();
     let pos = system_inner_orbit_position(sys, app.world());
     assert!((pos[0] - (5.0 + INNER_ORBIT_OFFSET_LY)).abs() < 1e-9);
     {
-        app.world_mut().init_resource::<PendingCoreDeploys>();
         app.world_mut()
             .init_resource::<macrocosmo::scripting::GameRng>();
-        let mut pending = app.world_mut().resource_mut::<PendingCoreDeploys>();
-        pending.tickets.push(CoreDeployTicket {
+        let mut msgs = app
+            .world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<CoreDeployRequested>>();
+        msgs.write(CoreDeployRequested {
+            command_id: CommandId(101),
             deployer,
             target_system: sys,
             deploy_pos: pos,
             faction_owner: Some(empire),
             owner: Owner::Empire(empire),
             design_id: "infrastructure_core_v1".to_string(),
-            cargo_item_index: 0,
             submitted_at: 0,
         });
     }
 
-    // Run the resolver and apply commands.
+    // Run the handler and apply commands.
     app.world_mut()
-        .run_system_once(resolve_core_deploys)
-        .expect("run resolver");
+        .run_system_once(handle_core_deploy_requested)
+        .expect("run core handler");
     app.update();
 
     // Exactly one CoreShip should now exist in sys.
@@ -177,10 +177,6 @@ fn pending_core_deploys_resolves_single_ticket() {
     let cores: Vec<_> = q.iter(app.world()).collect();
     assert_eq!(cores.len(), 1);
     assert_eq!(cores[0].1.0, sys);
-
-    // Pending queue should be empty.
-    let pending = app.world().resource::<PendingCoreDeploys>();
-    assert!(pending.tickets.is_empty());
 }
 
 #[test]
@@ -219,25 +215,26 @@ fn pending_core_deploys_discards_duplicate_on_owned_system() {
     let deployer = app.world_mut().spawn_empty().id();
     let pos = [INNER_ORBIT_OFFSET_LY, 0.0, 0.0];
     {
-        app.world_mut().init_resource::<PendingCoreDeploys>();
         app.world_mut()
             .init_resource::<macrocosmo::scripting::GameRng>();
-        let mut pending = app.world_mut().resource_mut::<PendingCoreDeploys>();
-        pending.tickets.push(CoreDeployTicket {
+        let mut msgs = app
+            .world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<CoreDeployRequested>>();
+        msgs.write(CoreDeployRequested {
+            command_id: CommandId(102),
             deployer,
             target_system: sys,
             deploy_pos: pos,
             faction_owner: Some(empire),
             owner: Owner::Empire(empire),
             design_id: "infrastructure_core_v1".to_string(),
-            cargo_item_index: 0,
             submitted_at: 0,
         });
     }
 
     app.world_mut()
-        .run_system_once(resolve_core_deploys)
-        .expect("run resolver");
+        .run_system_once(handle_core_deploy_requested)
+        .expect("run core handler");
     app.update();
 
     // Still only one Core in sys (the pre-existing).
@@ -289,27 +286,31 @@ fn pending_core_deploys_same_tick_tie_break_picks_one() {
     let deployer_b = app.world_mut().spawn_empty().id();
     let pos = [INNER_ORBIT_OFFSET_LY, 0.0, 0.0];
     {
-        app.world_mut().init_resource::<PendingCoreDeploys>();
         app.world_mut()
             .init_resource::<macrocosmo::scripting::GameRng>();
-        let mut pending = app.world_mut().resource_mut::<PendingCoreDeploys>();
-        for (deployer, faction) in [(deployer_a, empire_a), (deployer_b, empire_b)] {
-            pending.tickets.push(CoreDeployTicket {
+        let mut msgs = app
+            .world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<CoreDeployRequested>>();
+        for (i, (deployer, faction)) in [(deployer_a, empire_a), (deployer_b, empire_b)]
+            .into_iter()
+            .enumerate()
+        {
+            msgs.write(CoreDeployRequested {
+                command_id: CommandId(200 + i as u64),
                 deployer,
                 target_system: sys,
                 deploy_pos: pos,
                 faction_owner: Some(faction),
                 owner: Owner::Empire(faction),
                 design_id: "infrastructure_core_v1".to_string(),
-                cargo_item_index: 0,
                 submitted_at: 0,
             });
         }
     }
 
     app.world_mut()
-        .run_system_once(resolve_core_deploys)
-        .expect("run resolver");
+        .run_system_once(handle_core_deploy_requested)
+        .expect("run core handler");
     app.update();
 
     // Exactly one Core in sys, regardless of which ticket won.
@@ -352,31 +353,36 @@ fn pending_core_deploys_preserves_across_different_systems() {
     let deployer_a = app.world_mut().spawn_empty().id();
     let deployer_b = app.world_mut().spawn_empty().id();
     {
-        app.world_mut().init_resource::<PendingCoreDeploys>();
         app.world_mut()
             .init_resource::<macrocosmo::scripting::GameRng>();
-        // Collect positions before taking `&mut` on the resource, since
-        // `system_inner_orbit_position` borrows `&World`.
+        // Collect positions before taking `&mut` on the Messages resource,
+        // since `system_inner_orbit_position` borrows `&World`.
         let pos_a = system_inner_orbit_position(sys_a, app.world());
         let pos_b = system_inner_orbit_position(sys_b, app.world());
-        let mut pending = app.world_mut().resource_mut::<PendingCoreDeploys>();
-        for (deployer, target, pos) in [(deployer_a, sys_a, pos_a), (deployer_b, sys_b, pos_b)] {
-            pending.tickets.push(CoreDeployTicket {
+        let mut msgs = app
+            .world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<CoreDeployRequested>>();
+        for (i, (deployer, target, pos)) in
+            [(deployer_a, sys_a, pos_a), (deployer_b, sys_b, pos_b)]
+                .into_iter()
+                .enumerate()
+        {
+            msgs.write(CoreDeployRequested {
+                command_id: CommandId(300 + i as u64),
                 deployer,
                 target_system: target,
                 deploy_pos: pos,
                 faction_owner: Some(empire),
                 owner: Owner::Empire(empire),
                 design_id: "infrastructure_core_v1".to_string(),
-                cargo_item_index: 0,
                 submitted_at: 0,
             });
         }
     }
 
     app.world_mut()
-        .run_system_once(resolve_core_deploys)
-        .expect("run resolver");
+        .run_system_once(handle_core_deploy_requested)
+        .expect("run core handler");
     app.update();
 
     let mut q = app.world_mut().query::<(Entity, &AtSystem, &CoreShip)>();
@@ -715,25 +721,26 @@ fn core_deploy_sets_system_sovereignty() {
     let deployer = app.world_mut().spawn_empty().id();
     let pos = system_inner_orbit_position(sys, app.world());
     {
-        app.world_mut().init_resource::<PendingCoreDeploys>();
         app.world_mut()
             .init_resource::<macrocosmo::scripting::GameRng>();
-        let mut pending = app.world_mut().resource_mut::<PendingCoreDeploys>();
-        pending.tickets.push(CoreDeployTicket {
+        let mut msgs = app
+            .world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<CoreDeployRequested>>();
+        msgs.write(CoreDeployRequested {
+            command_id: CommandId(400),
             deployer,
             target_system: sys,
             deploy_pos: pos,
             faction_owner: Some(empire),
             owner: Owner::Empire(empire),
             design_id: "infrastructure_core_v1".to_string(),
-            cargo_item_index: 0,
             submitted_at: 0,
         });
     }
 
     app.world_mut()
-        .run_system_once(resolve_core_deploys)
-        .expect("run resolver");
+        .run_system_once(handle_core_deploy_requested)
+        .expect("run core handler");
     app.update();
     // Let update_sovereignty run.
     advance_time(&mut app, 1);

--- a/macrocosmo/tests/infrastructure_core.rs
+++ b/macrocosmo/tests/infrastructure_core.rs
@@ -362,10 +362,9 @@ fn pending_core_deploys_preserves_across_different_systems() {
         let mut msgs = app
             .world_mut()
             .resource_mut::<bevy::ecs::message::Messages<CoreDeployRequested>>();
-        for (i, (deployer, target, pos)) in
-            [(deployer_a, sys_a, pos_a), (deployer_b, sys_b, pos_b)]
-                .into_iter()
-                .enumerate()
+        for (i, (deployer, target, pos)) in [(deployer_a, sys_a, pos_a), (deployer_b, sys_b, pos_b)]
+            .into_iter()
+            .enumerate()
         {
             msgs.write(CoreDeployRequested {
                 command_id: CommandId(300 + i as u64),


### PR DESCRIPTION
## Summary

Phase 2 of the [#334 command dispatch refactor](../blob/main/docs/plan-334-command-dispatch-event-driven.md) (plan §7). Phase 1 landed in PR #341. This PR migrates the remaining non-Scout variants out of the legacy `process_deliverable_commands` / `process_command_queue` mutating loops and into the event-driven dispatcher + per-variant handler pipeline.

- `LoadDeliverable` + `DeployDeliverable` → `handlers::deliverable_handler` (Commit 1)
- `PendingCoreDeploys` resource retired; `resolve_core_deploys` → `handle_core_deploy_requested` reading `MessageReader<CoreDeployRequested>` (Commit 2)
- `TransferToStructure` + `LoadFromScrapyard` → handlers (Commit 3); `process_deliverable_commands` system deleted
- `Survey` + `Colonize` → new `handlers::settlement_handler` (Commit 4)
- `process_command_queue` fallthrough consolidated; only `Scout` remains for Phase 3 (Commit 5)

Commits:

| hash | subject |
|---|---|
| 55834df | #334 Phase 2 (Commit 1): LoadDeliverable / DeployDeliverable handlers |
| 2d5b1ef | #334 Phase 2 (Commit 2): CoreDeployRequested handler + PendingCoreDeploys retirement |
| 42965a2 | #334 Phase 2 (Commit 3): TransferToStructure / LoadFromScrapyard handlers |
| a209ac6 | #334 Phase 2 (Commit 4): Survey / Colonize handlers |
| 85f87ac | #334 Phase 2 (Commit 5): consolidate migrated-variant fallthrough in process_command_queue |
| 91b9d61 | #334 Phase 2: rustfmt |

## Behaviour changes

None — the refactor is behaviour-preserving. Validation / mutation logic is moved verbatim; the change is _where_ it lives (dispatcher vs handler) and _how_ results flow (inline mutation → `MessageWriter`). Command semantic semantics (Deploy Core self-destruct on deep-space / already-owned system, tie-break via `GameRng`, auto-MoveTo prefix on not-at-target, Load cargo-capacity gating, etc.) are unchanged.

One **observational** addition: every handler now emits a `CommandExecuted { Ok / Rejected / Deferred }` terminal keyed by the dispatcher-allocated `CommandId`, so the CommandLog 2-phase status (Phase 1 bridge) now covers all deliverable / settlement commands.

## `PendingCoreDeploys` retirement

- Resource + `CoreDeployTicket` struct deleted from `core_deliverable.rs`.
- `init_resource::<PendingCoreDeploys>()` removed from `ShipPlugin`, `test_app`, `full_test_app`.
- Deterministic tie-break (`GameRng` + grouping by `target_system` + neutral filter + already-has-core guard) is reproduced verbatim inside `handle_core_deploy_requested`. `tests/infrastructure_core.rs` tests exercise the same semantics via `Messages<CoreDeployRequested>` seeding + `run_system_once(handle_core_deploy_requested)`. All 10 tests pass.

## Plan deviations

- The legacy `process_command_queue` MoveTo/MoveToCoordinates fallthrough arm was downgraded from `warn! + drop` to silent skip in Commit 1. This was required because Phase 2 handlers can auto-inject those variants at the queue head mid-tick; the dropping behaviour ate the retries. Behaviour is preserved (next-tick dispatcher picks them up).
- Test-side `test_app` / `full_test_app` had to be split into two `add_systems` blocks to stay under Bevy 0.18's 20-arm `IntoScheduleConfigs` limit once the two Commit-4 settlement handlers were added. The second block is `.chain()`'d `.after(dispatch_queued_commands)` to preserve same-tick message delivery.
- The deploy handler's Core branch now emits `CommandExecuted { Deferred }` before `handle_core_deploy_requested` emits the terminal `Ok / Rejected` — this is the plan §4 two-phase pattern, explicitly validated against `tests/infrastructure_core.rs` (all tie-break / dedup / cross-system tests green).

No `Local` state is retained by any handler; all cross-system state flows through `MessageReader` / `MessageWriter`.

## Test plan

- [x] `cargo test --workspace` — 55 suites all green (1500+ tests), including:
  - [x] `tests/infrastructure_core.rs` (10 tests, tie-break / dedup / same-tick / cross-system)
  - [x] `tests/deliverable_pipeline.rs` (3 tests, full cargo load → deploy → salvage round-trip)
  - [x] `tests/smoke::all_systems_no_query_conflict` (B0001 detector)
  - [x] `tests/fixtures_smoke::load_minimal_game_fixture_smoke` (save format unchanged — `PendingCoreDeploys` was never persisted)
- [x] `cargo check --workspace --tests` — green
- [x] `rustfmt --edition 2024 --check` — green on touched files (fixup commit applied)

## Phase 3 / 4 follow-ups

Not in this PR:
- `Scout` variant (last non-migrated variant) → Phase 3
- `process_command_queue` deletion entirely → Phase 3
- `CommandExecuted → gamestate / Lua` bridge → Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)