### PR TITLE
#354 K-5: core:* namespace preload + drain unification + Rust fact emitter wire

### DIFF
--- a/macrocosmo/src/knowledge/facts.rs
+++ b/macrocosmo/src/knowledge/facts.rs
@@ -376,6 +376,185 @@ impl KnowledgeFact {
             | KnowledgeFact::Scripted { event_id, .. } => *event_id,
         }
     }
+
+    /// #354 (K-5): `core:*` kind id for each built-in variant. Returns
+    /// `None` for [`KnowledgeFact::Scripted`] — a Lua-origin fact
+    /// already carries its own kind id in the `kind_id` field.
+    ///
+    /// The mapping must stay in sync with
+    /// [`crate::knowledge::kind_registry::CORE_KIND_IDS`] — the unit
+    /// tests in `facts::tests::core_kind_id_mapping_matches_registry`
+    /// enforce this at CI time.
+    pub fn core_kind_id(&self) -> Option<&'static str> {
+        match self {
+            KnowledgeFact::HostileDetected { .. } => Some("core:hostile_detected"),
+            KnowledgeFact::CombatOutcome { .. } => Some("core:combat_outcome"),
+            KnowledgeFact::SurveyComplete { .. } => Some("core:survey_complete"),
+            KnowledgeFact::AnomalyDiscovered { .. } => Some("core:anomaly_discovered"),
+            KnowledgeFact::SurveyDiscovery { .. } => Some("core:survey_discovery"),
+            KnowledgeFact::StructureBuilt { .. } => Some("core:structure_built"),
+            KnowledgeFact::ColonyEstablished { .. } => Some("core:colony_established"),
+            KnowledgeFact::ColonyFailed { .. } => Some("core:colony_failed"),
+            KnowledgeFact::ShipArrived { .. } => Some("core:ship_arrived"),
+            KnowledgeFact::Scripted { .. } => None,
+        }
+    }
+
+    /// #354 (K-5): Flatten a core variant into a payload snapshot that
+    /// K-3 `<core:*>@recorded` / K-4 `<core:*>@observed` subscribers see
+    /// under `e.payload`. Returns `None` for [`KnowledgeFact::Scripted`]
+    /// — Lua-origin facts already carry their snapshot directly.
+    ///
+    /// Field mapping mirrors
+    /// [`crate::knowledge::kind_registry::core_kind_catalog`]:
+    /// * `Entity` values become [`PayloadValue::Entity`]
+    /// * `[f64; 3]` positions are flattened to `*_x/_y/_z` numbers
+    /// * `CombatVictor` becomes a `"player" | "hostile"` string
+    /// * `bool` becomes [`PayloadValue::Boolean`]
+    /// * `event_id` is **not** emitted — it lives in the Rust-internal
+    ///   `NotifiedEventIds` map and is not part of the observable
+    ///   `e.payload` surface (see plan-349 §3.5 field-rationale note).
+    ///
+    /// Optional `Entity` fields (`system: Option<Entity>` on
+    /// `StructureBuilt` / `ShipArrived`) are only inserted when `Some`.
+    pub fn to_core_payload_snapshot(&self) -> Option<super::payload::PayloadSnapshot> {
+        use super::payload::{PayloadSnapshot, PayloadValue};
+        use std::collections::HashMap;
+
+        let mut fields: HashMap<String, PayloadValue> = HashMap::new();
+        match self {
+            KnowledgeFact::HostileDetected {
+                target,
+                detector,
+                target_pos,
+                description,
+                ..
+            } => {
+                fields.insert("target".into(), PayloadValue::Entity(target.to_bits()));
+                fields.insert("detector".into(), PayloadValue::Entity(detector.to_bits()));
+                fields.insert("target_pos_x".into(), PayloadValue::Number(target_pos[0]));
+                fields.insert("target_pos_y".into(), PayloadValue::Number(target_pos[1]));
+                fields.insert("target_pos_z".into(), PayloadValue::Number(target_pos[2]));
+                fields.insert(
+                    "description".into(),
+                    PayloadValue::String(description.clone()),
+                );
+            }
+            KnowledgeFact::CombatOutcome {
+                system,
+                victor,
+                detail,
+                ..
+            } => {
+                fields.insert("system".into(), PayloadValue::Entity(system.to_bits()));
+                fields.insert(
+                    "victor".into(),
+                    PayloadValue::String(
+                        match victor {
+                            CombatVictor::Player => "player",
+                            CombatVictor::Hostile => "hostile",
+                        }
+                        .to_string(),
+                    ),
+                );
+                fields.insert("detail".into(), PayloadValue::String(detail.clone()));
+            }
+            KnowledgeFact::SurveyComplete {
+                system,
+                system_name,
+                detail,
+                ..
+            } => {
+                fields.insert("system".into(), PayloadValue::Entity(system.to_bits()));
+                fields.insert(
+                    "system_name".into(),
+                    PayloadValue::String(system_name.clone()),
+                );
+                fields.insert("detail".into(), PayloadValue::String(detail.clone()));
+            }
+            KnowledgeFact::AnomalyDiscovered {
+                system,
+                anomaly_id,
+                detail,
+                ..
+            } => {
+                fields.insert("system".into(), PayloadValue::Entity(system.to_bits()));
+                fields.insert(
+                    "anomaly_id".into(),
+                    PayloadValue::String(anomaly_id.clone()),
+                );
+                fields.insert("detail".into(), PayloadValue::String(detail.clone()));
+            }
+            KnowledgeFact::SurveyDiscovery { system, detail, .. } => {
+                fields.insert("system".into(), PayloadValue::Entity(system.to_bits()));
+                fields.insert("detail".into(), PayloadValue::String(detail.clone()));
+            }
+            KnowledgeFact::StructureBuilt {
+                system,
+                kind,
+                name,
+                destroyed,
+                detail,
+                ..
+            } => {
+                if let Some(s) = system {
+                    fields.insert("system".into(), PayloadValue::Entity(s.to_bits()));
+                }
+                fields.insert("kind".into(), PayloadValue::String(kind.clone()));
+                fields.insert("name".into(), PayloadValue::String(name.clone()));
+                fields.insert("destroyed".into(), PayloadValue::Boolean(*destroyed));
+                fields.insert("detail".into(), PayloadValue::String(detail.clone()));
+            }
+            KnowledgeFact::ColonyEstablished {
+                system,
+                planet,
+                name,
+                detail,
+                ..
+            } => {
+                fields.insert("system".into(), PayloadValue::Entity(system.to_bits()));
+                fields.insert("planet".into(), PayloadValue::Entity(planet.to_bits()));
+                fields.insert("name".into(), PayloadValue::String(name.clone()));
+                fields.insert("detail".into(), PayloadValue::String(detail.clone()));
+            }
+            KnowledgeFact::ColonyFailed {
+                system,
+                name,
+                reason,
+                ..
+            } => {
+                fields.insert("system".into(), PayloadValue::Entity(system.to_bits()));
+                fields.insert("name".into(), PayloadValue::String(name.clone()));
+                fields.insert("reason".into(), PayloadValue::String(reason.clone()));
+            }
+            KnowledgeFact::ShipArrived {
+                system,
+                name,
+                detail,
+                ..
+            } => {
+                if let Some(s) = system {
+                    fields.insert("system".into(), PayloadValue::Entity(s.to_bits()));
+                }
+                fields.insert("name".into(), PayloadValue::String(name.clone()));
+                fields.insert("detail".into(), PayloadValue::String(detail.clone()));
+            }
+            KnowledgeFact::Scripted { .. } => return None,
+        }
+        Some(PayloadSnapshot { fields })
+    }
+
+    /// #354 (K-5): Related star system for a core variant, matching the
+    /// `origin_system` metadata slot in `<core:*>@recorded` events. For
+    /// variants that already carry `Option<Entity>` (`StructureBuilt`,
+    /// `ShipArrived`) this forwards the optional field; other variants
+    /// provide their concrete system via `Some(_)`. Identical to
+    /// [`Self::related_system`] today but kept as a separate hook so
+    /// future core variants with a distinct "origin" vs "related"
+    /// semantic can diverge cleanly.
+    pub fn core_origin_system(&self) -> Option<Entity> {
+        self.related_system()
+    }
 }
 
 /// A [`KnowledgeFact`] plus the timing + provenance metadata the arrival
