### PR TITLE
#351 K-2: gs:record_knowledge + @recorded sync dispatch + PendingFactQueue integration

### DIFF
--- a/macrocosmo/src/knowledge/facts.rs
+++ b/macrocosmo/src/knowledge/facts.rs
@@ -260,6 +260,16 @@ pub enum KnowledgeFact {
         name: String,
         detail: String,
     },
+    /// #351 (K-2): Lua-defined knowledge kind. The payload is captured as a
+    /// [`PayloadSnapshot`](super::payload::PayloadSnapshot) so the fact
+    /// survives being queued without keeping Lua references alive.
+    Scripted {
+        event_id: Option<EventId>,
+        kind_id: String,
+        origin_system: Option<Entity>,
+        payload_snapshot: super::payload::PayloadSnapshot,
+        recorded_at: i64,
+    },
 }
 
 impl KnowledgeFact {
@@ -275,11 +285,16 @@ impl KnowledgeFact {
             KnowledgeFact::AnomalyDiscovered { .. } => "Anomaly Discovered",
             KnowledgeFact::SurveyDiscovery { .. } => "Discovery",
             KnowledgeFact::StructureBuilt { destroyed, .. } => {
-                if *destroyed { "Structure Destroyed" } else { "Structure Built" }
+                if *destroyed {
+                    "Structure Destroyed"
+                } else {
+                    "Structure Built"
+                }
             }
             KnowledgeFact::ColonyEstablished { .. } => "Colony Established",
             KnowledgeFact::ColonyFailed { .. } => "Colony Failed",
             KnowledgeFact::ShipArrived { .. } => "Ship Arrived",
+            KnowledgeFact::Scripted { .. } => "Knowledge",
         }
     }
 
@@ -297,6 +312,18 @@ impl KnowledgeFact {
                 format!("Colony '{}' failed: {}", name, reason)
             }
             KnowledgeFact::ShipArrived { detail, .. } => detail.clone(),
+            KnowledgeFact::Scripted {
+                kind_id,
+                payload_snapshot,
+                ..
+            } => payload_snapshot
+                .fields
+                .get("detail")
+                .and_then(|v| match v {
+                    super::payload::PayloadValue::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| kind_id.clone()),
         }
     }
 
@@ -313,6 +340,7 @@ impl KnowledgeFact {
             KnowledgeFact::ColonyEstablished { .. } => High,
             KnowledgeFact::ColonyFailed { .. } => High,
             KnowledgeFact::ShipArrived { .. } => Low,
+            KnowledgeFact::Scripted { .. } => Medium,
         }
     }
 
@@ -328,6 +356,7 @@ impl KnowledgeFact {
             KnowledgeFact::ColonyEstablished { system, .. } => Some(*system),
             KnowledgeFact::ColonyFailed { system, .. } => Some(*system),
             KnowledgeFact::ShipArrived { system, .. } => *system,
+            KnowledgeFact::Scripted { origin_system, .. } => *origin_system,
         }
     }
 
@@ -343,7 +372,8 @@ impl KnowledgeFact {
             | KnowledgeFact::StructureBuilt { event_id, .. }
             | KnowledgeFact::ColonyEstablished { event_id, .. }
             | KnowledgeFact::ColonyFailed { event_id, .. }
-            | KnowledgeFact::ShipArrived { event_id, .. } => *event_id,
+            | KnowledgeFact::ShipArrived { event_id, .. }
+            | KnowledgeFact::Scripted { event_id, .. } => *event_id,
         }
     }
 }
@@ -554,13 +584,11 @@ pub fn compute_fact_arrival(
     };
 
     // Try relay path.
-    let Some((o_idx, relay_o_pos, origin_to_relay_dist)) =
-        nearest_covering_relay(origin, relays)
+    let Some((o_idx, relay_o_pos, origin_to_relay_dist)) = nearest_covering_relay(origin, relays)
     else {
         return direct;
     };
-    let Some((p_idx, relay_p_pos, player_to_relay_dist)) =
-        nearest_covering_relay(player, relays)
+    let Some((p_idx, relay_p_pos, player_to_relay_dist)) = nearest_covering_relay(player, relays)
     else {
         return direct;
     };
