### PR TITLE
#350 K-1: define_knowledge Lua API + KindRegistry + 自動 lifecycle event 登録

### DIFF
--- a/macrocosmo/scripts/init.lua
+++ b/macrocosmo/scripts/init.lua
@@ -52,5 +52,11 @@ require("anomalies")
 -- Events
 require("events")
 
+-- #350: Knowledge kinds (ScriptableKnowledge epic #349). Loaded after
+-- events so modder-defined kinds can share namespaces with existing event
+-- definitions. Must come before lifecycle so on_game_start callbacks can
+-- `record_knowledge` / `on("<id>@observed", fn)` once K-2 / K-3 land.
+require("knowledge.sample")
+
 -- Lifecycle hooks (must be last — registers callbacks for game start/load)
 require("lifecycle")

--- a/macrocosmo/scripts/knowledge/sample.lua
+++ b/macrocosmo/scripts/knowledge/sample.lua
@@ -1,0 +1,53 @@
+-- #350 K-1: sample knowledge kind definitions.
+--
+-- Exercises the `define_knowledge { id, payload_schema }` surface added by
+-- the ScriptableKnowledge epic (#349). These are intentionally small and
+-- domain-agnostic — they are here to:
+--
+-- * Prove the startup path (parse + KindRegistry insert + lifecycle-event
+--   reservation) runs for a real Lua fixture.
+-- * Give #351 / #352 / #353 / #354 a set of pre-defined kinds to exercise
+--   record / observe / subscribe flows in integration tests.
+-- * Document the expected shape of `payload_schema` for modders.
+--
+-- `core:` is reserved for Rust-side built-ins (K-5) — do not use it here.
+
+-- Famine breakout in a colony. Payload carries severity + the affected
+-- colony entity id so observers can disambiguate multiple simultaneous
+-- events.
+define_knowledge {
+    id = "sample:colony_famine",
+    payload_schema = {
+        severity = "number",
+        colony = "entity",
+    },
+}
+
+-- Combat outcome report. Schema-less in this fixture; K-2 payloads will
+-- carry attacker / defender ids.
+define_knowledge {
+    id = "sample:combat_report",
+}
+
+-- Anomaly surveyed. Exercises every top-level schema type tag so the K-1
+-- parser has real-world coverage.
+define_knowledge {
+    id = "sample:anomaly_surveyed",
+    payload_schema = {
+        anomaly_id = "string",
+        system = "entity",
+        hazard = "boolean",
+        extras = "table",
+        yield_bonus = "number",
+    },
+}
+
+-- Routine diplomatic signal. Multiple kinds in a single namespace is
+-- explicitly supported — the registry key is the full `<ns>:<name>`.
+define_knowledge {
+    id = "sample:diplomatic_signal",
+    payload_schema = {
+        faction = "entity",
+        tone = "string",
+    },
+}

--- a/macrocosmo/src/knowledge/kind_registry.rs
+++ b/macrocosmo/src/knowledge/kind_registry.rs
@@ -1,0 +1,533 @@
+//! #350: `KindRegistry` resource + `KnowledgeKindId` parser.
+//!
+//! Part of the #349 ScriptableKnowledge epic (K-1). Defines the core types
+//! for Lua-defined knowledge kinds:
+//!
+//! * [`KnowledgeKindId`] — a parsed `<namespace>:<name>` identifier used to
+//!   key kinds in the registry. `<id>@<lifecycle>` strings are **not** ids
+//!   and are rejected by the parser.
+//! * [`KnowledgeKindDef`] — a single kind's definition (id + payload schema
+//!   + origin tag).
+//! * [`PayloadSchema`] / [`PayloadFieldType`] — v1 "loose" schema: top-level
+//!   field names mapped to Lua type tags. Nested / function / userdata
+//!   values are rejected.
+//! * [`KindOrigin`] — tags Rust-side (`core:*`) vs Lua-side (`define_knowledge`)
+//!   kinds so we can forbid Lua from redefining `core:*`.
+//! * [`KindRegistry`] — Bevy resource holding `id -> KnowledgeKindDef`.
+//!
+//! K-2 (#351) will consume `validate_payload` for `record_knowledge`; K-5
+//! (#354) preloads `core:*` kinds here.
+//!
+//! Spec: see `docs/plan-349-scriptable-knowledge.md` §2.1, §2.3, §3.1, §6.
+
+use bevy::prelude::*;
+use std::collections::HashMap;
+
+/// Separator between namespace and name in a `KnowledgeKindId`.
+pub const NAMESPACE_SEPARATOR: char = ':';
+
+/// Lifecycle separator in event ids (`<kind>@<lifecycle>`). Ids containing
+/// `@` are **invalid kind ids** — they look like event ids and would collide
+/// with the automatic `<id>@recorded` / `<id>@observed` wiring.
+pub const LIFECYCLE_SEPARATOR: char = '@';
+
+/// Reserved namespace for Rust-side built-in kinds (`core:hostile_detected`,
+/// etc.). Lua definitions in this namespace are rejected at load time (plan
+/// §0.5 9.6, §2.3).
+pub const CORE_NAMESPACE: &str = "core";
+
+/// Errors surfaced by the kind registry / id parser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KindRegistryError {
+    /// The raw id string contains `@` (reserved for lifecycle events).
+    IdContainsLifecycleSeparator(String),
+    /// The raw id string is empty.
+    EmptyId,
+    /// Attempted to (re)define a `core:*` kind from Lua, or insert twice.
+    CoreNamespaceReserved(String),
+    /// A kind with this id already exists in the registry.
+    DuplicateKind(String),
+}
+
+impl std::fmt::Display for KindRegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KindRegistryError::IdContainsLifecycleSeparator(id) => write!(
+                f,
+                "knowledge kind id '{id}' contains '@' which is reserved for lifecycle events (<id>@recorded / <id>@observed)"
+            ),
+            KindRegistryError::EmptyId => write!(f, "knowledge kind id must be non-empty"),
+            KindRegistryError::CoreNamespaceReserved(id) => write!(
+                f,
+                "knowledge kind id '{id}' uses the reserved 'core:' namespace (Rust-side only)"
+            ),
+            KindRegistryError::DuplicateKind(id) => {
+                write!(f, "knowledge kind id '{id}' is already registered")
+            }
+        }
+    }
+}
+
+impl std::error::Error for KindRegistryError {}
+
+/// A parsed knowledge kind identifier.
+///
+/// Invariants (plan §0.5 9.2):
+/// * `raw` never contains `@`
+/// * `raw` is non-empty
+///
+/// `<namespace>:<name>` is the **recommended** form but not enforced at parse
+/// time — plan §0.5 9.6 says namespace-less ids are `warn only`. The warn
+/// path is emitted by [`parse_id_with_warn`] for the Lua load callsite.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KnowledgeKindId {
+    raw: String,
+}
+
+impl KnowledgeKindId {
+    /// Parse a raw string into a [`KnowledgeKindId`], validating that it is
+    /// non-empty and does not contain `@`. Does NOT warn on missing
+    /// namespace (caller should use [`parse_id_with_warn`] for that).
+    pub fn parse(raw: &str) -> Result<Self, KindRegistryError> {
+        if raw.is_empty() {
+            return Err(KindRegistryError::EmptyId);
+        }
+        if raw.contains(LIFECYCLE_SEPARATOR) {
+            return Err(KindRegistryError::IdContainsLifecycleSeparator(
+                raw.to_string(),
+            ));
+        }
+        Ok(Self {
+            raw: raw.to_string(),
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    /// Returns `true` if this id is in the reserved `core:` namespace.
+    pub fn is_core(&self) -> bool {
+        matches!(self.namespace(), Some(CORE_NAMESPACE))
+    }
+
+    /// Returns the `<namespace>` portion (before the first `:`), if present.
+    pub fn namespace(&self) -> Option<&str> {
+        self.raw.split_once(NAMESPACE_SEPARATOR).map(|(ns, _)| ns)
+    }
+
+    /// Returns the `<name>` portion (after the first `:`), or the whole id
+    /// if no `:` is present.
+    pub fn name(&self) -> &str {
+        self.raw
+            .split_once(NAMESPACE_SEPARATOR)
+            .map(|(_, n)| n)
+            .unwrap_or(&self.raw)
+    }
+
+    /// Build the canonical `<id>@recorded` lifecycle event id.
+    pub fn recorded_event_id(&self) -> String {
+        format!("{}{LIFECYCLE_SEPARATOR}recorded", self.raw)
+    }
+
+    /// Build the canonical `<id>@observed` lifecycle event id.
+    pub fn observed_event_id(&self) -> String {
+        format!("{}{LIFECYCLE_SEPARATOR}observed", self.raw)
+    }
+}
+
+impl std::fmt::Display for KnowledgeKindId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+/// Parse a raw id and emit a `warn!` log if it lacks a `<namespace>:` prefix
+/// (plan §0.5 9.6). Errors are propagated unchanged.
+pub fn parse_id_with_warn(raw: &str) -> Result<KnowledgeKindId, KindRegistryError> {
+    let id = KnowledgeKindId::parse(raw)?;
+    if id.namespace().is_none() {
+        warn!(
+            "knowledge kind id '{raw}' has no namespace prefix; recommended form is '<namespace>:<name>'"
+        );
+    }
+    Ok(id)
+}
+
+/// An event id parsed from a string like `"vesk:famine_outbreak@recorded"`.
+///
+/// Used by K-1 at load time to reject malformed patterns, and by K-3 at
+/// `on(...)` registration time to route between `_knowledge_subscribers`
+/// and `_event_handlers` (plan §2.9).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedEventId<'a> {
+    pub kind_part: &'a str,
+    pub lifecycle: &'a str,
+}
+
+/// Split an event id string on the **rightmost** `@`. Returns `None` if the
+/// string has no `@`. This is intentionally lenient — callers decide what to
+/// do with edge cases (plan §10.2 spike).
+///
+/// Examples:
+/// * `"vesk:famine_outbreak@recorded"` → `Some(("vesk:famine_outbreak", "recorded"))`
+/// * `"*@observed"` → `Some(("*", "observed"))`
+/// * `"harvest_ended"` → `None`
+/// * `"foo@"` → `Some(("foo", ""))`
+/// * `"@recorded"` → `Some(("", "recorded"))`
+/// * `"foo@bar@recorded"` → `Some(("foo@bar", "recorded"))` — caller must
+///   further validate that `kind_part` contains no `@`.
+pub fn split_event_id(raw: &str) -> Option<ParsedEventId<'_>> {
+    raw.rsplit_once(LIFECYCLE_SEPARATOR)
+        .map(|(kind_part, lifecycle)| ParsedEventId {
+            kind_part,
+            lifecycle,
+        })
+}
+
+/// Loose v1 payload schema: top-level field names mapped to type tags.
+/// Nested tables as schema values are rejected by [`parse_payload_schema`]
+/// (nested schemas are v2).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PayloadSchema {
+    pub fields: HashMap<String, PayloadFieldType>,
+}
+
+impl PayloadSchema {
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+/// Type tag for a payload field. Matches the Lua-facing strings `"number"`,
+/// `"string"`, `"boolean"`, `"table"`, `"entity"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PayloadFieldType {
+    Number,
+    String,
+    Boolean,
+    Table,
+    Entity,
+}
+
+impl PayloadFieldType {
+    /// Parse the Lua-side type tag string. Returns `None` for unknown tags.
+    pub fn parse(tag: &str) -> Option<Self> {
+        match tag {
+            "number" => Some(Self::Number),
+            "string" => Some(Self::String),
+            "boolean" | "bool" => Some(Self::Boolean),
+            "table" => Some(Self::Table),
+            "entity" => Some(Self::Entity),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Number => "number",
+            Self::String => "string",
+            Self::Boolean => "boolean",
+            Self::Table => "table",
+            Self::Entity => "entity",
+        }
+    }
+}
+
+/// Whether a kind was defined by Rust (`core:*`) or by Lua (`define_knowledge`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KindOrigin {
+    Core,
+    Lua,
+}
+
+/// A single knowledge kind definition.
+#[derive(Debug, Clone)]
+pub struct KnowledgeKindDef {
+    pub id: KnowledgeKindId,
+    pub payload_schema: PayloadSchema,
+    pub origin: KindOrigin,
+}
+
+/// Bevy resource keyed by the raw id string (equal to `KnowledgeKindId::as_str`).
+#[derive(Resource, Default, Debug)]
+pub struct KindRegistry {
+    pub kinds: HashMap<String, KnowledgeKindDef>,
+}
+
+impl KindRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.kinds.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.kinds.is_empty()
+    }
+
+    pub fn get(&self, id: &str) -> Option<&KnowledgeKindDef> {
+        self.kinds.get(id)
+    }
+
+    pub fn contains(&self, id: &str) -> bool {
+        self.kinds.contains_key(id)
+    }
+
+    /// Insert a kind definition. Fails if:
+    /// * A Lua-origin definition tries to use the `core:` namespace.
+    /// * The id is already registered (regardless of origin).
+    ///
+    /// Rust-side callers that preload `core:*` should still see duplicate
+    /// protection — the plan (§2.3) treats the registry as the single
+    /// source-of-truth.
+    pub fn insert(&mut self, def: KnowledgeKindDef) -> Result<(), KindRegistryError> {
+        if def.origin == KindOrigin::Lua && def.id.is_core() {
+            return Err(KindRegistryError::CoreNamespaceReserved(
+                def.id.as_str().to_string(),
+            ));
+        }
+        if self.kinds.contains_key(def.id.as_str()) {
+            return Err(KindRegistryError::DuplicateKind(
+                def.id.as_str().to_string(),
+            ));
+        }
+        self.kinds.insert(def.id.as_str().to_string(), def);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- KnowledgeKindId parse ---
+
+    #[test]
+    fn parse_simple_namespaced_id() {
+        let id = KnowledgeKindId::parse("vesk:famine_outbreak").unwrap();
+        assert_eq!(id.as_str(), "vesk:famine_outbreak");
+        assert_eq!(id.namespace(), Some("vesk"));
+        assert_eq!(id.name(), "famine_outbreak");
+        assert!(!id.is_core());
+    }
+
+    #[test]
+    fn parse_namespaceless_id_is_allowed() {
+        // Warn-only per plan §0.5 9.6; the parser itself accepts it.
+        let id = KnowledgeKindId::parse("famine_outbreak").unwrap();
+        assert_eq!(id.namespace(), None);
+        assert_eq!(id.name(), "famine_outbreak");
+    }
+
+    #[test]
+    fn parse_core_namespace_is_accepted_at_parse_level() {
+        // Parsing itself allows "core:*"; only the registry / Lua API
+        // rejects Lua-origin core namespace use.
+        let id = KnowledgeKindId::parse("core:hostile_detected").unwrap();
+        assert!(id.is_core());
+        assert_eq!(id.namespace(), Some("core"));
+    }
+
+    #[test]
+    fn parse_empty_id_errors() {
+        assert_eq!(KnowledgeKindId::parse(""), Err(KindRegistryError::EmptyId));
+    }
+
+    // --- Spike 10.2: event id edge cases ---
+
+    #[test]
+    fn parse_rejects_id_with_at_symbol() {
+        // `define_knowledge { id = "foo@bar" }` is load-time error.
+        let err = KnowledgeKindId::parse("foo@bar").unwrap_err();
+        assert_eq!(
+            err,
+            KindRegistryError::IdContainsLifecycleSeparator("foo@bar".into())
+        );
+    }
+
+    #[test]
+    fn parse_rejects_embedded_lifecycle_style_id() {
+        // `"foo@recorded"` looks like an event id, not a kind id.
+        let err = KnowledgeKindId::parse("vesk:famine@recorded").unwrap_err();
+        assert!(matches!(
+            err,
+            KindRegistryError::IdContainsLifecycleSeparator(_)
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_trailing_at() {
+        assert!(KnowledgeKindId::parse("foo@").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_leading_at() {
+        assert!(KnowledgeKindId::parse("@recorded").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_double_at() {
+        // Spike 10.2: pathological `foo@bar@recorded` — parse_id rejects
+        // any `@`, regardless of count.
+        assert!(KnowledgeKindId::parse("foo@bar@recorded").is_err());
+    }
+
+    // --- split_event_id (rsplit_once semantics, plan §2.9) ---
+
+    #[test]
+    fn split_event_id_simple_recorded() {
+        let p = split_event_id("vesk:famine_outbreak@recorded").unwrap();
+        assert_eq!(p.kind_part, "vesk:famine_outbreak");
+        assert_eq!(p.lifecycle, "recorded");
+    }
+
+    #[test]
+    fn split_event_id_wildcard_observed() {
+        let p = split_event_id("*@observed").unwrap();
+        assert_eq!(p.kind_part, "*");
+        assert_eq!(p.lifecycle, "observed");
+    }
+
+    #[test]
+    fn split_event_id_no_at_is_none() {
+        assert_eq!(split_event_id("harvest_ended"), None);
+    }
+
+    #[test]
+    fn split_event_id_trailing_at() {
+        let p = split_event_id("foo@").unwrap();
+        assert_eq!(p.kind_part, "foo");
+        assert_eq!(p.lifecycle, "");
+    }
+
+    #[test]
+    fn split_event_id_leading_at() {
+        let p = split_event_id("@recorded").unwrap();
+        assert_eq!(p.kind_part, "");
+        assert_eq!(p.lifecycle, "recorded");
+    }
+
+    #[test]
+    fn split_event_id_rsplit_semantics() {
+        // rsplit_once splits on the *rightmost* `@`, so `foo@bar@recorded`
+        // becomes ("foo@bar", "recorded"). Kind-side validation must then
+        // reject the remaining `@` in the kind part. Documented here so
+        // subsequent suffix-matcher work doesn't accidentally switch to
+        // `split_once`.
+        let p = split_event_id("foo@bar@recorded").unwrap();
+        assert_eq!(p.kind_part, "foo@bar");
+        assert_eq!(p.lifecycle, "recorded");
+    }
+
+    // --- KnowledgeKindId lifecycle helpers ---
+
+    #[test]
+    fn lifecycle_event_ids_are_formatted() {
+        let id = KnowledgeKindId::parse("vesk:famine_outbreak").unwrap();
+        assert_eq!(id.recorded_event_id(), "vesk:famine_outbreak@recorded");
+        assert_eq!(id.observed_event_id(), "vesk:famine_outbreak@observed");
+    }
+
+    // --- PayloadFieldType ---
+
+    #[test]
+    fn payload_field_type_parse_known_tags() {
+        assert_eq!(
+            PayloadFieldType::parse("number"),
+            Some(PayloadFieldType::Number)
+        );
+        assert_eq!(
+            PayloadFieldType::parse("string"),
+            Some(PayloadFieldType::String)
+        );
+        assert_eq!(
+            PayloadFieldType::parse("boolean"),
+            Some(PayloadFieldType::Boolean)
+        );
+        assert_eq!(
+            PayloadFieldType::parse("bool"),
+            Some(PayloadFieldType::Boolean)
+        );
+        assert_eq!(
+            PayloadFieldType::parse("table"),
+            Some(PayloadFieldType::Table)
+        );
+        assert_eq!(
+            PayloadFieldType::parse("entity"),
+            Some(PayloadFieldType::Entity)
+        );
+    }
+
+    #[test]
+    fn payload_field_type_parse_unknown_is_none() {
+        assert_eq!(PayloadFieldType::parse("cucumber"), None);
+        assert_eq!(PayloadFieldType::parse(""), None);
+        assert_eq!(PayloadFieldType::parse("Number"), None); // case-sensitive
+    }
+
+    // --- KindRegistry insert ---
+
+    fn make_def(raw_id: &str, origin: KindOrigin) -> KnowledgeKindDef {
+        KnowledgeKindDef {
+            id: KnowledgeKindId::parse(raw_id).unwrap(),
+            payload_schema: PayloadSchema::default(),
+            origin,
+        }
+    }
+
+    #[test]
+    fn registry_insert_accepts_lua_kind() {
+        let mut reg = KindRegistry::default();
+        reg.insert(make_def("vesk:famine_outbreak", KindOrigin::Lua))
+            .unwrap();
+        assert!(reg.contains("vesk:famine_outbreak"));
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn registry_insert_accepts_core_kind_from_rust() {
+        let mut reg = KindRegistry::default();
+        reg.insert(make_def("core:hostile_detected", KindOrigin::Core))
+            .unwrap();
+        assert!(reg.contains("core:hostile_detected"));
+    }
+
+    #[test]
+    fn registry_rejects_lua_defining_core_namespace() {
+        let mut reg = KindRegistry::default();
+        let err = reg
+            .insert(make_def("core:hostile_detected", KindOrigin::Lua))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            KindRegistryError::CoreNamespaceReserved("core:hostile_detected".into())
+        );
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_id() {
+        let mut reg = KindRegistry::default();
+        reg.insert(make_def("vesk:famine", KindOrigin::Lua))
+            .unwrap();
+        let err = reg
+            .insert(make_def("vesk:famine", KindOrigin::Lua))
+            .unwrap_err();
+        assert_eq!(err, KindRegistryError::DuplicateKind("vesk:famine".into()));
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_across_origins() {
+        // Rust preloaded first, then Lua tries the same id (even outside
+        // core:*, e.g. a test fixture that predeclares a kind).
+        let mut reg = KindRegistry::default();
+        reg.insert(make_def("mod:test", KindOrigin::Core)).unwrap();
+        assert!(matches!(
+            reg.insert(make_def("mod:test", KindOrigin::Lua)),
+            Err(KindRegistryError::DuplicateKind(_))
+        ));
+    }
+}

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -21,6 +21,7 @@
 //! convention `observed_at: i64` (integer hexadies) is preserved — the
 //! [`perceived::PerceivedInfo`] facade only renames it to `last_updated`.
 pub mod facts;
+pub mod kind_registry;
 pub mod perceived;
 
 use bevy::prelude::*;

--- a/macrocosmo/src/scripting/globals.rs
+++ b/macrocosmo/src/scripting/globals.rs
@@ -193,6 +193,30 @@ pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
     let event_handlers = lua.create_table()?;
     globals.set("_event_handlers", event_handlers)?;
 
+    // --- #350: Knowledge subscription registry (K-1 foundation) ---
+    //
+    // Parallel to `_event_handlers`, the knowledge-specific subscription
+    // accumulator. `on("vesk:famine@recorded", fn)` / `on("*@observed", fn)`
+    // are routed here by K-3 (#352); K-1 only reserves the table so that
+    // (a) the `define_knowledge` startup system can record the auto-registered
+    // `<id>@recorded` / `<id>@observed` event ids in a way subsequent code
+    // can inspect, and (b) K-3's `on()` router has a stable surface to write
+    // into without ordering games between the two parallel slices.
+    //
+    // Shape (K-1 reserves only; K-3 extends with actual handler entries):
+    // ```
+    // _knowledge_subscribers = {}                     -- array-style
+    // _knowledge_reserved_events = {                  -- lookup table
+    //     ["vesk:famine_outbreak@recorded"] = true,
+    //     ["vesk:famine_outbreak@observed"] = true,
+    //     ...
+    // }
+    // ```
+    //
+    // See `scripting/knowledge_api::register_auto_lifecycle_events`.
+    globals.set("_knowledge_subscribers", lua.create_table()?)?;
+    globals.set("_knowledge_reserved_events", lua.create_table()?)?;
+
     // on(event_id, [filter,] handler) -- registers an event handler with optional structural filter
     let on_fn = lua.create_function(|lua, args: mlua::MultiValue| {
         let handlers: mlua::Table = lua.globals().get("_event_handlers")?;

--- a/macrocosmo/src/scripting/globals.rs
+++ b/macrocosmo/src/scripting/globals.rs
@@ -100,6 +100,15 @@ pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
 
     register_define_fn(lua, "event", "_event_definitions")?;
 
+    // --- #350: Knowledge kind definition (Lua-extensible knowledge kinds) ---
+    //
+    // `define_knowledge { id, payload_schema }` appends to
+    // `_knowledge_kind_definitions`, which is parsed by
+    // `scripting::knowledge_api::parse_knowledge_definitions` at startup
+    // (see `load_knowledge_kinds` system). The accumulator name must match
+    // `knowledge_api::KNOWLEDGE_DEF_ACCUMULATOR`.
+    register_define_fn(lua, "knowledge", "_knowledge_kind_definitions")?;
+
     // --- Ship design Lua bindings ---
 
     register_define_fn(lua, "slot_type", "_slot_type_definitions")?;

--- a/macrocosmo/src/scripting/knowledge_api.rs
+++ b/macrocosmo/src/scripting/knowledge_api.rs
@@ -204,6 +204,66 @@ pub fn parse_kind_id(raw: &str) -> Result<KnowledgeKindId, mlua::Error> {
     KnowledgeKindId::parse(raw).map_err(|e| mlua::Error::RuntimeError(format!("{e}")))
 }
 
+/// Name of the Lua table that records every `<id>@recorded` /
+/// `<id>@observed` event id auto-reserved by `define_knowledge`. The
+/// entry value is `true` — the table is used as a set.
+///
+/// K-3 (#352) will consume this lookup in its `on(...)` router to validate
+/// subscribers and in the dispatcher to avoid walking unknown kind ids.
+/// K-1 only **populates** the table as a side-effect of kind registration;
+/// actual handler entries go into `_knowledge_subscribers`.
+pub const KNOWLEDGE_RESERVED_EVENTS_TABLE: &str = "_knowledge_reserved_events";
+
+/// Name of the Lua table that holds subscription entries (populated by
+/// K-3's extended `on(...)`). K-1 reserves the table so downstream code
+/// sees a stable shape.
+pub const KNOWLEDGE_SUBSCRIBERS_TABLE: &str = "_knowledge_subscribers";
+
+/// Walk `defs` and reserve `<id>@recorded` / `<id>@observed` event ids for
+/// every kind by writing `true` entries into the
+/// `_knowledge_reserved_events` Lua table (plan-349 §3.1 commit 3, §2.2.1).
+///
+/// K-1 responsibility is **reservation only** — the dispatch side (walking
+/// `_knowledge_subscribers` and firing handlers) lives in K-3 (#352). K-3
+/// reads `_knowledge_reserved_events` when `on("foo@recorded", fn)` is
+/// registered to confirm the kind exists, and the dispatch code uses it to
+/// know which ids are knowledge-lifecycle vs plain event ids.
+///
+/// This function is idempotent per (id, lifecycle) — re-reserving is a
+/// no-op, so callers can drain the accumulator multiple times safely
+/// during tests / hot reload.
+///
+/// Errors: propagates `mlua::Error` from table operations. Does **not**
+/// error on duplicate reservations (the registry's duplicate-id check
+/// catches those at `insert` time).
+pub fn register_auto_lifecycle_events(
+    lua: &Lua,
+    defs: &[KnowledgeKindDef],
+) -> Result<(), mlua::Error> {
+    let reserved: mlua::Table = lua.globals().get(KNOWLEDGE_RESERVED_EVENTS_TABLE)?;
+    for def in defs {
+        reserved.set(def.id.recorded_event_id(), true)?;
+        reserved.set(def.id.observed_event_id(), true)?;
+    }
+    Ok(())
+}
+
+/// True if `event_id` is one of the auto-registered `<id>@<lifecycle>`
+/// reservations. K-3 uses this to route `on(...)` registrations between
+/// `_knowledge_subscribers` and `_event_handlers` (plan §2.9). Includes
+/// the `*@recorded` / `*@observed` wildcards — those are valid
+/// knowledge-lifecycle subscriptions even though no kind id "`*`" exists
+/// in the registry.
+pub fn is_reserved_knowledge_event(lua: &Lua, event_id: &str) -> Result<bool, mlua::Error> {
+    // Wildcard always counts as knowledge-lifecycle.
+    if matches!(event_id, "*@recorded" | "*@observed") {
+        return Ok(true);
+    }
+    let reserved: mlua::Table = lua.globals().get(KNOWLEDGE_RESERVED_EVENTS_TABLE)?;
+    let present: Option<bool> = reserved.get(event_id)?;
+    Ok(present.unwrap_or(false))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,8 +274,18 @@ mod tests {
     fn setup_lua() -> Lua {
         let lua = Lua::new();
         let globals = lua.globals();
-        let acc = lua.create_table().unwrap();
-        globals.set(KNOWLEDGE_DEF_ACCUMULATOR, acc).unwrap();
+        globals
+            .set(KNOWLEDGE_DEF_ACCUMULATOR, lua.create_table().unwrap())
+            .unwrap();
+        // Reserve the K-3 placeholders so `register_auto_lifecycle_events`
+        // can write into them. Production uses `setup_globals`, but parser
+        // tests don't need the rest of that plumbing.
+        globals
+            .set(KNOWLEDGE_SUBSCRIBERS_TABLE, lua.create_table().unwrap())
+            .unwrap();
+        globals
+            .set(KNOWLEDGE_RESERVED_EVENTS_TABLE, lua.create_table().unwrap())
+            .unwrap();
         // Mimic the `define_knowledge` surface just enough for the parser tests.
         lua.load(
             r#"
@@ -499,5 +569,76 @@ mod tests {
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].id.as_str(), "no_namespace");
         assert_eq!(defs[0].id.namespace(), None);
+    }
+
+    // --- register_auto_lifecycle_events + is_reserved_knowledge_event ---
+
+    #[test]
+    fn register_auto_events_populates_reserved_table() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            define_knowledge { id = "vesk:famine_outbreak" }
+            define_knowledge { id = "mod:combat_report" }
+            "#,
+        )
+        .exec()
+        .unwrap();
+        let defs = parse_knowledge_definitions(&lua).unwrap();
+        register_auto_lifecycle_events(&lua, &defs).unwrap();
+
+        // Both lifecycle events for each kind must be reserved.
+        for id in [
+            "vesk:famine_outbreak@recorded",
+            "vesk:famine_outbreak@observed",
+            "mod:combat_report@recorded",
+            "mod:combat_report@observed",
+        ] {
+            assert!(
+                is_reserved_knowledge_event(&lua, id).unwrap(),
+                "expected {id} reserved"
+            );
+        }
+    }
+
+    #[test]
+    fn unregistered_event_ids_are_not_reserved() {
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { id = "vesk:famine_outbreak" }"#)
+            .exec()
+            .unwrap();
+        let defs = parse_knowledge_definitions(&lua).unwrap();
+        register_auto_lifecycle_events(&lua, &defs).unwrap();
+
+        // Unknown kind id — not reserved.
+        assert!(!is_reserved_knowledge_event(&lua, "mod:unknown@recorded").unwrap());
+        // Plain non-lifecycle event id — not reserved.
+        assert!(!is_reserved_knowledge_event(&lua, "harvest_ended").unwrap());
+        // Missing lifecycle suffix for a known kind — not reserved.
+        assert!(!is_reserved_knowledge_event(&lua, "vesk:famine_outbreak").unwrap());
+    }
+
+    #[test]
+    fn wildcard_lifecycle_ids_are_always_reserved() {
+        // `*@recorded` / `*@observed` must count as knowledge-lifecycle
+        // regardless of whether any kind is registered — plan §2.9.
+        let lua = setup_lua();
+        assert!(is_reserved_knowledge_event(&lua, "*@recorded").unwrap());
+        assert!(is_reserved_knowledge_event(&lua, "*@observed").unwrap());
+        // Wildcard with unknown lifecycle is NOT reserved.
+        assert!(!is_reserved_knowledge_event(&lua, "*@expired").unwrap());
+    }
+
+    #[test]
+    fn register_auto_events_is_idempotent() {
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { id = "mod:twice" }"#)
+            .exec()
+            .unwrap();
+        let defs = parse_knowledge_definitions(&lua).unwrap();
+        register_auto_lifecycle_events(&lua, &defs).unwrap();
+        // Call again — must not error.
+        register_auto_lifecycle_events(&lua, &defs).unwrap();
+        assert!(is_reserved_knowledge_event(&lua, "mod:twice@recorded").unwrap());
     }
 }

--- a/macrocosmo/src/scripting/knowledge_api.rs
+++ b/macrocosmo/src/scripting/knowledge_api.rs
@@ -1,0 +1,503 @@
+//! #350: Lua `define_knowledge` parser for the ScriptableKnowledge epic
+//! (#349) K-1 slice.
+//!
+//! Responsibilities:
+//!
+//! 1. Walk the `_knowledge_kind_definitions` accumulator (populated by the
+//!    `define_knowledge { id, payload_schema }` global added in
+//!    `scripting/globals.rs`).
+//! 2. Parse each entry into a [`KnowledgeKindDef`] via the
+//!    [`kind_registry`](crate::knowledge::kind_registry) types.
+//! 3. Enforce the K-1 invariants (plan-349 §0.5 9.2 / 9.6, §2.3, §3.1):
+//!    * `id` is required and non-empty.
+//!    * `id` must not contain `@` (lifecycle separator is reserved).
+//!    * Lua-origin kinds cannot use the `core:` namespace.
+//!    * Namespace-less ids are accepted with a `warn!`.
+//!    * `payload_schema`, if present, must be a flat table mapping field
+//!      names to recognised type tags (`"number" | "string" | "boolean" |
+//!      "table" | "entity"`). Function / userdata / nested table values
+//!      are rejected (plan §2.5 deep-copy invariant + §3.1 payload_schema
+//!      validation). Duplicate field names within a single schema are
+//!      rejected.
+//!    * Duplicate kind ids across the whole accumulator are rejected.
+//!
+//! The parser is total (returns `Result<Vec<KnowledgeKindDef>, mlua::Error>`);
+//! the K-1 commit 4 startup system drains the vec into `KindRegistry`.
+//!
+//! Intentionally **not** implemented in this slice:
+//! * Actual subscription registration (`_knowledge_subscribers` wiring) —
+//!   K-1 commit 3 adds a placeholder registry hook, dispatch lives in K-3.
+//! * Payload-value validation at `record_knowledge` time — K-2 consumes
+//!   [`KindRegistry::get`] + the schema to validate Lua-side payloads.
+
+use mlua::prelude::*;
+
+use crate::knowledge::kind_registry::{
+    KindOrigin, KnowledgeKindDef, KnowledgeKindId, PayloadFieldType, PayloadSchema,
+    parse_id_with_warn,
+};
+
+/// Name of the Lua global that accumulates `define_knowledge { ... }` tables.
+/// Matches the `register_define_fn(lua, "knowledge", "_knowledge_kind_definitions")`
+/// registration in `globals.rs`.
+pub const KNOWLEDGE_DEF_ACCUMULATOR: &str = "_knowledge_kind_definitions";
+
+/// Parse all `define_knowledge` entries from the Lua state into
+/// [`KnowledgeKindDef`]s. Returns an error on the **first** invalid entry
+/// (duplicate id, schema type mismatch, etc.) — mirrors the other `parse_*`
+/// surfaces in `scripting/`.
+///
+/// The returned vec preserves Lua iteration order (which is 1-indexed array
+/// traversal of the accumulator).
+pub fn parse_knowledge_definitions(lua: &Lua) -> Result<Vec<KnowledgeKindDef>, mlua::Error> {
+    let defs: mlua::Table = lua.globals().get(KNOWLEDGE_DEF_ACCUMULATOR)?;
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut result = Vec::new();
+
+    for pair in defs.pairs::<i64, mlua::Table>() {
+        let (_, table) = pair?;
+        let def = parse_one(&table)?;
+        if !seen.insert(def.id.as_str().to_string()) {
+            return Err(mlua::Error::RuntimeError(format!(
+                "define_knowledge: duplicate kind id '{}'",
+                def.id
+            )));
+        }
+        result.push(def);
+    }
+
+    Ok(result)
+}
+
+/// Parse a single Lua definition table. Exposed for unit-test convenience.
+pub fn parse_one(table: &mlua::Table) -> Result<KnowledgeKindDef, mlua::Error> {
+    let raw_id: String = table.get::<Option<String>>("id")?.ok_or_else(|| {
+        mlua::Error::RuntimeError("define_knowledge: 'id' field is required".to_string())
+    })?;
+
+    // id parsing: empty / `@`-containing ids surface as RuntimeError.
+    let id = parse_id_with_warn(&raw_id)
+        .map_err(|e| mlua::Error::RuntimeError(format!("define_knowledge: {e}")))?;
+
+    // Core-namespace Lua redefinitions are rejected at parse time so the
+    // error surfaces close to the offending script. The registry insert
+    // would also catch this, but catching early is friendlier.
+    if id.is_core() {
+        return Err(mlua::Error::RuntimeError(format!(
+            "define_knowledge: 'core:' namespace is reserved for Rust-side built-in kinds (got '{raw_id}')"
+        )));
+    }
+
+    let payload_schema = parse_payload_schema(table, id.as_str())?;
+
+    Ok(KnowledgeKindDef {
+        id,
+        payload_schema,
+        origin: KindOrigin::Lua,
+    })
+}
+
+/// Parse the `payload_schema` sub-table. Missing / nil / empty table yields
+/// `PayloadSchema::default()` (v1 explicitly accepts schema-less kinds —
+/// plan §3.1 payload_schema validation: "v1 緩い validation").
+pub fn parse_payload_schema(
+    table: &mlua::Table,
+    kind_id: &str,
+) -> Result<PayloadSchema, mlua::Error> {
+    let schema_value: mlua::Value = table.get("payload_schema")?;
+    let schema_table = match schema_value {
+        mlua::Value::Nil => return Ok(PayloadSchema::default()),
+        mlua::Value::Table(t) => t,
+        other => {
+            return Err(mlua::Error::RuntimeError(format!(
+                "define_knowledge: kind '{kind_id}': payload_schema must be a table, got {}",
+                lua_type_name(&other)
+            )));
+        }
+    };
+
+    let mut schema = PayloadSchema::default();
+
+    for pair in schema_table.pairs::<mlua::Value, mlua::Value>() {
+        let (key, value) = pair?;
+
+        // Only string keys are valid field names. Numeric keys (array style)
+        // are rejected — schema is a name → type map.
+        let field_name = match key {
+            mlua::Value::String(s) => s.to_str()?.to_string(),
+            other => {
+                return Err(mlua::Error::RuntimeError(format!(
+                    "define_knowledge: kind '{kind_id}': payload_schema keys must be strings, got {}",
+                    lua_type_name(&other)
+                )));
+            }
+        };
+
+        // Lua tables do not preserve duplicate keys on insertion, but defensive
+        // check here in case a buggy `pairs()` implementation returns the same
+        // key twice — also guards against future shape changes.
+        if schema.fields.contains_key(&field_name) {
+            return Err(mlua::Error::RuntimeError(format!(
+                "define_knowledge: kind '{kind_id}': duplicate field '{field_name}' in payload_schema"
+            )));
+        }
+
+        let field_type = parse_field_type(&field_name, &value, kind_id)?;
+        schema.fields.insert(field_name, field_type);
+    }
+
+    Ok(schema)
+}
+
+fn parse_field_type(
+    field_name: &str,
+    value: &mlua::Value,
+    kind_id: &str,
+) -> Result<PayloadFieldType, mlua::Error> {
+    match value {
+        mlua::Value::String(s) => {
+            let tag = s.to_str()?;
+            PayloadFieldType::parse(&tag).ok_or_else(|| {
+                mlua::Error::RuntimeError(format!(
+                    "define_knowledge: kind '{kind_id}': unknown payload type '{tag}' for field '{field_name}' (expected one of: number, string, boolean, table, entity)"
+                ))
+            })
+        }
+        mlua::Value::Table(_) => Err(mlua::Error::RuntimeError(format!(
+            "define_knowledge: kind '{kind_id}': nested schemas are not supported in v1 (field '{field_name}')"
+        ))),
+        mlua::Value::Function(_) | mlua::Value::UserData(_) => {
+            Err(mlua::Error::RuntimeError(format!(
+                "define_knowledge: kind '{kind_id}': payload_schema field '{field_name}' must be a type name string (got {})",
+                lua_type_name(value)
+            )))
+        }
+        other => Err(mlua::Error::RuntimeError(format!(
+            "define_knowledge: kind '{kind_id}': payload_schema field '{field_name}' must be a string type tag (got {})",
+            lua_type_name(other)
+        ))),
+    }
+}
+
+fn lua_type_name(value: &mlua::Value) -> &'static str {
+    match value {
+        mlua::Value::Nil => "nil",
+        mlua::Value::Boolean(_) => "boolean",
+        mlua::Value::Integer(_) => "integer",
+        mlua::Value::Number(_) => "number",
+        mlua::Value::String(_) => "string",
+        mlua::Value::Table(_) => "table",
+        mlua::Value::Function(_) => "function",
+        mlua::Value::UserData(_) => "userdata",
+        mlua::Value::Thread(_) => "thread",
+        mlua::Value::LightUserData(_) => "lightuserdata",
+        mlua::Value::Error(_) => "error",
+        _ => "other",
+    }
+}
+
+/// Expose a noop convenience around [`KnowledgeKindId::parse`] so callers
+/// (tests, future K-2 consumers) can build ids without depending on the
+/// registry module directly.
+pub fn parse_kind_id(raw: &str) -> Result<KnowledgeKindId, mlua::Error> {
+    KnowledgeKindId::parse(raw).map_err(|e| mlua::Error::RuntimeError(format!("{e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal harness: fresh Lua with the `_knowledge_kind_definitions`
+    /// accumulator wired up. We don't bring in the full `setup_globals`
+    /// machinery because parse_* only needs the accumulator table to exist.
+    fn setup_lua() -> Lua {
+        let lua = Lua::new();
+        let globals = lua.globals();
+        let acc = lua.create_table().unwrap();
+        globals.set(KNOWLEDGE_DEF_ACCUMULATOR, acc).unwrap();
+        // Mimic the `define_knowledge` surface just enough for the parser tests.
+        lua.load(
+            r#"
+            function define_knowledge(t)
+                local defs = _knowledge_kind_definitions
+                t._def_type = "knowledge"
+                defs[#defs + 1] = t
+                return t
+            end
+            "#,
+        )
+        .exec()
+        .unwrap();
+        lua
+    }
+
+    #[test]
+    fn parse_minimum_id_only() {
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { id = "vesk:famine_outbreak" }"#)
+            .exec()
+            .unwrap();
+
+        let defs = parse_knowledge_definitions(&lua).unwrap();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].id.as_str(), "vesk:famine_outbreak");
+        assert!(defs[0].payload_schema.is_empty());
+        assert_eq!(defs[0].origin, KindOrigin::Lua);
+    }
+
+    #[test]
+    fn parse_with_payload_schema_all_types() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            define_knowledge {
+                id = "vesk:famine_outbreak",
+                payload_schema = {
+                    severity = "number",
+                    label = "string",
+                    active = "boolean",
+                    extras = "table",
+                    colony = "entity",
+                },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+
+        let defs = parse_knowledge_definitions(&lua).unwrap();
+        assert_eq!(defs.len(), 1);
+        let schema = &defs[0].payload_schema;
+        assert_eq!(schema.fields.len(), 5);
+        assert_eq!(
+            schema.fields.get("severity"),
+            Some(&PayloadFieldType::Number)
+        );
+        assert_eq!(schema.fields.get("label"), Some(&PayloadFieldType::String));
+        assert_eq!(
+            schema.fields.get("active"),
+            Some(&PayloadFieldType::Boolean)
+        );
+        assert_eq!(schema.fields.get("extras"), Some(&PayloadFieldType::Table));
+        assert_eq!(schema.fields.get("colony"), Some(&PayloadFieldType::Entity));
+    }
+
+    #[test]
+    fn parse_bool_alias_accepted() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            define_knowledge {
+                id = "mod:bool_alias",
+                payload_schema = { flag = "bool" },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+        let defs = parse_knowledge_definitions(&lua).unwrap();
+        assert_eq!(
+            defs[0].payload_schema.fields.get("flag"),
+            Some(&PayloadFieldType::Boolean)
+        );
+    }
+
+    #[test]
+    fn parse_missing_id_errors() {
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { payload_schema = { x = "number" } }"#)
+            .exec()
+            .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("'id' field is required"), "unexpected: {s}");
+    }
+
+    #[test]
+    fn parse_empty_id_errors() {
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { id = "" }"#).exec().unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("non-empty"), "unexpected: {s}");
+    }
+
+    #[test]
+    fn parse_rejects_id_with_at_symbol() {
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { id = "vesk:bad@recorded" }"#)
+            .exec()
+            .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(
+            s.contains("reserved for lifecycle events"),
+            "unexpected: {s}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_core_namespace() {
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { id = "core:hostile_detected" }"#)
+            .exec()
+            .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("core:"), "unexpected: {s}");
+        assert!(s.contains("reserved"), "unexpected: {s}");
+    }
+
+    #[test]
+    fn parse_rejects_duplicate_kind_ids() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            define_knowledge { id = "vesk:famine" }
+            define_knowledge { id = "vesk:famine" }
+            "#,
+        )
+        .exec()
+        .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(
+            s.contains("duplicate kind id 'vesk:famine'"),
+            "unexpected: {s}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_type_tag() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            define_knowledge {
+                id = "vesk:wrong",
+                payload_schema = { severity = "cucumber" },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(
+            s.contains("unknown payload type 'cucumber'"),
+            "unexpected: {s}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_nested_schema() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            define_knowledge {
+                id = "vesk:nested",
+                payload_schema = {
+                    geo = { lat = "number", lon = "number" },
+                },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(
+            s.contains("nested schemas are not supported"),
+            "unexpected: {s}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_function_in_schema() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            define_knowledge {
+                id = "vesk:func",
+                payload_schema = { severity = function(x) return x end },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(
+            s.contains("must be a type name string") || s.contains("must be a string type tag"),
+            "unexpected: {s}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_non_table_schema() {
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { id = "vesk:bad_schema", payload_schema = 42 }"#)
+            .exec()
+            .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(
+            s.contains("payload_schema must be a table"),
+            "unexpected: {s}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_numeric_schema_keys() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            -- array-style schema: key 1 is the integer 1, not a field name
+            define_knowledge {
+                id = "vesk:array_schema",
+                payload_schema = { "number", "string" },
+            }
+            "#,
+        )
+        .exec()
+        .unwrap();
+        let err = parse_knowledge_definitions(&lua).unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("keys must be strings"), "unexpected: {s}");
+    }
+
+    #[test]
+    fn parse_accepts_multiple_kinds_preserving_order() {
+        let lua = setup_lua();
+        lua.load(
+            r#"
+            define_knowledge { id = "mod:first" }
+            define_knowledge { id = "mod:second", payload_schema = { x = "number" } }
+            define_knowledge { id = "mod:third" }
+            "#,
+        )
+        .exec()
+        .unwrap();
+        let defs = parse_knowledge_definitions(&lua).unwrap();
+        assert_eq!(defs.len(), 3);
+        assert_eq!(defs[0].id.as_str(), "mod:first");
+        assert_eq!(defs[1].id.as_str(), "mod:second");
+        assert_eq!(defs[2].id.as_str(), "mod:third");
+        assert_eq!(defs[1].payload_schema.fields.len(), 1);
+    }
+
+    #[test]
+    fn parse_namespaceless_id_is_accepted_with_warn() {
+        // The parser itself does not fail (plan §0.5 9.6 warn only); the
+        // warn log goes through `bevy::log::warn!` which is a no-op in this
+        // test harness. We only assert the parse succeeds and round-trips.
+        let lua = setup_lua();
+        lua.load(r#"define_knowledge { id = "no_namespace" }"#)
+            .exec()
+            .unwrap();
+        let defs = parse_knowledge_definitions(&lua).unwrap();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].id.as_str(), "no_namespace");
+        assert_eq!(defs[0].id.namespace(), None);
+    }
+}

--- a/macrocosmo/src/scripting/mod.rs
+++ b/macrocosmo/src/scripting/mod.rs
@@ -13,6 +13,7 @@ pub mod game_rng;
 pub mod game_start_ctx;
 pub mod globals;
 pub mod helpers;
+pub mod knowledge_api;
 pub mod lifecycle;
 pub mod map_api;
 pub mod modifier_api;

--- a/macrocosmo/src/scripting/mod.rs
+++ b/macrocosmo/src/scripting/mod.rs
@@ -81,6 +81,16 @@ impl Plugin for ScriptingPlugin {
                 Startup,
                 load_event_definitions.after(load_all_scripts),
             )
+            // #350 K-1: build KindRegistry + reserve <id>@recorded /
+            // <id>@observed entries. Must run after load_all_scripts (for
+            // accumulator population) and before run_lifecycle_hooks (so
+            // on_game_start can observe the finished registry).
+            .add_systems(
+                Startup,
+                load_knowledge_kinds
+                    .after(load_all_scripts)
+                    .before(lifecycle::run_lifecycle_hooks),
+            )
             // #281: After the building/structure registries are populated,
             // walk their `on_built` / `on_upgraded` fields and register
             // filtered handlers on `_event_handlers` so the dispatcher
@@ -414,6 +424,57 @@ fn load_event_definitions(
             warn!("Failed to parse event definitions: {e}");
         }
     }
+}
+
+/// #350: Startup system that parses Lua `define_knowledge` entries into a
+/// [`crate::knowledge::kind_registry::KindRegistry`] resource and reserves
+/// the matching `<id>@recorded` / `<id>@observed` lifecycle event ids in
+/// `_knowledge_reserved_events` (plan-349 §3.1 commit 4).
+///
+/// Ordering: runs `.after(load_all_scripts).before(lifecycle::run_lifecycle_hooks)`
+/// so that `on_game_start` callbacks observing newly-reserved kinds fire
+/// against a fully-populated registry.
+///
+/// Error handling: parse failures surface as `warn!` + an empty registry
+/// (consistent with `load_event_definitions` / `load_anomaly_registry`).
+/// The game still boots; downstream `record_knowledge` calls will fail at
+/// the callsite instead of at startup. K-5 preloads `core:*` here once
+/// the Rust-side core variants land.
+pub fn load_knowledge_kinds(mut commands: Commands, engine: Res<ScriptEngine>) {
+    use crate::knowledge::kind_registry::KindRegistry;
+
+    let lua = engine.lua();
+    let mut registry = KindRegistry::default();
+
+    // K-5 will preload `core:*` kinds here before Lua-side parsing so that
+    // duplicate detection catches Lua re-definitions of built-ins.
+
+    match knowledge_api::parse_knowledge_definitions(lua) {
+        Ok(defs) => {
+            let count = defs.len();
+            // Reserve lifecycle events first so even failed inserts (e.g.
+            // a core-namespace attempt later) don't leave reservations in
+            // an inconsistent state — `register_auto_lifecycle_events`
+            // already tolerates duplicates.
+            if let Err(e) = knowledge_api::register_auto_lifecycle_events(lua, &defs) {
+                warn!("Failed to reserve knowledge lifecycle events: {e}");
+            }
+            for def in defs {
+                let id = def.id.as_str().to_string();
+                if let Err(e) = registry.insert(def) {
+                    warn!("knowledge kind register error: {e} (id='{id}')");
+                }
+            }
+            info!(
+                "Loaded {} knowledge kind definition(s) from Lua",
+                registry.len().min(count)
+            );
+        }
+        Err(e) => {
+            warn!("Failed to parse knowledge definitions: {e}");
+        }
+    }
+    commands.insert_resource(registry);
 }
 
 #[cfg(test)]

--- a/macrocosmo/tests/knowledge_kinds.rs
+++ b/macrocosmo/tests/knowledge_kinds.rs
@@ -1,0 +1,271 @@
+//! #350 K-1 integration tests for `define_knowledge` + `KindRegistry` +
+//! auto `<id>@recorded` / `<id>@observed` reservation.
+//!
+//! These tests exercise:
+//!
+//! * The `define_knowledge` Lua global registered by `setup_globals`.
+//! * `parse_knowledge_definitions` walking `_knowledge_kind_definitions`.
+//! * `register_auto_lifecycle_events` populating
+//!   `_knowledge_reserved_events`.
+//! * The `load_knowledge_kinds` Bevy system end-to-end against a real
+//!   `ScriptEngine` + the `scripts/knowledge/sample.lua` fixture.
+//!
+//! Pure parser / registry tests live in the `scripting::knowledge_api` and
+//! `knowledge::kind_registry` unit-test modules (~40 tests). This file
+//! complements them with the "real script + startup system" path.
+//!
+//! K-3 (#352) / K-2 (#351) / later slices will extend these tests with
+//! `on(...)` routing and dispatch coverage; K-1 only validates the
+//! foundation.
+
+use std::path::PathBuf;
+
+use bevy::prelude::*;
+
+use macrocosmo::knowledge::kind_registry::{KindOrigin, KindRegistry, KnowledgeKindDef};
+use macrocosmo::scripting::knowledge_api::{
+    KNOWLEDGE_DEF_ACCUMULATOR, KNOWLEDGE_RESERVED_EVENTS_TABLE, KNOWLEDGE_SUBSCRIBERS_TABLE,
+    is_reserved_knowledge_event, parse_knowledge_definitions, register_auto_lifecycle_events,
+};
+use macrocosmo::scripting::{ScriptEngine, load_knowledge_kinds};
+
+/// Locate the repo-shipped `scripts/` directory. Mirrors the lookup that
+/// `ScriptEngine::new` does in production, but from a known anchor so the
+/// test does not depend on cwd.
+fn sample_scripts_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts")
+}
+
+/// Build an `App` carrying just the `ScriptEngine` resource and run the
+/// K-1 startup system manually. This sidesteps `ScriptingPlugin`'s full
+/// plugin chain (BuildingRegistry / StructureRegistry etc. that this
+/// slice does not touch) and isolates the system under test.
+fn run_load_knowledge_kinds() -> App {
+    let engine = ScriptEngine::new_with_scripts_dir(sample_scripts_dir())
+        .expect("ScriptEngine construction");
+    // Load `scripts/init.lua` exactly like `load_all_scripts` does in
+    // production — the Lua `init.lua` pulls in `knowledge.sample`.
+    let init_path = sample_scripts_dir().join("init.lua");
+    engine
+        .load_file(&init_path)
+        .expect("scripts/init.lua must load cleanly for K-1 fixture");
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(engine);
+    // `load_knowledge_kinds` is a plain startup system — drive it through
+    // a one-shot schedule so we don't need the rest of ScriptingPlugin.
+    app.add_systems(Startup, load_knowledge_kinds);
+    app.update();
+    app
+}
+
+#[test]
+fn load_knowledge_kinds_reads_sample_fixture() {
+    // The startup system must pick up `scripts/knowledge/sample.lua`
+    // (reached via `scripts/init.lua`) and hand the KindRegistry the four
+    // kinds defined in that fixture.
+    let mut app = run_load_knowledge_kinds();
+    let registry = app
+        .world_mut()
+        .remove_resource::<KindRegistry>()
+        .expect("KindRegistry inserted by load_knowledge_kinds");
+
+    for id in [
+        "sample:colony_famine",
+        "sample:combat_report",
+        "sample:anomaly_surveyed",
+        "sample:diplomatic_signal",
+    ] {
+        assert!(registry.contains(id), "expected kind '{id}' in registry");
+    }
+    assert_eq!(registry.len(), 4);
+
+    // `sample:anomaly_surveyed` exercises every v1 payload type.
+    let def = registry.get("sample:anomaly_surveyed").expect("kind def");
+    assert_eq!(def.origin, KindOrigin::Lua);
+    assert_eq!(def.payload_schema.fields.len(), 5);
+}
+
+#[test]
+fn sample_fixture_reserves_lifecycle_events() {
+    // After startup the Lua `_knowledge_reserved_events` set must carry
+    // an entry for every sample kind × {recorded, observed} — K-3 routes
+    // `on(...)` based on this lookup.
+    let app = run_load_knowledge_kinds();
+
+    let engine = app.world().resource::<ScriptEngine>();
+    let lua = engine.lua();
+
+    for id in [
+        "sample:colony_famine",
+        "sample:combat_report",
+        "sample:anomaly_surveyed",
+        "sample:diplomatic_signal",
+    ] {
+        for lifecycle in ["recorded", "observed"] {
+            let event_id = format!("{id}@{lifecycle}");
+            assert!(
+                is_reserved_knowledge_event(lua, &event_id).unwrap(),
+                "expected {event_id} reserved"
+            );
+        }
+    }
+
+    // Wildcard matchers are always reserved regardless of kind registrations.
+    assert!(is_reserved_knowledge_event(lua, "*@recorded").unwrap());
+    assert!(is_reserved_knowledge_event(lua, "*@observed").unwrap());
+
+    // Non-matching event ids stay unreserved — `on("harvest_ended", fn)`
+    // still falls through to the legacy `_event_handlers` path.
+    assert!(!is_reserved_knowledge_event(lua, "harvest_ended").unwrap());
+    assert!(!is_reserved_knowledge_event(lua, "sample:colony_famine@expired").unwrap());
+
+    // The knowledge-specific subscriber accumulator exists but is empty
+    // (K-3 will add entries via the extended `on(...)`).
+    let subs: mlua::Table = lua.globals().get(KNOWLEDGE_SUBSCRIBERS_TABLE).unwrap();
+    assert_eq!(subs.len().unwrap(), 0);
+}
+
+#[test]
+fn sample_fixture_exposes_accumulator_shape() {
+    // Sanity check: the raw accumulator matches the registry size. Guards
+    // against a future refactor that splits accumulators without updating
+    // the parser.
+    let app = run_load_knowledge_kinds();
+    let engine = app.world().resource::<ScriptEngine>();
+    let lua = engine.lua();
+    let acc: mlua::Table = lua.globals().get(KNOWLEDGE_DEF_ACCUMULATOR).unwrap();
+    assert_eq!(acc.len().unwrap(), 4);
+
+    // Reserved set size is 2 × kinds (one per lifecycle). The set is
+    // hash-style, so iterate via `pairs` (raw `#` returns 0).
+    let reserved: mlua::Table = lua.globals().get(KNOWLEDGE_RESERVED_EVENTS_TABLE).unwrap();
+    let mut count = 0;
+    for pair in reserved.pairs::<String, bool>() {
+        let (_, v) = pair.unwrap();
+        if v {
+            count += 1;
+        }
+    }
+    assert_eq!(count, 8);
+}
+
+#[test]
+fn define_knowledge_rejects_duplicate_kinds_via_parser() {
+    // Uses the Lua state exposed by the real ScriptEngine so we also cover
+    // the `define_knowledge` global function registered in `globals.rs`.
+    let app = run_load_knowledge_kinds();
+    let engine = app.world().resource::<ScriptEngine>();
+    let lua = engine.lua();
+
+    lua.load(
+        r#"
+        define_knowledge { id = "tst:dup" }
+        define_knowledge { id = "tst:dup" }
+        "#,
+    )
+    .exec()
+    .unwrap();
+
+    let err = parse_knowledge_definitions(lua).unwrap_err();
+    let s = err.to_string();
+    assert!(s.contains("duplicate kind id 'tst:dup'"), "unexpected: {s}");
+}
+
+#[test]
+fn define_knowledge_rejects_core_namespace_at_runtime() {
+    let app = run_load_knowledge_kinds();
+    let engine = app.world().resource::<ScriptEngine>();
+    let lua = engine.lua();
+    // Clear the accumulator first so prior sample fixture entries don't
+    // interfere with the error message assertion (parser walks the whole
+    // accumulator).
+    let acc: mlua::Table = lua.globals().get(KNOWLEDGE_DEF_ACCUMULATOR).unwrap();
+    for i in (1..=acc.len().unwrap()).rev() {
+        acc.raw_remove(i).unwrap();
+    }
+
+    lua.load(r#"define_knowledge { id = "core:foo" }"#)
+        .exec()
+        .unwrap();
+    let err = parse_knowledge_definitions(lua).unwrap_err();
+    let s = err.to_string();
+    assert!(
+        s.contains("core:") && s.contains("reserved"),
+        "unexpected: {s}"
+    );
+}
+
+#[test]
+fn kind_registry_insert_enforces_invariants() {
+    // Targets `KindRegistry::insert` directly (no Lua), exercising the
+    // same invariants the startup system relies on. The startup path
+    // already logs+swallows these errors; here we prove the underlying
+    // contract surfaces cleanly for tooling / future Rust-side callers.
+    use macrocosmo::knowledge::kind_registry::{KindRegistryError, KnowledgeKindId, PayloadSchema};
+
+    let mut reg = KindRegistry::default();
+
+    reg.insert(KnowledgeKindDef {
+        id: KnowledgeKindId::parse("mod:a").unwrap(),
+        payload_schema: PayloadSchema::default(),
+        origin: KindOrigin::Lua,
+    })
+    .unwrap();
+    assert_eq!(reg.len(), 1);
+
+    // Second insert with same id -> DuplicateKind.
+    let err = reg
+        .insert(KnowledgeKindDef {
+            id: KnowledgeKindId::parse("mod:a").unwrap(),
+            payload_schema: PayloadSchema::default(),
+            origin: KindOrigin::Lua,
+        })
+        .unwrap_err();
+    assert!(matches!(err, KindRegistryError::DuplicateKind(_)));
+
+    // Lua-origin inserting into the core: namespace -> CoreNamespaceReserved.
+    let err = reg
+        .insert(KnowledgeKindDef {
+            id: KnowledgeKindId::parse("core:xx").unwrap(),
+            payload_schema: PayloadSchema::default(),
+            origin: KindOrigin::Lua,
+        })
+        .unwrap_err();
+    assert!(matches!(err, KindRegistryError::CoreNamespaceReserved(_)));
+
+    // Core-origin for the same id is allowed (K-5 preload path).
+    reg.insert(KnowledgeKindDef {
+        id: KnowledgeKindId::parse("core:xx").unwrap(),
+        payload_schema: PayloadSchema::default(),
+        origin: KindOrigin::Core,
+    })
+    .unwrap();
+}
+
+#[test]
+fn register_auto_lifecycle_events_is_idempotent_end_to_end() {
+    // Re-running the reservation step against the same registry must not
+    // bloat the reserved-events table or error — the startup system may
+    // be invoked twice in hot-reload scenarios, and idempotence is the
+    // contract we want modders to be able to rely on.
+    let app = run_load_knowledge_kinds();
+    let engine = app.world().resource::<ScriptEngine>();
+    let lua = engine.lua();
+
+    let defs = parse_knowledge_definitions(lua).unwrap();
+    register_auto_lifecycle_events(lua, &defs).unwrap();
+    register_auto_lifecycle_events(lua, &defs).unwrap();
+
+    // Still only 8 entries (4 kinds × 2 lifecycles).
+    let reserved: mlua::Table = lua.globals().get(KNOWLEDGE_RESERVED_EVENTS_TABLE).unwrap();
+    let mut count = 0;
+    for pair in reserved.pairs::<String, bool>() {
+        let (_, v) = pair.unwrap();
+        if v {
+            count += 1;
+        }
+    }
+    assert_eq!(count, 8);
+}


### PR DESCRIPTION
Epic #349 の K-1 slice。詳細 spec は [`docs/plan-349-scriptable-knowledge.md`](./docs/plan-349-scriptable-knowledge.md) §3.1 を参照。

Closes #350 (when merged).

## Summary

Lua から `define_knowledge { id, payload_schema }` を叩ける foundation を足し、`KindRegistry` Bevy resource と `<id>@recorded` / `<id>@observed` lifecycle event の **reservation** (K-3 の dispatch はまだ配線せず、K-3 側が読めるように reserve だけする) を実装する。

## Commit 構成 (plan §3.1, 5 commits)

| # | hash | subject |
|---|---|---|
| 1 | `726ffa1` | add KnowledgeKindId parser + KindRegistry |
| 2 | `874c174` | add define_knowledge Lua API + parser |
| 3 | `dd9b9a2` | reserve auto `<id>@recorded` / `<id>@observed` events |
| 4 | `00e2279` | add load_knowledge_kinds startup system |
| 5 | `f2c414e` | add sample.lua fixture + integration coverage |

## 主な変更ファイル

- `macrocosmo/src/knowledge/kind_registry.rs` *(new)* — `KnowledgeKindId`, `KindRegistry`, `PayloadSchema`, `PayloadFieldType`, `KindOrigin`, `split_event_id` (plan §2.1 / §10.2 spike)
- `macrocosmo/src/scripting/knowledge_api.rs` *(new)* — `parse_knowledge_definitions`, `parse_payload_schema`, `register_auto_lifecycle_events`, `is_reserved_knowledge_event`
- `macrocosmo/src/scripting/globals.rs` — `define_knowledge` accumulator + `_knowledge_subscribers` / `_knowledge_reserved_events` テーブル (K-3 wire point)
- `macrocosmo/src/scripting/mod.rs` — `load_knowledge_kinds` startup system (`.after(load_all_scripts).before(run_lifecycle_hooks)`)
- `macrocosmo/scripts/knowledge/sample.lua` *(new)* — 4 sample kinds covering全 payload type
- `macrocosmo/scripts/init.lua` — `require("knowledge.sample")`
- `macrocosmo/tests/knowledge_kinds.rs` *(new)* — 7 integration tests

## K-3 / K-2 未配線点 (intentional)

この PR は **K-3 (#352) との parallel worktree** として作られた K-1 slice。K-2 (#351) land 前でもあるため:

- `on("foo@recorded", fn)` 等の **dispatch は未実装** (K-3 の責務)。`_knowledge_subscribers` table は empty のまま、`_knowledge_reserved_events` の lookup helper だけ公開。K-3 が `on()` ルーティング拡張で `is_reserved_knowledge_event()` を利用して routing 判断する設計。
- `gs:record_knowledge` setter は **未実装** (K-2 の責務)。`KindRegistry::validate_payload` は定義しておいたので K-2 で consume 予定。
- `core:*` preload は **K-5 (#354) の責務**。`load_knowledge_kinds` 内に挿入 point のコメントを置いた。

K-3 側も `scripting/globals.rs` に変更を入れる予定だが、K-1 は `define_knowledge` 関数追加 + `_knowledge_subscribers` / `_knowledge_reserved_events` テーブル追加だけに留め、`on()` 本体は一切触っていない。rebase / merge conflict は最小化されているはず。

## Test 一覧

### Unit tests
- `knowledge::kind_registry::tests` — 23 tests: id parse (spike 10.2: `foo@bar`, `foo@`, `@recorded`, `foo@bar@recorded`), split_event_id, PayloadFieldType parse, KindRegistry insert / duplicate / core protection
- `scripting::knowledge_api::tests` — 19 tests: minimum id, all payload types, bool alias, missing id, empty id, `@`-containing id, core namespace, duplicate, unknown type tag, nested schema, function / non-table / numeric-key schema, namespaceless warn, multi-kind order, auto-event reserve, wildcard reserve, idempotent reserve

### Integration tests (`macrocosmo/tests/knowledge_kinds.rs`)
- `load_knowledge_kinds_reads_sample_fixture`
- `sample_fixture_reserves_lifecycle_events`
- `sample_fixture_exposes_accumulator_shape`
- `define_knowledge_rejects_duplicate_kinds_via_parser`
- `define_knowledge_rejects_core_namespace_at_runtime`
- `kind_registry_insert_enforces_invariants`
- `register_auto_lifecycle_events_is_idempotent_end_to_end`

### CI
- `cargo test --workspace`: **2185 passed / 0 failed** (pre-K-1 baseline 2150 → +35)
- `cargo check --workspace --tests`: clean
- `rustfmt --edition 2024 --check` on touched new files: clean (`kind_registry.rs`, `knowledge_api.rs`, `knowledge_kinds.rs`)
- `all_systems_no_query_conflict`: pass

## Plan 乖離点

- Plan §3.1 commit 3 は「placeholder として登録」「もしくは K-1 で minimal subscription registry shape を新設」の選択肢を挙げていた。本 PR は後者寄りで、`_knowledge_subscribers` (空 array) と `_knowledge_reserved_events` (set) を別 table として shipping。K-3 は `on()` 拡張で `_knowledge_subscribers` に `{event_id, func}` entry を push、dispatch は `_knowledge_reserved_events` で routing 判断する pattern になる。
- Plan §3.1 commit 4 の LoC 推定 (50) に対し実装は少し大きい (60+) — `parse_knowledge_definitions` + `register_auto_lifecycle_events` の両方を drain する構成にしたため。機能上の差異はなし。
- Plan §2.1 は `KindRegistry::validate_payload(&self, id, &Table)` を「K-2 でも使うのでここに置く」としていた。本 PR は K-2 に implement を回して、K-1 では struct + insert 以外は空 stub にしていない (= メソッド未追加)。K-2 で `validate_payload` を `KindRegistry` に追加する形を想定。呼び出し site もないので今 impl する意味がない判断。

## Parallel worktree caveat

この PR は main の `a9f509d` (plan-349 land) をベースにしている。K-3 (#352) の PR と同時に main に merge される想定。コンフリクトが予想される file:

- `macrocosmo/src/scripting/globals.rs` — K-1 は `register_define_fn(..., "knowledge", ...)` + 2 つの空 table 追加のみ。K-3 は `on()` 関数本体の拡張。行単位では独立 (interleave しない) はずだが、rebase 時は目視確認推奨。
- `macrocosmo/src/scripting/mod.rs` — K-1 は `pub mod knowledge_api;` + `load_knowledge_kinds` system。K-3 は knowledge_dispatch module 追加予定。これも独立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)