@@ -719,6 +898,13 @@ pub struct PlayerVantage {
 /// fact-writing callsite needs. Keeps the parameter count of the host system
 /// under Bevy's 16-param limit while avoiding a re-query of `Position` (the
 /// callsite supplies the vantage via [`PlayerVantage`]).
+///
+/// #354 K-5: [`FactSysParam::record`] now also pushes a
+/// [`PendingKnowledgeRecord`](crate::scripting::knowledge_dispatch::PendingKnowledgeRecord)
+/// mirroring the fact into the `core:*` kind so the K-2 pipeline can
+/// fire `<core:*>@recorded` subscribers on the next Update tick. This
+/// does **not** change the legacy banner / `PendingFactQueue` path —
+/// both flows are produced from the same `record()` call.
 #[derive(SystemParam)]
 pub struct FactSysParam<'w, 's> {
     pub fact_queue: ResMut<'w, PendingFactQueue>,
@@ -727,6 +913,12 @@ pub struct FactSysParam<'w, 's> {
     pub next_event_id: ResMut<'w, NextEventId>,
     pub relay_network: Res<'w, RelayNetwork>,
     pub empire_comms: Query<'w, 's, &'static CommsParams, With<crate::player::PlayerEmpire>>,
+    /// #354 K-5: core variant -> `PendingKnowledgeRecord` sink. Optional
+    /// so callsites that construct a `FactSysParam` outside
+    /// `ScriptingPlugin` (tests / observer-mode headless apps) don't
+    /// crash when the resource is absent.
+    pub pending_records:
+        Option<ResMut<'w, crate::scripting::knowledge_dispatch::PendingKnowledgeRecords>>,
 }
 
 impl<'w, 's> FactSysParam<'w, 's> {
@@ -764,6 +956,13 @@ impl<'w, 's> FactSysParam<'w, 's> {
     ///     &vantage,
     /// );
     /// ```
+    ///
+    /// #354 K-5: after the legacy `record_fact_or_local` call, a core
+    /// variant also pushes a `PendingKnowledgeRecord` so the K-2
+    /// `dispatch_knowledge_recorded` system can fire
+    /// `<core:*>@recorded` subscribers. Scripted variants are ignored
+    /// by the core push (they already come in through
+    /// `gs:record_knowledge`).
     pub fn record(
         &mut self,
         fact: KnowledgeFact,
@@ -775,6 +974,25 @@ impl<'w, 's> FactSysParam<'w, 's> {
         // overlap the borrow of `empire_comms` / `relay_network`.
         let comms = self.empire_comms.iter().next().cloned().unwrap_or_default();
         let relays = self.relay_network.relays.clone();
+
+        // #354 K-5: mirror the fact as a pending `core:*` record BEFORE
+        // the legacy dispatch consumes `fact` by move. We only push
+        // when we have a pending-records resource (production) and the
+        // variant maps to a core kind id (Scripted has `None`).
+        if let (Some(kind_id), Some(snapshot)) =
+            (fact.core_kind_id(), fact.to_core_payload_snapshot())
+            && let Some(records) = self.pending_records.as_mut()
+        {
+            records.push(
+                crate::scripting::knowledge_dispatch::PendingKnowledgeRecord {
+                    kind_id: kind_id.to_string(),
+                    origin_system: fact.core_origin_system(),
+                    payload_snapshot: snapshot,
+                    recorded_at: observed_at,
+                },
+            );
+        }
+
         record_fact_or_local(
             fact,
             origin_pos,
@@ -1125,6 +1343,311 @@ mod tests {
 
         // One future Scripted fact remains.
         assert_eq!(q.pending_len(), 1);
+    }
+
+    // --- #354 K-5: core variant -> kind id + payload converter ---
+
+    /// `core_kind_id` returns a `core:*` id for every built-in variant
+    /// and `None` for `Scripted`. The set must match `CORE_KIND_IDS`.
+    #[test]
+    fn core_kind_id_mapping_matches_registry() {
+        use crate::knowledge::kind_registry::CORE_KIND_IDS;
+        use std::collections::HashSet;
+
+        // Build one sample of each variant so we can interrogate `core_kind_id`.
+        let samples: Vec<KnowledgeFact> = vec![
+            KnowledgeFact::HostileDetected {
+                event_id: None,
+                target: Entity::PLACEHOLDER,
+                detector: Entity::PLACEHOLDER,
+                target_pos: [0.0; 3],
+                description: "".into(),
+            },
+            KnowledgeFact::CombatOutcome {
+                event_id: None,
+                system: Entity::PLACEHOLDER,
+                victor: CombatVictor::Player,
+                detail: "".into(),
+            },
+            KnowledgeFact::SurveyComplete {
+                event_id: None,
+                system: Entity::PLACEHOLDER,
+                system_name: "".into(),
+                detail: "".into(),
+            },
+            KnowledgeFact::AnomalyDiscovered {
+                event_id: None,
+                system: Entity::PLACEHOLDER,
+                anomaly_id: "".into(),
+                detail: "".into(),
+            },
+            KnowledgeFact::SurveyDiscovery {
+                event_id: None,
+                system: Entity::PLACEHOLDER,
+                detail: "".into(),
+            },
+            KnowledgeFact::StructureBuilt {
+                event_id: None,
+                system: None,
+                kind: "".into(),
+                name: "".into(),
+                destroyed: false,
+                detail: "".into(),
+            },
+            KnowledgeFact::ColonyEstablished {
+                event_id: None,
+                system: Entity::PLACEHOLDER,
+                planet: Entity::PLACEHOLDER,
+                name: "".into(),
+                detail: "".into(),
+            },
+            KnowledgeFact::ColonyFailed {
+                event_id: None,
+                system: Entity::PLACEHOLDER,
+                name: "".into(),
+                reason: "".into(),
+            },
+            KnowledgeFact::ShipArrived {
+                event_id: None,
+                system: None,
+                name: "".into(),
+                detail: "".into(),
+            },
+        ];
+
+        let seen: HashSet<&'static str> = samples
+            .iter()
+            .map(|f| f.core_kind_id().expect("built-in variant has core kind id"))
+            .collect();
+        let expected: HashSet<&'static str> = CORE_KIND_IDS.iter().copied().collect();
+        assert_eq!(
+            seen, expected,
+            "KnowledgeFact::core_kind_id must enumerate the same set as CORE_KIND_IDS"
+        );
+
+        // Scripted returns None.
+        let scripted = KnowledgeFact::Scripted {
+            event_id: None,
+            kind_id: "mod:x".into(),
+            origin_system: None,
+            payload_snapshot: super::super::payload::PayloadSnapshot::default(),
+            recorded_at: 0,
+        };
+        assert!(scripted.core_kind_id().is_none());
+    }
+
+    /// Converter drops `event_id`, flattens position + CombatVictor,
+    /// and covers every schema field declared by the registry.
+    #[test]
+    fn core_payload_snapshot_contains_expected_fields_hostile() {
+        use super::super::payload::PayloadValue;
+        let fact = KnowledgeFact::HostileDetected {
+            event_id: Some(EventId(7)),
+            target: Entity::from_bits(100),
+            detector: Entity::from_bits(200),
+            target_pos: [1.0, 2.5, -3.25],
+            description: "Saw pirate".into(),
+        };
+        let snap = fact.to_core_payload_snapshot().unwrap();
+        // `event_id` not present.
+        assert!(!snap.fields.contains_key("event_id"));
+        // Fields.
+        assert!(
+            matches!(snap.fields.get("target"), Some(PayloadValue::Entity(bits)) if *bits == 100)
+        );
+        assert!(
+            matches!(snap.fields.get("detector"), Some(PayloadValue::Entity(bits)) if *bits == 200)
+        );
+        assert!(
+            matches!(snap.fields.get("target_pos_x"), Some(PayloadValue::Number(n)) if (*n - 1.0).abs() < f64::EPSILON)
+        );
+        assert!(
+            matches!(snap.fields.get("target_pos_y"), Some(PayloadValue::Number(n)) if (*n - 2.5).abs() < f64::EPSILON)
+        );
+        assert!(
+            matches!(snap.fields.get("target_pos_z"), Some(PayloadValue::Number(n)) if (*n + 3.25).abs() < f64::EPSILON)
+        );
+        assert!(
+            matches!(snap.fields.get("description"), Some(PayloadValue::String(s)) if s == "Saw pirate")
+        );
+    }
+
+    #[test]
+    fn core_payload_snapshot_combat_victor_flattens_to_string() {
+        use super::super::payload::PayloadValue;
+        for (v, expected) in [
+            (CombatVictor::Player, "player"),
+            (CombatVictor::Hostile, "hostile"),
+        ] {
+            let fact = KnowledgeFact::CombatOutcome {
+                event_id: None,
+                system: Entity::PLACEHOLDER,
+                victor: v,
+                detail: "d".into(),
+            };
+            let snap = fact.to_core_payload_snapshot().unwrap();
+            assert!(
+                matches!(snap.fields.get("victor"), Some(PayloadValue::String(s)) if s == expected),
+                "victor={:?} should flatten to '{}'",
+                v,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn core_payload_snapshot_skips_system_when_none() {
+        // StructureBuilt / ShipArrived carry Option<Entity>; when None, the
+        // converter must omit the `system` field (not emit `Nil`) so the
+        // schema check upstream doesn't mis-type.
+        let fact = KnowledgeFact::StructureBuilt {
+            event_id: None,
+            system: None,
+            kind: "platform".into(),
+            name: "Beacon".into(),
+            destroyed: false,
+            detail: "".into(),
+        };
+        let snap = fact.to_core_payload_snapshot().unwrap();
+        assert!(!snap.fields.contains_key("system"));
+
+        let fact_with = KnowledgeFact::StructureBuilt {
+            event_id: None,
+            system: Some(Entity::from_bits(42)),
+            kind: "".into(),
+            name: "".into(),
+            destroyed: false,
+            detail: "".into(),
+        };
+        let snap_with = fact_with.to_core_payload_snapshot().unwrap();
+        assert!(snap_with.fields.contains_key("system"));
+    }
+
+    #[test]
+    fn core_payload_snapshot_scripted_returns_none() {
+        let fact = KnowledgeFact::Scripted {
+            event_id: None,
+            kind_id: "mod:x".into(),
+            origin_system: None,
+            payload_snapshot: super::super::payload::PayloadSnapshot::default(),
+            recorded_at: 0,
+        };
+        assert!(fact.to_core_payload_snapshot().is_none());
+    }
+
+    /// Every schema field declared by `core_kind_catalog` must be
+    /// emitted by the converter for its matching variant (when the
+    /// source field is not an `Option::None`). Catches future drift
+    /// between the schema list and the converter.
+    #[test]
+    fn core_payload_schema_matches_converter_output() {
+        use crate::knowledge::kind_registry::core_kind_catalog;
+
+        // Build one "populated" sample for each kind id so Option fields
+        // resolve to Some(_).
+        let samples: Vec<(&str, KnowledgeFact)> = vec![
+            (
+                "core:hostile_detected",
+                KnowledgeFact::HostileDetected {
+                    event_id: None,
+                    target: Entity::from_bits(1),
+                    detector: Entity::from_bits(2),
+                    target_pos: [0.0; 3],
+                    description: "".into(),
+                },
+            ),
+            (
+                "core:combat_outcome",
+                KnowledgeFact::CombatOutcome {
+                    event_id: None,
+                    system: Entity::from_bits(1),
+                    victor: CombatVictor::Player,
+                    detail: "".into(),
+                },
+            ),
+            (
+                "core:survey_complete",
+                KnowledgeFact::SurveyComplete {
+                    event_id: None,
+                    system: Entity::from_bits(1),
+                    system_name: "".into(),
+                    detail: "".into(),
+                },
+            ),
+            (
+                "core:anomaly_discovered",
+                KnowledgeFact::AnomalyDiscovered {
+                    event_id: None,
+                    system: Entity::from_bits(1),
+                    anomaly_id: "".into(),
+                    detail: "".into(),
+                },
+            ),
+            (
+                "core:survey_discovery",
+                KnowledgeFact::SurveyDiscovery {
+                    event_id: None,
+                    system: Entity::from_bits(1),
+                    detail: "".into(),
+                },
+            ),
+            (
+                "core:structure_built",
+                KnowledgeFact::StructureBuilt {
+                    event_id: None,
+                    system: Some(Entity::from_bits(1)),
+                    kind: "".into(),
+                    name: "".into(),
+                    destroyed: false,
+                    detail: "".into(),
+                },
+            ),
+            (
+                "core:colony_established",
+                KnowledgeFact::ColonyEstablished {
+                    event_id: None,
+                    system: Entity::from_bits(1),
+                    planet: Entity::from_bits(2),
+                    name: "".into(),
+                    detail: "".into(),
+                },
+            ),
+            (
+                "core:colony_failed",
+                KnowledgeFact::ColonyFailed {
+                    event_id: None,
+                    system: Entity::from_bits(1),
+                    name: "".into(),
+                    reason: "".into(),
+                },
+            ),
+            (
+                "core:ship_arrived",
+                KnowledgeFact::ShipArrived {
+                    event_id: None,
+                    system: Some(Entity::from_bits(1)),
+                    name: "".into(),
+                    detail: "".into(),
+                },
+            ),
+        ];
+
+        for (id, fact) in samples {
+            let snap = fact
+                .to_core_payload_snapshot()
+                .unwrap_or_else(|| panic!("no snapshot for {id}"));
+            let schema = core_kind_catalog()
+                .iter()
+                .find(|(k, _)| *k == id)
+                .unwrap_or_else(|| panic!("no schema for {id}"))
+                .1;
+            for (field_name, _) in schema {
+                assert!(
+                    snap.fields.contains_key(*field_name),
+                    "kind '{id}': converter missing field '{field_name}' declared in schema"
+                );
+            }
+        }
     }
 
     #[test]

--- a/macrocosmo/src/knowledge/facts.rs
+++ b/macrocosmo/src/knowledge/facts.rs
@@ -612,17 +612,15 @@ impl PendingFactQueue {
 
     /// #353 (K-4): Drain **only** `KnowledgeFact::Scripted` facts whose
     /// `arrives_at <= now`, leaving core variants in place for the legacy
-    /// `notify_from_knowledge_facts` path (banner drain). This is the
-    /// per-plan-349 §3.4 split: `dispatch_knowledge_observed` consumes the
-    /// Scripted subset, `notify_from_knowledge_facts` consumes the rest.
+    /// `notify_from_knowledge_facts` path (banner drain).
     ///
-    /// Ordering invariant: insertion order is preserved across both drains,
-    /// so the two systems can run in any order without double-processing
-    /// (the wrapper does not peek at the other subset).
-    ///
-    /// K-5 (#354) will unify this: core variants will also flow through
-    /// `dispatch_knowledge_observed` and `notify_from_knowledge_facts` will
-    /// become a thin bridge that reads the dispatched banner queue.
+    /// #354 K-5 status: this partitioned drain is **no longer used** by
+    /// the production pipeline — `dispatch_knowledge_observed` now
+    /// drains the whole queue via `drain_ready()` and handles both
+    /// core + scripted variants in a single pass. The partitioned
+    /// helper is retained for any future callsites that deliberately
+    /// want the Scripted-only subset (plus the K-4 unit tests that
+    /// exercise its ordering invariant).
     pub fn drain_ready_scripted(&mut self, now: i64) -> Vec<PerceivedFact> {
         let mut ready = Vec::new();
         let mut i = 0;

--- a/macrocosmo/src/knowledge/kind_registry.rs
+++ b/macrocosmo/src/knowledge/kind_registry.rs
@@ -297,6 +297,156 @@ impl KindRegistry {
         self.kinds.insert(def.id.as_str().to_string(), def);
         Ok(())
     }
+
+    /// #354 (K-5): Pre-populate the registry with the Rust-side built-in
+    /// kinds (`core:*`). Each kind mirrors one of the `KnowledgeFact`
+    /// variants listed in plan-349 §1.1 with a payload schema that
+    /// matches the field set emitted by the core→scripted converter in
+    /// [`crate::knowledge::facts`].
+    ///
+    /// The registry returned here is inserted into the world **before**
+    /// Lua `define_knowledge { id = "core:..." }` can run — the
+    /// subsequent Lua drain will find each `core:*` id already present
+    /// and raise `KindRegistryError::DuplicateKind` (which the loader
+    /// surfaces as a `warn!`; plan §0.5 9.6 "`core:` 上書きは常に error").
+    ///
+    /// The set of kinds and their field mapping **must** stay in sync
+    /// with the core→payload converter. [`CORE_KIND_IDS`] and
+    /// [`core_kind_catalog`] enumerate the id constants in one place so
+    /// callers can iterate without duplicating the string list.
+    pub fn preload_core() -> Self {
+        let mut r = Self::default();
+        for (id, fields) in core_kind_catalog() {
+            let schema = PayloadSchema {
+                fields: fields
+                    .iter()
+                    .map(|(k, ty)| ((*k).to_string(), *ty))
+                    .collect(),
+            };
+            let parsed = KnowledgeKindId::parse(id)
+                .expect("core kind ids must parse (unit-tested in registry tests)");
+            r.insert(KnowledgeKindDef {
+                id: parsed,
+                payload_schema: schema,
+                origin: KindOrigin::Core,
+            })
+            .expect("core kind catalog has no duplicates (unit-tested in registry tests)");
+        }
+        r
+    }
+}
+
+/// `core:*` kind ids (plan-349 §3.5). Exposed so callers that need a
+/// stable list (tests, notification bridges) don't have to re-derive it.
+pub const CORE_KIND_IDS: &[&str] = &[
+    "core:hostile_detected",
+    "core:combat_outcome",
+    "core:survey_complete",
+    "core:anomaly_discovered",
+    "core:survey_discovery",
+    "core:structure_built",
+    "core:colony_established",
+    "core:colony_failed",
+    "core:ship_arrived",
+];
+
+/// Full payload schema catalog for `core:*` kinds. The schema mirrors the
+/// field set that the core→payload converter emits for each variant —
+/// keep them synchronised.
+///
+/// Field type rationale:
+/// * `event_id`: **not** included — it is a Rust-internal dedup handle
+///   (see `NotifiedEventIds`), not part of the observable payload.
+/// * `Entity` values are exposed as `entity` (serialised as `u64`).
+/// * `[f64; 3]` positions are flattened into `target_pos_{x,y,z}`.
+/// * `CombatVictor` is flattened into `victor: string` ("player" /
+///   "hostile") to keep payloads purely scalar/string/entity typed.
+/// * `destroyed: bool` is exposed as `boolean`.
+pub fn core_kind_catalog() -> &'static [(&'static str, &'static [(&'static str, PayloadFieldType)])]
+{
+    &[
+        (
+            "core:hostile_detected",
+            &[
+                ("target", PayloadFieldType::Entity),
+                ("detector", PayloadFieldType::Entity),
+                ("target_pos_x", PayloadFieldType::Number),
+                ("target_pos_y", PayloadFieldType::Number),
+                ("target_pos_z", PayloadFieldType::Number),
+                ("description", PayloadFieldType::String),
+            ],
+        ),
+        (
+            "core:combat_outcome",
+            &[
+                ("system", PayloadFieldType::Entity),
+                ("victor", PayloadFieldType::String),
+                ("detail", PayloadFieldType::String),
+            ],
+        ),
+        (
+            "core:survey_complete",
+            &[
+                ("system", PayloadFieldType::Entity),
+                ("system_name", PayloadFieldType::String),
+                ("detail", PayloadFieldType::String),
+            ],
+        ),
+        (
+            "core:anomaly_discovered",
+            &[
+                ("system", PayloadFieldType::Entity),
+                ("anomaly_id", PayloadFieldType::String),
+                ("detail", PayloadFieldType::String),
+            ],
+        ),
+        (
+            "core:survey_discovery",
+            &[
+                ("system", PayloadFieldType::Entity),
+                ("detail", PayloadFieldType::String),
+            ],
+        ),
+        (
+            "core:structure_built",
+            &[
+                // `system` is Option<Entity>: the converter only inserts
+                // the field when the original variant had Some(_), so the
+                // schema marks it as Entity without imposing required-ness.
+                ("system", PayloadFieldType::Entity),
+                ("kind", PayloadFieldType::String),
+                ("name", PayloadFieldType::String),
+                ("destroyed", PayloadFieldType::Boolean),
+                ("detail", PayloadFieldType::String),
+            ],
+        ),
+        (
+            "core:colony_established",
+            &[
+                ("system", PayloadFieldType::Entity),
+                ("planet", PayloadFieldType::Entity),
+                ("name", PayloadFieldType::String),
+                ("detail", PayloadFieldType::String),
+            ],
+        ),
+        (
+            "core:colony_failed",
+            &[
+                ("system", PayloadFieldType::Entity),
+                ("name", PayloadFieldType::String),
+                ("reason", PayloadFieldType::String),
+            ],
+        ),
+        (
+            "core:ship_arrived",
+            &[
+                // Same Option<Entity> note as `core:structure_built`.
+                ("system", PayloadFieldType::Entity),
+                ("name", PayloadFieldType::String),
+                ("detail", PayloadFieldType::String),
+            ],
+        ),
+    ]
 }
 
 #[cfg(test)]
@@ -529,5 +679,83 @@ mod tests {
             reg.insert(make_def("mod:test", KindOrigin::Lua)),
             Err(KindRegistryError::DuplicateKind(_))
         ));
+    }
+
+    // --- #354 K-5: preload_core ---
+
+    #[test]
+    fn preload_core_registers_all_expected_ids() {
+        let reg = KindRegistry::preload_core();
+        // The catalog must match CORE_KIND_IDS exactly.
+        for id in CORE_KIND_IDS {
+            assert!(
+                reg.contains(id),
+                "preload_core() missing core kind id '{id}'"
+            );
+        }
+        assert_eq!(
+            reg.len(),
+            CORE_KIND_IDS.len(),
+            "preload_core() len mismatch — CORE_KIND_IDS and core_kind_catalog() drifted apart"
+        );
+    }
+
+    #[test]
+    fn preload_core_marks_every_kind_as_core_origin() {
+        let reg = KindRegistry::preload_core();
+        for id in CORE_KIND_IDS {
+            let def = reg.get(id).expect("core id preloaded");
+            assert_eq!(
+                def.origin,
+                KindOrigin::Core,
+                "core:* kind '{id}' must carry KindOrigin::Core"
+            );
+        }
+    }
+
+    #[test]
+    fn preload_core_then_lua_redefinition_is_duplicate_error() {
+        // plan §0.5 9.6 / §2.3: Lua cannot redefine core:* kinds. The
+        // first guard (`CoreNamespaceReserved`) also triggers, so we
+        // assert both protections are in effect.
+        let mut reg = KindRegistry::preload_core();
+        let err = reg
+            .insert(make_def("core:hostile_detected", KindOrigin::Lua))
+            .unwrap_err();
+        // Lua-origin hitting core namespace trips the CoreNamespaceReserved
+        // error *before* the duplicate check.
+        assert!(matches!(err, KindRegistryError::CoreNamespaceReserved(_)));
+
+        // Even if somehow we got past namespace (Rust Core inserting
+        // duplicate), duplicate check still holds.
+        let err2 = reg
+            .insert(make_def("core:hostile_detected", KindOrigin::Core))
+            .unwrap_err();
+        assert!(matches!(err2, KindRegistryError::DuplicateKind(_)));
+    }
+
+    #[test]
+    fn core_kind_catalog_matches_core_kind_ids_list() {
+        let catalog_ids: std::collections::HashSet<&str> =
+            core_kind_catalog().iter().map(|(id, _)| *id).collect();
+        let list_ids: std::collections::HashSet<&str> = CORE_KIND_IDS.iter().copied().collect();
+        assert_eq!(
+            catalog_ids, list_ids,
+            "CORE_KIND_IDS and core_kind_catalog() must enumerate the same set"
+        );
+    }
+
+    #[test]
+    fn preload_core_schemas_are_non_empty() {
+        // Every core kind should ship at least one schema field so
+        // record-time validation has something to check against.
+        let reg = KindRegistry::preload_core();
+        for id in CORE_KIND_IDS {
+            let def = reg.get(id).expect("core id preloaded");
+            assert!(
+                !def.payload_schema.fields.is_empty(),
+                "core:* kind '{id}' must ship a payload schema"
+            );
+        }
     }
 }

--- a/macrocosmo/src/notifications.rs
+++ b/macrocosmo/src/notifications.rs
@@ -283,26 +283,26 @@ pub fn auto_notify_from_events(
     }
 }
 
-/// #233: Drain facts whose arrival time has been reached and push them into
-/// the notification queue. Runs after `advance_game_time` so fresh facts
-/// written the same tick can arrive at `observed_at == clock.elapsed`.
+/// #233 / #354: Standalone fact-to-banner drainer.
 ///
-/// This is the systems-1 counterpart of `auto_notify_from_events`. Together
-/// the two cover the full notification surface area while keeping the
-/// light-speed contract intact for remote observations.
+/// **Historical note**: This system **used** to be the production drain
+/// in `NotificationsPlugin`; K-5 (#354) moves the production drain into
+/// `scripting::knowledge_dispatch::dispatch_knowledge_observed` so that
+/// all fact variants (core + scripted) flow through the same
+/// `@observed` dispatch path (plan §3.5 Commit 4, §0.5 9.5).
 ///
-/// #353 K-4: `KnowledgeFact::Scripted` variants are skipped here — they flow
-/// through `scripting::knowledge_dispatch::dispatch_knowledge_observed`,
-/// which drains them with `drain_ready_scripted` and fires `<kind>@observed`
-/// subscribers instead of pushing a banner. Without this skip, arriving
-/// Scripted facts would both surface a generic "Knowledge" banner *and*
-/// fire their subscriber chain — a double-notification bug.
+/// It is **no longer registered by `NotificationsPlugin`** — production
+/// flow goes through the K-5 dispatcher. The function is kept public
+/// and feature-complete so:
+/// * Integration tests that want to exercise the banner pipeline
+///   without the Lua scripting plugin (e.g.
+///   `tests/notification_knowledge_pipeline.rs`) can wire it manually
+///   via `app.add_systems(Update, notify_from_knowledge_facts)`.
+/// * Future headless / server-mode hosts can opt into the legacy
+///   non-Lua drain if they deliberately exclude the scripting plugin.
 ///
-/// K-5 (#354) will unify the drain: all fact variants (Scripted + core)
-/// will route through `dispatch_knowledge_observed`, and
-/// `notify_from_knowledge_facts` will become a thin bridge that consumes
-/// the post-dispatch banner queue. Until then, this system and
-/// `dispatch_knowledge_observed` drain disjoint subsets of the same queue.
+/// The function still skips `Scripted` variants so tests that set up a
+/// mixed queue do not produce spurious "Knowledge" banners.
 pub fn notify_from_knowledge_facts(
     clock: Res<GameClock>,
     mut queue: ResMut<PendingFactQueue>,
@@ -312,11 +312,9 @@ pub fn notify_from_knowledge_facts(
 ) {
     let ready = queue.drain_ready(clock.elapsed);
     for PerceivedFact { fact, .. } in ready {
-        // #353 K-4: Scripted facts are handled by
-        // dispatch_knowledge_observed. If one ended up here (e.g. tests
-        // that bypass drain_ready_scripted), drop the banner push without
-        // touching NotifiedEventIds so the scripted dispatcher can still
-        // process the id cleanly.
+        // Scripted facts never produce a banner through this drainer —
+        // they must go through the Lua subscriber path. Swallow the
+        // fact silently so tests that mix variants don't double-drain.
         if matches!(fact, KnowledgeFact::Scripted { .. }) {
             continue;
         }
@@ -393,6 +391,14 @@ pub fn drain_pending_notifications(
 
 /// Plugin wiring up the notification queue, the per-frame TTL ticker, and
 /// the auto-mapping from `GameEvent` to banners.
+///
+/// #354 K-5: `notify_from_knowledge_facts` is no longer registered
+/// here — the fact drain has moved into
+/// `scripting::knowledge_dispatch::dispatch_knowledge_observed` which
+/// handles both core + scripted variants in one pass (plan §0.5 9.5).
+/// The `sweep_notified_event_ids` order dependency on the dispatcher
+/// is declared via `.after(dispatch_knowledge_observed)` below so the
+/// NotifiedEventIds map is still trimmed each frame.
 pub struct NotificationsPlugin;
 
 impl Plugin for NotificationsPlugin {
@@ -403,16 +409,18 @@ impl Plugin for NotificationsPlugin {
             .add_systems(
                 Update,
                 (
-                    notify_from_knowledge_facts,
                     drain_pending_notifications,
-                    // #249: Frees notified ids each frame so the dedupe map
-                    // doesn't grow unbounded. Must run after both notify
-                    // systems flipped entries to `true`.
+                    // #249: Frees notified ids each frame so the dedupe
+                    // map doesn't grow unbounded. Must run after
+                    // `auto_notify_from_events` AND the K-5 dispatcher
+                    // (which is the new production drain) have flipped
+                    // entries to `true`.
                     crate::knowledge::sweep_notified_event_ids,
                 )
                     .chain()
                     .after(crate::time_system::advance_game_time)
-                    .after(auto_notify_from_events),
+                    .after(auto_notify_from_events)
+                    .after(crate::scripting::knowledge_dispatch::dispatch_knowledge_observed),
             );
     }
 }

--- a/macrocosmo/src/scripting/knowledge_dispatch.rs
+++ b/macrocosmo/src/scripting/knowledge_dispatch.rs
@@ -539,12 +539,15 @@ fn build_recorded_event_table(
 }
 
 // ======================================================================
-// #353 K-4: @observed dispatch (per-observer drain)
+// #353 K-4 / #354 K-5: @observed dispatch + notification bridge
 //
-// `dispatch_knowledge_observed` drains Scripted facts out of
-// `PendingFactQueue` when their `arrives_at <= clock.elapsed`, then for
-// each observer empire builds a sealed event table with lag metadata and
-// dispatches `<kind>@observed` subscribers.
+// `dispatch_knowledge_observed` drains **all** ready facts out of
+// `PendingFactQueue` (core + scripted, arrives_at <= clock.elapsed),
+// then for each observer empire builds a sealed event table with lag
+// metadata and dispatches `<kind>@observed` subscribers. After
+// dispatch completes, core variants additionally produce a
+// [`Notification`] via the bridge so the banner queue stays populated
+// (plan §3.5 K-5 Commit 4: "Rust 側 core:* bridge").
 //
 // Ordering / isolation invariants (plan-349 §2.5, §3.4):
 //   - observer iteration order is deterministic: empires are sorted by
@@ -557,10 +560,15 @@ fn build_recorded_event_table(
 //     `RuntimeError` on write (plan-349 §2.6). `payload` is mutable.
 //   - subscriber errors warn + chain continues (plan-349 §6 item 4).
 //
-// K-5 drain-unification (plan §0.5 9.5 / §5.4): this system currently
-// drains only Scripted variants via `drain_ready_scripted`. Core variants
-// stay on the legacy `notify_from_knowledge_facts` path for now. K-5
-// migrates core variants through the same @observed dispatch path.
+// #354 K-5 drain unification (plan §0.5 9.5, §3.5, §5.4):
+//   - The legacy `notify_from_knowledge_facts` system no longer drains
+//     the queue — it is removed from the plugin wiring. Banner pushes
+//     now live inside this system as a post-dispatch side-effect for
+//     core variants only (Scripted facts remain Lua-subscriber-only).
+//   - The `#249 NotifiedEventIds` tri-state map is honoured the same
+//     way the removed system did: the first registered `try_notify` for
+//     an `EventId` wins, subsequent pushes are silently suppressed.
+//   - `High` priority core banners also auto-pause `GameSpeed`.
 // ======================================================================
 
 /// Metadata keys injected into an `@observed` event table that must NOT
@@ -606,47 +614,54 @@ fn build_observed_event_table(
     Ok(event)
 }
 
-/// Exclusive system that drains Scripted facts whose `arrives_at` has
-/// elapsed and dispatches `<kind>@observed` subscribers for each
-/// observer empire.
+/// #354 K-5: Per-fact decision passed from the dispatcher to the
+/// post-dispatch notification bridge. Populated during `@observed`
+/// dispatch while we still have the full [`PerceivedFact`] in scope.
+struct BannerPush {
+    title: String,
+    description: String,
+    priority: crate::notifications::NotificationPriority,
+    related_system: Option<Entity>,
+    event_id: Option<crate::knowledge::facts::EventId>,
+}
+
+/// Exclusive system that drains all ready facts (core + scripted)
+/// whose `arrives_at` has elapsed, dispatches `<kind>@observed`
+/// subscribers for each observer empire, and — for `core:*` variants —
+/// pushes a banner into `NotificationQueue` as a post-dispatch
+/// side-effect.
 ///
-/// Schedule: `Update`, ordered `.after(advance_game_time)` and
-/// `.after(notify_from_knowledge_facts)`. The ordering against
-/// `notify_from_knowledge_facts` is defensive — Scripted variants are
-/// invisible to that system (§3 Commit 3) so the only coupling is the
-/// shared `PendingFactQueue` resource which Bevy serialises on
-/// `ResMut<PendingFactQueue>`.
+/// Schedule: `Update`, ordered `.after(advance_game_time)`. Before K-5
+/// this ran `.after(notify_from_knowledge_facts)`; with the legacy
+/// drainer removed the ordering is now just the clock dep.
 ///
 /// Uses `&mut World` exclusive access because dispatch_knowledge may
 /// trigger subscribers that call back into `gs:*` setters. Takes the
 /// subscription registry out of the world for the duration of dispatch
 /// (same pattern as `dispatch_knowledge_recorded`).
 pub fn dispatch_knowledge_observed(world: &mut World) {
+    use crate::knowledge::facts::{KnowledgeFact, PendingFactQueue};
+
     // Fast-path: nothing to drain.
     let now = world
         .get_resource::<crate::time_system::GameClock>()
         .map(|c| c.elapsed)
         .unwrap_or(0);
     let has_ready = world
-        .get_resource::<crate::knowledge::facts::PendingFactQueue>()
-        .map(|q| {
-            q.facts.iter().any(|pf| {
-                matches!(
-                    pf.fact,
-                    crate::knowledge::facts::KnowledgeFact::Scripted { .. }
-                ) && pf.arrives_at <= now
-            })
-        })
+        .get_resource::<PendingFactQueue>()
+        .map(|q| q.facts.iter().any(|pf| pf.arrives_at <= now))
         .unwrap_or(false);
     if !has_ready {
         return;
     }
 
-    // Drain ready Scripted facts out of the queue. Core variants remain
-    // for notify_from_knowledge_facts (banner path).
+    // #354 K-5: Drain ALL ready facts (core + scripted) from the queue.
+    // The legacy split between `drain_ready_scripted` (scripted) and
+    // `drain_ready` (core, via `notify_from_knowledge_facts`) collapses
+    // here into the unified drain required by plan §0.5 9.5.
     let ready: Vec<crate::knowledge::facts::PerceivedFact> = {
-        let mut queue = world.resource_mut::<crate::knowledge::facts::PendingFactQueue>();
-        queue.drain_ready_scripted(now)
+        let mut queue = world.resource_mut::<PendingFactQueue>();
+        queue.drain_ready(now)
     };
     if ready.is_empty() {
         return;
@@ -664,6 +679,11 @@ pub fn dispatch_knowledge_observed(world: &mut World) {
         v
     };
 
+    // #354 K-5: Collect banner pushes during the Lua dispatch so we can
+    // apply them in a subsequent world-scope once `ScriptEngine` is
+    // released.
+    let mut pending_banners: Vec<BannerPush> = Vec::new();
+
     // Remove the subscription registry so dispatch_knowledge can borrow
     // it without holding a world borrow (subscribers re-enter via gs:*).
     let registry_opt = world.remove_resource::<KnowledgeSubscriptionRegistry>();
@@ -671,8 +691,12 @@ pub fn dispatch_knowledge_observed(world: &mut World) {
     world.resource_scope::<super::ScriptEngine, _>(|_world, engine| {
         let lua = engine.lua();
         for pf in &ready {
+            // Derive the (kind_id, recorded_at, origin_system,
+            // payload_snapshot) tuple from the fact variant. Scripted
+            // facts carry these directly; core variants are flattened
+            // via `to_core_payload_snapshot()` (Commit 3).
             let (kind_id, recorded_at, origin_system, payload_snapshot) = match &pf.fact {
-                crate::knowledge::facts::KnowledgeFact::Scripted {
+                KnowledgeFact::Scripted {
                     kind_id,
                     recorded_at,
                     origin_system,
@@ -684,9 +708,25 @@ pub fn dispatch_knowledge_observed(world: &mut World) {
                     *origin_system,
                     payload_snapshot.clone(),
                 ),
-                // drain_ready_scripted filtered these out already — this
-                // arm is unreachable but kept as a defensive skip.
-                _ => continue,
+                _ => {
+                    // Core variant: synthesise the tuple from variant
+                    // fields via the K-5 converter. `core_kind_id` and
+                    // `to_core_payload_snapshot` are infallible for
+                    // built-in variants (covered by
+                    // `core_payload_schema_matches_converter_output`).
+                    let Some(kind_id) = pf.fact.core_kind_id() else {
+                        continue;
+                    };
+                    let Some(snap) = pf.fact.to_core_payload_snapshot() else {
+                        continue;
+                    };
+                    (
+                        kind_id.to_string(),
+                        pf.observed_at,
+                        pf.fact.core_origin_system(),
+                        snap,
+                    )
+                }
             };
             let observed_at = pf.arrives_at;
 
@@ -730,12 +770,80 @@ pub fn dispatch_knowledge_observed(world: &mut World) {
                     }
                 }
             }
+
+            // #354 K-5: Enqueue a banner push for core variants. Scripted
+            // facts stay Lua-subscriber-only (plan §3.5 Commit 4). We
+            // use the original `KnowledgeFact` helpers (`title()` /
+            // `description()` / `priority()` / `related_system()`) so
+            // the banner content exactly matches the pre-K-5 output.
+            if !matches!(pf.fact, KnowledgeFact::Scripted { .. }) {
+                pending_banners.push(BannerPush {
+                    title: pf.fact.title().to_string(),
+                    description: pf.fact.description(),
+                    priority: pf.fact.priority(),
+                    related_system: pf.fact.related_system(),
+                    event_id: pf.fact.event_id(),
+                });
+            }
         }
     });
 
     // Put the subscription registry back.
     if let Some(registry) = registry_opt {
         world.insert_resource(registry);
+    }
+
+    // #354 K-5: Apply the collected banner pushes with the full #249
+    // dedup + auto-pause semantics that `notify_from_knowledge_facts`
+    // used to provide. Resource access is cheap here because we're
+    // outside the ScriptEngine scope.
+    apply_pending_banners(world, pending_banners);
+}
+
+/// #354 K-5: Drain the per-tick banner push list collected during
+/// `@observed` dispatch. Honours:
+/// * `#249 NotifiedEventIds::try_notify` — first push for an id wins,
+///   subsequent pushes are suppressed.
+/// * `NotificationPriority::High` auto-pauses `GameSpeed`.
+/// * Low priority pushes return `None` from `queue.push()` but the
+///   EventId is still claimed so a follow-up higher-priority fact with
+///   the same id does not silently overwrite (matches the pre-K-5
+///   `NotifiedEventIds` contract — see
+///   `notifications::notify_from_knowledge_facts` history before this
+///   commit).
+fn apply_pending_banners(world: &mut World, pushes: Vec<BannerPush>) {
+    if pushes.is_empty() {
+        return;
+    }
+    let mut paused_any_high = false;
+    // Use `resource_scope` so we can hold `NotifiedEventIds` out of the
+    // world for the duration of the banner push loop — this keeps the
+    // borrow checker happy while we also hold `ResMut<NotificationQueue>`.
+    world.resource_scope::<crate::knowledge::facts::NotifiedEventIds, _>(|world, mut notified| {
+        let mut queue = world.resource_mut::<crate::notifications::NotificationQueue>();
+        for push in pushes {
+            // EventId dedup (tri-state). Facts with no id skip the gate.
+            if let Some(eid) = push.event_id
+                && !notified.try_notify(eid)
+            {
+                continue;
+            }
+            let id = queue.push(
+                push.title,
+                push.description,
+                None,
+                push.priority,
+                push.related_system,
+            );
+            if id.is_some() && push.priority.pauses_game() {
+                paused_any_high = true;
+            }
+        }
+    });
+    if paused_any_high
+        && let Some(mut speed) = world.get_resource_mut::<crate::time_system::GameSpeed>()
+    {
+        speed.pause();
     }
 }
 

--- a/macrocosmo/src/scripting/mod.rs
+++ b/macrocosmo/src/scripting/mod.rs
@@ -127,17 +127,19 @@ impl Plugin for ScriptingPlugin {
                 knowledge_dispatch::dispatch_knowledge_recorded
                     .after(crate::time_system::advance_game_time),
             )
-            // #353 K-4: drain Scripted facts whose arrival time has
-            // elapsed and fire <kind>@observed subscribers. Runs after
-            // notify_from_knowledge_facts so the two drains cannot
-            // overlap on the same PendingFactQueue resource in a single
-            // schedule pass. Exclusive (&mut World) because subscribers
-            // may re-enter gs:* setters.
+            // #353 K-4 / #354 K-5: drain ALL ready facts (core +
+            // scripted) whose arrival time has elapsed, fire
+            // `<kind>@observed` subscribers, and push banners for core
+            // variants as a post-dispatch side-effect. This replaces
+            // the legacy `notify_from_knowledge_facts` drainer (now
+            // unregistered from `NotificationsPlugin`). Exclusive
+            // (&mut World) because subscribers may re-enter gs:*
+            // setters.
             .add_systems(
                 Update,
                 knowledge_dispatch::dispatch_knowledge_observed
                     .after(crate::time_system::advance_game_time)
-                    .after(crate::notifications::notify_from_knowledge_facts),
+                    .after(crate::notifications::auto_notify_from_events),
             );
     }
 }

--- a/macrocosmo/src/scripting/mod.rs
+++ b/macrocosmo/src/scripting/mod.rs
@@ -466,10 +466,24 @@ pub fn load_knowledge_kinds(mut commands: Commands, engine: Res<ScriptEngine>) {
     use crate::knowledge::kind_registry::KindRegistry;
 
     let lua = engine.lua();
-    let mut registry = KindRegistry::default();
+    // #354 K-5: preload `core:*` kinds before draining the Lua
+    // accumulator so subsequent Lua definitions of the same id trip
+    // either `CoreNamespaceReserved` (Lua origin) or `DuplicateKind`
+    // (both caught by the warn-log below). plan §0.5 9.6 / §3.5.
+    let mut registry = KindRegistry::preload_core();
+    info!(
+        "Preloaded {} core:* knowledge kind definition(s)",
+        registry.len()
+    );
 
-    // K-5 will preload `core:*` kinds here before Lua-side parsing so that
-    // duplicate detection catches Lua re-definitions of built-ins.
+    // #354 K-5: Reserve `<core:*>@recorded` / `<core:*>@observed` event
+    // ids in the Lua-side `_knowledge_reserved_events` table so K-3's
+    // subscription tooling (`is_reserved_knowledge_event` + future
+    // modder diagnostics) sees core:* alongside Lua-defined kinds.
+    let core_defs: Vec<_> = registry.kinds.values().cloned().collect();
+    if let Err(e) = knowledge_api::register_auto_lifecycle_events(lua, &core_defs) {
+        warn!("Failed to reserve core:* knowledge lifecycle events: {e}");
+    }
 
     match knowledge_api::parse_knowledge_definitions(lua) {
         Ok(defs) => {

--- a/macrocosmo/tests/knowledge_core_wire.rs
+++ b/macrocosmo/tests/knowledge_core_wire.rs
@@ -1,0 +1,550 @@
+//! #354 K-5: integration tests for the `core:*` wire through the
+//! scripted-knowledge pipeline.
+//!
+//! After K-5, Rust-origin `KnowledgeFact` variants mirror themselves as
+//! `core:*` knowledge kinds — `@recorded` subscribers fire from the
+//! Rust-origin dispatcher on the same tick, and `@observed` subscribers
+//! (plus the notification bridge) fire when the fact's arrival time is
+//! reached (plan §3.5 Commit 5).
+//!
+//! The matrix below exercises the observable behaviour:
+//!
+//! * `core:*` kinds are preloaded into `KindRegistry`.
+//! * Rust fact emitter (via `FactSysParam::record`) pushes into
+//!   `PendingKnowledgeRecords` → `dispatch_knowledge_recorded` fires
+//!   `<core:*>@recorded` subscribers and enqueues a Scripted fact into
+//!   `PendingFactQueue`.
+//! * When the queue reaches `arrives_at <= clock.elapsed`,
+//!   `dispatch_knowledge_observed` fires `<core:*>@observed`
+//!   subscribers AND pushes a `Notification` via the bridge.
+//! * `*@observed` wildcard catches core + scripted kinds.
+//! * Lua `define_knowledge { id = "core:<foo>" }` fails at parse time.
+//! * The notification banner output for a core variant is
+//!   byte-identical to the pre-K-5 `notify_from_knowledge_facts`
+//!   output (banner regression guard).
+
+use bevy::prelude::*;
+use macrocosmo::knowledge::ObservationSource;
+use macrocosmo::knowledge::facts::{
+    KnowledgeFact, NextEventId, NotifiedEventIds, PendingFactQueue, PerceivedFact, RelayNetwork,
+};
+use macrocosmo::knowledge::kind_registry::{CORE_KIND_IDS, KindRegistry};
+use macrocosmo::notifications::{NotificationPriority, NotificationQueue};
+use macrocosmo::scripting::ScriptEngine;
+use macrocosmo::scripting::knowledge_api::parse_knowledge_definitions;
+use macrocosmo::scripting::knowledge_dispatch::{
+    PendingKnowledgeRecord, PendingKnowledgeRecords, dispatch_knowledge_observed,
+    dispatch_knowledge_recorded,
+};
+use macrocosmo::scripting::knowledge_registry::{
+    KnowledgeSubscriptionRegistry, drain_pending_subscriptions,
+};
+use macrocosmo::time_system::GameClock;
+
+// -------------------------------------------------------------------------
+// Shared harness
+// -------------------------------------------------------------------------
+
+/// Build a world with preloaded `core:*` kinds, a single `PlayerEmpire`
+/// observer, and all resources K-5 dispatchers need.
+fn make_world(clock_elapsed: i64) -> World {
+    let mut world = World::new();
+    world.insert_resource(GameClock::new(clock_elapsed));
+    world.insert_resource(macrocosmo::time_system::GameSpeed::default());
+    world.init_resource::<PendingFactQueue>();
+    world.init_resource::<NextEventId>();
+    world.init_resource::<NotifiedEventIds>();
+    world.insert_resource(NotificationQueue::new());
+    world.init_resource::<RelayNetwork>();
+    world.init_resource::<PendingKnowledgeRecords>();
+
+    // Preloaded core:* registry (production wiring).
+    world.insert_resource(KindRegistry::preload_core());
+
+    // Single observer empire.
+    world.spawn((
+        macrocosmo::player::Empire {
+            name: "Test".into(),
+        },
+        macrocosmo::player::PlayerEmpire,
+    ));
+
+    world
+}
+
+/// Install Lua subscribers and drain into the subscription registry.
+fn setup_subscribers(engine: &ScriptEngine, script: &str) -> KnowledgeSubscriptionRegistry {
+    if !script.is_empty() {
+        engine.lua().load(script).exec().unwrap();
+    }
+    let mut registry = KnowledgeSubscriptionRegistry::default();
+    drain_pending_subscriptions(engine.lua(), &mut registry).unwrap();
+    registry
+}
+
+/// Push a core `KnowledgeFact::HostileDetected` fact straight into the
+/// `PendingFactQueue` with a pre-computed arrival time. Mirrors what
+/// `FactSysParam::record` would do on the remote-arrival path, but
+/// without the light-speed maths.
+fn push_core_hostile_at(
+    world: &mut World,
+    arrives_at: i64,
+    target_bits: u64,
+    detector_bits: u64,
+    description: &str,
+) {
+    let fact = KnowledgeFact::HostileDetected {
+        event_id: None,
+        target: Entity::from_bits(target_bits),
+        detector: Entity::from_bits(detector_bits),
+        target_pos: [10.0, 20.0, 30.0],
+        description: description.to_string(),
+    };
+    let mut queue = world.resource_mut::<PendingFactQueue>();
+    queue.record(PerceivedFact {
+        fact,
+        observed_at: 0,
+        arrives_at,
+        source: ObservationSource::Direct,
+        origin_pos: [10.0, 20.0, 30.0],
+        related_system: None,
+    });
+}
+
+/// Inject a Scripted fact alongside core facts so wildcard coverage
+/// tests can assert both paths fire.
+fn push_scripted_fact_at(world: &mut World, kind_id: &str, arrives_at: i64) {
+    let fact = KnowledgeFact::Scripted {
+        event_id: None,
+        kind_id: kind_id.to_string(),
+        origin_system: None,
+        payload_snapshot: macrocosmo::knowledge::payload::PayloadSnapshot::default(),
+        recorded_at: 0,
+    };
+    let mut queue = world.resource_mut::<PendingFactQueue>();
+    queue.record(PerceivedFact {
+        fact,
+        observed_at: 0,
+        arrives_at,
+        source: ObservationSource::Direct,
+        origin_pos: [0.0; 3],
+        related_system: None,
+    });
+}
+
+// -------------------------------------------------------------------------
+// preload + namespace protection
+// -------------------------------------------------------------------------
+
+#[test]
+fn core_namespace_kinds_are_preloaded() {
+    let world = make_world(100);
+    let registry = world.resource::<KindRegistry>();
+    for id in CORE_KIND_IDS {
+        assert!(
+            registry.contains(id),
+            "core:* kind '{id}' must be preloaded into KindRegistry"
+        );
+    }
+}
+
+/// #354 (plan §2.3 / §3.5 Test plan): Lua cannot shadow a core:* id.
+/// The parse-time guard in `knowledge_api` fires even before the
+/// registry insert guard.
+#[test]
+fn define_knowledge_core_namespace_is_rejected_at_parse() {
+    let engine = ScriptEngine::new().unwrap();
+    // Populate the accumulator with a malicious redefinition.
+    engine
+        .lua()
+        .load(r#"define_knowledge { id = "core:hostile_detected" }"#)
+        .exec()
+        .unwrap();
+    let err = parse_knowledge_definitions(engine.lua()).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("core:"),
+        "expected core:* namespace message: {msg}"
+    );
+    assert!(
+        msg.contains("reserved"),
+        "expected reserved-namespace message: {msg}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// @recorded: Rust-origin fact mirrors through PendingKnowledgeRecords and
+// fires core:*@recorded subscribers in the same tick.
+// -------------------------------------------------------------------------
+
+/// Simulates `FactSysParam::record` by pushing the core variant's
+/// `(core_kind_id, payload_snapshot)` directly into
+/// `PendingKnowledgeRecords`, then running `dispatch_knowledge_recorded`.
+fn push_core_pending_record(world: &mut World, fact: &KnowledgeFact, recorded_at: i64) {
+    let kind_id = fact.core_kind_id().expect("core variant has kind id");
+    let snapshot = fact
+        .to_core_payload_snapshot()
+        .expect("core variant produces snapshot");
+    let origin_system = fact.core_origin_system();
+    let mut pending = world.resource_mut::<PendingKnowledgeRecords>();
+    pending.push(PendingKnowledgeRecord {
+        kind_id: kind_id.to_string(),
+        origin_system,
+        payload_snapshot: snapshot,
+        recorded_at,
+    });
+}
+
+#[test]
+fn rust_origin_fires_core_hostile_detected_recorded() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world(100);
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        _recorded_fired = 0
+        _recorded_target = nil
+        _recorded_description = nil
+        on("core:hostile_detected@recorded", function(e)
+            _recorded_fired = _recorded_fired + 1
+            _recorded_target = e.payload.target
+            _recorded_description = e.payload.description
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    // Simulate Rust-side fact emission for a remote-detected hostile.
+    let fact = KnowledgeFact::HostileDetected {
+        event_id: None,
+        target: Entity::from_bits(111),
+        detector: Entity::from_bits(222),
+        target_pos: [1.0, 2.0, 3.0],
+        description: "pirate patrol".into(),
+    };
+    push_core_pending_record(&mut world, &fact, 100);
+
+    dispatch_knowledge_recorded(&mut world);
+
+    world.resource_scope::<ScriptEngine, _>(|_world, engine| {
+        let fired: i64 = engine.lua().globals().get("_recorded_fired").unwrap();
+        assert_eq!(
+            fired, 1,
+            "core:hostile_detected@recorded fired exactly once"
+        );
+        let target: i64 = engine.lua().globals().get("_recorded_target").unwrap();
+        assert_eq!(target, 111, "payload.target = Entity(111) bits");
+        let description: String = engine.lua().globals().get("_recorded_description").unwrap();
+        assert_eq!(description, "pirate patrol");
+    });
+
+    // After dispatch, the resulting Scripted fact must sit in
+    // PendingFactQueue so `@observed` can drain it later.
+    let queue = world.resource::<PendingFactQueue>();
+    assert_eq!(queue.facts.len(), 1);
+    match &queue.facts[0].fact {
+        KnowledgeFact::Scripted { kind_id, .. } => {
+            assert_eq!(kind_id, "core:hostile_detected");
+        }
+        other => panic!("expected Scripted, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------------------
+// @observed: arrival-time fact drains via dispatch_knowledge_observed and
+// fires core:*@observed subscribers per observer with lag metadata.
+// -------------------------------------------------------------------------
+
+#[test]
+fn core_hostile_detected_fires_observed_on_arrival() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world(500);
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        _observed_fires = 0
+        _last_lag = nil
+        _last_description = nil
+        _last_target = nil
+        on("core:hostile_detected@observed", function(e)
+            _observed_fires = _observed_fires + 1
+            _last_lag = e.lag_hexadies
+            _last_description = e.payload.description
+            _last_target = e.payload.target
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    // Fact observed at t=100 at origin, arriving at t=500. Player is
+    // 400 hexadies away in light-delay terms.
+    {
+        let mut queue = world.resource_mut::<PendingFactQueue>();
+        queue.record(PerceivedFact {
+            fact: KnowledgeFact::HostileDetected {
+                event_id: None,
+                target: Entity::from_bits(777),
+                detector: Entity::from_bits(888),
+                target_pos: [0.0, 0.0, 0.0],
+                description: "incoming fleet".into(),
+            },
+            observed_at: 100,
+            arrives_at: 500,
+            source: ObservationSource::Direct,
+            origin_pos: [0.0; 3],
+            related_system: None,
+        });
+    }
+
+    dispatch_knowledge_observed(&mut world);
+
+    world.resource_scope::<ScriptEngine, _>(|_world, engine| {
+        let fires: i64 = engine.lua().globals().get("_observed_fires").unwrap();
+        assert_eq!(fires, 1, "core:hostile_detected@observed fires once");
+        // lag_hexadies = arrives_at - observed_at = 500 - 100 = 400.
+        // `observed_at` in the event table is the PerceivedFact.observed_at.
+        let lag: i64 = engine.lua().globals().get("_last_lag").unwrap();
+        assert_eq!(lag, 400, "lag_hexadies should reflect 500 - 100");
+        let description: String = engine.lua().globals().get("_last_description").unwrap();
+        assert_eq!(description, "incoming fleet");
+        let target: i64 = engine.lua().globals().get("_last_target").unwrap();
+        assert_eq!(target, 777);
+    });
+
+    // Queue fully drained.
+    let queue = world.resource::<PendingFactQueue>();
+    assert_eq!(queue.pending_len(), 0);
+}
+
+// -------------------------------------------------------------------------
+// Per-observer isolation for core variants (plan §3.5 Test plan).
+// -------------------------------------------------------------------------
+
+#[test]
+fn core_observed_per_observer_payload_isolation() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world(100);
+    // Add a second observer empire so per-observer dispatch fires twice.
+    world.spawn((
+        macrocosmo::player::Empire {
+            name: "Observer2".into(),
+        },
+        macrocosmo::player::PlayerEmpire,
+    ));
+
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        _seen = {}
+        on("core:hostile_detected@observed", function(e)
+            table.insert(_seen, { observer = e.observer_empire, description = e.payload.description })
+            -- Mutate only this observer's payload; the next one must not see it.
+            e.payload.description = "MUTATED"
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    push_core_hostile_at(&mut world, 100, 1, 2, "original");
+
+    dispatch_knowledge_observed(&mut world);
+
+    world.resource_scope::<ScriptEngine, _>(|_world, engine| {
+        let seen: mlua::Table = engine.lua().globals().get("_seen").unwrap();
+        assert_eq!(seen.len().unwrap(), 2, "each observer fires once");
+        let a: mlua::Table = seen.get(1).unwrap();
+        let b: mlua::Table = seen.get(2).unwrap();
+        let ad: String = a.get("description").unwrap();
+        let bd: String = b.get("description").unwrap();
+        assert_eq!(ad, "original", "observer A sees original");
+        assert_eq!(
+            bd, "original",
+            "observer B must see the ORIGINAL (per-observer isolation), not A's mutation"
+        );
+
+        let a_bits: i64 = a.get("observer").unwrap();
+        let b_bits: i64 = b.get("observer").unwrap();
+        assert_ne!(a_bits, b_bits, "observers carry distinct entity bits");
+    });
+}
+
+// -------------------------------------------------------------------------
+// Wildcard `*@observed` catches both core + scripted in registration order.
+// -------------------------------------------------------------------------
+
+#[test]
+fn wildcard_observed_catches_core_and_scripted() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world(100);
+    // Register a non-core kind so the scripted leg has something to
+    // dispatch against.
+    world
+        .resource_mut::<KindRegistry>()
+        .insert(macrocosmo::knowledge::kind_registry::KnowledgeKindDef {
+            id: macrocosmo::knowledge::kind_registry::KnowledgeKindId::parse("mod:alarm").unwrap(),
+            payload_schema: Default::default(),
+            origin: macrocosmo::knowledge::kind_registry::KindOrigin::Lua,
+        })
+        .unwrap();
+
+    let registry = setup_subscribers(
+        &engine,
+        r#"
+        _wildcard_kinds = {}
+        on("*@observed", function(e)
+            table.insert(_wildcard_kinds, e.kind)
+        end)
+        "#,
+    );
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    push_core_hostile_at(&mut world, 100, 1, 2, "core");
+    push_scripted_fact_at(&mut world, "mod:alarm", 100);
+
+    dispatch_knowledge_observed(&mut world);
+
+    world.resource_scope::<ScriptEngine, _>(|_world, engine| {
+        let kinds: mlua::Table = engine.lua().globals().get("_wildcard_kinds").unwrap();
+        assert_eq!(
+            kinds.len().unwrap(),
+            2,
+            "wildcard must fire for both core + scripted"
+        );
+        let k1: String = kinds.get(1).unwrap();
+        let k2: String = kinds.get(2).unwrap();
+        // Insertion order was core first, scripted second.
+        assert_eq!(k1, "core:hostile_detected");
+        assert_eq!(k2, "mod:alarm");
+    });
+}
+
+// -------------------------------------------------------------------------
+// Notification bridge regression: the banner a core fact produces on the
+// K-5 bridge must match the pre-K-5 `notify_from_knowledge_facts` output.
+// -------------------------------------------------------------------------
+
+#[test]
+fn core_notification_bridge_matches_pre_k5_banner() {
+    // Reproduce the exact wire the old drainer used to emit for a
+    // SurveyComplete fact (high-frequency event that existed well before
+    // K-5). Banner title/description/priority must stay byte-identical
+    // so `notification_knowledge_pipeline.rs`'s Spike 10.5 matrix does
+    // not regress under the new drain.
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world(100);
+    // No Lua subscribers — we only verify the Rust-side bridge output.
+    let registry = setup_subscribers(&engine, "");
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    let sys = world.spawn_empty().id();
+    {
+        let mut queue = world.resource_mut::<PendingFactQueue>();
+        queue.record(PerceivedFact {
+            fact: KnowledgeFact::SurveyComplete {
+                event_id: None,
+                system: sys,
+                system_name: "Tau Ceti".into(),
+                detail: "Tau Ceti surveyed".into(),
+            },
+            observed_at: 0,
+            arrives_at: 100,
+            source: ObservationSource::Direct,
+            origin_pos: [0.0; 3],
+            related_system: Some(sys),
+        });
+    }
+
+    dispatch_knowledge_observed(&mut world);
+
+    let q = world.resource::<NotificationQueue>();
+    assert_eq!(q.items.len(), 1, "core variant must produce a banner");
+    assert_eq!(
+        q.items[0].title, "Survey Complete",
+        "banner title must match the pre-K-5 output from KnowledgeFact::title()"
+    );
+    assert_eq!(
+        q.items[0].description, "Tau Ceti surveyed",
+        "banner description must match the pre-K-5 output from KnowledgeFact::description()"
+    );
+    assert_eq!(
+        q.items[0].priority,
+        NotificationPriority::Medium,
+        "SurveyComplete is Medium priority"
+    );
+}
+
+/// Low-priority core variants (ShipArrived, StructureBuilt) must NOT
+/// produce a banner — the same pre-K-5 contract.
+#[test]
+fn core_low_priority_facts_stay_silent_through_bridge() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world(100);
+    let registry = setup_subscribers(&engine, "");
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    {
+        let mut queue = world.resource_mut::<PendingFactQueue>();
+        queue.record(PerceivedFact {
+            fact: KnowledgeFact::ShipArrived {
+                event_id: None,
+                system: None,
+                name: "Corvette".into(),
+                detail: "Arrived".into(),
+            },
+            observed_at: 0,
+            arrives_at: 100,
+            source: ObservationSource::Direct,
+            origin_pos: [0.0; 3],
+            related_system: None,
+        });
+    }
+
+    dispatch_knowledge_observed(&mut world);
+
+    let q = world.resource::<NotificationQueue>();
+    assert_eq!(q.items.len(), 0, "Low-priority ShipArrived must not banner");
+}
+
+/// High-priority core variants auto-pause `GameSpeed` (matches the
+/// pre-K-5 `notify_from_knowledge_facts.speed.pause()` call).
+#[test]
+fn core_high_priority_fact_auto_pauses_game_speed() {
+    let engine = ScriptEngine::new().unwrap();
+    let mut world = make_world(100);
+    // `GameSpeed::default()` starts paused (hexadies_per_second = 0);
+    // unpause it here so the bridge's `speed.pause()` call has an
+    // observable transition to assert against.
+    world
+        .resource_mut::<macrocosmo::time_system::GameSpeed>()
+        .unpause();
+    assert!(
+        !world
+            .resource::<macrocosmo::time_system::GameSpeed>()
+            .is_paused(),
+        "GameSpeed should be running after explicit unpause"
+    );
+
+    let registry = setup_subscribers(&engine, "");
+    world.insert_resource(registry);
+    world.insert_resource(engine);
+
+    // HostileDetected is High priority per `KnowledgeFact::priority`.
+    push_core_hostile_at(&mut world, 100, 1, 2, "hostile");
+
+    dispatch_knowledge_observed(&mut world);
+
+    let speed = world.resource::<macrocosmo::time_system::GameSpeed>();
+    assert!(
+        speed.is_paused(),
+        "K-5 bridge must auto-pause on High-priority banner (hostile detected)"
+    );
+    let notifs = world.resource::<NotificationQueue>();
+    assert_eq!(notifs.items.len(), 1);
+    assert_eq!(notifs.items[0].priority, NotificationPriority::High);
+}

--- a/macrocosmo/tests/knowledge_kinds.rs
+++ b/macrocosmo/tests/knowledge_kinds.rs
@@ -65,6 +65,13 @@ fn load_knowledge_kinds_reads_sample_fixture() {
     // The startup system must pick up `scripts/knowledge/sample.lua`
     // (reached via `scripts/init.lua`) and hand the KindRegistry the four
     // kinds defined in that fixture.
+    //
+    // #354 K-5: the registry now also carries the 9 `core:*` kinds from
+    // `KindRegistry::preload_core()` (plan §3.5). The sample fixture
+    // kinds are appended after the preload, so we check their presence
+    // explicitly and use `CORE_KIND_IDS.len() + 4` for the full size.
+    use macrocosmo::knowledge::kind_registry::CORE_KIND_IDS;
+
     let mut app = run_load_knowledge_kinds();
     let registry = app
         .world_mut()
@@ -79,7 +86,14 @@ fn load_knowledge_kinds_reads_sample_fixture() {
     ] {
         assert!(registry.contains(id), "expected kind '{id}' in registry");
     }
-    assert_eq!(registry.len(), 4);
+    // Every `core:*` preloaded kind must also be present.
+    for id in CORE_KIND_IDS {
+        assert!(
+            registry.contains(id),
+            "expected preloaded core kind '{id}' in registry"
+        );
+    }
+    assert_eq!(registry.len(), CORE_KIND_IDS.len() + 4);
 
     // `sample:anomaly_surveyed` exercises every v1 payload type.
     let def = registry.get("sample:anomaly_surveyed").expect("kind def");
@@ -132,6 +146,15 @@ fn sample_fixture_exposes_accumulator_shape() {
     // Sanity check: the raw accumulator matches the registry size. Guards
     // against a future refactor that splits accumulators without updating
     // the parser.
+    //
+    // #354 K-5: the reserved-events table now also contains the 9
+    // `core:*` preload entries (one per `<id>@recorded` +
+    // `<id>@observed`). The Lua accumulator
+    // (`_knowledge_kind_definitions`) still holds only the Lua-origin
+    // kinds — core:* entries live directly in the Rust `KindRegistry`
+    // and skip the Lua accumulator — so its size stays at 4.
+    use macrocosmo::knowledge::kind_registry::CORE_KIND_IDS;
+
     let app = run_load_knowledge_kinds();
     let engine = app.world().resource::<ScriptEngine>();
     let lua = engine.lua();
@@ -148,7 +171,8 @@ fn sample_fixture_exposes_accumulator_shape() {
             count += 1;
         }
     }
-    assert_eq!(count, 8);
+    // 4 sample kinds + CORE_KIND_IDS.len() preloaded core kinds, each × 2 lifecycles.
+    assert_eq!(count, (4 + CORE_KIND_IDS.len()) * 2);
 }
 
 #[test]
@@ -250,6 +274,11 @@ fn register_auto_lifecycle_events_is_idempotent_end_to_end() {
     // bloat the reserved-events table or error — the startup system may
     // be invoked twice in hot-reload scenarios, and idempotence is the
     // contract we want modders to be able to rely on.
+    //
+    // #354 K-5: the reserved table also includes the 9 core:* kinds so
+    // the expected count is (4 sample + 9 core) × 2 lifecycles.
+    use macrocosmo::knowledge::kind_registry::CORE_KIND_IDS;
+
     let app = run_load_knowledge_kinds();
     let engine = app.world().resource::<ScriptEngine>();
     let lua = engine.lua();
@@ -258,7 +287,6 @@ fn register_auto_lifecycle_events_is_idempotent_end_to_end() {
     register_auto_lifecycle_events(lua, &defs).unwrap();
     register_auto_lifecycle_events(lua, &defs).unwrap();
 
-    // Still only 8 entries (4 kinds × 2 lifecycles).
     let reserved: mlua::Table = lua.globals().get(KNOWLEDGE_RESERVED_EVENTS_TABLE).unwrap();
     let mut count = 0;
     for pair in reserved.pairs::<String, bool>() {
@@ -267,5 +295,6 @@ fn register_auto_lifecycle_events_is_idempotent_end_to_end() {
             count += 1;
         }
     }
-    assert_eq!(count, 8);
+    // 4 sample kinds + CORE_KIND_IDS.len() preloaded core kinds, each × 2 lifecycles.
+    assert_eq!(count, (4 + CORE_KIND_IDS.len()) * 2);
 }

--- a/macrocosmo/tests/knowledge_observed.rs
+++ b/macrocosmo/tests/knowledge_observed.rs
@@ -498,15 +498,24 @@ fn notify_from_knowledge_facts_skips_scripted() {
 }
 
 // -------------------------------------------------------------------------
-// Drain order: when dispatch_knowledge_observed runs BEFORE
-// notify_from_knowledge_facts (e.g. on a tick when no core facts are
-// present), the Scripted fact drains cleanly.
+// #354 K-5 drain-unification: dispatch_knowledge_observed now drains
+// BOTH core + scripted facts in a single pass and pushes a banner for
+// core variants as a post-dispatch side-effect (replacing the removed
+// `notify_from_knowledge_facts` production drainer).
 // -------------------------------------------------------------------------
 
 #[test]
-fn observed_drain_leaves_non_scripted_alone() {
+fn observed_drain_consumes_core_and_scripted_together() {
     let engine = ScriptEngine::new().unwrap();
     let mut world = make_world("test:kind", 1, 100);
+    // Banner bridge relies on these resources existing (they're part
+    // of `make_world` already, but spell out the expectation here).
+    assert!(
+        world
+            .get_resource::<macrocosmo::notifications::NotificationQueue>()
+            .is_some()
+    );
+
     let registry = setup_subscribers(
         &engine,
         r#"
@@ -517,8 +526,9 @@ fn observed_drain_leaves_non_scripted_alone() {
     world.insert_resource(registry);
     world.insert_resource(engine);
 
-    // Queue up one core fact + one Scripted fact. Observed dispatch should
-    // drain only the Scripted one and leave the core for later.
+    // Queue one core fact + one Scripted fact. K-5 dispatcher drains
+    // both: scripted fires its @observed subscriber, core produces a
+    // notification banner via the post-dispatch bridge.
     {
         let mut q = world.resource_mut::<PendingFactQueue>();
         q.record(PerceivedFact {
@@ -554,14 +564,16 @@ fn observed_drain_leaves_non_scripted_alone() {
 
     world.resource_scope::<ScriptEngine, _>(|_, engine| {
         let n: i64 = engine.lua().globals().get("_scripted_fired").unwrap();
-        assert_eq!(n, 1);
+        assert_eq!(n, 1, "scripted @observed subscriber fired once");
     });
 
-    // Core fact remains in the queue.
+    // Both facts are drained (K-5 unification).
     let q = world.resource::<PendingFactQueue>();
-    assert_eq!(q.pending_len(), 1);
-    assert!(matches!(
-        q.facts[0].fact,
-        KnowledgeFact::SurveyComplete { .. }
-    ));
+    assert_eq!(q.pending_len(), 0, "K-5: dispatcher drains both variants");
+
+    // Core variant produced a banner via the notification bridge.
+    let notifs = world.resource::<macrocosmo::notifications::NotificationQueue>();
+    assert_eq!(notifs.items.len(), 1);
+    assert_eq!(notifs.items[0].title, "Survey Complete");
+    assert_eq!(notifs.items[0].description, "surveyed");
 }

--- a/macrocosmo/tests/notification_knowledge_pipeline.rs
+++ b/macrocosmo/tests/notification_knowledge_pipeline.rs
@@ -8,6 +8,39 @@
 //! 2. Player-local events (PlayerRespawn, ResourceAlert, Lua
 //!    `show_notification`) continue to fire the banner immediately via the
 //!    legacy `auto_notify_from_events` whitelist / `drain_pending_notifications`.
+//!
+//! # #354 K-5 Spike 10.5 — notification regression baseline
+//!
+//! The Rust-side K-5 migration (core:* kind preload + drain unification)
+//! moves the `PendingFactQueue` drain from `notify_from_knowledge_facts`
+//! into a post-dispatch bridge hanging off `dispatch_knowledge_observed`.
+//! The tests below pin the **observable** banner semantics that must not
+//! regress when the drain moves. Each test is tagged with the behaviour
+//! it covers so a reviewer can trace the before/after state:
+//!
+//! | test                                                      | covers                                   |
+//! |-----------------------------------------------------------|------------------------------------------|
+//! | `test_remote_detection_notification_light_speed_delayed`  | HostileDetected banner via light-delay   |
+//! | `test_detection_via_relay_network_near_instant`           | relay-path arrival (`ObservationSource`) |
+//! | `test_player_respawn_notification_instant`                | legacy whitelist (`PlayerRespawn`)       |
+//! | `test_lua_notification_instant`                           | Lua `show_notification` path             |
+//! | `test_survey_result_via_knowledge_store`                  | `SurveyComplete` banner title / body     |
+//! | `test_combat_victory_notification_delayed`                | `CombatOutcome` banner title             |
+//! | `test_channel_autoselect_picks_fastest`                   | `compute_fact_arrival` routing           |
+//! | `test_empire_comm_relay_inv_latency_increases_speed`      | CommsParams plumbing                     |
+//! | `test_empire_comm_relay_range_extends_coverage`           | `RelayNetwork` build                     |
+//! | `test_fleet_comm_relay_targets_routed_but_unused`         | storage-only modifier                    |
+//! | `test_legacy_whitelist_split`                             | whitelist surface (systems-2 only)       |
+//! | `test_survey_complete_fact_delayed_when_remote`           | remote survey → banner gated by arrival  |
+//! | `test_survey_hostile_dual_write_no_double_banner`         | #249 EventId dedupe (whitelist + fact)   |
+//! | `test_combat_defeat_per_ship_and_wipe_dedupe`             | #249 shared EventId dedupe               |
+//! | `test_ship_arrived_low_priority_silent`                   | Low priority = no banner                 |
+//! | `test_colony_established_remote_vs_local`                 | local bypass vs remote delay             |
+//! | `test_structure_built_low_priority_logged_only`           | Low priority + EventId dedupe tracking   |
+//!
+//! 17 tests total (all green as of K-4 land). They are the regression
+//! baseline for K-5: after the drain moves, the count and pass/fail
+//! shape here must stay identical.
 
 mod common;
 


### PR DESCRIPTION
## Summary

Implements K-5, the final slice of the #349 ScriptableKnowledge epic. Merging this PR closes the epic.

Wave 1 (#350 K-1), Wave 2 (#351 K-2), Wave 3 (#352 K-3, #353 K-4) have already landed on main.

This PR:

1. **Preloads `core:*` kinds** into `KindRegistry::preload_core()`. 9 built-in kinds (`core:hostile_detected`, `core:combat_outcome`, `core:survey_complete`, `core:anomaly_discovered`, `core:survey_discovery`, `core:structure_built`, `core:colony_established`, `core:colony_failed`, `core:ship_arrived`) each with a schema matching the corresponding `KnowledgeFact` variant's fields.
2. **Reserves `core:*@recorded` / `core:*@observed`** in the Lua `_knowledge_reserved_events` table at startup so K-3 tooling sees the full surface.
3. **Wires Rust fact emitters** (`FactSysParam::record`) to push a `PendingKnowledgeRecord` alongside the legacy `record_fact_or_local` call; `dispatch_knowledge_recorded` (K-2) then fires `<core:*>@recorded` subscribers on the same tick.
4. **Unifies the `PendingFactQueue` drain** in `dispatch_knowledge_observed`: both core and scripted facts flow through a single `drain_ready()` pass, `<kind>@observed` subscribers fire per observer, and core variants push a `Notification` via a post-dispatch Rust-side bridge.
5. **Removes `notify_from_knowledge_facts`** from `NotificationsPlugin` (function kept public for test back-compat).

See `docs/plan-349-scriptable-knowledge.md` §3.5 K-5 for the full spec.

## Commits (5 + 0 fixup)

| # | hash | subject |
|---|---|---|
| 1 | `be76482` | Spike 10.5 notification regression baseline (doc only) |
| 2 | `8f5de9c` | preload core:* kinds into KindRegistry |
| 3 | `df133d2` | Rust fact emitter wire to PendingKnowledgeRecords |
| 4 | `f0c8267` | unify PendingFactQueue drain + Rust notification bridge |
| 5 | `cc21061` | integration tests for core:* wire |

## Preloaded `core:*` kind ids

All 9 `KnowledgeFact` variants are mirrored (ids live in `knowledge::kind_registry::CORE_KIND_IDS`):

- `core:hostile_detected`
- `core:combat_outcome`
- `core:survey_complete`
- `core:anomaly_discovered`
- `core:survey_discovery`
- `core:structure_built`
- `core:colony_established`
- `core:colony_failed`
- `core:ship_arrived`

## `KnowledgeFact::Hostile` / etc. variant retention

**Kept.** Plan §3.5 explicitly allows "K-5 では wire のみ、variant 削除は future cleanup". Deleting the variants in this PR would touch ~13 emitter callsites (ship/pursuit.rs, ship/combat.rs, ship/survey.rs, colony/settlement.rs, colony/colonization.rs, colony/building_queue.rs, deep_space/mod.rs, ship/movement.rs, ship/handlers/deliverable_handler.rs, ship/settlement.rs, events.rs, etc.) without any test-visible gain. The new converter (`KnowledgeFact::core_kind_id()` + `to_core_payload_snapshot()`) makes deletion mechanical for a follow-up issue.

## Notification bridge signature

`dispatch_knowledge_observed` is an exclusive `&mut World` system. The post-dispatch bridge is **inlined** into the dispatcher rather than a standalone `.after(dispatch_knowledge_observed)` system because we already have the `KnowledgeFact` helpers in scope during the per-observer loop; plan §3.5 allowed either layout. The inlined implementation uses a `Vec<BannerPush>` accumulator populated during the `resource_scope::<ScriptEngine>` block and drained in a subsequent `apply_pending_banners` pass that re-borrows `NotificationQueue` + `NotifiedEventIds` + `GameSpeed`. No SystemParam 16-arg concern since it's a single exclusive system.

## Notification regression matrix (Spike 10.5)

All 17 tests in `notification_knowledge_pipeline.rs` pass with byte-identical behaviour to pre-K-5 (they exercise `notify_from_knowledge_facts` which is retained as a public function). The tests pin:

- HostileDetected / SurveyComplete / CombatOutcome / ColonyEstablished banner titles + descriptions + priorities
- Light-speed delay via `compute_fact_arrival`
- `#249 NotifiedEventIds` tri-state EventId dedup
- Local vs remote path differentiation (`record_fact_or_local` short-circuit)
- Low-priority `ShipArrived` / `StructureBuilt` silent paths
- `PlayerRespawn` / `ResourceAlert` whitelist retained

The new `knowledge_core_wire::core_notification_bridge_matches_pre_k5_banner` + `core_low_priority_facts_stay_silent_through_bridge` + `core_high_priority_fact_auto_pauses_game_speed` tests re-verify the same semantics through the NEW dispatcher path.

## Test matrix

```
cargo test --workspace --lib --tests:
  62 test suites, all green
  + knowledge_core_wire.rs (9 new tests, all pass)
  + knowledge::facts::tests core_* (6 new unit tests, all pass)
  + knowledge::kind_registry::tests preload_core + catalog (5 new unit tests, all pass)
  + notification_knowledge_pipeline.rs (17 unchanged, all pass)
  + knowledge_observed.rs (10 — 1 renamed/updated for K-5 drain semantics)
  + knowledge_kinds.rs (7 updated for CORE_KIND_IDS.len() + 4 registry size)
  + knowledge_record.rs (all pass)
  + knowledge_subscription_dispatch.rs (all pass)
  + fixtures_smoke::load_minimal_game_fixture_smoke (pass)
  + smoke::all_systems_no_query_conflict (pass)
```

Doctest failure exists in the worktree (`@rpath/libstd-*.dylib` not found) — unrelated to changes, affects all tests in this environment.

## Plan deviations

- Plan Commit 4 described "a separate `.after(dispatch_knowledge_observed)` system" for the notification bridge. Inlined instead (rationale: already have `KnowledgeFact` helpers in scope + single exclusive-system means no ordering concerns + simpler state). Plan §3.5 allowed either; the observable behaviour is identical.
- Plan `KnowledgeFact::Hostile{...}` variant retention: chose "wire-only" (variants kept). Converter makes future cleanup mechanical.
- Plan `scripting/lifecycle.rs` §5.1 unify dispatch: **not** implemented in this PR. K-3 (#352) kept `dispatch_knowledge` as a stand-alone dispatcher separate from `dispatch_event_handlers`, and the K-5 path re-uses that separation. `_knowledge_subscribers` are still dispatched via the K-3 `dispatch_knowledge` / `dispatch_knowledge_observed` paths; `_event_handlers` handle plain Lua events. The §5.1 unification would be a cosmetic cleanup — no test-visible gain — and is deferred.

## `#349` epic closure

Merging this PR completes all 5 K slices (K-1 / K-2 / K-3 / K-4 / K-5). The `v1 で含めない` items (subscription cancellation, priority control, prefix wildcards, `@expired` lifecycle, NPC observers, persistence, unified bus dispatch) remain explicitly deferred per plan §7. Ready to close #349.

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo test --workspace --lib --tests` all pass
- [x] `rustfmt --edition 2024 --check` on each touched file (pre-existing unrelated diffs in scripting submodules + `notification_knowledge_pipeline.rs` lines 50/59/368 are NOT introduced by this PR and are left untouched per `feedback_cargo_fmt_scope`)
- [x] `fixtures_smoke::load_minimal_game_fixture_smoke` passes (no save format change)
- [x] `smoke::all_systems_no_query_conflict` passes (no new Query conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)