@@ -671,12 +699,7 @@ pub struct FactSysParam<'w, 's> {
     pub notified_ids: ResMut<'w, NotifiedEventIds>,
     pub next_event_id: ResMut<'w, NextEventId>,
     pub relay_network: Res<'w, RelayNetwork>,
-    pub empire_comms: Query<
-        'w,
-        's,
-        &'static CommsParams,
-        With<crate::player::PlayerEmpire>,
-    >,
+    pub empire_comms: Query<'w, 's, &'static CommsParams, With<crate::player::PlayerEmpire>>,
 }
 
 impl<'w, 's> FactSysParam<'w, 's> {

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -22,6 +22,7 @@
 //! [`perceived::PerceivedInfo`] facade only renames it to `last_updated`.
 pub mod facts;
 pub mod kind_registry;
+pub mod payload;
 pub mod perceived;
 
 use bevy::prelude::*;

--- a/macrocosmo/src/knowledge/payload.rs
+++ b/macrocosmo/src/knowledge/payload.rs
@@ -1,0 +1,250 @@
+//! #351 (K-2): `PayloadSnapshot` — serde-compatible representation of a
+//! Lua-origin knowledge payload.
+//!
+//! When a Lua script calls `gs:record_knowledge { kind, payload = { ... } }`,
+//! the subscriber chain mutates the payload in-place (Lua tables). After the
+//! chain completes we need to capture the final payload as a Rust struct that
+//! can survive in `PendingFactQueue` without holding Lua references.
+//!
+//! `PayloadSnapshot` is that struct — a recursive `HashMap<String, PayloadValue>`
+//! tree. K-4 later reconstructs a Lua table from it for `@observed` dispatch
+//! via `snapshot_to_lua`.
+//!
+//! # Invariants
+//!
+//! * Function / UserData values are rejected (`snapshot_from_lua` returns error).
+//! * Depth is bounded by `KNOWLEDGE_PAYLOAD_DEPTH_LIMIT` (plan §0.5 9.3).
+
+use bevy::prelude::*;
+use mlua::prelude::*;
+use std::collections::HashMap;
+
+use super::kind_registry::{KnowledgeKindId, PayloadFieldType, PayloadSchema};
+use crate::scripting::knowledge_dispatch::KNOWLEDGE_PAYLOAD_DEPTH_LIMIT;
+
+/// Serde-compatible snapshot of a Lua payload table. Survives without
+/// holding any Lua references.
+#[derive(Clone, Debug, Default)]
+pub struct PayloadSnapshot {
+    pub fields: HashMap<String, PayloadValue>,
+}
+
+/// Individual payload field value. Mirrors Lua's type system minus
+/// Function / UserData (which are schema violations).
+#[derive(Clone, Debug)]
+pub enum PayloadValue {
+    Number(f64),
+    Int(i64),
+    String(String),
+    Boolean(bool),
+    Table(PayloadSnapshot),
+    /// Entity encoded as `u64` bits (from `Entity::to_bits()`).
+    Entity(u64),
+    Nil,
+}
+
+/// Capture a Lua table as a `PayloadSnapshot`, recursing into nested
+/// tables up to `depth_limit`. Returns error for Function / UserData
+/// values or depth limit exceeded.
+pub fn snapshot_from_lua(
+    lua: &Lua,
+    table: &mlua::Table,
+    depth_limit: usize,
+) -> LuaResult<PayloadSnapshot> {
+    if depth_limit == 0 {
+        return Err(LuaError::RuntimeError(
+            "snapshot_from_lua: depth limit exceeded".into(),
+        ));
+    }
+    let mut fields = HashMap::new();
+    for pair in table.pairs::<mlua::Value, mlua::Value>() {
+        let (k, v) = pair?;
+        let key = match k {
+            mlua::Value::String(ref s) => s.to_str()?.to_string(),
+            mlua::Value::Integer(i) => i.to_string(),
+            mlua::Value::Number(n) => n.to_string(),
+            _ => continue, // skip non-string keys
+        };
+        let value = lua_value_to_payload(lua, v, depth_limit - 1)?;
+        fields.insert(key, value);
+    }
+    Ok(PayloadSnapshot { fields })
+}
+
+fn lua_value_to_payload(lua: &Lua, v: mlua::Value, depth: usize) -> LuaResult<PayloadValue> {
+    match v {
+        mlua::Value::Nil => Ok(PayloadValue::Nil),
+        mlua::Value::Boolean(b) => Ok(PayloadValue::Boolean(b)),
+        mlua::Value::Integer(i) => Ok(PayloadValue::Int(i)),
+        mlua::Value::Number(n) => Ok(PayloadValue::Number(n)),
+        mlua::Value::String(s) => Ok(PayloadValue::String(s.to_str()?.to_string())),
+        mlua::Value::Table(ref t) => {
+            let snap = snapshot_from_lua(lua, t, depth)?;
+            Ok(PayloadValue::Table(snap))
+        }
+        mlua::Value::Function(_) => Err(LuaError::RuntimeError(
+            "snapshot_from_lua: Function values not allowed in knowledge payloads".into(),
+        )),
+        mlua::Value::UserData(_) => Err(LuaError::RuntimeError(
+            "snapshot_from_lua: UserData values not allowed in knowledge payloads".into(),
+        )),
+        _ => Ok(PayloadValue::Nil), // LightUserData, Thread, Error -> treat as nil
+    }
+}
+
+/// Reconstruct a Lua table from a `PayloadSnapshot`. Used by K-4 for
+/// `@observed` dispatch (per-observer copy).
+pub fn snapshot_to_lua(lua: &Lua, snapshot: &PayloadSnapshot) -> LuaResult<mlua::Table> {
+    let t = lua.create_table()?;
+    for (k, v) in &snapshot.fields {
+        t.set(k.as_str(), payload_value_to_lua(lua, v)?)?;
+    }
+    Ok(t)
+}
+
+fn payload_value_to_lua(lua: &Lua, v: &PayloadValue) -> LuaResult<mlua::Value> {
+    match v {
+        PayloadValue::Nil => Ok(mlua::Value::Nil),
+        PayloadValue::Boolean(b) => Ok(mlua::Value::Boolean(*b)),
+        PayloadValue::Int(i) => Ok(mlua::Value::Integer(*i)),
+        PayloadValue::Number(n) => Ok(mlua::Value::Number(*n)),
+        PayloadValue::String(s) => Ok(mlua::Value::String(lua.create_string(s)?)),
+        PayloadValue::Table(snap) => {
+            let t = snapshot_to_lua(lua, snap)?;
+            Ok(mlua::Value::Table(t))
+        }
+        PayloadValue::Entity(bits) => Ok(mlua::Value::Integer(*bits as i64)),
+    }
+}
+
+/// Validate a Lua payload table against a `PayloadSchema`. Schema violations
+/// are returned as `RuntimeError`. Unknown fields produce a warning but are
+/// allowed (v1 loose validation, plan §3.1).
+pub fn validate_payload_schema(
+    kind_id: &KnowledgeKindId,
+    schema: &PayloadSchema,
+    table: &mlua::Table,
+) -> LuaResult<()> {
+    if schema.is_empty() {
+        return Ok(());
+    }
+    for pair in table.pairs::<mlua::Value, mlua::Value>() {
+        let (k, v) = pair?;
+        let key = match k {
+            mlua::Value::String(ref s) => s.to_str()?.to_string(),
+            _ => continue,
+        };
+        if let Some(expected_type) = schema.fields.get(&key) {
+            let actual_ok = match (expected_type, &v) {
+                (PayloadFieldType::Number, mlua::Value::Number(_))
+                | (PayloadFieldType::Number, mlua::Value::Integer(_)) => true,
+                (PayloadFieldType::String, mlua::Value::String(_)) => true,
+                (PayloadFieldType::Boolean, mlua::Value::Boolean(_)) => true,
+                (PayloadFieldType::Table, mlua::Value::Table(_)) => true,
+                (PayloadFieldType::Entity, mlua::Value::Integer(_))
+                | (PayloadFieldType::Entity, mlua::Value::Number(_)) => true,
+                _ => false,
+            };
+            if !actual_ok {
+                return Err(LuaError::RuntimeError(format!(
+                    "record_knowledge('{}'): payload field '{}' expected type '{}', got '{}'",
+                    kind_id,
+                    key,
+                    expected_type.as_str(),
+                    v.type_name(),
+                )));
+            }
+        }
+        // Unknown fields: allowed in v1 (warn only is done at a higher level if desired).
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_round_trip_flat() {
+        let lua = Lua::new();
+        let src = lua.create_table().unwrap();
+        src.set("name", "test").unwrap();
+        src.set("value", 42.5).unwrap();
+        src.set("active", true).unwrap();
+
+        let snap = snapshot_from_lua(&lua, &src, KNOWLEDGE_PAYLOAD_DEPTH_LIMIT).unwrap();
+        assert_eq!(snap.fields.len(), 3);
+
+        let rebuilt = snapshot_to_lua(&lua, &snap).unwrap();
+        assert_eq!(rebuilt.get::<String>("name").unwrap(), "test");
+        let v: f64 = rebuilt.get("value").unwrap();
+        assert!((v - 42.5).abs() < f64::EPSILON);
+        assert!(rebuilt.get::<bool>("active").unwrap());
+    }
+
+    #[test]
+    fn snapshot_round_trip_nested() {
+        let lua = Lua::new();
+        let inner = lua.create_table().unwrap();
+        inner.set("x", 1).unwrap();
+        let src = lua.create_table().unwrap();
+        src.set("inner", inner).unwrap();
+
+        let snap = snapshot_from_lua(&lua, &src, KNOWLEDGE_PAYLOAD_DEPTH_LIMIT).unwrap();
+        let rebuilt = snapshot_to_lua(&lua, &snap).unwrap();
+        let ri: mlua::Table = rebuilt.get("inner").unwrap();
+        assert_eq!(ri.get::<i64>("x").unwrap(), 1);
+    }
+
+    #[test]
+    fn snapshot_rejects_function() {
+        let lua = Lua::new();
+        let src = lua.create_table().unwrap();
+        let f: mlua::Function = lua.load("function() end").eval().unwrap();
+        src.set("cb", f).unwrap();
+        assert!(snapshot_from_lua(&lua, &src, KNOWLEDGE_PAYLOAD_DEPTH_LIMIT).is_err());
+    }
+
+    #[test]
+    fn snapshot_depth_limit() {
+        let lua = Lua::new();
+        let t1 = lua.create_table().unwrap();
+        let t2 = lua.create_table().unwrap();
+        let t3 = lua.create_table().unwrap();
+        t3.set("leaf", true).unwrap();
+        t2.set("c", t3).unwrap();
+        t1.set("c", t2).unwrap();
+        assert!(snapshot_from_lua(&lua, &t1, 2).is_err());
+        assert!(snapshot_from_lua(&lua, &t1, 3).is_ok());
+    }
+
+    #[test]
+    fn validate_schema_type_mismatch() {
+        let lua = Lua::new();
+        let schema = PayloadSchema {
+            fields: [("severity".to_string(), PayloadFieldType::Number)]
+                .into_iter()
+                .collect(),
+        };
+        let t = lua.create_table().unwrap();
+        t.set("severity", "high").unwrap(); // string instead of number
+        let id = KnowledgeKindId::parse("test:kind").unwrap();
+        let err = validate_payload_schema(&id, &schema, &t);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn validate_schema_allows_unknown_fields() {
+        let lua = Lua::new();
+        let schema = PayloadSchema {
+            fields: [("severity".to_string(), PayloadFieldType::Number)]
+                .into_iter()
+                .collect(),
+        };
+        let t = lua.create_table().unwrap();
+        t.set("severity", 0.7).unwrap();
+        t.set("unknown_field", "allowed").unwrap();
+        let id = KnowledgeKindId::parse("test:kind").unwrap();
+        assert!(validate_payload_schema(&id, &schema, &t).is_ok());
+    }
+}

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -3152,6 +3152,11 @@ impl SavedKnowledgeFact {
                 detail: detail.clone(),
                 event_id: event_id.map(|e| e.0),
             },
+            // #351: Scripted facts are not persisted in v1. The queue
+            // serializer filters them out before calling from_live.
+            KnowledgeFact::Scripted { .. } => {
+                unreachable!("Scripted facts must be filtered out before serialization")
+            }
         }
     }
     pub fn into_live(self, map: &EntityMap) -> KnowledgeFact {
@@ -3307,7 +3312,14 @@ pub struct SavedPendingFactQueue {
 impl SavedPendingFactQueue {
     pub fn from_live(v: &PendingFactQueue) -> Self {
         Self {
-            facts: v.facts.iter().map(SavedPerceivedFact::from_live).collect(),
+            // #351: Scripted facts are not persisted in v1 — filter
+            // them out so SavedKnowledgeFact::from_live never sees them.
+            facts: v
+                .facts
+                .iter()
+                .filter(|f| !matches!(f.fact, KnowledgeFact::Scripted { .. }))
+                .map(SavedPerceivedFact::from_live)
+                .collect(),
         }
     }
     pub fn into_live(self, map: &EntityMap) -> PendingFactQueue {

--- a/macrocosmo/src/scripting/gamestate_scope.rs
+++ b/macrocosmo/src/scripting/gamestate_scope.rs
@@ -319,6 +319,163 @@ fn build_scoped_gamestate<'scope, 'env>(
                 apply::request_command(&mut **borrow, parsed)
             })?;
         gs.set("request_command", request_command)?;
+
+        // :record_knowledge({ kind = "...", origin_system = id?, payload = { ... } })
+        //
+        // #351 K-2: Lua-origin knowledge record with sync @recorded dispatch.
+        //
+        // Flow (plan-349 §2.4 / §0.5 9.1):
+        //   1. Parse args (Lua table reads, no Rust state needed)
+        //   2. Borrow world -> validate kind in KindRegistry, get clock.elapsed
+        //   3. Release world borrow
+        //   4. Build sealed event table + dispatch_knowledge(@recorded)
+        //      (subscribers may call gs:set_flag etc. — world is unborrowed)
+        //   5. Snapshot final payload (Lua table -> PayloadSnapshot)
+        //   6. Re-borrow world -> apply::enqueue_scripted_fact (Lua-free)
+        //
+        // NOTE: Unlike other setters, this closure uses `lua` (the scope-
+        // provided &Lua) for steps 4-5. The `apply::enqueue_scripted_fact`
+        // helper in step 6 is still Lua-unaware (§6 invariant). The dispatch
+        // in step 4 is NOT a write helper — it is a scope-closure operation
+        // that happens while the world is unborrowed.
+        let record_knowledge =
+            s.create_function_mut(move |lua, (_this, args): (Table, Table)| {
+                use crate::knowledge::kind_registry::KindRegistry;
+                use crate::knowledge::payload::{snapshot_from_lua, validate_payload_schema};
+                use crate::scripting::knowledge_dispatch::{
+                    KNOWLEDGE_PAYLOAD_DEPTH_LIMIT, KnowledgeLifecycle, dispatch_knowledge,
+                    seal_immutable_keys,
+                };
+                use crate::scripting::knowledge_registry::KnowledgeSubscriptionRegistry;
+
+                // Step 1: parse args from Lua (no world borrow needed).
+                let kind_id: String = args.get("kind").map_err(|_| {
+                    mlua::Error::RuntimeError(
+                        "record_knowledge: missing required field 'kind'".into(),
+                    )
+                })?;
+                let origin_system_bits: Option<u64> = args.get("origin_system").ok();
+                let payload_lua: Table = args.get("payload").map_err(|_| {
+                    mlua::Error::RuntimeError(
+                        "record_knowledge: missing required field 'payload'".into(),
+                    )
+                })?;
+
+                // Step 2: borrow world to validate kind + get clock.
+                let (recorded_at, kind_id_parsed) = {
+                    let mut borrow = world_cell.try_borrow_mut().map_err(map_reentrancy_err)?;
+                    let world = &mut **borrow;
+
+                    let registry = world.get_resource::<KindRegistry>().ok_or_else(|| {
+                        mlua::Error::RuntimeError("KindRegistry not found".into())
+                    })?;
+                    let kid = crate::knowledge::kind_registry::KnowledgeKindId::parse(&kind_id)
+                        .map_err(|e| mlua::Error::RuntimeError(format!("{e}")))?;
+                    let def = registry.get(kid.as_str()).ok_or_else(|| {
+                        mlua::Error::RuntimeError(format!(
+                            "record_knowledge: unknown kind '{kind_id}'"
+                        ))
+                    })?;
+                    validate_payload_schema(&kid, &def.payload_schema, &payload_lua)?;
+
+                    let clock_elapsed = world
+                        .get_resource::<crate::time_system::GameClock>()
+                        .map(|c| c.elapsed)
+                        .unwrap_or(0);
+
+                    (clock_elapsed, kid)
+                    // borrow released here
+                };
+
+                // Step 3-4: build sealed event table + dispatch @recorded.
+                let event = lua.create_table()?;
+                event.set("kind", kind_id.as_str())?;
+                if let Some(oid) = origin_system_bits {
+                    event.set("origin_system", oid)?;
+                }
+                event.set("recorded_at", recorded_at)?;
+                event.set("payload", payload_lua)?;
+                seal_immutable_keys(lua, &event, &["kind", "origin_system", "recorded_at"])?;
+
+                // Try to get registry for dispatch. If it doesn't exist yet
+                // (e.g. during startup before drain), skip dispatch.
+                let dispatch_result = {
+                    let borrow = world_cell.try_borrow_mut().map_err(map_reentrancy_err)?;
+                    let world = &**borrow;
+                    world
+                        .get_resource::<KnowledgeSubscriptionRegistry>()
+                        .map(|r| {
+                            // Clone the bucket keys we need for dispatch. We
+                            // cannot hold the world borrow during dispatch
+                            // because subscribers may call gs:*.
+                            // Instead, we collect RegistryKeys we need.
+                            // Actually, we need the whole registry reference.
+                            // Since we can't hold it across the borrow release,
+                            // we check if any subscribers exist and gather them.
+                            (
+                                r.exact.contains_key(&kind_id_parsed.recorded_event_id())
+                                    || r.wildcard.contains_key(&KnowledgeLifecycle::Recorded),
+                                // We need the registry itself for dispatch...
+                            )
+                        })
+                };
+                drop(dispatch_result);
+
+                // The tricky part: we need the KnowledgeSubscriptionRegistry
+                // to call dispatch_knowledge, but we can't hold the world
+                // borrow during dispatch. Solution: resource_scope-like
+                // manual take+put, but we can't do that with RefCell<&mut World>.
+                //
+                // Better approach: temporarily remove the registry from
+                // the world, dispatch, then put it back.
+                {
+                    let mut borrow = world_cell.try_borrow_mut().map_err(map_reentrancy_err)?;
+                    let world = &mut **borrow;
+                    let registry_opt = world.remove_resource::<KnowledgeSubscriptionRegistry>();
+                    drop(borrow); // release world borrow before dispatch
+
+                    if let Some(registry) = &registry_opt {
+                        // Subscribers may call gs:set_flag, gs:record_knowledge,
+                        // etc. — world is unborrowed so try_borrow_mut succeeds.
+                        if let Err(e) = dispatch_knowledge(
+                            lua,
+                            registry,
+                            kind_id_parsed.as_str(),
+                            KnowledgeLifecycle::Recorded,
+                            &event,
+                        ) {
+                            bevy::prelude::warn!(
+                                "record_knowledge dispatch error for '{}': {e}",
+                                kind_id
+                            );
+                        }
+                    }
+
+                    // Put the registry back.
+                    let mut borrow = world_cell.try_borrow_mut().map_err(map_reentrancy_err)?;
+                    if let Some(registry) = registry_opt {
+                        (**borrow).insert_resource(registry);
+                    }
+                }
+
+                // Step 5: snapshot the final (possibly mutated) payload.
+                let final_payload: Table = event.get("payload")?;
+                let snapshot =
+                    snapshot_from_lua(lua, &final_payload, KNOWLEDGE_PAYLOAD_DEPTH_LIMIT)?;
+
+                // Step 6: re-borrow world and enqueue (Lua-free apply).
+                let mut borrow = world_cell.try_borrow_mut().map_err(map_reentrancy_err)?;
+                apply::enqueue_scripted_fact(
+                    &mut **borrow,
+                    apply::ParsedKnowledgeRecord {
+                        kind_id,
+                        origin_system: origin_system_bits.map(Entity::from_bits),
+                        payload_snapshot: snapshot,
+                        recorded_at,
+                    },
+                )
+            })?;
+        gs.set("record_knowledge", record_knowledge)?;
     }
 
     Ok(gs)
@@ -1646,6 +1803,110 @@ pub(crate) mod apply {
             }
         }
         Ok(command_id.0)
+    }
+
+    // ==================================================================
+    // #351 K-2: `gs:record_knowledge` apply helper
+    //
+    // Enqueues a scripted KnowledgeFact into PendingFactQueue. Never
+    // touches Lua — the subscriber dispatch chain runs upstream in
+    // the scope closure *before* this function is called.
+    //
+    // Invariant (plan §6 item 1 / feedback_rust_no_lua_callback.md):
+    // this helper takes no `&Lua` and never invokes Lua code.
+    // ==================================================================
+
+    /// Parsed, Lua-free knowledge record request.
+    #[derive(Debug, Clone)]
+    pub struct ParsedKnowledgeRecord {
+        pub kind_id: String,
+        pub origin_system: Option<Entity>,
+        pub payload_snapshot: crate::knowledge::payload::PayloadSnapshot,
+        pub recorded_at: i64,
+    }
+
+    /// Enqueue a [`KnowledgeFact::Scripted`] into [`PendingFactQueue`]
+    /// with light-speed delay calculation. Never touches `&Lua`.
+    pub fn enqueue_scripted_fact(
+        world: &mut World,
+        req: ParsedKnowledgeRecord,
+    ) -> mlua::Result<()> {
+        use crate::components::Position;
+        use crate::empire::comms::CommsParams;
+        use crate::knowledge::facts::*;
+        use crate::player::PlayerEmpire;
+
+        // Allocate event id for dedup.
+        let event_id = {
+            let mut nid = world
+                .get_resource_mut::<NextEventId>()
+                .ok_or_else(|| mlua::Error::RuntimeError("NextEventId resource missing".into()))?;
+            nid.allocate()
+        };
+        if let Some(mut nids) = world.get_resource_mut::<NotifiedEventIds>() {
+            nids.register(event_id);
+        }
+
+        let fact = KnowledgeFact::Scripted {
+            event_id: Some(event_id),
+            kind_id: req.kind_id,
+            origin_system: req.origin_system,
+            payload_snapshot: req.payload_snapshot,
+            recorded_at: req.recorded_at,
+        };
+
+        // Compute origin position.
+        let origin_pos = req
+            .origin_system
+            .and_then(|e| world.get::<Position>(e).map(|p| p.as_array()))
+            .unwrap_or([0.0, 0.0, 0.0]);
+
+        // Collect player vantage.
+        let (player_pos, player_aboard) = {
+            use crate::player::{AboardShip, StationedAt};
+            let mut q = world
+                .query_filtered::<(Option<&StationedAt>, Option<&AboardShip>), With<PlayerEmpire>>(
+                );
+            let (stationed, aboard) = q.iter(world).next().unwrap_or((None, None));
+            let pos = stationed
+                .and_then(|s| world.get::<Position>(s.system).map(|p| p.as_array()))
+                .unwrap_or([0.0, 0.0, 0.0]);
+            (pos, aboard.is_some())
+        };
+
+        // Collect comms params.
+        let comms = {
+            let mut q = world.query_filtered::<&CommsParams, With<PlayerEmpire>>();
+            q.iter(world).next().cloned().unwrap_or_default()
+        };
+
+        // Get relay network.
+        let relays = world
+            .get_resource::<RelayNetwork>()
+            .map(|r| r.relays.clone())
+            .unwrap_or_default();
+
+        // Compute arrival time and enqueue.
+        let related_system = fact.related_system();
+        let plan = crate::knowledge::facts::compute_fact_arrival(
+            req.recorded_at,
+            origin_pos,
+            player_pos,
+            &relays,
+            &comms,
+        );
+
+        let mut queue = world.resource_mut::<PendingFactQueue>();
+        queue.record(PerceivedFact {
+            fact,
+            observed_at: req.recorded_at,
+            arrives_at: plan.arrives_at,
+            source: plan.source,
+            origin_pos,
+            related_system,
+        });
+
+        Ok(())
     }
 }
 

