### PR TITLE
#334 Phase 4: Lua bridge — on_command_completed hook + ctx.gamestate:request_command setter

### DIFF
--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -222,6 +222,84 @@ Phase B で lifecycle hook 拡張 + legacy 廃止が完了:
 
 memory: `project_lua_gamestate_api.md`、issue: **#332**
 
+## 10bis. Command dispatch pipeline (#334)
+
+Event-driven command dispatch, landed across Phase 1 (PR #341), Phase 2
+(PR #342), Phase 3 (PR #343), and Phase 4 (this PR):
+
+```
+UI / Lua / AI
+  ↓ enqueues QueuedCommand on ship.CommandQueue
+  OR  evt.gamestate:request_command(kind, args)  -- #334 Phase 4 Lua setter
+  ↓
+ship::dispatcher::dispatch_queued_commands      -- validates + allocates CommandId
+  ↓                                              -- emits CommandRequested<T>
+ship::handlers::handle_*_requested              -- per-variant handler system
+  ↓                                              -- writes CommandExecuted { result }
+ship::bridges::bridge_command_executed_to_log   -- flips CommandLog UI entry
+ship::bridges::bridge_command_executed_to_gamestate
+  ↓                                              -- enqueues COMMAND_COMPLETED_EVENT
+  ↓                                              -- on EventSystem (queue-only)
+scripting::lifecycle::dispatch_event_handlers   -- next tick
+  ↓
+Lua `on("macrocosmo:command_completed", fn)`    -- hook observer (may re-issue)
+```
+
+**Invariants** (`memory/feedback_rust_no_lua_callback.md`):
+
+- `apply::request_command(&mut World, ParsedRequest) -> mlua::Result<u64>`
+  takes **no `&Lua`**; it allocates a `CommandId`, writes one
+  `CommandRequested<T>` via `World::resource_mut::<Messages<_>>`, and
+  returns the fresh id. Lua callback / Function / RegistryKey is never
+  invoked from the write path.
+- `bridge_command_executed_to_gamestate` is a normal Bevy reader; it
+  calls `EventSystem::fire_event_with_payload`, which pushes to
+  `fired_log`. `dispatch_event_handlers` on a later tick delivers the
+  payload to Lua. No synchronous callback is permitted from inside a
+  handler system.
+- `CommandResult::Deferred` (async route, auto-prefixed MoveTo) is
+  **skipped** by the gamestate bridge so the hook fires exactly once
+  per terminal result (plan §10 R8).
+
+**Supported Lua kinds (Phase 4)**: `"move"`, `"move_to_coordinates"`,
+`"scout"`, `"load_deliverable"`, `"deploy_deliverable"`,
+`"transfer_to_structure"`, `"load_from_scrapyard"`, `"colonize"`,
+`"survey"`. `"core_deploy"` / `"attack"` raise `RuntimeError`
+("not yet supported") — their Rust sides land with the
+diplomacy-v2 (#302/#321) / combat (#219/#220) work.
+
+**Lua API example**:
+
+```lua
+on("macrocosmo:some_trigger", function(evt)
+    local ship_id    = _some_ship_bits
+    local target_id  = _some_system_bits
+    local cmd_id = evt.gamestate:request_command("move", {
+        ship   = ship_id,
+        target = target_id,
+    })
+    -- cmd_id is returned as a Lua number; match against the hook's
+    -- string-ified `evt.command_id` via `tonumber`.
+    _pending_cmd = cmd_id
+end)
+
+on("macrocosmo:command_completed", function(evt)
+    -- evt.kind        : "move" | "survey" | ...
+    -- evt.result      : "ok" | "rejected"
+    -- evt.reason      : string (only when rejected)
+    -- evt.command_id  : decimal string
+    -- evt.ship        : entity bits as decimal string
+    -- evt.completed_at: hexadies as decimal string
+    if evt.result == "rejected" then
+        log("command " .. evt.command_id .. " failed: " .. (evt.reason or ""))
+    end
+end)
+```
+
+Full lifecycle / invariant walkthrough: `docs/plan-334-command-dispatch-event-driven.md`.
+Example script stub: `scripts/examples/on_command_completed.lua` (docs
+only — not loaded by `init.lua`).
+
 ## 11. Scripting 設計原則
 
 - **単一エントリポイント**: `scripts/init.lua` → require() で依存順に読み込み。

--- a/docs/plan-334-command-dispatch-event-driven.md
+++ b/docs/plan-334-command-dispatch-event-driven.md
@@ -1,0 +1,921 @@
+# Implementation Plan: Issue #334 — Command dispatch refactor (event-driven split, Option C)
+
+_Prepared 2026-04-15 by Plan agent. Depends on #332 (merged) for the `CommandExecuted` → gamestate scope-closure integration (Phase 4). #296 (merged) provides the current `PendingCoreDeploys` / `resolve_core_deploys` path that this refactor folds back into the event pipeline. Blocker for #268 (Courier opportunistic relay — needs dedup plumbing) and #302/#321 (diplomacy v2 setter family — lands on the same Phase 4 event surface)._
+
+---
+
+## 0. TL;DR
+
+`process_deliverable_commands` already hits Bevy's 16-arg SystemParam cap even after #296 merged two Core-related queries into a tuple query. The next generation of commands (Port combat engage #219, defensive platforms #220, courier relay #268, diplomacy v2 setter #321) will double or triple the variant count within a milestone, and the current shape (**one fat dispatcher that both validates AND mutates per variant**) cannot absorb them.
+
+This plan introduces an **event-driven split** (Option C from the issue):
+
+- **Single lightweight dispatcher** (`process_queued_commands` replacing the mutating loop in `process_deliverable_commands` / `process_command_queue`) that only validates, dedups, and emits typed `CommandRequested` messages.
+- **One handler system per command kind**, each holding only the queries it actually needs. Handlers read a single `MessageReader<CommandRequested::X>` (or a tagged enum — see §2.1 trade-off) and are ordered `.after(dispatcher)` for same-tick execution.
+- **Post-handler `CommandExecuted` message** emitted by each handler. Consumed by `CommandLog`, `GameEvent`, the #332 gamestate hook bridge, and (future) the `on_command_completed` Lua hook via the queue-only pattern from `feedback_rust_no_lua_callback.md`.
+- **Migration is phased** (4 phases, ≈15 commits total, 3 landable PRs). No semantic changes to command behaviour at any phase boundary.
+
+The refactor is a **behaviour-preserving mechanical reshape**. Every variant's validation logic moves verbatim; what changes is where it lives (dispatcher, handler) and how results flow (inline state write → message → deferred handler). Tests are the contract.
+
+---
+
+## §1 現状棚卸し
+
+### 1.1 `process_deliverable_commands` SystemParam (16 args, at cap)
+
+Source: `macrocosmo/src/ship/deliverable_ops.rs:44-78`.
+
+| # | param | kind | notes |
+|---|---|---|---|
+| 1 | `commands: Commands` | deferred writes | spawn deliverable entity |
+| 2 | `clock: Res<GameClock>` | read | `clock.elapsed` for event timestamps / ticket submit_at |
+| 3 | `balance: Res<GameBalance>` | read | `mass_per_item_slot` |
+| 4 | `registry: Res<StructureRegistry>` | read | cargo size lookup, `spawns_as_ship` marker |
+| 5 | `events: MessageWriter<GameEvent>` | write | dual-write `ShipBuilt` events |
+| 6 | `ships: Query<(Entity, &Ship, &ShipState, &Position, &mut CommandQueue, &mut Cargo, &ShipModifiers)>` | read+write | 7-tuple, main driver |
+| 7 | `stockpiles: Query<&mut DeliverableStockpile>` | write | load/unload |
+| 8 | `platforms: Query<(&Position, &mut ConstructionPlatform), Without<Ship>>` | write | `TransferToStructure` |
+| 9 | `scrapyards: Query<(&Position, &mut Scrapyard), Without<Ship>>` | write | `LoadFromScrapyard` |
+| 10 | `structures: Query<(&DeepSpaceStructure, &Position), Without<Ship>>` | read (unused, reserved) | future use; currently `let _ = structures` |
+| 11 | `player_q: Query<&StationedAt, Without<Ship>>` | read | vantage snapshot |
+| 12 | `player_aboard_q: Query<&AboardShip, With<Player>>` | read | vantage snapshot |
+| 13 | `star_systems: Query<(Entity, &Position), (Without<Ship>, With<StarSystem>)>` | read | vantage + Core proximity (tuple-merged in #296) |
+| 14 | `existing_cores: Query<&AtSystem, With<CoreShip>>` | read | "already has Core" validation (#296) |
+| 15 | `pending_cores: ResMut<PendingCoreDeploys>` | write | Core ticket queue (#296, becomes `MessageWriter<CoreDeployRequested>` post-refactor) |
+| 16 | `fact_sys: FactSysParam` | bundle | knowledge dual-writes |
+
+`FactSysParam` is itself a multi-field `SystemParam` bundle (knowledge writers + event id allocator), so the 16 count understates the internal pressure. Adding any new read query — e.g. `FactionOwner` lookups for diplomacy gating, or a relay-ship-state query for #268 — requires either another tuple merge (which hurts readability) or splitting the system (which is this plan).
+
+### 1.2 `QueuedCommand` variants (pub enum)
+
+Source: `macrocosmo/src/ship/mod.rs:117-166`.
+
+| variant | fields | current dispatcher | kind |
+|---|---|---|---|
+| `MoveTo` | `{ system: Entity }` | `process_command_queue` (`command.rs:263-373`) | movement |
+| `MoveToCoordinates` | `{ target: [f64; 3] }` | `process_command_queue` (`command.rs:374-402`) | movement |
+| `Survey` | `{ system: Entity }` | `process_command_queue` (`command.rs:486-523`) | action |
+| `Colonize` | `{ system, planet: Option<Entity> }` | `process_command_queue` (`command.rs:525-553`) | action |
+| `Scout` | `{ target_system, observation_duration, report_mode }` | `process_command_queue` (`command.rs:403-481`) | action |
+| `LoadDeliverable` | `{ system, stockpile_index }` | `process_deliverable_commands` (`deliverable_ops.rs:100-179`) | cargo |
+| `DeployDeliverable` | `{ position, item_index }` | `process_deliverable_commands` (`deliverable_ops.rs:180-323`) | cargo + Core branch |
+| `TransferToStructure` | `{ structure, minerals, energy }` | `process_deliverable_commands` (`deliverable_ops.rs:325-367`) | cargo |
+| `LoadFromScrapyard` | `{ structure }` | `process_deliverable_commands` (`deliverable_ops.rs:368-425`) | cargo |
+
+Nine variants today. Near-term additions already on the roadmap:
+- `AttackTarget { ship_or_structure }` or similar (#219 / #220)
+- `RelayCommand { command_id }` (#268)
+- Multiple diplomacy setter commands (#302 / #321 — declare war, offer trade, etc.) in Phase 4
+
+### 1.3 Variant → handler flow map (current, per grep)
+
+From `Grep QueuedCommand::Variant` across `macrocosmo/src/ship/`:
+
+```
+MoveTo          → process_command_queue (async routing via routing::spawn_route_task_full)
+                  → poll_pending_routes (after ApplyDeferred) finalizes FTL/sublight
+                  → (for remote path) process_pending_ship_commands (command.rs:83-143)
+MoveToCoordinates → process_command_queue (inline sublight)
+Survey          → process_command_queue
+                  + process_pending_ship_commands (remote path)
+Colonize        → process_command_queue
+                  + process_pending_ship_commands (remote path)
+Scout           → process_command_queue
+LoadDeliverable → process_deliverable_commands
+DeployDeliverable → process_deliverable_commands
+                    ├─ non-Core: spawn_deliverable_entity (inline)
+                    └─ Core branch: push CoreDeployTicket → resolve_core_deploys
+TransferToStructure → process_deliverable_commands
+LoadFromScrapyard  → process_deliverable_commands
+```
+
+Note: `process_command_queue` and `process_deliverable_commands` **both match every variant exhaustively** because `QueuedCommand` is `#[non_exhaustive]`-free — each system has a `_ => {}` fallthrough arm that explicitly lists the other system's variants as no-ops. This enforces ordering invariants at the compiler level but also means every new variant touches two files.
+
+### 1.4 `CommandLog` write sites
+
+Source: `macrocosmo/src/communication/mod.rs:293-418`.
+
+`CommandLog` is a per-empire Resource+Component that holds user-facing `CommandLogEntry { description, sent_at, arrives_at, arrived }`. Current write sites:
+
+1. `send_remote_command` (`mod.rs:397-409`) — **dispatcher-side**, on message send: `arrived = false`.
+2. `process_pending_commands` (`mod.rs:420+`) — **handler-side**, on message arrival: flips `arrived = true` via description match (string key, fragile).
+
+The event-driven refactor replaces this brittle string match with a stable `command_id: u64` (newtype) carried through both the `CommandRequested` message and the `CommandExecuted` message. See §4.
+
+### 1.5 `PendingCoreDeploys` intermediate resource (#296)
+
+Source: `macrocosmo/src/ship/core_deliverable.rs:71-77, 110-206`.
+
+Current flow:
+1. `process_deliverable_commands` validates the Core-deploy (`deliverable_ops.rs:218-286`), then `pending_cores.tickets.push(ticket)` and removes the cargo item.
+2. `resolve_core_deploys` runs `.after(process_deliverable_commands)` (`mod.rs:200-201`), drains the resource, tie-breaks with `GameRng`, spawns via `spawn_core_ship_from_deliverable`.
+
+**This is already half an event pipeline** — a side channel resource passed between systems in the same tick. Converting it to `MessageReader<CoreDeployRequested>` is mechanical; the tie-break logic moves into the handler unchanged. Worth noting that Bevy 0.18 renames `Event` → `Message`, `EventReader` → `MessageReader`, `EventWriter` → `MessageWriter`, `add_event` → `add_message` (see `events.rs:112` and `notifications.rs:586`). This plan uses the Bevy 0.18 terminology throughout.
+
+### 1.6 Lua callback path (from `feedback_rust_no_lua_callback.md`)
+
+Critical invariant confirmed in Phase 4: `CommandExecuted` **must not be delivered synchronously into a Lua callback from a handler system**. Instead, a reader system (`bridge_command_events_to_lua` in Phase 4) enqueues `_pending_script_events` entries for the existing `fire_event` dispatch loop to process on the next tick. This preserves the queue-only reentrancy discipline #332 relies on.
+
+---
+
+## §2 Event-driven design
+
+### 2.1 Message type shape — one enum vs. per-variant types
+
+**Recommendation: per-variant message types** wrapped in a trait-free module, not a single enum.
+
+```rust
+// macrocosmo/src/ship/command_events.rs (new module)
+
+/// Stable command identifier — allocated by the dispatcher, stitched into
+/// `CommandRequested` and `CommandExecuted` so `CommandLog` and #268 relay
+/// dedup can match them without string keys. Monotonic per-game-session.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct CommandId(pub u64);
+
+#[derive(Resource, Default)]
+pub struct NextCommandId(pub u64);
+
+#[derive(Message, Debug, Clone)]
+pub struct MoveRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub target: Entity,         // target star system
+    pub issued_at: i64,
+}
+
+#[derive(Message, Debug, Clone)]
+pub struct MoveToCoordinatesRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub target: [f64; 3],
+    pub issued_at: i64,
+}
+
+#[derive(Message, Debug, Clone)]
+pub struct SurveyRequested { pub command_id: CommandId, pub ship: Entity, pub target_system: Entity, pub issued_at: i64 }
+
+#[derive(Message, Debug, Clone)]
+pub struct ColonizeRequested { pub command_id: CommandId, pub ship: Entity, pub target_system: Entity, pub planet: Option<Entity>, pub issued_at: i64 }
+
+#[derive(Message, Debug, Clone)]
+pub struct ScoutRequested { /* … ship, target, duration, report_mode, cmd_id, issued_at */ }
+
+#[derive(Message, Debug, Clone)]
+pub struct LoadDeliverableRequested { /* … ship, system, stockpile_index, cmd_id, issued_at */ }
+
+#[derive(Message, Debug, Clone)]
+pub struct DeployDeliverableRequested {
+    pub command_id: CommandId,
+    pub ship: Entity,
+    pub position: [f64; 3],
+    pub item_index: usize,
+    pub issued_at: i64,
+}
+
+/// Produced by the `DeployDeliverable` handler's Core-branch instead of
+/// `PendingCoreDeploys` tickets. Consumed by `resolve_core_deploys` (or a
+/// renamed `handle_core_deploy_requested`).
+#[derive(Message, Debug, Clone)]
+pub struct CoreDeployRequested {
+    pub command_id: CommandId,
+    pub deployer: Entity,
+    pub target_system: Entity,
+    pub deploy_pos: [f64; 3],
+    pub faction_owner: Option<Entity>,
+    pub owner: crate::ship::Owner,
+    pub design_id: String,
+    pub submitted_at: i64,
+}
+
+#[derive(Message, Debug, Clone)]
+pub struct TransferToStructureRequested { /* … */ }
+
+#[derive(Message, Debug, Clone)]
+pub struct LoadFromScrapyardRequested { /* … */ }
+
+#[derive(Message, Debug, Clone)]
+pub struct AttackRequested { /* #219 / #220 forward-compat skeleton */ pub command_id: CommandId, pub attacker: Entity, pub target: Entity, pub issued_at: i64 }
+
+/// Post-handler notification. `kind` is a small enum (no payload) so
+/// subscribers that only care about "command X completed" don't have to
+/// match on each variant's arg tuple.
+#[derive(Message, Debug, Clone)]
+pub struct CommandExecuted {
+    pub command_id: CommandId,
+    pub kind: CommandKind,
+    pub ship: Entity,
+    pub result: CommandResult,
+    pub completed_at: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandKind {
+    Move, MoveToCoordinates, Survey, Colonize, Scout,
+    LoadDeliverable, DeployDeliverable, CoreDeploy,
+    TransferToStructure, LoadFromScrapyard, Attack,
+}
+
+#[derive(Debug, Clone)]
+pub enum CommandResult {
+    /// Handler completed the semantic mutation successfully.
+    Ok,
+    /// Handler detected a late condition (race, state change, target
+    /// despawn) and rolled back. `reason` is a short log-friendly key.
+    Rejected { reason: String },
+    /// Handler split the command — e.g. auto-inserted MoveTo prefix for
+    /// Survey when not at target. No terminal execution yet; another
+    /// `CommandExecuted` (or another `CommandRequested`) will follow.
+    Deferred,
+}
+```
+
+**Why per-variant and not `enum CommandRequested { Move(…), Survey(…), … }`**:
+
+1. Bevy's `MessageReader<T>` is typed — a single-enum design forces every handler to `.read()` the full variant stream and match on its own tag, spending cycles and cache lines on messages it ignores. Per-variant types keep the hot path narrow (one handler, one message stream).
+2. Adding a new command = adding one struct + one `app.add_message::<X>()` call. No touching an "all commands" enum — preserves open/closed.
+3. `CommandExecuted` stays a single enum-tagged message because subscribers (CommandLog, Lua hook bridge) genuinely want the merged stream — the cost of dispatch there is in the subscriber side and is small.
+
+**Downside**: each variant adds an `app.add_message::<X>()` line. Recommend a `CommandEventsPlugin` in `src/ship/command_events.rs` that registers them all so `main.rs` stays quiet. **Acceptable** given we replace nine fat `match` arms with a clean plugin init.
+
+### 2.2 Dispatcher system signature
+
+```rust
+pub fn dispatch_queued_commands(
+    clock: Res<GameClock>,
+    mut next_id: ResMut<NextCommandId>,
+    // ONE mutable ship view — peek head, remove on consume.
+    mut ships: Query<(Entity, &Ship, &ShipState, &Position, &mut CommandQueue)>,
+    // read-only lookups for validation only — no mutation from dispatcher.
+    systems: Query<(Entity, &Position), With<StarSystem>>,
+    existing_cores: Query<&AtSystem, With<CoreShip>>,
+    design_registry: Res<ShipDesignRegistry>,
+    // message writers — one per request variant.
+    mut move_req: MessageWriter<MoveRequested>,
+    mut move_xy_req: MessageWriter<MoveToCoordinatesRequested>,
+    mut survey_req: MessageWriter<SurveyRequested>,
+    mut colonize_req: MessageWriter<ColonizeRequested>,
+    mut scout_req: MessageWriter<ScoutRequested>,
+    mut load_req: MessageWriter<LoadDeliverableRequested>,
+    mut deploy_req: MessageWriter<DeployDeliverableRequested>,
+    mut transfer_req: MessageWriter<TransferToStructureRequested>,
+    mut scrap_req: MessageWriter<LoadFromScrapyardRequested>,
+    // CommandLog write on dispatch (see §4).
+    mut command_log_q: Query<&mut CommandLog, With<PlayerEmpire>>,
+) {
+    // ~50 lines of peek-head / validate-preconditions / emit-message /
+    // pop-from-queue. NO state mutation beyond CommandQueue pop and
+    // CommandLog append. Per-variant validation logic is inlined because
+    // the rules are small; if a rule balloons it can extract to a
+    // `fn validate_move(..) -> Result<MoveRequested, Reject>` helper.
+}
+```
+
+Param count: **12** (well below the 16-arg cap). The two read queries are needed for tie-break / pre-validation; all writers are `MessageWriter` which is the same `SystemParam` class as the old `&mut` queries but holds zero per-tick cost when empty.
+
+**Critical validation pushed to dispatcher** (see §3):
+- Ship exists
+- Ship not in FTL mid-transit for commands that require Docked/Loitering
+- Target entities exist in systems query
+- `ship.is_immobile()` rejection for MoveTo / MoveToCoordinates
+- FTL gate + scout module presence for Scout
+- Core deploy "already has Core" early check (current `deliverable_ops.rs:248-258`)
+
+**Handler-only validation** (things the dispatcher cannot see without becoming fat again):
+- Cargo fit check (needs `Cargo` + `ShipModifiers` + `DeliverableStockpile`)
+- Co-location epsilon check for Deploy / Transfer (needs `ConstructionPlatform` / `Scrapyard` positions)
+- Colony ship capability (needs `design_registry.can_colonize`)
+- Same-tick tie-break for multi-deploy on one system (moved into `resolve_core_deploys` already — unchanged)
+
+### 2.3 Handler signatures (example: MoveTo)
+
+```rust
+// macrocosmo/src/ship/handlers/move_handler.rs (new module)
+
+pub fn handle_move_requested(
+    mut commands: Commands,
+    clock: Res<GameClock>,
+    mut reqs: MessageReader<MoveRequested>,
+    empire_params_q: Query<&GlobalParams, With<PlayerEmpire>>,
+    balance: Res<GameBalance>,
+    empire_knowledge_q: Query<&KnowledgeStore, With<PlayerEmpire>>,
+    mut ships: Query<(&Ship, &mut ShipState, &Position, Option<&RulesOfEngagement>)>,
+    systems: Query<(Entity, &StarSystem, &Position), Without<Ship>>,
+    system_buildings: Query<&SystemBuildings>,
+    hostiles_q: Query<(&AtSystem, &FactionOwner), With<Hostile>>,
+    relations: Res<FactionRelations>,
+    mut pending_count: ResMut<RouteCalculationsPending>,
+    design_registry: Res<ShipDesignRegistry>,
+    building_registry: Res<BuildingRegistry>,
+    regions: Query<&ForbiddenRegion>,
+    mut executed: MessageWriter<CommandExecuted>,
+) {
+    // Same logic as process_command_queue's MoveTo arm (command.rs:263-373),
+    // refactored to read from reqs instead of peeking a queue head.
+    for req in reqs.read() {
+        /* … original body, verbatim … */
+        executed.write(CommandExecuted {
+            command_id: req.command_id,
+            kind: CommandKind::Move,
+            ship: req.ship,
+            result: CommandResult::Ok, // or Deferred if async route is spawned
+            completed_at: clock.elapsed,
+        });
+    }
+}
+```
+
+Param count: **14** (fits, with slack for future needs). Each handler scope is narrow: only MoveTo needs route planner resources; Deploy needs Cargo+Stockpile+Registry; Survey needs `start_survey_with_bonus` supports. The key win: **no handler ever has to pull in every other handler's params**.
+
+`handle_deploy_deliverable_requested` is the biggest handler (because it handles both structure-spawn AND the Core-branch message emit):
+
+```rust
+pub fn handle_deploy_deliverable_requested(
+    mut commands: Commands,
+    clock: Res<GameClock>,
+    balance: Res<GameBalance>,
+    registry: Res<StructureRegistry>,
+    mut reqs: MessageReader<DeployDeliverableRequested>,
+    mut core_out: MessageWriter<CoreDeployRequested>,
+    mut executed: MessageWriter<CommandExecuted>,
+    mut events: MessageWriter<GameEvent>,
+    ships: Query<(&Ship, &ShipState, &Position, &mut Cargo)>,
+    existing_cores: Query<&AtSystem, With<CoreShip>>,
+    star_systems: Query<(Entity, &Position), (Without<Ship>, With<StarSystem>)>,
+    mut fact_sys: FactSysParam,
+) {
+    /* … logic from deliverable_ops.rs:180-323 verbatim … */
+}
+```
+
+Param count: **12**. Below cap.
+
+### 2.4 System ordering — same-tick delivery
+
+Bevy 0.18's `Messages<T>` buffer is double-buffered per frame. A `MessageWriter` call in system A and a `MessageReader` call in system B **will see the message in the same frame** if B is ordered `.after(A)` (scheduler guarantees this; the message sits in the current-frame buffer until the next `Messages::update` call at end of frame). This is exactly the ordering we need.
+
+Schedule:
+
+```rust
+app.add_systems(Update, (
+    dispatch_queued_commands,
+    (
+        handle_move_requested,
+        handle_move_to_coordinates_requested,
+        handle_survey_requested,
+        handle_colonize_requested,
+        handle_scout_requested,
+        handle_load_deliverable_requested,
+        handle_deploy_deliverable_requested,
+        handle_transfer_to_structure_requested,
+        handle_load_from_scrapyard_requested,
+        handle_attack_requested, // future
+    ),
+    handle_core_deploy_requested, // .after(handle_deploy_deliverable_requested) specifically
+    bridge_command_executed_to_log,       // reads CommandExecuted, updates CommandLog
+    bridge_command_executed_to_gamestate, // Phase 4, enqueues _pending_script_events
+).chain()
+ .after(crate::time_system::advance_game_time));
+```
+
+The per-handler tuple is **not** `.chain()`'d internally — they're independent and can run in parallel where Bevy's scheduler allows (no query conflicts between them since each has a different handler's query set). `handle_core_deploy_requested` specifically chains after Deploy because the Core message is emitted inside that handler.
+
+---
+
+## §3 Validation error handling policy (Open question 1)
+
+**Decision: dispatcher-side early validation, handler rollback as exception.**
+
+### 3.1 Dispatcher validation — `warn!` + drop, no message emit
+
+For all preconditions the dispatcher can evaluate from its 12-param view, the rule is:
+
+1. Peek queue head
+2. Run validation
+3. If fail: `warn!(…)`, pop the command (`queue.commands.remove(0)`), **do not emit** a `CommandRequested`.
+4. If pass: emit `CommandRequested`, pop the command.
+
+No `CommandExecuted` is emitted on dispatcher-side fail — the command never had an execution phase. `CommandLog` receives a synthetic `rejected: true` entry (see §4) written inline by the dispatcher; this is the one CommandLog write from the dispatcher.
+
+**Checks performed in dispatcher**:
+
+| check | applies to | today's location |
+|---|---|---|
+| ship exists | all | implicit in today's queries |
+| target system exists | MoveTo, Survey, Colonize, Scout, LoadDeliverable | `command.rs:265, 487, 527, 417`, `deliverable_ops.rs:113` |
+| ship Docked/Loitering | MoveTo (loitering OK), Deploy, Transfer, Scrap, Survey, Colonize, Scout | `command.rs:247-253`, `deliverable_ops.rs:182-189` |
+| ship immobile rejection | MoveTo, MoveToCoordinates | `command.rs:283-291, 379-401` |
+| scout FTL + module gate | Scout | `command.rs:425-441` |
+| Core "already has Core" early filter | DeployDeliverable (Core branch) | `deliverable_ops.rs:248-258` |
+| owner-is-Empire gate | CoreDeploy (Neutral filtered) | `core_deliverable.rs:174` |
+
+### 3.2 Handler rollback — for races only
+
+The handler may still detect failure after the dispatcher passed validation:
+
+- Another handler despawned the target this tick (`systems.get(target).is_err()`).
+- Resource state changed (e.g. cargo item consumed by a parallel command).
+- Async condition (route planner declares target unreachable).
+
+In these cases the handler:
+
+1. Performs no state mutation (or rolls back partial state).
+2. Emits `CommandExecuted { result: CommandResult::Rejected { reason: "target despawned" }, … }`.
+3. `warn!` for developer debugging.
+
+This split means **subscribers always see a terminal signal**: every `CommandRequested` yields exactly one `CommandExecuted` (`Ok`, `Rejected`, or `Deferred → later Ok/Rejected`). Dispatcher-side rejections are visible through `CommandLog` but not `CommandExecuted`.
+
+### 3.3 `Deferred` handling (MoveTo async + auto-inserted prefixes)
+
+Two existing patterns need the `CommandResult::Deferred` disposition:
+
+1. **MoveTo async route** (`command.rs:356-372`): `spawn_route_task_full` starts a task and inserts `PendingRoute`; `poll_pending_routes` finalizes later. The handler emits `CommandExecuted { result: Deferred }` on spawn, and the poll system emits the terminal `CommandExecuted { result: Ok/Rejected }` when the route resolves. `command_id` is threaded through `PendingRoute` so the terminal event keys correctly.
+
+2. **Auto-inserted MoveTo prefix** for Survey/Colonize/Scout when ship not at target (`command.rs:443-462, 494-499, 531-535`): handler emits `CommandExecuted { result: Deferred }`, re-inserts the original command back at the head of the queue, **and** inserts a MoveTo in front. The dispatcher picks those up next tick as fresh `MoveRequested` + `SurveyRequested`. The **new `command_id` for the re-inserted Survey** is the same as the original (so `CommandLog` shows one entry); this is plumbed via a `CommandQueue` field extension (`QueuedCommand` gains a `Option<CommandId>` — see §7 Phase 1 migration detail).
+
+---
+
+## §4 CommandLog 記録箇所 (Open question 2)
+
+**Decision: two-phase record keyed by `CommandId`.**
+
+### 4.1 Schema change
+
+```rust
+pub struct CommandLogEntry {
+    pub command_id: Option<CommandId>, // None for legacy remote messages
+    pub description: String,
+    pub sent_at: i64,
+    pub arrives_at: i64,    // equals sent_at for local (non-remote) cmds
+    pub dispatched_at: Option<i64>,
+    pub executed_at: Option<i64>,
+    pub status: CommandLogStatus,
+}
+
+pub enum CommandLogStatus {
+    Pending,      // remote cmd in flight
+    Dispatched,   // dispatcher emitted CommandRequested
+    Executed,     // handler emitted CommandExecuted::Ok
+    Rejected { reason: String },
+    Deferred,     // CommandExecuted::Deferred, awaiting follow-up
+}
+```
+
+### 4.2 Write sites
+
+1. **Remote command send** (existing `send_remote_command`, `mod.rs:397-418`): status = `Pending`, `command_id = None` (or allocated at send — TBD, #268 may need it). No change in Phase 1-3; Phase 4 unifies.
+2. **Dispatcher** (new): on successful validation → append entry with `status = Dispatched`, `command_id = Some(id)`, `dispatched_at = clock.elapsed`. On validation fail → append with `status = Rejected { reason }`, `executed_at = clock.elapsed`.
+3. **Handler bridge system** `bridge_command_executed_to_log`: reads `MessageReader<CommandExecuted>`, looks up entry by `command_id`, updates `status` + `executed_at`.
+
+Bridge system signature:
+
+```rust
+pub fn bridge_command_executed_to_log(
+    mut executed: MessageReader<CommandExecuted>,
+    mut log_q: Query<&mut CommandLog, With<PlayerEmpire>>,
+) {
+    let Ok(mut log) = log_q.single_mut() else { return; };
+    for event in executed.read() {
+        if let Some(entry) = log.entries.iter_mut().find(|e| e.command_id == Some(event.command_id)) {
+            entry.executed_at = Some(event.completed_at);
+            entry.status = match &event.result {
+                CommandResult::Ok => CommandLogStatus::Executed,
+                CommandResult::Rejected { reason } => CommandLogStatus::Rejected { reason: reason.clone() },
+                CommandResult::Deferred => CommandLogStatus::Deferred,
+            };
+        }
+    }
+}
+```
+
+**Timing gap risk**: the bridge runs `.after(all handlers)`, so within a single `Update` pass a command's `Dispatched` → `Executed` transition is atomic from the player's perspective (the UI reads `CommandLog` in the `EguiPrimaryContextPass` schedule, which runs after `Update`). No visible intermediate state.
+
+**Remote command bridging** (Phase 4): once a remote `PendingCommand` arrives at the target system, its execution should push a `CommandRequested` through the same pipeline. That integration lives under #302/#321 diplomacy work; this plan only commits to not breaking the existing flow.
+
+---
+
+## §5 Observer mode / faction filter (Open question 3)
+
+**Decision: events are emitted for all factions unfiltered; faction filter happens at consumers.**
+
+### 5.1 Rationale
+
+- Knowledge propagation (#175/#176) is the proper place to hide other factions' commands from the player — not the command pipeline itself.
+- NPC-empire commands (#173) run through the same dispatcher/handler path. If we filtered events by faction at emit time, AI tooling and observer-mode replay would go dark.
+- The event bus is an engine-internal channel. UIs, log panels, and Lua hooks each decide whether to subscribe to all factions or just the player's empire. This matches how `GameEvent` + `KnowledgeStore` relate today.
+
+### 5.2 Observer mode debug telemetry
+
+`ui/ai_debug/` already consumes cross-faction signals; extending the AI debug stream to subscribe to all `CommandExecuted` messages is a one-system addition (a `MessageReader<CommandExecuted>` in `stream.rs`). Out of scope for this plan but explicitly enabled by the design.
+
+### 5.3 Player-facing filter point
+
+`CommandLog` is attached to `PlayerEmpire`. The bridge system writes only to the player's log; NPC commands trigger `CommandExecuted` but not `CommandLog` entries. Knowledge propagation for NPC commands happens through the existing `FactSysParam` dual-writes (already in the handlers — we're moving code, not changing it).
+
+---
+
+## §6 同 tick 多重 command の順序 (Open question 4)
+
+**Decision: FIFO at dispatcher emit time is sufficient.**
+
+### 6.1 Per-ship FIFO via single dispatcher
+
+`dispatch_queued_commands` is a single system that iterates `ships.iter_mut()` and peeks one command per ship per frame. Each ship's queue is drained sequentially, so the per-ship order matches the pre-refactor behaviour exactly.
+
+### 6.2 Cross-ship order and `MessageReader` guarantees
+
+Bevy's `MessageReader` iterates messages **in the order they were emitted** (confirmed by `bevy_ecs::message` docs: the internal buffer is a `Vec`, not a priority queue; `iter()` and `drain()` are FIFO). So if ship A emits `MoveRequested` before ship B in the same dispatcher iteration, the `handle_move_requested` handler processes A then B.
+
+**Spec verification needed at Phase 1 spike**: add a test `test_message_reader_preserves_emit_order` in `tests/` that writes 100 `MoveRequested` messages with distinct `command_id`s and asserts the reader sees them in order. Lock the assumption before it becomes implicit across 10 handlers.
+
+### 6.3 Same-system tie-break for Core deploys
+
+Unchanged from #296. `handle_core_deploy_requested` reads **all** `CoreDeployRequested` messages for the current frame, groups by `target_system`, runs `GameRng` tie-break, spawns the winner. The grouping happens entirely inside the handler, decoupled from message ordering.
+
+---
+
+## §7 Migration phase plan
+
+### Phase 1 — Event skeleton + MoveTo
+
+**Scope**: define `command_events.rs`, register plugin, migrate `MoveTo` + `MoveToCoordinates` only. All other variants remain in `process_deliverable_commands` / `process_command_queue` unchanged.
+
+**Commits (4 commits, ~500 LoC)**:
+
+1. `[334] add command_events module + CommandId + CommandKind + CommandResult`
+   - New file `macrocosmo/src/ship/command_events.rs` (~200 LoC).
+   - `NextCommandId` resource + `CommandEventsPlugin` registering all message types (even pre-declared — cheap to list, avoids churn as later phases land).
+   - Unit tests for `CommandId` monotonicity.
+2. `[334] dispatcher skeleton + MoveRequested / MoveToCoordinatesRequested`
+   - New file `macrocosmo/src/ship/dispatcher.rs` (~150 LoC).
+   - Dispatcher emits only `MoveRequested` / `MoveToCoordinatesRequested` for those two variants; other variants fall through to the old `process_command_queue` untouched.
+   - Wire into `ShipPlugin` ordered before `process_command_queue`.
+3. `[334] handle_move_requested + handle_move_to_coordinates_requested`
+   - Extract MoveTo logic from `process_command_queue` into `macrocosmo/src/ship/handlers/move_handler.rs`.
+   - Remove matching arms from `process_command_queue` (keep the other variants!).
+   - Thread `command_id` through `PendingRoute` so `poll_pending_routes` can emit terminal `CommandExecuted`.
+4. `[334] CommandLog 2-phase status + bridge_command_executed_to_log`
+   - Extend `CommandLogEntry` with optional `command_id` and `status` enum (backwards-compatible default).
+   - Bridge system registered in `CommunicationPlugin`.
+   - Integration test: dispatch a MoveTo, assert `CommandLog.entries.last().status == Executed` within the same tick, `command_id` matches.
+
+**PR split**: single PR (atomic; touches `command_events` + MoveTo path together). Regression risk concentrated in the MoveTo flow — already the most-tested movement command.
+
+**LoC estimate**: +~700, -~200 (removed dispatching code from `process_command_queue`).
+
+**Acceptance tests** (all must pass):
+- `full_test_app()` with no query conflicts.
+- `all_systems_no_query_conflict` integration test.
+- Existing `tests/movement.rs` + `tests/routing.rs` + remote MoveTo tests (`tests/communication.rs`) unchanged green.
+- New test: `test_move_to_dispatcher_emits_request`, `test_move_to_command_id_preserved_through_pending_route`, `test_move_to_immobile_rejected_by_dispatcher`.
+
+### Phase 2 — DeployDeliverable + Core deploy + settlement commands
+
+**Scope**: migrate `DeployDeliverable`, `LoadDeliverable`, `TransferToStructure`, `LoadFromScrapyard`, `Colonize`, `Survey`. Convert `PendingCoreDeploys` resource → `CoreDeployRequested` message; `resolve_core_deploys` becomes `handle_core_deploy_requested` reading a `MessageReader`. **Delete the `PendingCoreDeploys` resource entirely.**
+
+**Commits (5 commits, ~900 LoC)**:
+
+1. `[334] dispatcher: emit all deliverable + settlement variant requests`
+2. `[334] handle_deploy_deliverable_requested (with Core branch emitting CoreDeployRequested)`
+3. `[334] handle_core_deploy_requested — replace PendingCoreDeploys resource`
+   - Remove `PendingCoreDeploys` resource and its `init_resource` in `ShipPlugin`.
+   - Renamed `resolve_core_deploys` to `handle_core_deploy_requested`, reads `MessageReader<CoreDeployRequested>` instead of `ResMut<PendingCoreDeploys>`.
+   - Same tie-break + GameRng logic, verbatim.
+4. `[334] handle_load_deliverable + handle_transfer + handle_scrap + handle_survey + handle_colonize`
+5. `[334] shrink process_deliverable_commands to deleted shell + remove dead variant arms from process_command_queue`
+
+**PR split**: can be one large PR, or split 3+2 commits into two PRs (deliverables first, then settlement + core). Recommend **one PR** because Phase 2 has high semantic coherence; reviewer mental load is easier than splitting.
+
+**LoC estimate**: +~900, -~700 (delete `process_deliverable_commands` body and the `match` arms in `process_command_queue`).
+
+**Critical regression tests**:
+- `tests/infrastructure_core.rs` — all Core deploy tests (§10 of #296 plan) must pass without `PendingCoreDeploys`.
+- `tests/deliverable_ops.rs` (if present — grep confirms this is in unit tests within `deliverable_ops.rs`).
+- `tests/settlement.rs` colonize flow.
+- Fixture `minimal_game.bin` (committed fixture) — `PendingCoreDeploys` is not persisted (it's a transient per-tick resource), so the save format is **not** affected. Confirm in `persistence/savebag.rs:856-869` and note in PR.
+
+### Phase 3 — Scout + attack scaffolding + dispatcher-only `process_command_queue`
+
+**Scope**: migrate Scout; add `AttackRequested` skeleton for #219/#220 adoption (no handler yet — just message type + dispatcher arm if we have a QueuedCommand::Attack to migrate, otherwise defer). Delete `process_command_queue` (all variants now handled elsewhere); delete `process_deliverable_commands`.
+
+**Commits (3 commits, ~300 LoC)**:
+
+1. `[334] handle_scout_requested + remove Scout from process_command_queue`
+2. `[334] delete process_command_queue + process_deliverable_commands entirely`
+   - The two systems' mod registrations in `ShipPlugin` collapse to the dispatcher + handler set.
+3. `[334] AttackRequested skeleton (no handler) for #219/#220 foundation`
+
+**PR split**: single PR, relatively small.
+
+**LoC**: +~200, -~500.
+
+### Phase 4 — CommandExecuted → gamestate / Lua bridge (depends on #332 merged)
+
+**Scope**: add `bridge_command_executed_to_gamestate` that reads `MessageReader<CommandExecuted>` and enqueues `_pending_script_events` entries for the existing `fire_event` dispatch loop to pick up next tick. This gives Lua scripts an `on_command_completed(cmd)` hook without synchronous callback from the handler system — preserving the queue-only reentrancy invariant.
+
+**Commits (3 commits, ~400 LoC)**:
+
+1. `[334] bridge_command_executed_to_gamestate (queue-only enqueue)`
+   - Reads `MessageReader<CommandExecuted>`.
+   - Builds an event-like payload keyed by `command_id` + `kind` + `ship`.
+   - Enqueues `_pending_script_events` (same path existing fire_event queue uses).
+2. `[334] Lua API: ctx.gamestate:request_command(kind, args) → emit CommandRequested`
+   - Gamestate scope closure gets a new setter (`create_function_mut` with `&mut World` handle).
+   - Rust side: construct the appropriate `CommandRequested` struct and write it via `World::send_message` inside the closure.
+   - Opens the door to diplomacy v2 setters (#302/#321) and Lua-side AI (#173).
+3. `[334] docs: command lifecycle diagram + Lua hook example script`
+
+**PR split**: single PR, gated on #332 merge (which is already merged as of 2026-04-15). Should land together with the first diplomacy-v2 hook consumer so we can exercise the full path end-to-end.
+
+**LoC**: +~400, -~0.
+
+### Phase summary table
+
+| Phase | Commits | LoC (+/-) | PR count | Prereqs |
+|---|---|---|---|---|
+| 1 | 4 | +700 / -200 | 1 | none |
+| 2 | 5 | +900 / -700 | 1 | Phase 1 merged |
+| 3 | 3 | +200 / -500 | 1 | Phase 2 merged |
+| 4 | 3 | +400 / 0 | 1 | Phase 3 merged + #332 merged (done) |
+| **Total** | **15** | **+2200 / -1400** (net +~800) | **4 PRs** | |
+
+Each phase is **independently landable and shippable**: no intermediate commit leaves the tree in a broken state, because we're adding parallel infrastructure and swapping variants one at a time.
+
+---
+
+## §8 #268 (Courier opportunistic relay) との統合
+
+### 8.1 Command ID dedup is the dispatcher's job
+
+`CommandId` allocated by `NextCommandId` in the dispatcher (§2.1) is the dedup key #268 needs. When a courier ship reaches a system and opportunistically relays pending commands, the relay path must not re-dispatch commands already in flight or already executed.
+
+**Algorithm**:
+
+1. Relay picks up a bundle of `PendingCommand` components to forward (light-speed catch-up).
+2. At delivery, before enqueueing a new `CommandRequested`, check `CommandLog` or a new `DispatchedCommandIds: HashSet<CommandId>` resource for prior dispatch.
+3. If already dispatched: drop the relay copy with `trace!` log (normal case — light-speed msg + relay both arrived).
+4. If new: proceed through the dispatcher normally, allocating a fresh `CommandId` tied to the relay source.
+
+**Data structure**:
+
+```rust
+#[derive(Resource, Default)]
+pub struct DispatchedCommandIds {
+    // cleared at end of frame or bounded by retention policy
+    ids: HashSet<CommandId>,
+}
+```
+
+Alternative: allocate `CommandId` at `send_remote_command` time (dispatcher-side of the remote pipeline), thread it through `PendingCommand`, and the delivery-side dispatcher simply checks its own `CommandLog`. This is cleaner but requires reshuffling remote-command plumbing — **defer to #268 PR itself**, don't prescribe.
+
+### 8.2 Dependency registration
+
+This plan recommends registering **#268 blocked-by #334 Phase 1** (so #268 implementor can assume `CommandId` exists). Mark Phase 2 as the point where `PendingCoreDeploys` is deleted — #268 can then freely use the message bus without worrying about intermediate-resource patterns proliferating.
+
+---
+
+## §9 Diplomacy v2 setter (#302/#321) との統合
+
+### 9.1 Three-layer command pipeline
+
+Phase 4 enables the clean pattern diplomacy v2 needs:
+
+1. **Lua setter**: `ctx.gamestate:declare_war(other_empire, reason)` — a scope closure `create_function_mut` that constructs a Rust-side `CommandRequested::DeclareWar { … }` struct and writes it via `World::send_message`.
+2. **Rust dispatcher**: this is not `dispatch_queued_commands` but a diplomacy-specific dispatcher (out of scope for this plan). Alternative: reuse the same dispatcher if `QueuedCommand` gains diplomacy variants. **Recommendation**: keep `QueuedCommand` for ship actions and introduce a parallel `EmpireCommand` enum + dispatcher for empire-level actions, with the **same message-event pattern**. The plumbing is identical; the entity target differs.
+3. **Handler**: `handle_declare_war_requested` mutates faction relations, emits `CommandExecuted`.
+4. **Subscribers**: UI log, Lua `on_command_completed` hook, knowledge propagation.
+
+The three-layer story (setter → dispatcher → handler, plus post-event subscribers) maps directly to what diplomacy v2 already wants. This plan's deliverables make that pattern **the established one in the codebase**, so #321 doesn't need to invent new machinery.
+
+### 9.2 Setter reentrancy safety
+
+Per `feedback_rust_no_lua_callback.md`: the Lua-side `request_command` setter is a `create_function_mut` that **does not call back into Lua**. It constructs a pure Rust struct and emits a message — no `Function::call`, no stored `RegistryKey` invocation. The handler (normal Bevy system) writes the terminal `CommandExecuted`, which a separate bridge system enqueues into `_pending_script_events` for the next-tick fire_event loop to deliver to `on_command_completed` Lua handlers.
+
+This means the diplomacy Lua hook loop is:
+
+```
+Lua event handler
+  → ctx.gamestate:declare_war(x)        -- write closure emits CommandRequested
+  → Rust dispatcher handler runs       -- mutates state, emits CommandExecuted
+  → bridge enqueues _pending_script_events
+  → next tick: fire_event dispatches on_command_completed to Lua
+  → Lua handler reads ctx.gamestate.empires[x].relations (live via scope closure)
+```
+
+No synchronous callback, no reentrancy. Matches #332's scope-closure invariant exactly.
+
+---
+
+## §10 リスク表
+
+| # | risk | likelihood | impact | mitigation |
+|---|---|---|---|---|
+| R1 | `Messages<T>` same-frame delivery semantics break with scheduler change | low | high | Add `test_message_same_frame_visible` in Phase 1; document Bevy 0.18 version dependency |
+| R2 | Dispatcher hits 16-arg cap as #268 + #219 + #220 add validation reads | medium | medium | Dispatcher starts with slack (12 args); plan for `DispatcherValidationParams` SystemParam bundle when cap approached. Note: dispatcher's per-tick cost is dominated by the ship-queue peek, not param count, so splitting the dispatcher by variant group (movement vs cargo vs combat) is the escape hatch if needed |
+| R3 | 2-phase CommandLog timing gap visible to UI | low | low | UI reads in `EguiPrimaryContextPass` which runs after `Update`; entries transition atomically from the player's frame |
+| R4 | Tests depending on `process_deliverable_commands` direct run order break | medium | medium | Phase 2 keeps the old systems alive for one phase, deletes in Phase 3 once all tests migrate to handler-based assertions. Prefer integration test that asserts `CommandExecuted` result over "system X mutated component Y". |
+| R5 | B0001 query conflict: `handle_move_requested` and `handle_transfer_to_structure_requested` both need ship mutable access | medium | medium | Each handler takes `Query<(&Ship, &mut ShipState)>` or `Query<(&Ship, &mut Cargo)>` — different mutable components, no conflict. Run `full_test_app()` at every commit. Detected early by `all_systems_no_query_conflict` integration test. |
+| R6 | `CommandId` wraps on a 292M-year game (u64 increments per dispatched command) | neglectable | low | Not a real concern |
+| R7 | Saved game + mid-upgrade fixture: `CommandRequested` in-flight messages not in save | high | low | Messages are not saved (they're frame-transient buffers). If a save is taken mid-frame between dispatcher and handler, the command is lost. **This is already the behaviour for `PendingRoute` tasks today.** `tests/fixtures_smoke.rs` `minimal_game.bin` fixture should remain green; confirm in Phase 2 PR. |
+| R8 | Lua bridge double-fires `on_command_completed` on `Deferred` → `Ok` pairs | medium | low | Bridge filters `Deferred` results, only enqueues on terminal `Ok`/`Rejected`. Test: `test_deferred_does_not_fire_lua_hook` |
+| R9 | Merge conflict with open #328 or other in-flight ship-module work | medium | low | Phase 1 touches `ship/command.rs` + `ship/mod.rs` plugin wiring — coordinate with any open PR touching those files. Run `cargo test` after merge (per `feedback_semantic_merge_conflict.md`). |
+| R10 | `CommandLog` description format change breaks existing UI assertions | low | low | Keep `description: String` field intact; add new fields behind `Option<>` so `Default` impls in tests don't break |
+
+---
+
+## §11 Test plan
+
+### 11.1 Pattern: event-emit → handler-run → effect-observed
+
+Canonical integration-test shape for the new pipeline:
+
+```rust
+#[test]
+fn test_move_to_dispatcher_emits_request_and_handler_consumes() {
+    let mut app = full_test_app();
+    let ship = spawn_test_ship(&mut app, /* … */);
+    let target = spawn_test_system(&mut app, /* … */);
+    // enqueue directly (skip UI)
+    app.world_mut().entity_mut(ship).get_mut::<CommandQueue>().unwrap()
+        .commands.push(QueuedCommand::MoveTo { system: target });
+    app.update(); // one tick: dispatcher emits, handler consumes
+    // assert CommandRequested was emitted
+    let msgs = app.world().resource::<Messages<MoveRequested>>();
+    assert_eq!(msgs.len(), 1);
+    // assert handler ran (ship state transitioned)
+    let state = app.world().get::<ShipState>(ship).unwrap();
+    assert!(matches!(state, ShipState::Ftl { .. } | ShipState::SubLight { .. }));
+    // assert CommandExecuted recorded Ok
+    let executed: Vec<_> = app.world().resource::<Messages<CommandExecuted>>().iter_current_update_events().collect();
+    assert_eq!(executed.len(), 1);
+    assert!(matches!(executed[0].result, CommandResult::Ok | CommandResult::Deferred));
+}
+```
+
+### 11.2 Regression matrix per phase
+
+| phase | required tests |
+|---|---|
+| 1 | MoveTo: ftl happy path, ftl→sublight fallback, immobile reject, route async happy, route async fail. MoveToCoordinates: sublight happy, immobile reject |
+| 2 | DeployDeliverable: structure spawn, Core branch with valid target, Core deep-space self-destruct, Core already-has-core reject, same-tick tie-break. Load/Transfer/Scrap: existing tests should pass with no code change beyond plumbing. Survey: start+complete flow, not-at-target auto-MoveTo prefix. Colonize: start+complete flow |
+| 3 | Scout: not-at-target auto-MoveTo prefix, FTL gate, module gate, observation→report flow. Legacy `process_command_queue` / `process_deliverable_commands` deletion: grep must return zero matches; all `ShipPlugin` tests still green |
+| 4 | Lua `on_command_completed` fires once per terminal result; Deferred does not fire; `ctx.gamestate:request_command` setter emits correct message; reentrancy test (command → hook → another command → hook) |
+
+### 11.3 Runtime query-conflict detection
+
+Use `full_test_app()` in a Phase 1 regression test:
+
+```rust
+#[test]
+fn all_command_handler_systems_run_without_query_conflict() {
+    let mut app = full_test_app();
+    for _ in 0..5 { app.update(); } // exercise scheduler
+}
+```
+
+This is the canonical B0001 detector — already used in the codebase (see CLAUDE.md "Query conflicts"). Each phase PR must include this assertion passing.
+
+### 11.4 Save-file fixture guard
+
+`tests/fixtures_smoke.rs` `load_minimal_game_fixture_smoke` — as long as no field in `SavedComponentBag` changes, this stays green. The refactor intentionally avoids touching save format:
+
+- `PendingCoreDeploys` was not in savebag (verified grep on `savebag.rs`).
+- `CommandLog`'s new `command_id`/`status` fields should be `#[serde(default)]` on the persistence path (or excluded entirely if CommandLog isn't persisted — confirm in Phase 1).
+
+If Phase 1 PR intends to persist `CommandLog` with the new schema, bump `SAVE_VERSION` and regenerate the fixture per `CLAUDE.md` "Save-file Fixtures" procedure.
+
+---
+
+## §12 Out of scope
+
+- **Exclusive system (`&mut World`) migration**: rejected in the issue itself. Handlers remain normal parallel systems.
+- **Handler trait-object / registry (Option D)**: rejected. Per-variant functions wired into `ShipPlugin` is simpler and matches Bevy idioms.
+- **Command semantics changes**: movement, deploy, survey, colonize, scout, transfer, scrap, attack behave identically pre- and post-refactor. Every behavioural change this plan introduces (CommandLog 2-phase status, `CommandId`, `CommandExecuted`) is additive / observational.
+- **Remote (light-speed) command unification with local dispatch**: Phase 4 opens the door (diplomacy v2 path) but doesn't require migrating `PendingCommand` / `send_remote_command` flow to message buses. That lives under #302/#321.
+- **UI refactor** to consume `CommandExecuted` stream: current UI reads `CommandLog` which we preserve.
+- **Event-sourcing / command replay**: message buffers are frame-local; full replay requires persistence that's out of scope.
+
+---
+
+## §13 Critical files for implementation
+
+### New files
+
+- `macrocosmo/src/ship/command_events.rs` — message type definitions, `CommandId`, `NextCommandId`, `CommandEventsPlugin`.
+- `macrocosmo/src/ship/dispatcher.rs` — `dispatch_queued_commands` system.
+- `macrocosmo/src/ship/handlers/mod.rs` — re-export module.
+- `macrocosmo/src/ship/handlers/move_handler.rs` — `handle_move_requested`, `handle_move_to_coordinates_requested`.
+- `macrocosmo/src/ship/handlers/deploy_handler.rs` — `handle_deploy_deliverable_requested`, `handle_core_deploy_requested`.
+- `macrocosmo/src/ship/handlers/cargo_handler.rs` — Load / Transfer / Scrap.
+- `macrocosmo/src/ship/handlers/settlement_handler.rs` — Survey / Colonize.
+- `macrocosmo/src/ship/handlers/scout_handler.rs` — Scout.
+- `macrocosmo/src/ship/bridges.rs` — `bridge_command_executed_to_log`, Phase 4 `bridge_command_executed_to_gamestate`.
+- `macrocosmo/tests/command_pipeline.rs` — new integration-test file.
+
+### Modified files
+
+- `macrocosmo/src/ship/mod.rs` — `ShipPlugin::build` schedule overhaul (replace `process_command_queue` / `process_deliverable_commands` / `resolve_core_deploys` with dispatcher + handler wiring). `QueuedCommand` enum possibly extended with an internal `command_id: Option<CommandId>` to track auto-inserted re-queues.
+- `macrocosmo/src/ship/command.rs` — `process_command_queue` shrinks across phases, deletion in Phase 3.
+- `macrocosmo/src/ship/deliverable_ops.rs` — `process_deliverable_commands` shrinks in Phase 2, deletion in Phase 3.
+- `macrocosmo/src/ship/core_deliverable.rs` — delete `PendingCoreDeploys` resource (Phase 2); `resolve_core_deploys` renamed + rewired to `MessageReader` (Phase 2).
+- `macrocosmo/src/ship/routing.rs` — thread `command_id` through `PendingRoute`; `poll_pending_routes` emits terminal `CommandExecuted`.
+- `macrocosmo/src/ship/command.rs` — `process_pending_ship_commands` remains for remote command arrival; Phase 4 bridges into the local dispatcher instead of inlining state mutation.
+- `macrocosmo/src/communication/mod.rs` — `CommandLogEntry` schema extension; `dispatch_pending_colony_commands` and `process_pending_commands` unchanged in Phase 1-3.
+- `macrocosmo/src/ship/movement.rs`, `macrocosmo/src/ship/survey.rs`, `macrocosmo/src/ship/settlement.rs`, `macrocosmo/src/ship/scout.rs` — handler delegations. The `start_*` helpers remain and are called from handlers.
+- `macrocosmo/src/scripting/lifecycle.rs` — Phase 4: consume `_pending_script_events` path for `on_command_completed` hook, keyed by bridge system.
+- `macrocosmo/src/main.rs` — register `CommandEventsPlugin` before `ShipPlugin` (Phase 1).
+- `macrocosmo/tests/infrastructure_core.rs` — update Core deploy tests to assert via `MessageReader<CoreDeployRequested>` instead of `PendingCoreDeploys` resource (Phase 2).
+
+### Files that should NOT change
+
+- `macrocosmo/src/ship/fleet.rs` — fleet membership unrelated.
+- `macrocosmo/src/ship/combat.rs` — combat remains a separate system for now; `AttackRequested` skeleton is additive, combat resolution logic unchanged.
+- `macrocosmo/src/persistence/savebag.rs` — no save-format changes (verified: `PendingCoreDeploys` never persisted; `CommandLog` changes use `serde(default)`).
+- `macrocosmo/assets/shaders/territory.wgsl` — visualization unrelated.
+- `macrocosmo/scripts/**` — no Lua changes in Phases 1-3; Phase 4 adds `on_command_completed` hook examples but doesn't alter existing scripts.
+
+---
+
+## Appendix A — Decision log summary
+
+| Open question | Decision | §  |
+|---|---|---|
+| Validation fail location | Dispatcher-side early (`warn!` + drop), handler rollback for races only | §3 |
+| CommandLog write site | Two-phase, keyed by `CommandId`: dispatcher writes `Dispatched`, bridge system writes `Executed/Rejected/Deferred` | §4 |
+| Observer mode event filter | No filter at emit; subscribers filter by faction/empire | §5 |
+| Same-tick command order | FIFO via single dispatcher + `MessageReader` iteration order (verify in Phase 1 test) | §6 |
+| One-enum vs. per-variant messages | Per-variant messages; single-enum `CommandExecuted` for post-events | §2.1 |
+| `PendingCoreDeploys` fate | Delete in Phase 2, replaced by `CoreDeployRequested` message | §1.5 / §7 |
+| `CommandId` allocation point | Dispatcher allocates via `NextCommandId` resource | §2.1 / §8 |
+
+## Appendix B — Phase 1 PR-ready checklist
+
+- [ ] `command_events.rs` + `CommandEventsPlugin` lands, all 10 message types registered (even those with no handler yet).
+- [ ] `dispatch_queued_commands` handles only MoveTo + MoveToCoordinates; other variants fall through to old paths (test: dispatcher does nothing for `QueuedCommand::Survey`).
+- [ ] `handle_move_requested` replaces the MoveTo arm in `process_command_queue` (the arm is deleted, not just gated).
+- [ ] `CommandLog` schema extended; bridge system registered.
+- [ ] New test file `tests/command_pipeline.rs` with ≥5 integration tests per §11.1.
+- [ ] `all_systems_no_query_conflict` passes.
+- [ ] `cargo test` all green (fixtures fixture included).
+- [ ] No warnings introduced (run `cargo clippy -- -D warnings`).
+- [ ] Commit count ≤ 4, total diff ≤ 1000 LoC.
+
+---
+
+## Appendix C — Phase 4 landed (2026-04-15)
+
+All four phases are now merged. #334 is ready to close.
+
+**Commits**:
+
+* **Commit 1** — `bridge_command_executed_to_gamestate` (queue-only).
+  Adds `CommandCompletedContext: EventContext`, registers the
+  `COMMAND_COMPLETED_EVENT = "macrocosmo:command_completed"` constant,
+  and wires the bridge after every handler / `poll_pending_routes`
+  alongside the Phase 1 `bridge_command_executed_to_log`. Deferred
+  results are filtered per §10 R8. **345 LoC net.**
+* **Commit 2** — `ctx.gamestate:request_command(kind, args)`.
+  Adds `apply::ParsedRequest` + `apply::parse_request` +
+  `apply::request_command` (no `&Lua`, no Lua call). Exposes the
+  setter on `ReadWrite` gamestates only. Supports 9 kinds; rejects
+  `core_deploy` / `attack` with a diagnostic until their Rust
+  handlers land. 6 unit tests + 4 integration tests. **931 LoC.**
+* **Commit 3** — docs & example. Adds §10bis to
+  `docs/architecture-decisions.md`, creates
+  `scripts/examples/on_command_completed.lua` (docs-only; not
+  loaded by `init.lua`), and this Phase 4 landed note.
+
+**Plan deviations**:
+
+* `core_deploy` and `attack` kinds are **not** exposed via the Lua
+  setter yet. `core_deploy` is produced inside the deliverable
+  pipeline (not standalone), so exposing it would invert the
+  dependency; `attack` is still skeleton-only (#219/#220). Both
+  raise a `not yet supported` `RuntimeError` so modders get a clean
+  diagnostic.
+* The hook transport is `EventSystem::fire_event_with_payload` rather
+  than direct `_pending_script_events` push. The queue discipline is
+  identical (fired_log → next-tick `dispatch_event_handlers`), but
+  `fire_event_with_payload` carries a typed
+  `EventContext` so the hook observes structured fields
+  (`command_id`, `kind`, `ship`, `result`, `reason`, `completed_at`)
+  rather than just `event_id` + `target`. This matches the
+  `BUILDING_BUILT_EVENT` convention (#281).
+* Integration tests run against a handler surrogate rather than the
+  real `handle_move_requested` — the bridge + Lua API path is
+  orthogonal to the FTL router, and pulling in `handle_move_requested`
+  would require a galaxy / empire / design-registry fixture that
+  dominates the test.
+
+**Invariant audit**:
+
+* `apply::request_command` signature: `(&mut World, ParsedRequest) -> mlua::Result<u64>`. No `&Lua` parameter.
+* Scope-closure body for `request_command` uses `_lua` (underscored unused).
+* `bridge_command_executed_to_gamestate` is a pure Bevy reader; no Lua access.
+* `spike_mlua_scope` test 4/4 passes (regression guard for scope/UserData/borrow discipline).
+* `all_systems_no_query_conflict` passes.
+* `load_minimal_game_fixture_smoke` passes (save format untouched).
+
+---
+
+_End of plan._

--- a/macrocosmo/scripts/examples/on_command_completed.lua
+++ b/macrocosmo/scripts/examples/on_command_completed.lua
@@ -1,0 +1,82 @@
+-- #334 Phase 4 — example Lua hook for `on("macrocosmo:command_completed")`
+--
+-- NOT LOADED BY `init.lua`. This file documents the canonical shape of
+-- the `request_command` setter and `on_command_completed` observer, and
+-- is referenced from `docs/architecture-decisions.md` §10bis. Copy into
+-- a real `scripts/events/` module (or a mod) to wire it into the game.
+--
+-- Invariant: `evt.gamestate:request_command(kind, args)` is ONLY
+-- available in ReadWrite contexts (event callbacks, lifecycle hooks).
+-- Fire-condition callbacks use `GamestateMode::ReadOnly` and will see
+-- `nil` here — see `memory/feedback_rust_no_lua_callback.md`.
+
+-- ---------------------------------------------------------------------
+-- Supported kinds (Phase 4)
+-- ---------------------------------------------------------------------
+-- "move"                  -- { ship = u64, target = u64 }
+-- "move_to_coordinates"   -- { ship = u64, target = {x, y, z} }
+-- "scout"                 -- { ship = u64, target_system = u64,
+--                             observation_duration? = i64,
+--                             report_mode? = "return" | "ftl_comm" }
+-- "load_deliverable"      -- { ship = u64, system = u64, stockpile_index = int }
+-- "deploy_deliverable"    -- { ship = u64, position = {x, y, z}, item_index = int }
+-- "transfer_to_structure" -- { ship = u64, structure = u64,
+--                             minerals = number, energy = number }
+-- "load_from_scrapyard"   -- { ship = u64, structure = u64 }
+-- "colonize"              -- { ship = u64, target_system = u64, planet? = u64 }
+-- "survey"                -- { ship = u64, target_system = u64 }
+
+-- ---------------------------------------------------------------------
+-- Example: auto-reissue a rejected Survey as a Scout
+-- ---------------------------------------------------------------------
+
+on("macrocosmo:command_completed", function(evt)
+    -- All fields arrive as strings (consistent with LuaDefinedEventContext);
+    -- coerce to numbers before comparing / re-feeding into gamestate.
+    if evt.kind ~= "survey" or evt.result ~= "rejected" then
+        return
+    end
+
+    local ship         = tonumber(evt.ship)
+    local reason       = evt.reason or "unknown"
+    -- The surveyed system is not carried by the completed event in
+    -- Phase 4 (only ship / kind / result are generic). A real hook
+    -- would persist the target somewhere (e.g. a per-ship
+    -- `_pending_survey_targets` table keyed by command_id) at
+    -- request_command time and look it up here. Sketch only:
+    local target_system = _pending_survey_targets and _pending_survey_targets[evt.command_id]
+    if not target_system then
+        return
+    end
+
+    log("survey rejected (" .. reason .. "), retrying as scout for ship " .. ship)
+    local new_id = evt.gamestate:request_command("scout", {
+        ship                 = ship,
+        target_system        = target_system,
+        observation_duration = 5,
+        report_mode          = "ftl_comm",
+    })
+    log("scout queued as command id " .. new_id)
+end)
+
+-- ---------------------------------------------------------------------
+-- Example: track outstanding commands in a Lua table
+-- ---------------------------------------------------------------------
+
+_pending_cmds = _pending_cmds or {}
+
+-- Helper wrapper that remembers the kind + command_id mapping locally.
+function queue_command(gs, kind, args)
+    local id = gs:request_command(kind, args)
+    _pending_cmds[tostring(id)] = { kind = kind, args = args }
+    return id
+end
+
+on("macrocosmo:command_completed", function(evt)
+    local key = evt.command_id
+    local tracked = _pending_cmds[key]
+    if tracked then
+        _pending_cmds[key] = nil
+        log("finished tracked " .. tracked.kind .. " id " .. key .. " with " .. evt.result)
+    end
+end)

--- a/macrocosmo/src/event_system.rs
+++ b/macrocosmo/src/event_system.rs
@@ -347,6 +347,22 @@ impl EventSystem {
 /// (upgrade only).
 pub const BUILDING_BUILT_EVENT: &str = "macrocosmo:building_built";
 
+/// #334 Phase 4: Event id fired when a `CommandExecuted` message reaches
+/// terminal disposition (`Ok` / `Rejected`). `Deferred` results are NOT
+/// bridged — they represent an in-flight handoff (async route planner,
+/// auto-prefix queueing) and a follow-up `CommandExecuted` will fire the
+/// hook when the work actually finishes. Payload keys: `command_id`
+/// (decimal string), `kind` (`"move"`, `"survey"`, etc. — lowercase), `ship`
+/// (entity bits as decimal string), `result` (`"ok"` | `"rejected"`),
+/// `reason` (only when rejected), `completed_at` (hexadies, decimal string).
+///
+/// Dispatched by `ship::bridges::bridge_command_executed_to_gamestate` via
+/// `EventSystem::fire_event_with_payload`, so Lua handlers registered with
+/// `on("macrocosmo:command_completed", ...)` observe the event on the next
+/// `dispatch_event_handlers` run — the queue-only invariant from
+/// `memory/feedback_rust_no_lua_callback.md` is preserved.
+pub const COMMAND_COMPLETED_EVENT: &str = "macrocosmo:command_completed";
+
 /// Central event bus for dispatching events to Lua handlers.
 ///
 /// Handlers are stored in the Lua global `_event_handlers` table to avoid

--- a/macrocosmo/src/scripting/gamestate_scope.rs
+++ b/macrocosmo/src/scripting/gamestate_scope.rs
@@ -298,6 +298,27 @@ fn build_scoped_gamestate<'scope, 'env>(
             },
         )?;
         gs.set("clear_flag", clear_flag)?;
+
+        // :request_command(kind, args) -> u64 (new CommandId)
+        //
+        // #334 Phase 4 Commit 2: Lua-side counterpart to the dispatcher.
+        // Parses `args` into a plain Rust `apply::ParsedRequest` inside the
+        // closure body (no Lua call-back; only table reads + primitive
+        // extraction), then hands `&mut World` + the parsed struct to
+        // `apply::request_command` which emits the appropriate
+        // `CommandRequested` message via `World::resource_mut::<Messages<_>>`.
+        //
+        // Invariant (plan §9.2 / feedback_rust_no_lua_callback.md): the
+        // apply helper takes no `&Lua` and never invokes Lua code. Message
+        // emit is a pure Rust event-bus push; the downstream handler runs
+        // in a separate Bevy system on the next tick, breaking reentrancy.
+        let request_command =
+            s.create_function_mut(move |_lua, (_this, kind, args): (Table, String, Table)| {
+                let parsed = apply::parse_request(&kind, &args)?;
+                let mut borrow = world_cell.try_borrow_mut().map_err(map_reentrancy_err)?;
+                apply::request_command(&mut **borrow, parsed)
+            })?;
+        gs.set("request_command", request_command)?;
     }
 
     Ok(gs)
@@ -1257,6 +1278,375 @@ pub(crate) mod apply {
     ) -> mlua::Result<()> {
         set_flag(world, scope_kind, entity, name, false)
     }
+
+    // ==================================================================
+    // #334 Phase 4 Commit 2: `ctx.gamestate:request_command(kind, args)`
+    //
+    // Lua calls the scope closure, which calls `parse_request` with the
+    // (kind, args) table (Lua-side read) and then `request_command` with
+    // `&mut World` + the parsed struct (Rust-only mutation / event emit).
+    //
+    // * `parse_request` receives `&Table` purely as a data source —
+    //   primitives are extracted eagerly; no Lua callback / Function is
+    //   invoked, no `RegistryKey` is stored.
+    // * `request_command` takes `&mut World` **and no `&Lua`**; it
+    //   allocates a `CommandId` from `NextCommandId`, pushes the
+    //   appropriate `CommandRequested` message onto the Bevy message
+    //   queue (`World::resource_mut::<Messages<_>>`), and returns the
+    //   fresh id as `u64` so the Lua caller can track it (e.g. to match
+    //   against the `evt.command_id` field delivered by the Phase 4
+    //   Commit 1 bridge).
+    // * Unknown `kind` / missing required fields surface as
+    //   `mlua::Error::RuntimeError` so a modder's typo is diagnosed at
+    //   the call site instead of silently dropping the command.
+    // ==================================================================
+
+    use crate::amount::Amt;
+    use crate::ship::ReportMode;
+    use crate::ship::command_events::{
+        ColonizeRequested, CommandId, DeployDeliverableRequested, LoadDeliverableRequested,
+        LoadFromScrapyardRequested, MoveRequested, MoveToCoordinatesRequested, NextCommandId,
+        ScoutRequested, SurveyRequested, TransferToStructureRequested,
+    };
+    use crate::time_system::GameClock;
+    use bevy::ecs::message::Messages;
+
+    /// Parsed, Lua-free command request. Every variant carries everything
+    /// the corresponding Bevy `CommandRequested` message needs — the
+    /// downstream `request_command` helper never touches `&Lua`.
+    #[derive(Debug, Clone)]
+    pub enum ParsedRequest {
+        Move {
+            ship: Entity,
+            target: Entity,
+        },
+        MoveToCoordinates {
+            ship: Entity,
+            target: [f64; 3],
+        },
+        Scout {
+            ship: Entity,
+            target_system: Entity,
+            observation_duration: i64,
+            report_mode: ReportMode,
+        },
+        LoadDeliverable {
+            ship: Entity,
+            system: Entity,
+            stockpile_index: usize,
+        },
+        DeployDeliverable {
+            ship: Entity,
+            position: [f64; 3],
+            item_index: usize,
+        },
+        TransferToStructure {
+            ship: Entity,
+            structure: Entity,
+            minerals: Amt,
+            energy: Amt,
+        },
+        LoadFromScrapyard {
+            ship: Entity,
+            structure: Entity,
+        },
+        Colonize {
+            ship: Entity,
+            target_system: Entity,
+            planet: Option<Entity>,
+        },
+        Survey {
+            ship: Entity,
+            target_system: Entity,
+        },
+        // NOTE: CoreDeploy + Attack are listed by plan but intentionally
+        // not exposed yet:
+        // * CoreDeploy is produced by handle_deploy_deliverable_requested
+        //   in the deliverable pipeline; letting Lua short-circuit that
+        //   path would invert the dependency.
+        // * Attack handler is a skeleton (#219 / #220); exposing a Lua
+        //   setter before the handler works would create dead messages.
+        // Both can be added when their Rust sides land.
+    }
+
+    /// Error helper: a required field was missing or of the wrong type.
+    fn missing(kind: &str, field: &str) -> mlua::Error {
+        mlua::Error::RuntimeError(format!(
+            "request_command(\"{kind}\"): missing or invalid field '{field}'"
+        ))
+    }
+
+    /// Extract an `Entity` from a u64 bits field.
+    fn get_entity(args: &Table, key: &str, kind: &str) -> mlua::Result<Entity> {
+        let bits: u64 = args.get(key).map_err(|_| missing(kind, key))?;
+        Ok(Entity::from_bits(bits))
+    }
+
+    /// Extract an optional `Entity`.
+    fn get_opt_entity(args: &Table, key: &str) -> Option<Entity> {
+        args.get::<u64>(key).ok().map(Entity::from_bits)
+    }
+
+    /// Extract a `[f64; 3]` coordinate from {x=, y=, z=} or {[1]=,[2]=,[3]=}.
+    fn get_coords(args: &Table, key: &str, kind: &str) -> mlua::Result<[f64; 3]> {
+        let t: Table = args.get(key).map_err(|_| missing(kind, key))?;
+        // Prefer named keys x/y/z; fall back to array indices.
+        let x: f64 = t
+            .get("x")
+            .or_else(|_| t.get::<f64>(1))
+            .map_err(|_| missing(kind, &format!("{key}.x")))?;
+        let y: f64 = t
+            .get("y")
+            .or_else(|_| t.get::<f64>(2))
+            .map_err(|_| missing(kind, &format!("{key}.y")))?;
+        let z: f64 = t
+            .get("z")
+            .or_else(|_| t.get::<f64>(3))
+            .map_err(|_| missing(kind, &format!("{key}.z")))?;
+        Ok([x, y, z])
+    }
+
+    /// Extract an `Amt` from a numeric (interpreted as units).
+    fn get_amt(args: &Table, key: &str, kind: &str) -> mlua::Result<Amt> {
+        let v: f64 = args.get(key).map_err(|_| missing(kind, key))?;
+        Ok(Amt::from_f64(v))
+    }
+
+    /// Extract a ReportMode from a string ("return" | "ftl_comm"), default Return.
+    fn parse_report_mode(args: &Table) -> ReportMode {
+        let s: Option<String> = args.get("report_mode").ok();
+        match s.as_deref() {
+            Some("ftl_comm") | Some("ftl") => ReportMode::FtlComm,
+            _ => ReportMode::Return,
+        }
+    }
+
+    /// Parse `(kind, args)` into a `ParsedRequest`. Invoked from the Lua
+    /// scope closure — no mutation, no `&Lua`. Returns a `RuntimeError`
+    /// for unknown kinds or missing fields.
+    pub fn parse_request(kind: &str, args: &Table) -> mlua::Result<ParsedRequest> {
+        match kind {
+            "move" => Ok(ParsedRequest::Move {
+                ship: get_entity(args, "ship", kind)?,
+                target: get_entity(args, "target", kind)?,
+            }),
+            "move_to_coordinates" => Ok(ParsedRequest::MoveToCoordinates {
+                ship: get_entity(args, "ship", kind)?,
+                target: get_coords(args, "target", kind)?,
+            }),
+            "scout" => Ok(ParsedRequest::Scout {
+                ship: get_entity(args, "ship", kind)?,
+                target_system: get_entity(args, "target_system", kind)?,
+                observation_duration: args.get::<i64>("observation_duration").unwrap_or(10),
+                report_mode: parse_report_mode(args),
+            }),
+            "load_deliverable" => Ok(ParsedRequest::LoadDeliverable {
+                ship: get_entity(args, "ship", kind)?,
+                system: get_entity(args, "system", kind)?,
+                stockpile_index: args
+                    .get::<i64>("stockpile_index")
+                    .map_err(|_| missing(kind, "stockpile_index"))?
+                    .max(0) as usize,
+            }),
+            "deploy_deliverable" => Ok(ParsedRequest::DeployDeliverable {
+                ship: get_entity(args, "ship", kind)?,
+                position: get_coords(args, "position", kind)?,
+                item_index: args
+                    .get::<i64>("item_index")
+                    .map_err(|_| missing(kind, "item_index"))?
+                    .max(0) as usize,
+            }),
+            "transfer_to_structure" => Ok(ParsedRequest::TransferToStructure {
+                ship: get_entity(args, "ship", kind)?,
+                structure: get_entity(args, "structure", kind)?,
+                minerals: get_amt(args, "minerals", kind)?,
+                energy: get_amt(args, "energy", kind)?,
+            }),
+            "load_from_scrapyard" => Ok(ParsedRequest::LoadFromScrapyard {
+                ship: get_entity(args, "ship", kind)?,
+                structure: get_entity(args, "structure", kind)?,
+            }),
+            "colonize" => Ok(ParsedRequest::Colonize {
+                ship: get_entity(args, "ship", kind)?,
+                target_system: get_entity(args, "target_system", kind)?,
+                planet: get_opt_entity(args, "planet"),
+            }),
+            "survey" => Ok(ParsedRequest::Survey {
+                ship: get_entity(args, "ship", kind)?,
+                target_system: get_entity(args, "target_system", kind)?,
+            }),
+            // Plan-listed but not yet wired (see ParsedRequest docstring).
+            "core_deploy" | "attack" => Err(mlua::Error::RuntimeError(format!(
+                "request_command: kind '{kind}' is not yet supported via the \
+                 Lua bridge; see plan-334 §7 Phase 4 + #219/#220 for the \
+                 handler side"
+            ))),
+            other => Err(mlua::Error::RuntimeError(format!(
+                "request_command: unknown kind '{other}'; supported kinds: \
+                 move, move_to_coordinates, scout, load_deliverable, \
+                 deploy_deliverable, transfer_to_structure, \
+                 load_from_scrapyard, colonize, survey"
+            ))),
+        }
+    }
+
+    /// Allocate a fresh `CommandId` and emit the appropriate
+    /// `CommandRequested` message. **Never touches Lua.**
+    ///
+    /// Returns the new `CommandId` as `u64` so Lua can correlate the
+    /// subsequent `macrocosmo:command_completed` hook payload
+    /// (`evt.command_id` — stored as decimal string in the payload, so
+    /// callers do `tonumber(evt.command_id) == returned_id`).
+    pub fn request_command(world: &mut World, req: ParsedRequest) -> mlua::Result<u64> {
+        // Allocate command id.
+        let command_id: CommandId = {
+            // `NextCommandId` is installed by `CommandEventsPlugin`; if
+            // it's missing (test-only app without the plugin), surface a
+            // diagnostic rather than panicking.
+            let Some(mut counter) = world.get_resource_mut::<NextCommandId>() else {
+                return Err(mlua::Error::RuntimeError(
+                    "request_command: NextCommandId resource missing; \
+                     CommandEventsPlugin must be installed"
+                        .into(),
+                ));
+            };
+            counter.allocate()
+        };
+        let issued_at = world
+            .get_resource::<GameClock>()
+            .map(|c| c.elapsed)
+            .unwrap_or(0);
+
+        // Emit the request on the matching Bevy message queue. Using
+        // `resource_mut::<Messages<_>>()` + `write` mirrors what Bevy's
+        // `MessageWriter` param does internally, without needing a full
+        // SystemParam context.
+        match req {
+            ParsedRequest::Move { ship, target } => {
+                world
+                    .resource_mut::<Messages<MoveRequested>>()
+                    .write(MoveRequested {
+                        command_id,
+                        ship,
+                        target,
+                        issued_at,
+                    });
+            }
+            ParsedRequest::MoveToCoordinates { ship, target } => {
+                world
+                    .resource_mut::<Messages<MoveToCoordinatesRequested>>()
+                    .write(MoveToCoordinatesRequested {
+                        command_id,
+                        ship,
+                        target,
+                        issued_at,
+                    });
+            }
+            ParsedRequest::Scout {
+                ship,
+                target_system,
+                observation_duration,
+                report_mode,
+            } => {
+                world
+                    .resource_mut::<Messages<ScoutRequested>>()
+                    .write(ScoutRequested {
+                        command_id,
+                        ship,
+                        target_system,
+                        observation_duration,
+                        report_mode,
+                        issued_at,
+                    });
+            }
+            ParsedRequest::LoadDeliverable {
+                ship,
+                system,
+                stockpile_index,
+            } => {
+                world
+                    .resource_mut::<Messages<LoadDeliverableRequested>>()
+                    .write(LoadDeliverableRequested {
+                        command_id,
+                        ship,
+                        system,
+                        stockpile_index,
+                        issued_at,
+                    });
+            }
+            ParsedRequest::DeployDeliverable {
+                ship,
+                position,
+                item_index,
+            } => {
+                world
+                    .resource_mut::<Messages<DeployDeliverableRequested>>()
+                    .write(DeployDeliverableRequested {
+                        command_id,
+                        ship,
+                        position,
+                        item_index,
+                        issued_at,
+                    });
+            }
+            ParsedRequest::TransferToStructure {
+                ship,
+                structure,
+                minerals,
+                energy,
+            } => {
+                world
+                    .resource_mut::<Messages<TransferToStructureRequested>>()
+                    .write(TransferToStructureRequested {
+                        command_id,
+                        ship,
+                        structure,
+                        minerals,
+                        energy,
+                        issued_at,
+                    });
+            }
+            ParsedRequest::LoadFromScrapyard { ship, structure } => {
+                world
+                    .resource_mut::<Messages<LoadFromScrapyardRequested>>()
+                    .write(LoadFromScrapyardRequested {
+                        command_id,
+                        ship,
+                        structure,
+                        issued_at,
+                    });
+            }
+            ParsedRequest::Colonize {
+                ship,
+                target_system,
+                planet,
+            } => {
+                world
+                    .resource_mut::<Messages<ColonizeRequested>>()
+                    .write(ColonizeRequested {
+                        command_id,
+                        ship,
+                        target_system,
+                        planet,
+                        issued_at,
+                    });
+            }
+            ParsedRequest::Survey {
+                ship,
+                target_system,
+            } => {
+                world
+                    .resource_mut::<Messages<SurveyRequested>>()
+                    .write(SurveyRequested {
+                        command_id,
+                        ship,
+                        target_system,
+                        issued_at,
+                    });
+            }
+        }
+        Ok(command_id.0)
+    }
 }
 
 #[cfg(test)]
@@ -1412,5 +1802,172 @@ mod tests {
             })
             .unwrap();
         });
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 4 Commit 2: request_command parse / apply unit tests
+    // ------------------------------------------------------------------
+    // Integration-level tests that exercise the full Lua → message →
+    // handler → Lua-hook round-trip live in
+    // `tests/lua_request_command.rs`.
+    // ------------------------------------------------------------------
+
+    use crate::ship::command_events::{
+        CommandEventsPlugin, MoveRequested, NextCommandId, ScoutRequested, SurveyRequested,
+    };
+    use bevy::ecs::message::Messages;
+
+    fn make_command_world() -> World {
+        // Minimal world with just the CommandEventsPlugin's resources +
+        // message types manually seeded. `App::new()` pulls in scheduler
+        // plumbing we don't need for unit-level apply_* tests, so we
+        // register what's required by hand.
+        let mut world = World::new();
+        world.insert_resource(crate::time_system::GameClock::new(7));
+        world.insert_resource(NextCommandId::default());
+        // Seed Messages<T> directly — we don't run the plugin so we add
+        // each queue manually. This mirrors what `app.add_message::<T>()`
+        // does internally.
+        world.insert_resource(Messages::<MoveRequested>::default());
+        world.insert_resource(Messages::<SurveyRequested>::default());
+        world.insert_resource(Messages::<ScoutRequested>::default());
+        world
+    }
+
+    #[test]
+    fn parse_request_unknown_kind_returns_runtime_error() {
+        let lua = mlua::Lua::new();
+        let args = lua.create_table().unwrap();
+        let err = apply::parse_request("not_a_real_kind", &args).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown kind"),
+            "expected unknown-kind diagnostic, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_request_move_missing_target_returns_runtime_error() {
+        let lua = mlua::Lua::new();
+        let args = lua.create_table().unwrap();
+        let ship = Entity::from_raw_u32(1).unwrap();
+        args.set("ship", ship.to_bits()).unwrap();
+        let err = apply::parse_request("move", &args).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("missing") && msg.contains("target"),
+            "expected missing-target diagnostic, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn request_command_move_emits_message_and_returns_monotonic_id() {
+        let mut world = make_command_world();
+        let ship = Entity::from_raw_u32(10).unwrap();
+        let target = Entity::from_raw_u32(20).unwrap();
+        let id_a = apply::request_command(&mut world, apply::ParsedRequest::Move { ship, target })
+            .unwrap();
+        let id_b = apply::request_command(&mut world, apply::ParsedRequest::Move { ship, target })
+            .unwrap();
+        assert!(id_b > id_a, "command ids must be strictly monotonic");
+
+        let msgs = world.resource::<Messages<MoveRequested>>();
+        let mut cursor = msgs.get_cursor();
+        let all: Vec<&MoveRequested> = cursor.read(msgs).collect();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].ship, ship);
+        assert_eq!(all[0].target, target);
+        assert_eq!(all[0].command_id.0, id_a);
+        assert_eq!(all[1].command_id.0, id_b);
+    }
+
+    #[test]
+    fn request_command_scout_parses_report_mode_and_emits() {
+        let lua = mlua::Lua::new();
+        let args = lua.create_table().unwrap();
+        let ship = Entity::from_raw_u32(10).unwrap();
+        let target = Entity::from_raw_u32(20).unwrap();
+        args.set("ship", ship.to_bits()).unwrap();
+        args.set("target_system", target.to_bits()).unwrap();
+        args.set("observation_duration", 5i64).unwrap();
+        args.set("report_mode", "ftl_comm").unwrap();
+        let parsed = apply::parse_request("scout", &args).unwrap();
+        match &parsed {
+            apply::ParsedRequest::Scout {
+                report_mode,
+                observation_duration,
+                ..
+            } => {
+                assert_eq!(*observation_duration, 5);
+                assert!(matches!(report_mode, crate::ship::ReportMode::FtlComm));
+            }
+            other => panic!("expected Scout, got {other:?}"),
+        }
+        let mut world = make_command_world();
+        let _ = apply::request_command(&mut world, parsed).unwrap();
+        let msgs = world.resource::<Messages<ScoutRequested>>();
+        let mut cursor = msgs.get_cursor();
+        let all: Vec<&ScoutRequested> = cursor.read(msgs).collect();
+        assert_eq!(all.len(), 1);
+        assert!(matches!(
+            all[0].report_mode,
+            crate::ship::ReportMode::FtlComm
+        ));
+    }
+
+    #[test]
+    fn request_command_rejects_core_deploy_and_attack() {
+        // Plan §7 Phase 4 intentionally defers these kinds until the
+        // corresponding Rust-side handlers land.
+        let lua = mlua::Lua::new();
+        let args = lua.create_table().unwrap();
+        for kind in ["core_deploy", "attack"] {
+            let err = apply::parse_request(kind, &args).unwrap_err();
+            assert!(
+                err.to_string().contains("not yet supported"),
+                "expected 'not yet supported' for '{kind}'"
+            );
+        }
+    }
+
+    #[test]
+    fn request_command_exposed_in_readwrite_only() {
+        // Smoke: ReadOnly mode must NOT expose `request_command` (the
+        // write-closure block is gated on `GamestateMode::ReadWrite`).
+        let mut world = {
+            let mut w = World::new();
+            w.insert_resource(crate::time_system::GameClock::new(0));
+            w.insert_resource(ScriptEngine::new().unwrap());
+            w
+        };
+        let mut saw_ro_nil = false;
+        let mut saw_rw_fn = false;
+        world.resource_scope::<ScriptEngine, _>(|world, engine| {
+            let lua = engine.lua();
+            // ReadOnly: request_command must be nil.
+            {
+                let payload = lua.create_table().unwrap();
+                dispatch_with_gamestate(lua, world, &payload, GamestateMode::ReadOnly, |_l, p| {
+                    let gs: Table = p.get("gamestate")?;
+                    let rc: mlua::Value = gs.get("request_command")?;
+                    saw_ro_nil = matches!(rc, mlua::Value::Nil);
+                    Ok(())
+                })
+                .unwrap();
+            }
+            // ReadWrite: request_command must be a Function.
+            {
+                let payload = lua.create_table().unwrap();
+                dispatch_with_gamestate(lua, world, &payload, GamestateMode::ReadWrite, |_l, p| {
+                    let gs: Table = p.get("gamestate")?;
+                    let rc: mlua::Value = gs.get("request_command")?;
+                    saw_rw_fn = matches!(rc, mlua::Value::Function(_));
+                    Ok(())
+                })
+                .unwrap();
+            }
+        });
+        assert!(saw_ro_nil, "ReadOnly mode must not expose request_command");
+        assert!(saw_rw_fn, "ReadWrite mode must expose request_command");
     }
 }

--- a/macrocosmo/src/ship/bridges.rs
+++ b/macrocosmo/src/ship/bridges.rs
@@ -1,17 +1,26 @@
-//! #334 Phase 1: event-bus subscribers that translate `CommandExecuted`
-//! messages into side-effects for downstream consumers (`CommandLog`,
-//! future Lua `on_command_completed` hooks, AI debug telemetry).
+//! #334 Phase 1/4: event-bus subscribers that translate `CommandExecuted`
+//! messages into side-effects for downstream consumers (`CommandLog`, the
+//! Lua `on("macrocosmo:command_completed", ...)` hook, AI debug telemetry).
 //!
-//! Phase 1 scope: `bridge_command_executed_to_log` — keeps the per-empire
-//! `CommandLog` UI component in sync with the dispatcher/handler pipeline
-//! by matching entries via `CommandId` and flipping `status` /
-//! `executed_at`. Phase 4 adds `bridge_command_executed_to_gamestate`.
+//! * **Phase 1** — `bridge_command_executed_to_log`: keeps the per-empire
+//!   `CommandLog` UI component in sync with the dispatcher/handler pipeline
+//!   by matching entries via `CommandId` and flipping `status` /
+//!   `executed_at`.
+//! * **Phase 4** — `bridge_command_executed_to_gamestate`: forwards terminal
+//!   results (`Ok` / `Rejected`) to the event bus as a
+//!   [`crate::event_system::COMMAND_COMPLETED_EVENT`] with a typed
+//!   [`CommandCompletedContext`] payload, so Lua scripts get an
+//!   `on_command_completed(evt)`-equivalent hook **via the queue** — never
+//!   sync-dispatched from inside a handler. See plan §7 Phase 4 and
+//!   `memory/feedback_rust_no_lua_callback.md` for the reentrancy rationale.
 
 use bevy::prelude::*;
 
 use crate::communication::{CommandLog, CommandLogStatus};
+use crate::event_system::EventSystem;
 use crate::player::PlayerEmpire;
-use crate::ship::command_events::{CommandExecuted, CommandResult};
+use crate::ship::command_events::{CommandCompletedContext, CommandExecuted, CommandResult};
+use crate::time_system::GameClock;
 
 /// Reads every `CommandExecuted` this frame and updates the matching
 /// `CommandLog` entry on the player empire. Entries are keyed by
@@ -51,6 +60,39 @@ pub fn bridge_command_executed_to_log(
         // shows "arrived"; Deferred stays false while the follow-up is
         // pending).
         entry.arrived = !matches!(entry.status, CommandLogStatus::Deferred);
+    }
+}
+
+/// #334 Phase 4 bridge: reads every terminal `CommandExecuted` this frame
+/// and enqueues a [`COMMAND_COMPLETED_EVENT`](crate::event_system::COMMAND_COMPLETED_EVENT)
+/// on `EventSystem` so the standard `dispatch_event_handlers` loop picks it
+/// up next tick and delivers it to any Lua handler registered via
+/// `on("macrocosmo:command_completed", ...)`.
+///
+/// **Queue-only, never sync-dispatched** (plan §9.2 /
+/// `feedback_rust_no_lua_callback.md`). The Rust handler that emits
+/// `CommandExecuted` has already released its borrows by the time this
+/// bridge runs; the bridge itself never calls into Lua. When the Lua hook
+/// eventually runs (next invocation of `dispatch_event_handlers`), it
+/// receives a fresh `ctx.gamestate` scope and may call
+/// `gs:request_command(...)` to re-enter the command pipeline without
+/// reentrancy because the dispatcher/handler path runs in a distinct
+/// system and a distinct Bevy message cycle.
+///
+/// **Deferred filter** (plan §10 R8): `CommandResult::Deferred` messages are
+/// skipped so the hook never double-fires for async routes. Only the
+/// terminal follow-up emits the event.
+pub fn bridge_command_executed_to_gamestate(
+    clock: Res<GameClock>,
+    mut executed: MessageReader<CommandExecuted>,
+    mut event_system: ResMut<EventSystem>,
+) {
+    for ev in executed.read() {
+        // Skip `Deferred` — a terminal `CommandExecuted` will follow.
+        let Some(ctx) = CommandCompletedContext::from_executed(ev) else {
+            continue;
+        };
+        event_system.fire_event_with_payload(None, clock.elapsed, Box::new(ctx));
     }
 }
 
@@ -219,5 +261,149 @@ mod tests {
         };
         // The kept entry stays Dispatched.
         assert_eq!(log[0].status, CommandLogStatus::Dispatched);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 4: `bridge_command_executed_to_gamestate` tests.
+    // ------------------------------------------------------------------
+
+    fn make_gs_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CommandEventsPlugin);
+        app.insert_resource(EventSystem::default());
+        app.insert_resource(GameClock::new(100));
+        app.add_systems(Update, bridge_command_executed_to_gamestate);
+        app
+    }
+
+    #[test]
+    fn gamestate_bridge_ok_enqueues_command_completed_event() {
+        let mut app = make_gs_app();
+        {
+            let mut msgs = app.world_mut().resource_mut::<Messages<CommandExecuted>>();
+            msgs.write(CommandExecuted {
+                command_id: CommandId(17),
+                kind: CommandKind::Move,
+                ship: Entity::from_raw_u32(3).unwrap(),
+                result: CommandResult::Ok,
+                completed_at: 100,
+            });
+        }
+        app.update();
+
+        let es = app.world().resource::<EventSystem>();
+        assert_eq!(
+            es.fired_log.len(),
+            1,
+            "terminal Ok result should enqueue exactly one event"
+        );
+        let fired = &es.fired_log[0];
+        assert_eq!(
+            fired.event_id,
+            crate::event_system::COMMAND_COMPLETED_EVENT
+        );
+        let ctx = fired.payload.as_ref().expect("payload attached");
+        // Filter-compatible accessors match what `on(id, filter, fn)` sees.
+        assert_eq!(ctx.payload_get("kind").as_deref(), Some("move"));
+        assert_eq!(ctx.payload_get("result").as_deref(), Some("ok"));
+        assert_eq!(ctx.payload_get("command_id").as_deref(), Some("17"));
+        assert_eq!(ctx.payload_get("completed_at").as_deref(), Some("100"));
+    }
+
+    #[test]
+    fn gamestate_bridge_rejected_carries_reason() {
+        let mut app = make_gs_app();
+        {
+            let mut msgs = app.world_mut().resource_mut::<Messages<CommandExecuted>>();
+            msgs.write(CommandExecuted {
+                command_id: CommandId(5),
+                kind: CommandKind::Survey,
+                ship: Entity::from_raw_u32(2).unwrap(),
+                result: CommandResult::Rejected {
+                    reason: "ship despawned".into(),
+                },
+                completed_at: 42,
+            });
+        }
+        app.update();
+
+        let es = app.world().resource::<EventSystem>();
+        assert_eq!(es.fired_log.len(), 1);
+        let ctx = es.fired_log[0].payload.as_ref().unwrap();
+        assert_eq!(ctx.payload_get("result").as_deref(), Some("rejected"));
+        assert_eq!(
+            ctx.payload_get("reason").as_deref(),
+            Some("ship despawned")
+        );
+        assert_eq!(ctx.payload_get("kind").as_deref(), Some("survey"));
+    }
+
+    #[test]
+    fn gamestate_bridge_deferred_is_skipped() {
+        // Plan §10 R8: Deferred must not enqueue — the subsequent terminal
+        // CommandExecuted is the one that fires the hook.
+        let mut app = make_gs_app();
+        {
+            let mut msgs = app.world_mut().resource_mut::<Messages<CommandExecuted>>();
+            msgs.write(CommandExecuted {
+                command_id: CommandId(1),
+                kind: CommandKind::Move,
+                ship: Entity::from_raw_u32(1).unwrap(),
+                result: CommandResult::Deferred,
+                completed_at: 10,
+            });
+        }
+        app.update();
+
+        let es = app.world().resource::<EventSystem>();
+        assert!(
+            es.fired_log.is_empty(),
+            "Deferred result must not enqueue a command_completed event"
+        );
+    }
+
+    #[test]
+    fn gamestate_bridge_terminal_payload_shape_for_all_kinds() {
+        // Regression: every CommandKind must map to a non-empty `kind_str`
+        // so `evt.kind == "..."` in Lua can match. The full table lives on
+        // `CommandCompletedContext::kind_str`; this exercises the path end
+        // to end for one representative kind per result variant.
+        let mut app = make_gs_app();
+        {
+            let mut msgs = app.world_mut().resource_mut::<Messages<CommandExecuted>>();
+            for (i, kind) in [
+                CommandKind::Move,
+                CommandKind::MoveToCoordinates,
+                CommandKind::Survey,
+                CommandKind::Colonize,
+                CommandKind::Scout,
+                CommandKind::LoadDeliverable,
+                CommandKind::DeployDeliverable,
+                CommandKind::CoreDeploy,
+                CommandKind::TransferToStructure,
+                CommandKind::LoadFromScrapyard,
+                CommandKind::Attack,
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                msgs.write(CommandExecuted {
+                    command_id: CommandId((i + 1) as u64),
+                    kind,
+                    ship: Entity::from_raw_u32((i + 1) as u32).unwrap(),
+                    result: CommandResult::Ok,
+                    completed_at: 1,
+                });
+            }
+        }
+        app.update();
+        let es = app.world().resource::<EventSystem>();
+        assert_eq!(es.fired_log.len(), 11, "one event per CommandKind");
+        for entry in &es.fired_log {
+            let ctx = entry.payload.as_ref().expect("payload attached");
+            let kind = ctx.payload_get("kind").unwrap_or_default().to_string();
+            assert!(!kind.is_empty(), "kind must be a non-empty string");
+        }
     }
 }

--- a/macrocosmo/src/ship/bridges.rs
+++ b/macrocosmo/src/ship/bridges.rs
@@ -299,10 +299,7 @@ mod tests {
             "terminal Ok result should enqueue exactly one event"
         );
         let fired = &es.fired_log[0];
-        assert_eq!(
-            fired.event_id,
-            crate::event_system::COMMAND_COMPLETED_EVENT
-        );
+        assert_eq!(fired.event_id, crate::event_system::COMMAND_COMPLETED_EVENT);
         let ctx = fired.payload.as_ref().expect("payload attached");
         // Filter-compatible accessors match what `on(id, filter, fn)` sees.
         assert_eq!(ctx.payload_get("kind").as_deref(), Some("move"));
@@ -332,10 +329,7 @@ mod tests {
         assert_eq!(es.fired_log.len(), 1);
         let ctx = es.fired_log[0].payload.as_ref().unwrap();
         assert_eq!(ctx.payload_get("result").as_deref(), Some("rejected"));
-        assert_eq!(
-            ctx.payload_get("reason").as_deref(),
-            Some("ship despawned")
-        );
+        assert_eq!(ctx.payload_get("reason").as_deref(), Some("ship despawned"));
         assert_eq!(ctx.payload_get("kind").as_deref(), Some("survey"));
     }
 

--- a/macrocosmo/src/ship/command_events.rs
+++ b/macrocosmo/src/ship/command_events.rs
@@ -223,6 +223,115 @@ pub struct CommandExecuted {
 }
 
 // ---------------------------------------------------------------------------
+// CommandCompletedContext — Phase 4: EventContext carrying a CommandExecuted
+// payload for the Lua `on("macrocosmo:command_completed", ...)` hook.
+// ---------------------------------------------------------------------------
+
+/// Typed `EventContext` payload built by
+/// [`crate::ship::bridges::bridge_command_executed_to_gamestate`] from a
+/// terminal [`CommandExecuted`] message. Exposes the command identity /
+/// result as a flat Lua table so user scripts can read
+/// `evt.command_id`, `evt.kind`, `evt.ship`, `evt.result`, `evt.reason`,
+/// `evt.completed_at` from the standard `on(event_id, ...)` callback.
+///
+/// # Invariants
+///
+/// * Only constructed for **terminal** results (`Ok` / `Rejected`).
+///   `Deferred` pairs do not produce a context — the follow-up
+///   `CommandExecuted` is the one that fires the hook. See plan §10 R8.
+/// * Values are serialised as `String` to match the
+///   [`crate::event_system::EventContext::payload_get`] contract used by
+///   `on(id, filter, fn)` structural filters — that filter path flattens
+///   everything to strings and we mirror the existing `LuaDefinedEventContext`
+///   shape rather than inventing a new serialisation.
+/// * Never calls Lua code; only `lua.create_table()` + `table.set(...)`.
+#[derive(Clone, Debug)]
+pub struct CommandCompletedContext {
+    pub command_id: CommandId,
+    pub kind: CommandKind,
+    pub ship: Entity,
+    pub result_tag: &'static str,
+    pub reason: Option<String>,
+    pub completed_at: i64,
+}
+
+impl CommandCompletedContext {
+    /// Map `CommandKind` to the string Lua scripts use to compare `evt.kind`.
+    /// Lowercase snake-case matches what `request_command(kind, args)`
+    /// accepts on the setter side (Phase 4 Commit 2) so a modder can write
+    /// `if evt.kind == "move" then ... end` after calling
+    /// `gs:request_command("move", ...)`.
+    pub fn kind_str(kind: CommandKind) -> &'static str {
+        match kind {
+            CommandKind::Move => "move",
+            CommandKind::MoveToCoordinates => "move_to_coordinates",
+            CommandKind::Survey => "survey",
+            CommandKind::Colonize => "colonize",
+            CommandKind::Scout => "scout",
+            CommandKind::LoadDeliverable => "load_deliverable",
+            CommandKind::DeployDeliverable => "deploy_deliverable",
+            CommandKind::CoreDeploy => "core_deploy",
+            CommandKind::TransferToStructure => "transfer_to_structure",
+            CommandKind::LoadFromScrapyard => "load_from_scrapyard",
+            CommandKind::Attack => "attack",
+        }
+    }
+
+    /// Build from a terminal `CommandExecuted`. Returns `None` when the
+    /// result is `Deferred` — plan §10 R8 bans double-fires.
+    pub fn from_executed(ev: &CommandExecuted) -> Option<Self> {
+        let (tag, reason) = match &ev.result {
+            CommandResult::Ok => ("ok", None),
+            CommandResult::Rejected { reason } => ("rejected", Some(reason.clone())),
+            CommandResult::Deferred => return None,
+        };
+        Some(Self {
+            command_id: ev.command_id,
+            kind: ev.kind,
+            ship: ev.ship,
+            result_tag: tag,
+            reason,
+            completed_at: ev.completed_at,
+        })
+    }
+}
+
+impl crate::event_system::EventContext for CommandCompletedContext {
+    fn event_id(&self) -> &str {
+        crate::event_system::COMMAND_COMPLETED_EVENT
+    }
+
+    fn to_lua_table(&self, lua: &mlua::Lua) -> mlua::Result<mlua::Table> {
+        let t = lua.create_table()?;
+        t.set("event_id", crate::event_system::COMMAND_COMPLETED_EVENT)?;
+        // Command id as decimal string — mirror the `LuaDefinedEventContext`
+        // discipline (everything is strings, filter-compatible).
+        t.set("command_id", self.command_id.0.to_string())?;
+        t.set("kind", Self::kind_str(self.kind))?;
+        t.set("ship", self.ship.to_bits().to_string())?;
+        t.set("result", self.result_tag)?;
+        if let Some(r) = &self.reason {
+            t.set("reason", r.as_str())?;
+        }
+        t.set("completed_at", self.completed_at.to_string())?;
+        Ok(t)
+    }
+
+    fn payload_get(&self, key: &str) -> Option<std::borrow::Cow<'_, str>> {
+        use std::borrow::Cow;
+        match key {
+            "kind" => Some(Cow::Borrowed(Self::kind_str(self.kind))),
+            "result" => Some(Cow::Borrowed(self.result_tag)),
+            "reason" => self.reason.as_deref().map(Cow::Borrowed),
+            "command_id" => Some(Cow::Owned(self.command_id.0.to_string())),
+            "ship" => Some(Cow::Owned(self.ship.to_bits().to_string())),
+            "completed_at" => Some(Cow::Owned(self.completed_at.to_string())),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 

--- a/macrocosmo/src/ship/mod.rs
+++ b/macrocosmo/src/ship/mod.rs
@@ -335,6 +335,32 @@ impl Plugin for ShipPlugin {
                 .after(crate::time_system::advance_game_time)
                 .before(crate::colony::advance_production_tick),
         );
+        // #334 Phase 4: CommandExecuted → Lua `on_command_completed` hook.
+        // Runs alongside the CommandLog bridge — both read the same
+        // `CommandExecuted` messages independently (different `MessageReader`
+        // cursors), so the two subscribers never race. Queue-only: this
+        // bridge enqueues a `COMMAND_COMPLETED_EVENT` on `EventSystem`;
+        // `dispatch_event_handlers` in the scripting plugin drains the
+        // fired_log on its own tick. See plan §7 Phase 4 +
+        // `memory/feedback_rust_no_lua_callback.md`.
+        app.add_systems(
+            Update,
+            bridges::bridge_command_executed_to_gamestate
+                .after(routing::poll_pending_routes)
+                .after(handlers::handle_move_requested)
+                .after(handlers::handle_move_to_coordinates_requested)
+                .after(handlers::handle_load_deliverable_requested)
+                .after(handlers::handle_deploy_deliverable_requested)
+                .after(handlers::handle_transfer_to_structure_requested)
+                .after(handlers::handle_load_from_scrapyard_requested)
+                .after(handlers::handle_survey_requested)
+                .after(handlers::handle_colonize_requested)
+                .after(handlers::handle_scout_requested)
+                .after(handlers::handle_attack_requested)
+                .after(core_deliverable::handle_core_deploy_requested)
+                .after(crate::time_system::advance_game_time)
+                .before(crate::colony::advance_production_tick),
+        );
         // #128: Poll route tasks after Commands emitted by handlers are flushed.
         app.add_systems(
             Update,

--- a/macrocosmo/tests/lua_request_command.rs
+++ b/macrocosmo/tests/lua_request_command.rs
@@ -1,0 +1,374 @@
+//! #334 Phase 4 Commit 2: end-to-end test for
+//! `ctx.gamestate:request_command(kind, args)` + the Phase 4 Commit 1
+//! `bridge_command_executed_to_gamestate` → `on("macrocosmo:command_completed")`
+//! hook.
+//!
+//! The test exercises the full Lua-initiated command round-trip:
+//! 1. A Lua event handler calls `evt.gamestate:request_command("move", {...})`
+//!    which pushes a `MoveRequested` message via the scope-closure setter
+//!    (`apply::request_command`).
+//! 2. A minimal Bevy schedule runs the MoveRequested handler surrogate
+//!    that writes `CommandExecuted { result: Ok }`.
+//! 3. `bridge_command_executed_to_gamestate` forwards the terminal
+//!    `CommandExecuted` to `EventSystem::fire_event_with_payload`.
+//! 4. `dispatch_event_handlers` delivers the payload to a second Lua
+//!    handler registered on `macrocosmo:command_completed`, which
+//!    records the observed fields in a Lua-visible global.
+//!
+//! The surrogate handler (`run_move_requested_surrogate`) mimics the
+//! Phase 1 handler's terminal emit without pulling in the heavyweight
+//! routing-dependent `handle_move_requested` system — this test is about
+//! the **bridge + Lua API + hook** path, not the FTL route planner.
+
+use bevy::ecs::message::Messages;
+use bevy::prelude::*;
+use macrocosmo::event_system::{EventSystem, FiredEvent};
+use macrocosmo::scripting::ScriptEngine;
+use macrocosmo::scripting::gamestate_scope::{GamestateMode, dispatch_with_gamestate};
+use macrocosmo::scripting::lifecycle::dispatch_event_handlers;
+use macrocosmo::ship::bridges::bridge_command_executed_to_gamestate;
+use macrocosmo::ship::command_events::{
+    CommandEventsPlugin, CommandExecuted, CommandId, CommandKind, CommandResult, MoveRequested,
+    NextCommandId,
+};
+use macrocosmo::time_system::GameClock;
+
+fn make_world() -> World {
+    let mut app = App::new();
+    app.add_plugins(bevy::MinimalPlugins);
+    app.add_plugins(CommandEventsPlugin);
+    app.insert_resource(EventSystem::default());
+    app.insert_resource(ScriptEngine::new().unwrap());
+    app.insert_resource(GameClock::new(100));
+    std::mem::take(app.world_mut())
+}
+
+/// Stand-in for the real move handler. Drains every `MoveRequested` and
+/// writes a terminal `CommandExecuted { Ok }`. This keeps the test
+/// focused on the bridge + hook, not on FTL routing logic.
+fn run_move_requested_surrogate(world: &mut World, clock: i64) {
+    let requests: Vec<MoveRequested> = {
+        let mut msgs = world.resource_mut::<Messages<MoveRequested>>();
+        let mut cursor = msgs.get_cursor();
+        let collected: Vec<MoveRequested> = cursor.read(&msgs).cloned().collect();
+        // Advance the cursor — the real handler would read via MessageReader.
+        drop(cursor);
+        // Clear the queue so it doesn't leak into the next iteration.
+        msgs.update();
+        collected
+    };
+    if requests.is_empty() {
+        return;
+    }
+    let mut exec = world.resource_mut::<Messages<CommandExecuted>>();
+    for req in requests {
+        exec.write(CommandExecuted {
+            command_id: req.command_id,
+            kind: CommandKind::Move,
+            ship: req.ship,
+            result: CommandResult::Ok,
+            completed_at: clock,
+        });
+    }
+}
+
+fn run_bridge(world: &mut World) {
+    // `bridge_command_executed_to_gamestate` is a Bevy system — call it
+    // by running a one-shot Schedule that contains only it, so we can
+    // exercise the exact system logic.
+    let mut schedule = Schedule::default();
+    schedule.add_systems(bridge_command_executed_to_gamestate);
+    schedule.run(world);
+}
+
+/// End-to-end: Lua handler `fires → request_command` → surrogate handler
+/// emits CommandExecuted(Ok) → bridge enqueues command_completed →
+/// dispatch_event_handlers delivers to the on(...) callback.
+#[test]
+fn request_command_move_triggers_command_completed_hook() {
+    let mut world = make_world();
+
+    // Spawn two dummy entities — a ship and a target system. We never
+    // actually move them; the surrogate handler short-circuits the
+    // request. They just need valid Entity bits for the Lua payload.
+    let ship = world.spawn_empty().id();
+    let target = world.spawn_empty().id();
+
+    // Register Lua-side state + handlers. Two handlers:
+    //   1. `macrocosmo:lua_kickoff` — the caller of `request_command`.
+    //   2. `macrocosmo:command_completed` — the hook-side observer.
+    {
+        let lua = world.resource::<ScriptEngine>().lua();
+        lua.globals().set("_ship", ship.to_bits()).unwrap();
+        lua.globals().set("_target", target.to_bits()).unwrap();
+        lua.load(
+            r#"
+            -- initialise observer globals
+            _observed_kind = nil
+            _observed_result = nil
+            _observed_cmd_id = nil
+            _returned_cmd_id = nil
+
+            -- kickoff handler: calls request_command and stores the returned id
+            on("macrocosmo:lua_kickoff", function(evt)
+                local id = evt.gamestate:request_command("move", {
+                    ship = _ship,
+                    target = _target,
+                })
+                _returned_cmd_id = id
+            end)
+
+            -- hook handler: records the fields it observed
+            on("macrocosmo:command_completed", function(evt)
+                _observed_kind = evt.kind
+                _observed_result = evt.result
+                _observed_cmd_id = evt.command_id
+            end)
+            "#,
+        )
+        .exec()
+        .unwrap();
+    }
+
+    // --- Tick 1: fire the kickoff event; Lua handler calls request_command. ---
+    {
+        let mut es = world.resource_mut::<EventSystem>();
+        es.fired_log.push(FiredEvent {
+            event_id: "macrocosmo:lua_kickoff".into(),
+            target: None,
+            fired_at: 100,
+            payload: None,
+        });
+    }
+    dispatch_event_handlers(&mut world);
+
+    // request_command should have emitted a MoveRequested message and
+    // returned a non-zero id.
+    let returned_id: u64 = world
+        .resource::<ScriptEngine>()
+        .lua()
+        .globals()
+        .get("_returned_cmd_id")
+        .unwrap();
+    assert!(returned_id > 0, "request_command must return a fresh id");
+    // NextCommandId should have advanced.
+    assert_eq!(
+        world.resource::<NextCommandId>().0,
+        returned_id,
+        "returned id must match the counter"
+    );
+    // Peek the MoveRequested message.
+    {
+        let msgs = world.resource::<Messages<MoveRequested>>();
+        let mut cursor = msgs.get_cursor();
+        let all: Vec<&MoveRequested> = cursor.read(msgs).collect();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].ship, ship);
+        assert_eq!(all[0].target, target);
+        assert_eq!(all[0].command_id, CommandId(returned_id));
+    }
+
+    // --- Tick 2: run the surrogate handler (emits terminal CommandExecuted). ---
+    run_move_requested_surrogate(&mut world, 101);
+
+    // --- Tick 3: bridge forwards to EventSystem.fire_event_with_payload. ---
+    run_bridge(&mut world);
+
+    // EventSystem should now have a command_completed event queued.
+    let has_completed = world
+        .resource::<EventSystem>()
+        .fired_log
+        .iter()
+        .any(|f| f.event_id == macrocosmo::event_system::COMMAND_COMPLETED_EVENT);
+    assert!(
+        has_completed,
+        "bridge must push command_completed into fired_log"
+    );
+
+    // --- Tick 4: dispatch_event_handlers delivers to the Lua hook. ---
+    dispatch_event_handlers(&mut world);
+
+    // Verify the Lua observer recorded the fields.
+    let engine = world.resource::<ScriptEngine>();
+    let lua = engine.lua();
+    let kind: String = lua.globals().get("_observed_kind").unwrap();
+    let result: String = lua.globals().get("_observed_result").unwrap();
+    let cmd_id: String = lua.globals().get("_observed_cmd_id").unwrap();
+    assert_eq!(kind, "move");
+    assert_eq!(result, "ok");
+    assert_eq!(
+        cmd_id,
+        returned_id.to_string(),
+        "hook command_id (decimal string) must match request_command return"
+    );
+}
+
+/// Reentrancy: a `command_completed` hook callback can itself call
+/// `request_command` for a **new** command without tripping the
+/// gamestate `try_borrow_mut` guard. Because the bridge runs outside
+/// the Lua scope and fire_event queues the next dispatch, there is no
+/// synchronous callback chain from the handler into Lua.
+#[test]
+fn on_command_completed_may_call_request_command_again() {
+    let mut world = make_world();
+    let ship = world.spawn_empty().id();
+    let target = world.spawn_empty().id();
+
+    {
+        let lua = world.resource::<ScriptEngine>().lua();
+        lua.globals().set("_ship", ship.to_bits()).unwrap();
+        lua.globals().set("_target", target.to_bits()).unwrap();
+        lua.load(
+            r#"
+            _second_cmd_id = nil
+            on("macrocosmo:lua_kickoff", function(evt)
+                evt.gamestate:request_command("move", { ship = _ship, target = _target })
+            end)
+            -- Reentrancy exercise: issue another command from inside the hook.
+            on("macrocosmo:command_completed", function(evt)
+                if evt.kind == "move" and _second_cmd_id == nil then
+                    _second_cmd_id = evt.gamestate:request_command("survey", {
+                        ship = _ship,
+                        target_system = _target,
+                    })
+                end
+            end)
+            "#,
+        )
+        .exec()
+        .unwrap();
+    }
+
+    // Round 1: kickoff.
+    {
+        let mut es = world.resource_mut::<EventSystem>();
+        es.fired_log.push(FiredEvent {
+            event_id: "macrocosmo:lua_kickoff".into(),
+            target: None,
+            fired_at: 100,
+            payload: None,
+        });
+    }
+    dispatch_event_handlers(&mut world);
+    run_move_requested_surrogate(&mut world, 101);
+    run_bridge(&mut world);
+
+    // Round 2: hook fires, reissues survey via gamestate.
+    dispatch_event_handlers(&mut world);
+
+    let second_id: Option<u64> = world
+        .resource::<ScriptEngine>()
+        .lua()
+        .globals()
+        .get("_second_cmd_id")
+        .ok();
+    assert!(
+        second_id.is_some() && second_id.unwrap() > 0,
+        "the hook must successfully call request_command a second time"
+    );
+
+    // A SurveyRequested message should have been emitted.
+    let msgs = world.resource::<Messages<macrocosmo::ship::command_events::SurveyRequested>>();
+    let mut cursor = msgs.get_cursor();
+    let surveys: Vec<_> = cursor.read(msgs).collect();
+    assert_eq!(surveys.len(), 1);
+}
+
+/// Malformed arguments surface as Lua errors (surfaced as pcall `false`).
+#[test]
+fn request_command_missing_arg_bubbles_runtime_error_to_lua() {
+    let mut world = make_world();
+
+    // Register a handler that intentionally omits `target`.
+    {
+        let lua = world.resource::<ScriptEngine>().lua();
+        lua.load(
+            r#"
+            _ok = nil
+            _err = nil
+            on("macrocosmo:bad_req", function(evt)
+                local ok, err = pcall(function()
+                    evt.gamestate:request_command("move", { ship = 1 })
+                end)
+                _ok = ok
+                _err = err and tostring(err) or nil
+            end)
+            "#,
+        )
+        .exec()
+        .unwrap();
+    }
+
+    {
+        let mut es = world.resource_mut::<EventSystem>();
+        es.fired_log.push(FiredEvent {
+            event_id: "macrocosmo:bad_req".into(),
+            target: None,
+            fired_at: 100,
+            payload: None,
+        });
+    }
+    dispatch_event_handlers(&mut world);
+
+    let lua = world.resource::<ScriptEngine>().lua();
+    let ok: bool = lua.globals().get("_ok").unwrap();
+    let err: Option<String> = lua.globals().get("_err").unwrap();
+    assert!(!ok, "malformed args must raise a Lua error");
+    let msg = err.unwrap_or_default();
+    assert!(
+        msg.contains("missing") && msg.contains("target"),
+        "error must name the missing field, got: {msg}"
+    );
+
+    // No MoveRequested should have been emitted.
+    let msgs = world.resource::<Messages<MoveRequested>>();
+    let mut cursor = msgs.get_cursor();
+    assert_eq!(cursor.read(msgs).count(), 0);
+}
+
+/// Deferred results do not fire the hook (plan §10 R8).
+#[test]
+fn deferred_command_executed_does_not_fire_hook() {
+    let mut world = make_world();
+
+    {
+        let lua = world.resource::<ScriptEngine>().lua();
+        lua.load(
+            r#"
+            _hook_fired = false
+            on("macrocosmo:command_completed", function(evt)
+                _hook_fired = true
+            end)
+            "#,
+        )
+        .exec()
+        .unwrap();
+    }
+
+    // Write a Deferred result directly — no dispatcher involvement.
+    {
+        let mut exec = world.resource_mut::<Messages<CommandExecuted>>();
+        exec.write(CommandExecuted {
+            command_id: CommandId(1),
+            kind: CommandKind::Move,
+            ship: Entity::from_raw_u32(1).unwrap(),
+            result: CommandResult::Deferred,
+            completed_at: 42,
+        });
+    }
+    run_bridge(&mut world);
+
+    assert!(
+        world.resource::<EventSystem>().fired_log.is_empty(),
+        "Deferred must not enqueue command_completed"
+    );
+
+    dispatch_event_handlers(&mut world);
+    let fired: bool = world
+        .resource::<ScriptEngine>()
+        .lua()
+        .globals()
+        .get("_hook_fired")
+        .unwrap();
+    assert!(!fired, "hook must not fire for Deferred results");
+}


### PR DESCRIPTION
## Summary

Closes the #334 command-dispatch epic by landing Phase 4:

- **Commit 1** (`ab081a3`) — `bridge_command_executed_to_gamestate`: queue-only reader system that forwards terminal `CommandExecuted` messages to `EventSystem::fire_event_with_payload` so Lua scripts can register `on("macrocosmo:command_completed", ...)` handlers. `CommandResult::Deferred` is filtered (plan §10 R8).
- **Commit 2** (`82aecea`) — `ctx.gamestate:request_command(kind, args)`: Lua-side entrypoint into the command pipeline. Parses the `args` table in the scope closure, calls `apply::request_command(&mut World, ParsedRequest) -> mlua::Result<u64>` — **`&Lua` is never passed and Lua is never called back into** (see `memory/feedback_rust_no_lua_callback.md`). Returns the freshly-allocated `CommandId.0` so Lua can correlate the subsequent hook payload.
- **Commit 3** (`0964061`) — docs + example script + plan close note.
- **Fixup** (`1058f20`) — rustfmt on bridges.rs assertions (Commit 1 style only).

Plan: `docs/plan-334-command-dispatch-event-driven.md` §7 Phase 4 (appendix C records landed state).

Related PRs landing the earlier phases: #341 (Phase 1), #342 (Phase 2), #343 (Phase 3).

## Supported Lua kinds (Phase 4)

`"move"`, `"move_to_coordinates"`, `"scout"`, `"load_deliverable"`, `"deploy_deliverable"`, `"transfer_to_structure"`, `"load_from_scrapyard"`, `"colonize"`, `"survey"`.

`"core_deploy"` and `"attack"` surface `mlua::Error::RuntimeError("not yet supported")` — their Rust handlers are either nested inside a larger pipeline (CoreDeploy comes out of `handle_deploy_deliverable_requested`) or skeleton-only (#219 / #220). They land when those sides do.

## Invariant check (queue-only Rust↔Lua discipline)

- `apply::request_command` signature: `(&mut World, ParsedRequest) -> mlua::Result<u64>`. No `&Lua`, no `mlua::Value`, no Lua callback / Function.
- Scope-closure body uses `_lua` (underscored unused).
- `bridge_command_executed_to_gamestate` is a pure Bevy reader; calls `EventSystem::fire_event_with_payload`, which pushes to `fired_log`. `dispatch_event_handlers` drains it on a later tick — no synchronous dispatch from inside the handler system.
- `spike_mlua_scope` test 4/4 passes (regression guard).
- Reentrancy test `on_command_completed_may_call_request_command_again` in the new integration suite verifies that the hook can re-enter the setter without tripping the `RefCell` borrow guard.

## Tests

New:
- `ship::bridges::tests::gamestate_bridge_{ok,rejected,deferred,all_kinds}` (4 unit tests).
- `scripting::gamestate_scope::tests::{parse_request_unknown_kind,parse_request_move_missing_target,request_command_move_emits_message_and_returns_monotonic_id,request_command_scout_parses_report_mode_and_emits,request_command_rejects_core_deploy_and_attack,request_command_exposed_in_readwrite_only}` (6 unit tests).
- `tests/lua_request_command.rs` — 4 integration tests covering end-to-end round-trip, reentrancy, malformed-args diagnostic, and Deferred-suppression.

## Test plan

- [x] `cargo test --workspace` — 2094 passed / 0 failed
- [x] `cargo check --workspace --tests` — clean
- [x] `rustfmt --edition 2024 --check` on every touched file — clean
- [x] `tests/spike_mlua_scope` — 4/4 pass
- [x] `tests/fixtures_smoke::load_minimal_game_fixture_smoke` — pass (save format unchanged)
- [x] `tests/smoke::all_systems_no_query_conflict` — pass
- [x] New end-to-end `tests/lua_request_command.rs::request_command_move_triggers_command_completed_hook` — pass

## Plan deviations

- `"core_deploy"` / `"attack"` kinds not exposed — diagnostic `RuntimeError` instead.
- Hook transport uses `EventSystem::fire_event_with_payload` rather than direct `_pending_script_events` push, so the hook carries structured fields (`command_id`, `kind`, `ship`, `result`, `reason`, `completed_at`) instead of just `event_id`. Queue-only discipline is identical (fired_log → next-tick dispatch).
- Integration test uses a surrogate move handler to avoid pulling in the FTL-router fixture; the bridge + Lua API is orthogonal to the router.

## #334 close status

With PRs #341 / #342 / #343 + this PR merged, every item in `docs/plan-334-command-dispatch-event-driven.md` §7 is landed. **#334 is ready to close** once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)