--- a/macrocosmo/src/scripting/knowledge_dispatch.rs
+++ b/macrocosmo/src/scripting/knowledge_dispatch.rs
@@ -305,6 +305,54 @@ fn call_subscriber(lua: &Lua, key: &mlua::RegistryKey, payload: &mlua::Table, ev
     }
 }
 
+/// Maximum nesting depth for `deep_copy_table`. Exceeding this triggers
+/// `mlua::Error::RuntimeError` (plan-349 §0.5 9.3).
+pub const KNOWLEDGE_PAYLOAD_DEPTH_LIMIT: usize = 16;
+
+/// Deep-copy a Lua table, recursing into nested tables up to `depth_limit`.
+///
+/// Returns `mlua::Error::RuntimeError` if:
+/// - nesting exceeds `depth_limit`
+/// - a `Function` or `UserData` value is encountered (schema violation,
+///   spike 10.3)
+///
+/// Metatables are **not** copied — the result is a plain table. Callers
+/// that need sealed metadata should call `seal_immutable_keys` on the
+/// copy separately.
+pub fn deep_copy_table(
+    lua: &Lua,
+    src: &mlua::Table,
+    depth_limit: usize,
+) -> mlua::Result<mlua::Table> {
+    if depth_limit == 0 {
+        return Err(mlua::Error::RuntimeError(
+            "deep_copy_table: depth limit exceeded".into(),
+        ));
+    }
+    let dst = lua.create_table()?;
+    for pair in src.pairs::<mlua::Value, mlua::Value>() {
+        let (k, v) = pair?;
+        let copied_v = match v {
+            mlua::Value::Table(ref t) => {
+                mlua::Value::Table(deep_copy_table(lua, t, depth_limit - 1)?)
+            }
+            mlua::Value::Function(_) => {
+                return Err(mlua::Error::RuntimeError(
+                    "deep_copy_table: Function values are not allowed in knowledge payloads".into(),
+                ));
+            }
+            mlua::Value::UserData(_) => {
+                return Err(mlua::Error::RuntimeError(
+                    "deep_copy_table: UserData values are not allowed in knowledge payloads".into(),
+                ));
+            }
+            other => other,
+        };
+        dst.set(k, copied_v)?;
+    }
+    Ok(dst)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -400,5 +448,148 @@ mod tests {
             "foo:bar",
             KnowledgeLifecycle::Recorded
         ));
+    }
+
+    // --- deep_copy_table ---
+
+    #[test]
+    fn deep_copy_flat_table() {
+        let lua = Lua::new();
+        let src = lua.create_table().unwrap();
+        src.set("a", 1).unwrap();
+        src.set("b", "hello").unwrap();
+        let dst = deep_copy_table(&lua, &src, KNOWLEDGE_PAYLOAD_DEPTH_LIMIT).unwrap();
+        assert_eq!(dst.get::<i64>("a").unwrap(), 1);
+        assert_eq!(dst.get::<String>("b").unwrap(), "hello");
+        // Mutation isolation: mutating dst should not affect src.
+        dst.set("a", 99).unwrap();
+        assert_eq!(src.get::<i64>("a").unwrap(), 1);
+    }
+
+    #[test]
+    fn deep_copy_nested_table() {
+        let lua = Lua::new();
+        let inner = lua.create_table().unwrap();
+        inner.set("x", 42).unwrap();
+        let src = lua.create_table().unwrap();
+        src.set("inner", inner).unwrap();
+        let dst = deep_copy_table(&lua, &src, KNOWLEDGE_PAYLOAD_DEPTH_LIMIT).unwrap();
+        let dst_inner: mlua::Table = dst.get("inner").unwrap();
+        dst_inner.set("x", 99).unwrap();
+        // Original should be untouched.
+        let src_inner: mlua::Table = src.get("inner").unwrap();
+        assert_eq!(src_inner.get::<i64>("x").unwrap(), 42);
+    }
+
+    // Spike 10.3: Function value in table triggers error.
+    #[test]
+    fn spike_deep_copy_rejects_function() {
+        let lua = Lua::new();
+        let src = lua.create_table().unwrap();
+        let f: mlua::Function = lua.load("function() end").eval().unwrap();
+        src.set("callback", f).unwrap();
+        let err = deep_copy_table(&lua, &src, KNOWLEDGE_PAYLOAD_DEPTH_LIMIT).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("Function"), "got: {msg}");
+    }
+
+    #[test]
+    fn deep_copy_depth_limit_exceeded() {
+        let lua = Lua::new();
+        // Build a chain 3 levels deep, then copy with limit=2 -> should error.
+        let t1 = lua.create_table().unwrap();
+        let t2 = lua.create_table().unwrap();
+        let t3 = lua.create_table().unwrap();
+        t3.set("leaf", true).unwrap();
+        t2.set("child", t3).unwrap();
+        t1.set("child", t2).unwrap();
+        let err = deep_copy_table(&lua, &t1, 2).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("depth limit"), "got: {msg}");
+    }
+
+    // Spike 10.4: borrow_mut release -> dispatch -> re-borrow is safe.
+    // This tests the pattern used by gs:record_knowledge (K-2 Commit 3).
+    #[test]
+    fn spike_reentrancy_release_before_dispatch() {
+        use std::cell::RefCell;
+
+        let lua = Lua::new();
+        let counter = RefCell::new(0i32);
+
+        // Simulate: borrow_mut -> release -> dispatch (lua call) -> re-borrow.
+        {
+            let mut borrow = counter.borrow_mut();
+            *borrow += 1;
+            // release borrow
+        }
+
+        // Now call a Lua function that in turn would "re-borrow" (simulated).
+        let f: mlua::Function = lua.load("function() end").eval().unwrap();
+        f.call::<()>(()).unwrap();
+
+        // re-borrow succeeds
+        {
+            let mut borrow = counter.borrow_mut();
+            *borrow += 1;
+        }
+        assert_eq!(*counter.borrow(), 2);
+    }
+
+    // Spike 10.4: verify that a scope closure can release its world
+    // borrow, call dispatch_knowledge (which invokes subscribers), and
+    // re-borrow without conflict.
+    #[test]
+    fn spike_scope_closure_borrow_release_dispatch_reborrow() {
+        use super::*;
+        use crate::scripting::knowledge_registry::{
+            KnowledgeSubscriptionRegistry, drain_pending_subscriptions,
+        };
+        use std::cell::RefCell;
+
+        let lua = Lua::new();
+        // Set up the on() global + accumulator.
+        let engine = crate::scripting::ScriptEngine::new().unwrap();
+        engine
+            .lua()
+            .load(
+                r#"
+            _side_effect = 0
+            on("test:kind@recorded", function(e)
+                _side_effect = _side_effect + 1
+            end)
+        "#,
+            )
+            .exec()
+            .unwrap();
+        let mut registry = KnowledgeSubscriptionRegistry::default();
+        drain_pending_subscriptions(engine.lua(), &mut registry).unwrap();
+
+        // Simulate the RefCell<&mut World> pattern.
+        let mut world_data: i32 = 0;
+        let world_cell = RefCell::new(&mut world_data);
+
+        // Step 1: borrow, do work, release.
+        {
+            let mut borrow = world_cell.try_borrow_mut().unwrap();
+            **borrow = 42;
+        }
+        // Step 2: dispatch (Lua executes, could re-enter world via gs:*).
+        let payload = engine.lua().create_table().unwrap();
+        dispatch_knowledge(
+            engine.lua(),
+            &registry,
+            "test:kind",
+            KnowledgeLifecycle::Recorded,
+            &payload,
+        )
+        .unwrap();
+        // Step 3: re-borrow succeeds.
+        {
+            let borrow = world_cell.try_borrow_mut().unwrap();
+            assert_eq!(**borrow, 42);
+        }
+        let se: i64 = engine.lua().globals().get("_side_effect").unwrap();
+        assert_eq!(se, 1);
     }
 }

--- a/macrocosmo/src/scripting/knowledge_dispatch.rs
+++ b/macrocosmo/src/scripting/knowledge_dispatch.rs
@@ -29,7 +29,7 @@
 //!   have been released before calling, because subscribers may re-enter
 //!   via `gs:*` setters (spike 10.4, K-2).
 
-use bevy::prelude::warn;
+use bevy::prelude::*;
 use mlua::prelude::*;
 
 use super::knowledge_registry::KnowledgeSubscriptionRegistry;
@@ -351,6 +351,191 @@ pub fn deep_copy_table(
         dst.set(k, copied_v)?;
     }
     Ok(dst)
+}
+
+// ======================================================================
+// #351 K-2 Commit 4: Rust-origin knowledge record path
+//
+// Rust systems that produce knowledge facts cannot call Lua directly
+// (feedback_rust_no_lua_callback). Instead they push records into
+// PendingKnowledgeRecords, and a separate system
+// (dispatch_knowledge_recorded) drains the queue with ScriptEngine
+// exclusive access and fires @recorded subscribers.
+//
+// This is the system skeleton — K-5 will wire existing Rust fact
+// emitters to push into this queue.
+// ======================================================================
+
+/// A pending knowledge record request from Rust-origin code.
+#[derive(Debug, Clone)]
+pub struct PendingKnowledgeRecord {
+    pub kind_id: String,
+    pub origin_system: Option<Entity>,
+    pub payload_snapshot: crate::knowledge::payload::PayloadSnapshot,
+    pub recorded_at: i64,
+}
+
+/// Resource queue for Rust-origin knowledge records awaiting @recorded
+/// dispatch. Drained by [`dispatch_knowledge_recorded`] each tick.
+#[derive(Resource, Default, Debug)]
+pub struct PendingKnowledgeRecords {
+    pub records: Vec<PendingKnowledgeRecord>,
+}
+
+impl PendingKnowledgeRecords {
+    pub fn push(&mut self, record: PendingKnowledgeRecord) {
+        self.records.push(record);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+/// System that drains [`PendingKnowledgeRecords`], dispatches `@recorded`
+/// subscribers for each record, and enqueues the (possibly mutated)
+/// results into `PendingFactQueue`.
+///
+/// Scheduled `.after(knowledge emitters)` in the Update schedule so
+/// records pushed by Rust systems are dispatched within the same tick
+/// (plan-349 §0.5 9.1).
+///
+/// This system takes exclusive `&mut World` access to use
+/// `resource_scope` for `ScriptEngine`. The `@recorded` subscriber
+/// chain runs inside the scope with the subscription registry
+/// temporarily removed from the world (same pattern as
+/// `gs:record_knowledge` in gamestate_scope.rs).
+pub fn dispatch_knowledge_recorded(world: &mut World) {
+    // Fast-path: nothing to drain.
+    let has_records = world
+        .get_resource::<PendingKnowledgeRecords>()
+        .map(|r| !r.is_empty())
+        .unwrap_or(false);
+    if !has_records {
+        return;
+    }
+
+    // Take the pending records.
+    let records = {
+        let mut res = world.resource_mut::<PendingKnowledgeRecords>();
+        std::mem::take(&mut res.records)
+    };
+
+    // Take the subscription registry out of the world so we don't need
+    // to hold a world borrow during Lua dispatch.
+    let registry_opt = world.remove_resource::<KnowledgeSubscriptionRegistry>();
+
+    // Use resource_scope for ScriptEngine to get Lua access.
+    world.resource_scope::<super::ScriptEngine, _>(|world, engine| {
+        let lua = engine.lua();
+        for record in &records {
+            // Build the event table for @recorded dispatch.
+            let event = match build_recorded_event_table(lua, record) {
+                Ok(t) => t,
+                Err(e) => {
+                    warn!(
+                        "dispatch_knowledge_recorded: failed to build event table for '{}': {e}",
+                        record.kind_id
+                    );
+                    continue;
+                }
+            };
+
+            // Seal immutable keys.
+            if let Err(e) =
+                seal_immutable_keys(lua, &event, &["kind", "origin_system", "recorded_at"])
+            {
+                warn!(
+                    "dispatch_knowledge_recorded: seal error for '{}': {e}",
+                    record.kind_id
+                );
+                continue;
+            }
+
+            // Dispatch @recorded subscribers.
+            if let Some(ref registry) = registry_opt {
+                if let Err(e) = dispatch_knowledge(
+                    lua,
+                    registry,
+                    &record.kind_id,
+                    KnowledgeLifecycle::Recorded,
+                    &event,
+                ) {
+                    warn!(
+                        "dispatch_knowledge_recorded: dispatch error for '{}': {e}",
+                        record.kind_id
+                    );
+                }
+            }
+
+            // Snapshot the final payload after subscriber mutations.
+            let final_payload: mlua::Table = match event.get("payload") {
+                Ok(t) => t,
+                Err(e) => {
+                    warn!(
+                        "dispatch_knowledge_recorded: payload read error for '{}': {e}",
+                        record.kind_id
+                    );
+                    continue;
+                }
+            };
+            let snapshot = match crate::knowledge::payload::snapshot_from_lua(
+                lua,
+                &final_payload,
+                KNOWLEDGE_PAYLOAD_DEPTH_LIMIT,
+            ) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(
+                        "dispatch_knowledge_recorded: snapshot error for '{}': {e}",
+                        record.kind_id
+                    );
+                    continue;
+                }
+            };
+
+            // Enqueue via the same Lua-free apply helper.
+            use crate::scripting::gamestate_scope::apply::{
+                ParsedKnowledgeRecord, enqueue_scripted_fact,
+            };
+            if let Err(e) = enqueue_scripted_fact(
+                world,
+                ParsedKnowledgeRecord {
+                    kind_id: record.kind_id.clone(),
+                    origin_system: record.origin_system,
+                    payload_snapshot: snapshot,
+                    recorded_at: record.recorded_at,
+                },
+            ) {
+                warn!(
+                    "dispatch_knowledge_recorded: enqueue error for '{}': {e}",
+                    record.kind_id
+                );
+            }
+        }
+    });
+
+    // Put the subscription registry back.
+    if let Some(registry) = registry_opt {
+        world.insert_resource(registry);
+    }
+}
+
+/// Build a Lua event table for @recorded dispatch from a Rust-origin
+/// pending record.
+fn build_recorded_event_table(
+    lua: &Lua,
+    record: &PendingKnowledgeRecord,
+) -> mlua::Result<mlua::Table> {
+    let event = lua.create_table()?;
+    event.set("kind", record.kind_id.as_str())?;
+    if let Some(origin) = record.origin_system {
+        event.set("origin_system", origin.to_bits())?;
+    }
+    event.set("recorded_at", record.recorded_at)?;
+    let payload = crate::knowledge::payload::snapshot_to_lua(lua, &record.payload_snapshot)?;
+    event.set("payload", payload)?;
+    Ok(event)
 }
 
 #[cfg(test)]

--- a/macrocosmo/src/scripting/mod.rs
+++ b/macrocosmo/src/scripting/mod.rs
@@ -6,11 +6,11 @@ pub mod effect_scope;
 pub mod engine;
 pub mod event_api;
 pub mod faction_api;
-pub mod gamestate_scope;
 pub mod galaxy_api;
 pub mod galaxy_gen_ctx;
 pub mod game_rng;
 pub mod game_start_ctx;
+pub mod gamestate_scope;
 pub mod globals;
 pub mod helpers;
 pub mod knowledge_api;
@@ -26,11 +26,10 @@ pub mod structure_api;
 
 // Re-exports for backward compatibility
 pub use engine::{
-    find_scripts_dir_upwards, resolve_scripts_dir, resolve_scripts_dir_from,
-    try_resolve_scripts_dir, ScriptEngine, ScriptsDirError, ScriptsDirInputs,
-    SCRIPTS_DIR_ENV_VAR,
+    SCRIPTS_DIR_ENV_VAR, ScriptEngine, ScriptsDirError, ScriptsDirInputs, find_scripts_dir_upwards,
+    resolve_scripts_dir, resolve_scripts_dir_from, try_resolve_scripts_dir,
 };
-pub use game_rng::{register_game_rand, GameRng};
+pub use game_rng::{GameRng, register_game_rand};
 pub use helpers::{extract_id_from_lua_value, extract_ref_id, parse_lua_function_field};
 
 use bevy::prelude::*;
@@ -41,14 +40,8 @@ impl Plugin for ScriptingPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<GameRng>()
             .add_systems(Startup, init_scripting)
-            .add_systems(
-                Startup,
-                load_all_scripts.after(init_scripting),
-            )
-            .add_systems(
-                Startup,
-                load_faction_type_registry.after(load_all_scripts),
-            )
+            .add_systems(Startup, load_all_scripts.after(init_scripting))
+            .add_systems(Startup, load_faction_type_registry.after(load_all_scripts))
             .add_systems(
                 Startup,
                 load_faction_registry
@@ -67,22 +60,10 @@ impl Plugin for ScriptingPlugin {
                 Startup,
                 load_predefined_system_registry.after(load_all_scripts),
             )
-            .add_systems(
-                Startup,
-                load_map_type_registry.after(load_all_scripts),
-            )
-            .add_systems(
-                Startup,
-                load_region_type_registry.after(load_all_scripts),
-            )
-            .add_systems(
-                Startup,
-                load_region_spec_queue.after(load_all_scripts),
-            )
-            .add_systems(
-                Startup,
-                load_event_definitions.after(load_all_scripts),
-            )
+            .add_systems(Startup, load_map_type_registry.after(load_all_scripts))
+            .add_systems(Startup, load_region_type_registry.after(load_all_scripts))
+            .add_systems(Startup, load_region_spec_queue.after(load_all_scripts))
+            .add_systems(Startup, load_event_definitions.after(load_all_scripts))
             // #350 K-1: build KindRegistry + reserve <id>@recorded /
             // <id>@observed entries.
             .add_systems(
@@ -138,6 +119,13 @@ impl Plugin for ScriptingPlugin {
                 lifecycle::dispatch_event_handlers
                     .after(crate::event_system::tick_events)
                     .after(crate::time_system::advance_game_time),
+            )
+            // #351 K-2: Rust-origin knowledge records queue + dispatch.
+            .init_resource::<knowledge_dispatch::PendingKnowledgeRecords>()
+            .add_systems(
+                Update,
+                knowledge_dispatch::dispatch_knowledge_recorded
+                    .after(crate::time_system::advance_game_time),
             );
     }
 }
@@ -163,15 +151,25 @@ pub fn load_all_scripts(engine: Res<ScriptEngine>) {
                 return;
             }
             Err(e) => {
-                warn!("Failed to load {}: {e}; falling back to directory loading", init_path.display());
+                warn!(
+                    "Failed to load {}: {e}; falling back to directory loading",
+                    init_path.display()
+                );
             }
         }
     }
 
     // Fallback: load directories individually (legacy path, used when init.lua is absent)
     let subdirs = [
-        "stars", "planets", "jobs", "species", "buildings",
-        "tech", "ships", "structures", "events",
+        "stars",
+        "planets",
+        "jobs",
+        "species",
+        "buildings",
+        "tech",
+        "ships",
+        "structures",
+        "events",
     ];
     for subdir in &subdirs {
         let path = scripts_dir.join(subdir);
@@ -319,7 +317,10 @@ pub fn load_region_spec_queue(mut commands: Commands, engine: Res<ScriptEngine>)
     match region_api::parse_region_specs(engine.lua()) {
         Ok(specs) => {
             queue.specs = specs;
-            info!("Loaded {} region placement specs from Lua", queue.specs.len());
+            info!(
+                "Loaded {} region placement specs from Lua",
+                queue.specs.len()
+            );
         }
         Err(e) => {
             warn!("Failed to parse region placement specs: {e}");
@@ -565,10 +566,7 @@ mod tests {
         let store: mlua::Table = lua.globals().get("_flag_store").unwrap();
         store.set("my_flag", true).unwrap();
 
-        let result: bool = lua
-            .load(r#"return check_flag("my_flag")"#)
-            .eval()
-            .unwrap();
+        let result: bool = lua.load(r#"return check_flag("my_flag")"#).eval().unwrap();
         assert!(result);
     }
 
@@ -728,9 +726,7 @@ mod tests {
         let engine = ScriptEngine::new().unwrap();
         let lua = engine.lua();
 
-        let r: mlua::Result<()> = lua
-            .load(r#"on("foo@expired", function(e) end)"#)
-            .exec();
+        let r: mlua::Result<()> = lua.load(r#"on("foo@expired", function(e) end)"#).exec();
         assert!(r.is_err(), "unknown lifecycle must error");
         let msg = format!("{}", r.unwrap_err());
         assert!(msg.contains("unknown lifecycle"), "got: {msg}");
@@ -740,9 +736,7 @@ mod tests {
     fn on_empty_kind_errors() {
         let engine = ScriptEngine::new().unwrap();
         let lua = engine.lua();
-        let r: mlua::Result<()> = lua
-            .load(r#"on("@recorded", function(e) end)"#)
-            .exec();
+        let r: mlua::Result<()> = lua.load(r#"on("@recorded", function(e) end)"#).exec();
         assert!(r.is_err(), "empty kind must error");
         let msg = format!("{}", r.unwrap_err());
         assert!(msg.contains("empty kind"), "got: {msg}");
@@ -752,9 +746,7 @@ mod tests {
     fn on_double_at_errors() {
         let engine = ScriptEngine::new().unwrap();
         let lua = engine.lua();
-        let r: mlua::Result<()> = lua
-            .load(r#"on("a@b@recorded", function(e) end)"#)
-            .exec();
+        let r: mlua::Result<()> = lua.load(r#"on("a@b@recorded", function(e) end)"#).exec();
         assert!(r.is_err(), "double '@' must error");
         let msg = format!("{}", r.unwrap_err());
         assert!(msg.contains("may not contain '@'"), "got: {msg}");
@@ -766,16 +758,11 @@ mod tests {
         let engine = ScriptEngine::new().unwrap();
         let lua = engine.lua();
         let r: mlua::Result<()> = lua
-            .load(
-                r#"on("foo@recorded", { kind = "x" }, function(e) end)"#,
-            )
+            .load(r#"on("foo@recorded", { kind = "x" }, function(e) end)"#)
             .exec();
         assert!(r.is_err(), "filter on knowledge id must error");
         let msg = format!("{}", r.unwrap_err());
-        assert!(
-            msg.contains("does not accept a filter"),
-            "got: {msg}"
-        );
+        assert!(msg.contains("does not accept a filter"), "got: {msg}");
     }
 
     #[test]
@@ -885,18 +872,17 @@ mod tests {
         let lua = engine.lua();
 
         // String form (backward compatible)
-        let cond_str: mlua::Table = lua
-            .load(r#"return has_tech("my_tech")"#)
-            .eval()
-            .unwrap();
+        let cond_str: mlua::Table = lua.load(r#"return has_tech("my_tech")"#).eval().unwrap();
         assert_eq!(cond_str.get::<String>("id").unwrap(), "my_tech");
 
         // Reference form
         let cond_ref: mlua::Table = lua
-            .load(r#"
+            .load(
+                r#"
                 local t = define_tech { id = "ref_tech", name = "Ref" }
                 return has_tech(t)
-            "#)
+            "#,
+            )
             .eval()
             .unwrap();
         assert_eq!(cond_ref.get::<String>("id").unwrap(), "ref_tech");

--- a/macrocosmo/tests/knowledge_record.rs
+++ b/macrocosmo/tests/knowledge_record.rs
@@ -1,0 +1,466 @@
+//! #351 K-2: Integration tests for `gs:record_knowledge` + `@recorded`
+//! sync dispatch + PendingFactQueue integration.
+//!
+//! Tests exercise:
+//! - Lua-origin record -> @recorded subscriber chain -> PendingFactQueue
+//! - Subscriber payload mutation (chain sequential)
+//! - Sealed metadata write error
+//! - Unknown kind error
+//! - Schema violation error
+//! - Wildcard subscriber
+//! - Rust-origin record path (PendingKnowledgeRecords -> system -> queue)
+
+mod common;
+
+use bevy::prelude::*;
+use macrocosmo::knowledge::facts::{KnowledgeFact, PendingFactQueue};
+use macrocosmo::knowledge::kind_registry::{
+    KindOrigin, KindRegistry, KnowledgeKindDef, KnowledgeKindId, PayloadFieldType, PayloadSchema,
+};
+use macrocosmo::knowledge::payload::PayloadValue;
+use macrocosmo::scripting::ScriptEngine;
+use macrocosmo::scripting::gamestate_scope::{GamestateMode, dispatch_with_gamestate};
+use macrocosmo::scripting::knowledge_dispatch::PendingKnowledgeRecords;
+use macrocosmo::scripting::knowledge_registry::{
+    KnowledgeSubscriptionRegistry, drain_pending_subscriptions,
+};
+use macrocosmo::time_system::GameClock;
+
+/// Build a minimal world with resources required by record_knowledge.
+fn make_world_with_kind(kind_id: &str, schema_fields: Vec<(&str, PayloadFieldType)>) -> World {
+    let mut world = World::new();
+    world.insert_resource(GameClock::new(100));
+    world.init_resource::<PendingFactQueue>();
+    world.init_resource::<macrocosmo::knowledge::facts::NextEventId>();
+    world.init_resource::<macrocosmo::knowledge::facts::NotifiedEventIds>();
+    world.insert_resource(macrocosmo::notifications::NotificationQueue::new());
+    world.init_resource::<macrocosmo::knowledge::facts::RelayNetwork>();
+    world.init_resource::<PendingKnowledgeRecords>();
+
+    let mut registry = KindRegistry::default();
+    let schema = PayloadSchema {
+        fields: schema_fields
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+    };
+    registry
+        .insert(KnowledgeKindDef {
+            id: KnowledgeKindId::parse(kind_id).unwrap(),
+            payload_schema: schema,
+            origin: KindOrigin::Lua,
+        })
+        .unwrap();
+    world.insert_resource(registry);
+
+    // Player empire for vantage computation.
+    world.spawn((
+        macrocosmo::player::Empire {
+            name: "Test".into(),
+        },
+        macrocosmo::player::PlayerEmpire,
+        macrocosmo::components::Position {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        },
+        macrocosmo::technology::GameFlags::default(),
+        macrocosmo::condition::ScopedFlags::default(),
+        macrocosmo::technology::EmpireModifiers::default(),
+    ));
+
+    world
+}
+
+/// Register Lua on() subscribers and drain into registry.
+fn setup_subscribers(engine: &ScriptEngine, script: &str) -> KnowledgeSubscriptionRegistry {
+    if !script.is_empty() {
+        engine.lua().load(script).exec().unwrap();
+    }
+    let mut registry = KnowledgeSubscriptionRegistry::default();
+    drain_pending_subscriptions(engine.lua(), &mut registry).unwrap();
+    registry
+}
+
+/// Run a Lua script inside a gamestate scope with ReadWrite mode.
+fn run_in_scope(world: &mut World, engine: &ScriptEngine, lua_code: &str) -> mlua::Result<()> {
+    let lua = engine.lua();
+    let payload = lua.create_table()?;
+    dispatch_with_gamestate(lua, world, &payload, GamestateMode::ReadWrite, |lua, p| {
+        let gs: mlua::Table = p.get("gamestate")?;
+        lua.globals().set("_gs", gs)?;
+        lua.load(lua_code).exec()?;
+        lua.globals().set("_gs", mlua::Value::Nil)?;
+        Ok(())
+    })
+}
+
+#[test]
+fn record_knowledge_no_subscribers_enqueues_fact() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![]);
+    let registry = setup_subscribers(&engine, "");
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    world.resource_scope::<ScriptEngine, _>(|world, engine| {
+        run_in_scope(
+            world,
+            &engine,
+            r#"
+            _gs:record_knowledge({
+                kind = "test:kind",
+                payload = { value = 42 },
+            })
+            "#,
+        )
+        .unwrap();
+    });
+
+    let queue = world.resource::<PendingFactQueue>();
+    assert_eq!(queue.facts.len(), 1);
+    match &queue.facts[0].fact {
+        KnowledgeFact::Scripted {
+            kind_id,
+            payload_snapshot,
+            recorded_at,
+            ..
+        } => {
+            assert_eq!(kind_id, "test:kind");
+            assert_eq!(*recorded_at, 100);
+            assert!(payload_snapshot.fields.contains_key("value"));
+        }
+        other => panic!("Expected Scripted, got {:?}", other),
+    }
+}
+
+#[test]
+fn record_knowledge_subscriber_mutates_payload() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![("severity", PayloadFieldType::Number)]);
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        on("test:kind@recorded", function(e)
+            e.payload.severity = 0.5
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    world.resource_scope::<ScriptEngine, _>(|world, engine| {
+        run_in_scope(
+            world,
+            &engine,
+            r#"
+            _gs:record_knowledge({
+                kind = "test:kind",
+                payload = { severity = 0.9 },
+            })
+            "#,
+        )
+        .unwrap();
+    });
+
+    let queue = world.resource::<PendingFactQueue>();
+    assert_eq!(queue.facts.len(), 1);
+    if let KnowledgeFact::Scripted {
+        payload_snapshot, ..
+    } = &queue.facts[0].fact
+    {
+        match payload_snapshot.fields.get("severity") {
+            Some(PayloadValue::Number(n)) => {
+                assert!(
+                    (*n - 0.5).abs() < f64::EPSILON,
+                    "severity should be 0.5 (mutated by subscriber), got {n}"
+                );
+            }
+            other => panic!("Expected Number(0.5), got {:?}", other),
+        }
+    } else {
+        panic!("Expected Scripted fact");
+    }
+}
+
+#[test]
+fn record_knowledge_subscriber_chain_sequential() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![]);
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        on("test:kind@recorded", function(e) e.payload.step = "first" end)
+        on("test:kind@recorded", function(e) e.payload.step = "second" end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    world.resource_scope::<ScriptEngine, _>(|world, engine| {
+        run_in_scope(
+            world,
+            &engine,
+            r#"
+            _gs:record_knowledge({
+                kind = "test:kind",
+                payload = {},
+            })
+            "#,
+        )
+        .unwrap();
+    });
+
+    let queue = world.resource::<PendingFactQueue>();
+    if let KnowledgeFact::Scripted {
+        payload_snapshot, ..
+    } = &queue.facts[0].fact
+    {
+        match payload_snapshot.fields.get("step") {
+            Some(PayloadValue::String(s)) => {
+                assert_eq!(s, "second", "Last subscriber should win");
+            }
+            other => panic!("Expected String(\"second\"), got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn record_knowledge_sealed_metadata_write_errors() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![]);
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        _seal_error = nil
+        on("test:kind@recorded", function(e)
+            local ok, err = pcall(function() e.kind = "other" end)
+            _seal_error = tostring(err)
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    world.resource_scope::<ScriptEngine, _>(|world, engine| {
+        run_in_scope(
+            world,
+            &engine,
+            r#"
+            _gs:record_knowledge({
+                kind = "test:kind",
+                payload = {},
+            })
+            "#,
+        )
+        .unwrap();
+
+        let err: String = engine.lua().globals().get("_seal_error").unwrap();
+        assert!(
+            err.contains("immutable"),
+            "Expected immutable key error, got: {err}"
+        );
+    });
+}
+
+#[test]
+fn record_knowledge_unknown_kind_errors() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![]);
+    let registry = setup_subscribers(&engine, "");
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    let mut errored = false;
+    world.resource_scope::<ScriptEngine, _>(|world, engine| {
+        let result = run_in_scope(
+            world,
+            &engine,
+            r#"
+            _gs:record_knowledge({
+                kind = "nonexistent:kind",
+                payload = {},
+            })
+            "#,
+        );
+        errored = result.is_err();
+        if let Err(e) = result {
+            let msg = format!("{e}");
+            assert!(
+                msg.contains("unknown kind"),
+                "Expected 'unknown kind' error, got: {msg}"
+            );
+        }
+    });
+    assert!(errored, "Should error on unknown kind");
+}
+
+#[test]
+fn record_knowledge_schema_violation_errors() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![("severity", PayloadFieldType::Number)]);
+    let registry = setup_subscribers(&engine, "");
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    let mut errored = false;
+    world.resource_scope::<ScriptEngine, _>(|world, engine| {
+        let result = run_in_scope(
+            world,
+            &engine,
+            r#"
+            _gs:record_knowledge({
+                kind = "test:kind",
+                payload = { severity = "high" },
+            })
+            "#,
+        );
+        errored = result.is_err();
+    });
+    assert!(errored, "Schema violation should error");
+}
+
+#[test]
+fn record_knowledge_wildcard_subscriber_fires() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![]);
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        _wildcard_fired = false
+        on("*@recorded", function(e)
+            _wildcard_fired = true
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    world.resource_scope::<ScriptEngine, _>(|world, engine| {
+        run_in_scope(
+            world,
+            &engine,
+            r#"
+            _gs:record_knowledge({
+                kind = "test:kind",
+                payload = {},
+            })
+            "#,
+        )
+        .unwrap();
+
+        let fired: bool = engine.lua().globals().get("_wildcard_fired").unwrap();
+        assert!(fired, "*@recorded wildcard subscriber should fire");
+    });
+}
+
+#[test]
+fn record_knowledge_subscriber_error_continues_chain() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![]);
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        _chain_reached = false
+        on("test:kind@recorded", function(e)
+            error("intentional error")
+        end)
+        on("test:kind@recorded", function(e)
+            _chain_reached = true
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    world.resource_scope::<ScriptEngine, _>(|world, engine| {
+        // Should not propagate the subscriber error.
+        run_in_scope(
+            world,
+            &engine,
+            r#"
+            _gs:record_knowledge({
+                kind = "test:kind",
+                payload = {},
+            })
+            "#,
+        )
+        .unwrap();
+
+        let reached: bool = engine.lua().globals().get("_chain_reached").unwrap();
+        assert!(
+            reached,
+            "Second subscriber should fire despite first erroring"
+        );
+    });
+
+    // Fact should still be enqueued.
+    let queue = world.resource::<PendingFactQueue>();
+    assert_eq!(queue.facts.len(), 1);
+}
+
+#[test]
+fn rust_origin_dispatch_knowledge_recorded() {
+    use macrocosmo::knowledge::payload::PayloadSnapshot;
+    use macrocosmo::scripting::knowledge_dispatch::{
+        PendingKnowledgeRecord, dispatch_knowledge_recorded,
+    };
+
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world_with_kind("test:kind", vec![]);
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        _rust_origin_fired = false
+        on("test:kind@recorded", function(e)
+            _rust_origin_fired = true
+            e.payload.enriched = true
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    // Push a Rust-origin record.
+    {
+        let mut pending = world.resource_mut::<PendingKnowledgeRecords>();
+        pending.push(PendingKnowledgeRecord {
+            kind_id: "test:kind".to_string(),
+            origin_system: None,
+            payload_snapshot: PayloadSnapshot {
+                fields: [("initial".to_string(), PayloadValue::Boolean(true))]
+                    .into_iter()
+                    .collect(),
+            },
+            recorded_at: 100,
+        });
+    }
+
+    // Run the dispatch system.
+    dispatch_knowledge_recorded(&mut world);
+
+    // Verify subscriber fired.
+    world.resource_scope::<ScriptEngine, _>(|_world, engine| {
+        let fired: bool = engine.lua().globals().get("_rust_origin_fired").unwrap();
+        assert!(fired, "Rust-origin @recorded subscriber should fire");
+    });
+
+    // Verify fact was enqueued with enriched payload.
+    let queue = world.resource::<PendingFactQueue>();
+    assert_eq!(queue.facts.len(), 1);
+    if let KnowledgeFact::Scripted {
+        payload_snapshot, ..
+    } = &queue.facts[0].fact
+    {
+        assert!(
+            payload_snapshot.fields.contains_key("enriched"),
+            "Subscriber should have enriched the payload"
+        );
+        assert!(
+            payload_snapshot.fields.contains_key("initial"),
+            "Original payload should be preserved"
+        );
+    } else {
+        panic!("Expected Scripted fact");
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `gs:record_knowledge({ kind, origin_system?, payload })` setter for Lua-origin knowledge records with sync `@recorded` subscriber dispatch
- Adds `KnowledgeFact::Scripted` variant + `PayloadSnapshot` for Lua-free fact queuing
- Adds `PendingKnowledgeRecords` resource + `dispatch_knowledge_recorded` system for Rust-origin records
- Adds `deep_copy_table` helper with Function/UserData rejection + depth limit

## Context

Wave 2 of epic #349 (ScriptableKnowledge). Depends on K-1 (#350 / PR #357) and K-3 (#352 / PR #356), both landed on main.

Plan reference: `docs/plan-349-scriptable-knowledge.md` §3.3 (K-2 detailed design), §2.4 (mutation chain), §2.5 (deep-copy), §2.6 (sealed metadata).

## Key Design: borrow-release-dispatch-reborrow pattern

The `gs:record_knowledge` setter implements a special flow within the scope closure:

1. **Parse args** from Lua table (no world borrow needed)
2. **Borrow world** -> validate kind in `KindRegistry`, get `clock.elapsed`
3. **Release world borrow**
4. **Build sealed event table** + `dispatch_knowledge(@recorded)` — subscribers may call `gs:set_flag` etc. since world is unborrowed
5. **Snapshot final payload** (Lua table -> `PayloadSnapshot`)
6. **Re-borrow world** -> `apply::enqueue_scripted_fact` (Lua-free)

The `KnowledgeSubscriptionRegistry` is temporarily removed from the world during step 4 (via `remove_resource` / `insert_resource`) to avoid holding the `RefCell` borrow during Lua execution. Validated by spike 10.4.

## Test matrix

| Test | What it verifies |
|---|---|
| `record_knowledge_no_subscribers_enqueues_fact` | Basic record -> queue |
| `record_knowledge_subscriber_mutates_payload` | @recorded mutation reflected in final snapshot |
| `record_knowledge_subscriber_chain_sequential` | Last subscriber wins (sequential chain) |
| `record_knowledge_sealed_metadata_write_errors` | `e.kind = "other"` -> RuntimeError |
| `record_knowledge_unknown_kind_errors` | Unknown kind -> error |
| `record_knowledge_schema_violation_errors` | Wrong field type -> error |
| `record_knowledge_wildcard_subscriber_fires` | `*@recorded` matches |
| `record_knowledge_subscriber_error_continues_chain` | Error in sub1 doesn't block sub2 |
| `rust_origin_dispatch_knowledge_recorded` | Rust queue -> system -> @recorded -> queue |
| `spike_deep_copy_rejects_function` | Spike 10.3: Function in table -> error |
| `spike_scope_closure_borrow_release_dispatch_reborrow` | Spike 10.4: RefCell safe |
| `deep_copy_flat_table` / `deep_copy_nested_table` / `deep_copy_depth_limit_exceeded` | deep_copy utility |
| `snapshot_round_trip_flat` / `snapshot_round_trip_nested` / `snapshot_rejects_function` / `snapshot_depth_limit` | PayloadSnapshot |
| `validate_schema_type_mismatch` / `validate_schema_allows_unknown_fields` | Schema validation |

## Plan deviations

1. **Registry temporarily removed from world during dispatch** — plan §2.4 describes borrow release pattern but doesn't specify the exact mechanism for getting `KnowledgeSubscriptionRegistry` without holding world borrow. We use `remove_resource` / `insert_resource` rather than `resource_scope` because the latter takes `&mut World` which conflicts with the `RefCell` pattern.

2. **`enqueue_scripted_fact` always goes through `PendingFactQueue`** — plan §3.3 sketches a `record_fact_or_local` path for local bypass (instant banner for player-aboard), but since Scripted facts don't produce banners until K-4 (@observed) and #345 (notification bridge), we always queue. The arrival time is still computed correctly for future use.

3. **`@recorded` subscribers don't receive `gamestate`** — the event table passed to subscribers contains `kind`, `origin_system`, `recorded_at`, and `payload`, but not a `gamestate` reference. Subscribers can mutate `e.payload.*` but cannot call `gs:*` setters unless they captured the gamestate from an outer scope. This is consistent with the plan's focus on payload enrichment rather than world mutation.

4. **Commit count: 5 as specified**, matching plan §3.3.

## K-4 / K-5 notes

- K-4 (#353) will add `@observed` dispatch by draining Scripted facts from `PendingFactQueue` at arrival time
- K-5 (#354) will wire existing Rust `KnowledgeFact` variants to push into `PendingKnowledgeRecords` with `core:*` kind ids
- `notify_from_knowledge_facts` currently processes Scripted facts through the legacy banner path. K-4 should add `drain_ready_scripted` and skip Scripted in the notification path.