### PR TITLE
#345 ESC-2: Notifications tab + default_bridge.lua wildcard subscriber + push_notification dedup

### DIFF
--- a/macrocosmo/scripts/init.lua
+++ b/macrocosmo/scripts/init.lua
@@ -58,5 +58,14 @@ require("events")
 -- `record_knowledge` / `on("<id>@observed", fn)` once K-2 / K-3 land.
 require("knowledge.sample")
 
+-- #345 ESC-2: default Lua bridge from `*@observed` events to the ESC
+-- Notifications tab. Must come AFTER knowledge.sample (so the
+-- reserved events exist) and BEFORE lifecycle (so the `on()`
+-- subscriber is registered before lifecycle callbacks may fire
+-- `gs:record_knowledge` at game start). Loaded from a separate
+-- subdirectory so future notification bridges / policy overrides
+-- can sit alongside without cluttering the root init ordering.
+require("notifications.default_bridge")
+
 -- Lifecycle hooks (must be last — registers callbacks for game start/load)
 require("lifecycle")

--- a/macrocosmo/scripts/notifications/default_bridge.lua
+++ b/macrocosmo/scripts/notifications/default_bridge.lua
@@ -1,0 +1,286 @@
+-- #345 ESC-2: default Lua bridge from ScriptableKnowledge `*@observed`
+-- events to the Empire Situation Center (ESC) Notifications tab.
+--
+-- This file registers a single wildcard subscriber via `on("*@observed",
+-- fn)` and maps each built-in `core:*` kind (see
+-- `crate::knowledge::kind_registry::CORE_KIND_IDS` — 9 kinds as of
+-- K-5) to a `push_notification { ... }` call. The push lands in
+-- `_pending_esc_notifications`; the Rust-side
+-- `scripting::esc_notifications::drain_pending_esc_notifications`
+-- system drains it the same frame.
+--
+-- The bridge is pure policy: severity / message formatting / source
+-- mapping for each kind. Because it is Lua, downstream games /
+-- modders can copy this file, tweak the policy, and override the
+-- defaults without touching Rust.
+--
+-- ## Why a wildcard subscriber?
+--
+-- * A wildcard (`*@observed`) subscriber fires for every `core:*` +
+--   `sample:*` + modder-defined kind in one registration. The
+--   `.kind` switch below dispatches per-kind policy.
+-- * The subscriber is queue-only: it calls `push_notification { ... }`
+--   which enqueues a plain Lua table, never invoking Rust callbacks.
+--   Rust owns the subsequent parse + queue mutation.
+-- * Subscriber errors `warn` + chain continues (see
+--   `knowledge_dispatch::dispatch_knowledge` semantics).
+--
+-- ## Out of scope
+--
+-- * `sample:*` kinds (from `scripts/knowledge/sample.lua`) are NOT
+--   mapped by this default bridge. Those are fixtures for testing the
+--   K-1..K-5 pipeline. If a game wants to turn them into ESC
+--   notifications, it should add a separate `require(...)`-loaded
+--   bridge file keyed on those ids.
+-- * Top-banner (#151) behaviour is unchanged — banners continue to
+--   flow through `auto_notify_from_events` + the inlined core:*
+--   banner bridge in `dispatch_knowledge_observed`. The ESC queue is
+--   a separate history path.
+
+-- Helper: extract `e.payload.<field>` safely. Payload fields follow
+-- the `core:*` schema in `crate::knowledge::kind_registry::core_kind_catalog`.
+local function payload_field(e, key)
+    if e.payload == nil then
+        return nil
+    end
+    return e.payload[key]
+end
+
+-- Helper: format the "(lag N hd)" suffix when lag_hexadies is present
+-- and non-trivial. Many core:* events are local / near-instant at
+-- game start, and showing "(lag 0 hd)" everywhere is noise.
+local function lag_suffix(e)
+    if e.lag_hexadies == nil or e.lag_hexadies <= 0 then
+        return ""
+    end
+    return string.format(" (lag %d hd)", e.lag_hexadies)
+end
+
+-- Helper: build a system-scoped source table when the payload carries
+-- a `system` entity. Falls back to origin_system for variants where
+-- the system is optional (core:structure_built, core:ship_arrived).
+local function system_source(e)
+    local system_id = payload_field(e, "system") or e.origin_system
+    if system_id ~= nil then
+        return { kind = "system", id = system_id }
+    end
+    return { kind = "none" }
+end
+
+-- Table of per-kind policy functions. Each entry takes the sealed
+-- observed event table and returns a push_notification args table
+-- (OR nil to skip). Keeping each entry as a function — instead of a
+-- flat per-kind if/elseif ladder — isolates message formatting so
+-- modders can swap entries without touching other kinds.
+local KIND_POLICY = {
+    ["core:hostile_detected"] = function(e)
+        -- Payload: target (entity), detector (entity), target_pos_x/y/z,
+        -- description. We dedupe by target entity so repeated spotting
+        -- of the same hostile doesn't flood the tab.
+        local target = payload_field(e, "target")
+        local event_id = nil
+        if target ~= nil then
+            event_id = string.format("core:hostile:%d", target)
+        end
+        local description = payload_field(e, "description") or "Hostile contact"
+        return {
+            event_id = event_id,
+            severity = "warn",
+            source = system_source(e),
+            message = description .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+
+    ["core:combat_outcome"] = function(e)
+        -- Payload: system, victor ("player"|"hostile"), detail.
+        local victor = payload_field(e, "victor") or "unknown"
+        local detail = payload_field(e, "detail") or ""
+        -- Victory = info, defeat = critical (mirrors banner priority).
+        local severity = "info"
+        local label = "Combat victory"
+        if victor == "hostile" then
+            severity = "critical"
+            label = "Combat defeat"
+        end
+        local system = payload_field(e, "system")
+        local event_id = nil
+        if system ~= nil then
+            event_id = string.format("core:combat:%d:%s", system, victor)
+        end
+        return {
+            event_id = event_id,
+            severity = severity,
+            source = system_source(e),
+            message = label .. ": " .. detail .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+
+    ["core:survey_complete"] = function(e)
+        -- Payload: system, system_name, detail.
+        local system_name = payload_field(e, "system_name") or "(unnamed)"
+        local system = payload_field(e, "system")
+        local event_id = nil
+        if system ~= nil then
+            event_id = string.format("core:survey_complete:%d", system)
+        end
+        return {
+            event_id = event_id,
+            severity = "info",
+            source = system_source(e),
+            message = "Survey complete: " .. system_name .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+
+    ["core:anomaly_discovered"] = function(e)
+        -- Payload: system, anomaly_id, detail.
+        local anomaly_id = payload_field(e, "anomaly_id") or "(unknown anomaly)"
+        local detail = payload_field(e, "detail") or ""
+        local system = payload_field(e, "system")
+        local event_id = nil
+        if system ~= nil then
+            event_id = string.format("core:anomaly:%d:%s", system, tostring(anomaly_id))
+        end
+        local message
+        if detail == "" then
+            message = "Anomaly discovered: " .. anomaly_id
+        else
+            message = "Anomaly discovered (" .. anomaly_id .. "): " .. detail
+        end
+        return {
+            event_id = event_id,
+            severity = "warn",
+            source = system_source(e),
+            message = message .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+
+    ["core:survey_discovery"] = function(e)
+        -- Payload: system, detail.
+        local detail = payload_field(e, "detail") or "(unspecified)"
+        local system = payload_field(e, "system")
+        local event_id = nil
+        if system ~= nil then
+            -- Discoveries can stack per-system — include `detail` hash
+            -- in id so different findings are tracked separately.
+            event_id = string.format("core:discovery:%d:%s", system, tostring(detail))
+        end
+        return {
+            event_id = event_id,
+            severity = "info",
+            source = system_source(e),
+            message = "Discovery: " .. detail .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+
+    ["core:structure_built"] = function(e)
+        -- Payload: system (optional), kind, name, destroyed (bool), detail.
+        local name = payload_field(e, "name") or "(unnamed structure)"
+        local destroyed = payload_field(e, "destroyed")
+        local label
+        local severity
+        if destroyed == true then
+            label = "Structure destroyed: "
+            severity = "warn"
+        else
+            label = "Structure built: "
+            severity = "info"
+        end
+        -- Dedup per structure name — repeated fact propagation (relay
+        -- + direct channel) should only show once in the tab.
+        local event_id = string.format("core:structure:%s:%s", tostring(name), tostring(destroyed))
+        return {
+            event_id = event_id,
+            severity = severity,
+            source = system_source(e),
+            message = label .. name .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+
+    ["core:colony_established"] = function(e)
+        -- Payload: system, planet, name, detail.
+        local name = payload_field(e, "name") or "(unnamed colony)"
+        local planet = payload_field(e, "planet")
+        local event_id = nil
+        if planet ~= nil then
+            event_id = string.format("core:colony_est:%d", planet)
+        end
+        return {
+            event_id = event_id,
+            severity = "info",
+            source = system_source(e),
+            message = "Colony established: " .. name .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+
+    ["core:colony_failed"] = function(e)
+        -- Payload: system, name, reason.
+        local name = payload_field(e, "name") or "(unnamed colony)"
+        local reason = payload_field(e, "reason") or "(unknown)"
+        local system = payload_field(e, "system")
+        local event_id = nil
+        if system ~= nil then
+            event_id = string.format("core:colony_failed:%d:%s", system, tostring(name))
+        end
+        return {
+            event_id = event_id,
+            severity = "critical",
+            source = system_source(e),
+            message = "Colony failed: " .. name .. " — " .. reason .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+
+    ["core:ship_arrived"] = function(e)
+        -- Payload: system (optional), name, detail.
+        local name = payload_field(e, "name") or "(unnamed ship)"
+        local detail = payload_field(e, "detail") or ""
+        -- Ship arrivals are high-frequency; dedup per ship name would
+        -- mask fleet movements. Instead we namespace by observed_at so
+        -- distinct arrival moments each get one entry. `observed_at`
+        -- is tick-accurate so two arrivals at the exact same tick of
+        -- the same ship (unusual) still collapse cleanly.
+        local event_id = string.format(
+            "core:ship_arr:%s:%d",
+            tostring(name),
+            e.observed_at or 0
+        )
+        local message
+        if detail == "" then
+            message = "Ship arrived: " .. name
+        else
+            message = "Ship arrived: " .. name .. " (" .. detail .. ")"
+        end
+        return {
+            event_id = event_id,
+            severity = "info",
+            source = system_source(e),
+            message = message .. lag_suffix(e),
+            timestamp = e.observed_at,
+        }
+    end,
+}
+
+-- Wildcard `*@observed` subscriber. See `on()` semantics in
+-- `scripting/globals.rs` — this registration routes through the
+-- bucketed `KnowledgeSubscriptionRegistry` at startup.
+on("*@observed", function(e)
+    local policy = KIND_POLICY[e.kind]
+    if policy == nil then
+        -- Non-core kinds (sample:*, modder ids) are intentionally
+        -- not handled by this bridge. Return silently so the
+        -- dispatcher can continue to other subscribers.
+        return
+    end
+    local args = policy(e)
+    if args == nil then
+        return
+    end
+    push_notification(args)
+end)

--- a/macrocosmo/src/notifications.rs
+++ b/macrocosmo/src/notifications.rs
@@ -283,23 +283,38 @@ pub fn auto_notify_from_events(
     }
 }
 
-/// #233 / #354: Standalone fact-to-banner drainer.
+/// #233 / #354 / #345: Standalone fact-to-banner drainer (legacy test-only).
 ///
 /// **Historical note**: This system **used** to be the production drain
-/// in `NotificationsPlugin`; K-5 (#354) moves the production drain into
+/// in `NotificationsPlugin`; K-5 (#354) moved the production drain into
 /// `scripting::knowledge_dispatch::dispatch_knowledge_observed` so that
 /// all fact variants (core + scripted) flow through the same
-/// `@observed` dispatch path (plan §3.5 Commit 4, §0.5 9.5).
+/// `@observed` dispatch path (plan §3.5 Commit 4, §0.5 9.5). ESC-2
+/// (#345) adds the ESC Notifications tab + `push_notification` Lua
+/// bridge as a *second* consumer of the same `@observed` dispatch.
 ///
-/// It is **no longer registered by `NotificationsPlugin`** — production
-/// flow goes through the K-5 dispatcher. The function is kept public
-/// and feature-complete so:
-/// * Integration tests that want to exercise the banner pipeline
-///   without the Lua scripting plugin (e.g.
-///   `tests/notification_knowledge_pipeline.rs`) can wire it manually
-///   via `app.add_systems(Update, notify_from_knowledge_facts)`.
-/// * Future headless / server-mode hosts can opt into the legacy
-///   non-Lua drain if they deliberately exclude the scripting plugin.
+/// This function is **not registered by any production plugin** —
+/// `NotificationsPlugin` no longer adds it to the schedule, and
+/// `ScriptingPlugin::dispatch_knowledge_observed` is the sole drain
+/// for `PendingFactQueue` in production. The function is retained
+/// only as:
+/// * A **regression harness** for the 17 banner tests in
+///   `tests/notification_knowledge_pipeline.rs`, which exercise the
+///   banner semantics (light-speed delay, relay path, #249 EventId
+///   dedupe, priority mapping, whitelist split) without spinning up
+///   the full Lua scripting plugin. Those tests wire
+///   `notify_from_knowledge_facts` manually via
+///   `app.add_systems(Update, notify_from_knowledge_facts)`.
+/// * A fallback for future headless / server-mode hosts that
+///   deliberately exclude the scripting plugin.
+///
+/// **Do not re-register this system in any plugin.** Doing so would
+/// double-drain `PendingFactQueue` alongside
+/// `dispatch_knowledge_observed` and both break the ESC Lua bridge
+/// (by draining facts before they reach `*@observed` subscribers) and
+/// double-push banners. The `notification_knowledge_pipeline` tests
+/// deliberately run in isolation for this reason — they never
+/// construct a full `ScriptingPlugin` / `NotificationsPlugin` stack.
 ///
 /// The function still skips `Scripted` variants so tests that set up a
 /// mixed queue do not produce spurious "Knowledge" banners.

--- a/macrocosmo/src/scripting/esc_notifications.rs
+++ b/macrocosmo/src/scripting/esc_notifications.rs
@@ -1,0 +1,704 @@
+//! #345 ESC-2: Lua → ESC notification bridge drain.
+//!
+//! The Lua-side `push_notification { ... }` API appends raw table
+//! entries to the `_pending_esc_notifications` global. This module
+//! hosts the Rust-side drain system that parses those entries each
+//! frame and applies them to [`EscNotificationQueue`] with the
+//! `NotifiedEventIds` dedup + current-tick timestamp defaulting
+//! that the production push path needs.
+//!
+//! The drain is idempotent: a successful drain clears the Lua
+//! accumulator. Malformed entries are logged via `warn!` and skipped —
+//! the chain never aborts because a bridge function returned garbage
+//! (plan-349 §6 subscriber-error contract, which `default_bridge.lua`
+//! extends into).
+//!
+//! ## Field shape
+//!
+//! See the doc-comment on `push_notification` in [`super::globals`]
+//! for the full Lua surface. The parser here accepts:
+//!
+//! | field         | Lua type    | Rust mapping                                   | default              |
+//! |---------------|-------------|------------------------------------------------|----------------------|
+//! | `title`       | string      | prepended to `message` when both present       | `""`                 |
+//! | `message`     | string      | `Notification.message`                         | falls back to title  |
+//! | `severity`    | string      | `"info" / "warn" / "critical"` → `Severity::*` | `Severity::Info`     |
+//! | `source`      | table       | `{ kind: string, id: u64 }` → `NotificationSource` | `NotificationSource::None` |
+//! | `event_id`    | string/int  | `EventId` for `NotifiedEventIds` dedup         | `None` (no dedup)    |
+//! | `timestamp`   | i64         | `Notification.timestamp`                       | `GameClock.elapsed`  |
+//! | `children`    | table array | recursive; each child uses the same shape      | `vec![]`             |
+//!
+//! `kind` / `id` pairs come from the Lua side using raw `Entity::to_bits`
+//! — Lua scripts today expose entity ids via `gamestate` view fields
+//! that return numbers, so this is the wire format the ScriptableKnowledge
+//! epic (#349) already uses.
+//!
+//! ## event_id handling
+//!
+//! `event_id` can be either a string (Lua scripts synthesise stable
+//! identifiers like `"hostile:<entity>"` from payload fields) or an
+//! integer. Both are hashed into a `u64` and registered with
+//! [`NotifiedEventIds`] via `try_notify` at drain time. The first
+//! push for an id wins; subsequent pushes are suppressed in the same
+//! frame the shared banner queue would have suppressed them. Pushes
+//! without `event_id` never dedupe.
+//!
+//! ## Depth limit
+//!
+//! Nested `children` are walked up to [`CHILD_DEPTH_LIMIT`] levels deep
+//! (default 4). Beyond that, further children are dropped with a
+//! `warn!` and the partial subtree is retained. This matches the
+//! `KNOWLEDGE_PAYLOAD_DEPTH_LIMIT = 16` style of depth bounding used
+//! elsewhere in the scripting layer.
+
+use bevy::prelude::*;
+use mlua::prelude::*;
+
+use super::ScriptEngine;
+use crate::knowledge::{EventId, NotifiedEventIds};
+use crate::time_system::GameClock;
+use crate::ui::situation_center::{
+    EscNotificationQueue, Notification, NotificationSource, PushOutcome, Severity,
+};
+
+/// Maximum `children` nesting depth accepted by the Lua bridge. Trees
+/// deeper than this have their overflow children dropped with a
+/// `warn!`. 4 is deep enough for realistic groupings (hostile attack →
+/// per-ship loss → per-module subhit) while bounding pathological
+/// input from buggy Lua bridges.
+pub const CHILD_DEPTH_LIMIT: usize = 4;
+
+/// Bevy Startup / init-side helper: ensure `_pending_esc_notifications`
+/// exists on the Lua globals table. `setup_globals` already creates
+/// the table; this helper is the recovery path used by the drain
+/// itself (mirrors `drain_pending_notifications` in `notifications.rs`).
+fn clear_pending_table(lua: &Lua) -> mlua::Result<()> {
+    let new_table = lua.create_table()?;
+    lua.globals().set("_pending_esc_notifications", new_table)?;
+    Ok(())
+}
+
+/// Drain the Lua-side `_pending_esc_notifications` accumulator into
+/// the [`EscNotificationQueue`]. Runs in `Update` after
+/// `dispatch_knowledge_observed` so subscribers that fired during
+/// this tick's `@observed` dispatch land in the queue the same frame.
+///
+/// Field parsing is intentionally permissive: missing fields fall
+/// back to sensible defaults, unknown `severity` / `source.kind`
+/// values map to `Info` / `None` respectively. The only hard failure
+/// is a non-table entry at the top level — those are `warn!`-logged
+/// and skipped.
+pub fn drain_pending_esc_notifications(world: &mut World) {
+    // Fast-path: check whether anything is pending without acquiring
+    // the exclusive engine scope.
+    let has_pending = world
+        .get_resource::<ScriptEngine>()
+        .and_then(|engine| {
+            let lua = engine.lua();
+            let globals = lua.globals();
+            let table = globals
+                .get::<mlua::Table>("_pending_esc_notifications")
+                .ok()?;
+            let len = table.len().ok()?;
+            Some(len > 0)
+        })
+        .unwrap_or(false);
+    if !has_pending {
+        return;
+    }
+
+    let now = world
+        .get_resource::<GameClock>()
+        .map(|c| c.elapsed)
+        .unwrap_or(0);
+
+    // Parse + clear under the engine scope, then apply pushes without
+    // holding the engine borrow — so the push path can also borrow
+    // `NotifiedEventIds` + `EscNotificationQueue` from the world
+    // without fighting the engine resource.
+    let parsed: Vec<ParsedPush> =
+        world.resource_scope::<ScriptEngine, Vec<ParsedPush>>(|_world, engine| {
+            let lua = engine.lua();
+            parse_pending_entries(lua, now)
+        });
+
+    if parsed.is_empty() {
+        return;
+    }
+
+    // Apply parsed pushes to the queue. `resource_scope` over
+    // `NotifiedEventIds` lets us also hold `ResMut<EscNotificationQueue>`
+    // without the borrow checker complaining about two resource borrows.
+    //
+    // `NotifiedEventIds::try_notify` returns `false` unless the id is
+    // already `register`-ed in the `Some(false)` state. ESC-originated
+    // ids never go through `FactSysParam::allocate_event_id`, so we
+    // must register them here before the first push for the dedup
+    // handshake to admit the push. The second push for the same id
+    // then finds the entry in `Some(true)` state and is suppressed.
+    world.resource_scope::<NotifiedEventIds, _>(|world, mut notified| {
+        let mut queue = world.resource_mut::<EscNotificationQueue>();
+        for push in parsed {
+            if let Some(eid) = push.event_id {
+                notified.register(eid);
+            }
+            match queue.push(push.notification, push.event_id, Some(&mut *notified)) {
+                PushOutcome::Pushed(_) | PushOutcome::DedupedByEventId => {}
+            }
+        }
+    });
+}
+
+/// Parsed representation of a single Lua-side `push_notification`
+/// call. Kept as a private value-type between `parse_pending_entries`
+/// and the queue apply loop so the apply loop never touches Lua state.
+struct ParsedPush {
+    notification: Notification,
+    event_id: Option<EventId>,
+}
+
+/// Parse the Lua `_pending_esc_notifications` accumulator into a
+/// `Vec<ParsedPush>` and clear the accumulator. Each malformed entry
+/// is logged and skipped; the result is always populated as best we
+/// can so partial failure does not swallow the whole batch.
+fn parse_pending_entries(lua: &Lua, now: i64) -> Vec<ParsedPush> {
+    let globals = lua.globals();
+    let table: mlua::Table = match globals.get("_pending_esc_notifications") {
+        Ok(t) => t,
+        Err(e) => {
+            warn!("drain_pending_esc_notifications: missing accumulator: {e}");
+            return Vec::new();
+        }
+    };
+
+    let len = match table.len() {
+        Ok(n) => n,
+        Err(e) => {
+            warn!("drain_pending_esc_notifications: accumulator len error: {e}");
+            if let Err(ce) = clear_pending_table(lua) {
+                warn!("drain_pending_esc_notifications: recovery clear failed: {ce}");
+            }
+            return Vec::new();
+        }
+    };
+
+    let mut out = Vec::with_capacity(len as usize);
+    for i in 1..=len {
+        let entry = match table.get::<mlua::Value>(i) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("push_notification[{i}]: read error: {e}");
+                continue;
+            }
+        };
+        let entry_table = match entry {
+            mlua::Value::Table(t) => t,
+            other => {
+                warn!(
+                    "push_notification[{i}]: expected table, got {}",
+                    value_type_name(&other)
+                );
+                continue;
+            }
+        };
+        match parse_entry(&entry_table, now, 0) {
+            Ok(push) => out.push(push),
+            Err(e) => warn!("push_notification[{i}]: {e}"),
+        }
+    }
+
+    // Clear the accumulator so the next frame starts fresh. We
+    // replace rather than iterate-+-nil because `pairs` order on a
+    // sparse Lua table is not specified.
+    if let Err(e) = clear_pending_table(lua) {
+        warn!("drain_pending_esc_notifications: clear failed: {e}");
+    }
+    out
+}
+
+/// Parse a single `push_notification` table into a [`ParsedPush`].
+/// Recursion is depth-bounded by [`CHILD_DEPTH_LIMIT`]; children
+/// beyond the limit are dropped with a `warn!`.
+fn parse_entry(table: &mlua::Table, now: i64, depth: usize) -> mlua::Result<ParsedPush> {
+    let severity = parse_severity(table.get::<Option<String>>("severity").ok().flatten());
+
+    let title: Option<String> = table.get("title").ok();
+    let message_field: Option<String> = table.get("message").ok();
+    // Prefer `message` for the body; fall back to `title` when
+    // `message` is absent so simple `push_notification { title = ... }`
+    // calls still render something meaningful.
+    let message = match (title.as_deref(), message_field.as_deref()) {
+        (Some(t), Some(m)) if !t.is_empty() && !m.is_empty() => format!("{t}: {m}"),
+        (_, Some(m)) if !m.is_empty() => m.to_string(),
+        (Some(t), _) => t.to_string(),
+        _ => String::new(),
+    };
+
+    let timestamp: i64 = table.get::<i64>("timestamp").unwrap_or(now);
+
+    let source = match table.get::<mlua::Value>("source") {
+        Ok(mlua::Value::Table(st)) => parse_source(&st),
+        Ok(_) | Err(_) => NotificationSource::None,
+    };
+
+    let event_id = parse_event_id(table);
+
+    let children: Vec<Notification> = if depth + 1 >= CHILD_DEPTH_LIMIT {
+        // Silently drop the children sub-list at the depth limit.
+        let _ = table.get::<mlua::Value>("children");
+        Vec::new()
+    } else {
+        parse_children(table, now, depth + 1)?
+    };
+
+    let notification = Notification {
+        id: 0, // Overwritten by `EscNotificationQueue::push`.
+        source,
+        timestamp,
+        severity,
+        message,
+        acked: false,
+        children,
+    };
+
+    Ok(ParsedPush {
+        notification,
+        event_id,
+    })
+}
+
+fn parse_children(table: &mlua::Table, now: i64, depth: usize) -> mlua::Result<Vec<Notification>> {
+    let children_val: mlua::Value = match table.get("children") {
+        Ok(v) => v,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let children_table = match children_val {
+        mlua::Value::Table(t) => t,
+        mlua::Value::Nil => return Ok(Vec::new()),
+        other => {
+            warn!(
+                "push_notification.children: expected table, got {}",
+                value_type_name(&other)
+            );
+            return Ok(Vec::new());
+        }
+    };
+    let len = children_table.len().unwrap_or(0);
+    let mut out = Vec::with_capacity(len.max(0) as usize);
+    for i in 1..=len {
+        let child_val = match children_table.get::<mlua::Value>(i) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("push_notification.children[{i}]: read error: {e}");
+                continue;
+            }
+        };
+        let child_table = match child_val {
+            mlua::Value::Table(t) => t,
+            other => {
+                warn!(
+                    "push_notification.children[{i}]: expected table, got {}",
+                    value_type_name(&other)
+                );
+                continue;
+            }
+        };
+        match parse_entry(&child_table, now, depth) {
+            Ok(parsed) => out.push(parsed.notification),
+            Err(e) => warn!("push_notification.children[{i}]: {e}"),
+        }
+    }
+    Ok(out)
+}
+
+fn parse_severity(raw: Option<String>) -> Severity {
+    match raw.as_deref() {
+        Some("warn") | Some("warning") => Severity::Warn,
+        Some("critical") | Some("crit") | Some("error") => Severity::Critical,
+        // "info" / None / anything unknown → Info.
+        _ => Severity::Info,
+    }
+}
+
+fn parse_source(table: &mlua::Table) -> NotificationSource {
+    let kind: String = table
+        .get::<String>("kind")
+        .unwrap_or_else(|_| "none".to_string());
+    let id_bits: Option<u64> = table.get::<u64>("id").ok();
+    match (kind.as_str(), id_bits) {
+        ("empire", Some(bits)) => NotificationSource::Empire(Entity::from_bits(bits)),
+        ("system", Some(bits)) => NotificationSource::System(Entity::from_bits(bits)),
+        ("colony", Some(bits)) => NotificationSource::Colony(Entity::from_bits(bits)),
+        ("ship", Some(bits)) => NotificationSource::Ship(Entity::from_bits(bits)),
+        ("fleet", Some(bits)) => NotificationSource::Fleet(Entity::from_bits(bits)),
+        ("faction", Some(bits)) => NotificationSource::Faction(Entity::from_bits(bits)),
+        ("build_order", Some(bits)) => NotificationSource::BuildOrder(bits),
+        // Missing id or unknown kind falls back to None.
+        _ => NotificationSource::None,
+    }
+}
+
+/// Parse `event_id` — accept either a string or an integer.
+/// String ids are hashed to `u64` via `DefaultHasher` so the
+/// `NotifiedEventIds` tri-state map (keyed by `EventId(u64)`) can
+/// dedupe them without carrying a separate string-id registry.
+fn parse_event_id(table: &mlua::Table) -> Option<EventId> {
+    let v: mlua::Value = table.get("event_id").ok()?;
+    match v {
+        mlua::Value::Nil => None,
+        mlua::Value::String(s) => {
+            let raw = s.to_str().ok()?.to_string();
+            if raw.is_empty() {
+                return None;
+            }
+            Some(EventId(hash_string_to_u64(&raw)))
+        }
+        mlua::Value::Integer(i) => Some(EventId(i as u64)),
+        mlua::Value::Number(n) => {
+            // Lua numbers without an integer cast — best-effort convert.
+            if n.is_finite() && n >= 0.0 {
+                Some(EventId(n as u64))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn hash_string_to_u64(s: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    // Namespace the hash so string ids never collide with raw integer
+    // ids — e.g. the integer `42` and the string `"42"` produce
+    // different `EventId` values.
+    "esc:push_notification:".hash(&mut hasher);
+    s.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn value_type_name(v: &mlua::Value) -> &'static str {
+    match v {
+        mlua::Value::Nil => "nil",
+        mlua::Value::Boolean(_) => "boolean",
+        mlua::Value::Integer(_) => "integer",
+        mlua::Value::Number(_) => "number",
+        mlua::Value::String(_) => "string",
+        mlua::Value::Table(_) => "table",
+        mlua::Value::Function(_) => "function",
+        mlua::Value::UserData(_) => "userdata",
+        mlua::Value::Thread(_) => "thread",
+        _ => "other",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::situation_center::Notification;
+
+    fn new_engine() -> ScriptEngine {
+        // Reuse the same test-engine bootstrap pattern as the other
+        // scripting tests — instantiate with a deterministic RNG and
+        // the crate-relative scripts dir (we don't load scripts here,
+        // only set up globals).
+        let rng = crate::scripting::GameRng::default().handle();
+        ScriptEngine::new_with_rng_and_dir(rng, scripts_dir_for_tests()).expect("engine boot")
+    }
+
+    fn scripts_dir_for_tests() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts")
+    }
+
+    /// Helper — build a world with the minimal resources the drain
+    /// needs. Inserts a fresh `EscNotificationQueue` + `GameClock` +
+    /// `NotifiedEventIds` + a real `ScriptEngine`. Returns the world
+    /// plus a reference to the engine lua handle for pushing test
+    /// entries directly.
+    fn make_test_world() -> World {
+        let mut world = World::new();
+        world.insert_resource(EscNotificationQueue::default());
+        world.insert_resource(NotifiedEventIds::default());
+        world.insert_resource(GameClock::new(0));
+        let engine = new_engine();
+        // Mirror the globals setup normally done by `init_scripting`
+        // so `_pending_esc_notifications` exists on the Lua side.
+        let lua = engine.lua();
+        super::super::globals::setup_globals(lua, &scripts_dir_for_tests()).expect("setup_globals");
+        world.insert_resource(engine);
+        world
+    }
+
+    fn run_drain(world: &mut World) {
+        let mut sys = bevy::ecs::system::IntoSystem::into_system(drain_pending_esc_notifications);
+        sys.initialize(world);
+        sys.run((), world);
+    }
+
+    fn call_push_notification(world: &World, body: &str) {
+        let engine = world.resource::<ScriptEngine>();
+        let lua = engine.lua();
+        lua.load(body).exec().expect("lua exec");
+    }
+
+    #[test]
+    fn push_notification_drains_to_queue_with_defaults() {
+        let mut world = make_test_world();
+        call_push_notification(
+            &world,
+            r#"push_notification { message = "hello world", severity = "warn" }"#,
+        );
+        run_drain(&mut world);
+
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(q.items[0].message, "hello world");
+        assert_eq!(q.items[0].severity, Severity::Warn);
+        assert!(matches!(q.items[0].source, NotificationSource::None));
+    }
+
+    #[test]
+    fn push_notification_dedupes_by_event_id_string() {
+        let mut world = make_test_world();
+        call_push_notification(
+            &world,
+            r#"
+            push_notification {
+                event_id = "hostile:123",
+                severity = "critical",
+                message = "first"
+            }
+            push_notification {
+                event_id = "hostile:123",
+                severity = "critical",
+                message = "second"
+            }
+        "#,
+        );
+        run_drain(&mut world);
+
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1, "dedup by event_id");
+        assert_eq!(q.items[0].message, "first");
+    }
+
+    #[test]
+    fn push_notification_dedupes_by_event_id_integer() {
+        let mut world = make_test_world();
+        call_push_notification(
+            &world,
+            r#"
+            push_notification { event_id = 42, message = "a" }
+            push_notification { event_id = 42, message = "b" }
+        "#,
+        );
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1);
+    }
+
+    #[test]
+    fn push_notification_no_event_id_never_dedupes() {
+        let mut world = make_test_world();
+        call_push_notification(
+            &world,
+            r#"
+            push_notification { message = "x" }
+            push_notification { message = "x" }
+            push_notification { message = "x" }
+        "#,
+        );
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 3);
+    }
+
+    #[test]
+    fn push_notification_accepts_source_table() {
+        let mut world = make_test_world();
+        let entity = world.spawn_empty().id();
+        let bits = entity.to_bits();
+        call_push_notification(
+            &world,
+            &format!(
+                r#"push_notification {{
+                    message = "system-scoped",
+                    severity = "info",
+                    source = {{ kind = "system", id = {bits} }}
+                }}"#
+            ),
+        );
+        run_drain(&mut world);
+
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1);
+        match q.items[0].source {
+            NotificationSource::System(e) => assert_eq!(e.to_bits(), bits),
+            other => panic!("expected System source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_notification_unknown_severity_defaults_to_info() {
+        let mut world = make_test_world();
+        call_push_notification(
+            &world,
+            r#"push_notification { message = "m", severity = "garbage" }"#,
+        );
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(q.items[0].severity, Severity::Info);
+    }
+
+    #[test]
+    fn push_notification_timestamp_defaults_to_game_clock() {
+        let mut world = make_test_world();
+        world.resource_mut::<GameClock>().elapsed = 4321;
+        call_push_notification(&world, r#"push_notification { message = "m" }"#);
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items[0].timestamp, 4321);
+    }
+
+    #[test]
+    fn push_notification_explicit_timestamp_overrides_clock() {
+        let mut world = make_test_world();
+        world.resource_mut::<GameClock>().elapsed = 1;
+        call_push_notification(
+            &world,
+            r#"push_notification { message = "m", timestamp = 9999 }"#,
+        );
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items[0].timestamp, 9999);
+    }
+
+    #[test]
+    fn push_notification_parses_children() {
+        let mut world = make_test_world();
+        call_push_notification(
+            &world,
+            r#"push_notification {
+                message = "parent",
+                severity = "warn",
+                children = {
+                    { message = "child1", severity = "info" },
+                    { message = "child2", severity = "critical" },
+                }
+            }"#,
+        );
+        run_drain(&mut world);
+
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(q.items[0].message, "parent");
+        assert_eq!(q.items[0].children.len(), 2);
+        assert_eq!(q.items[0].children[0].message, "child1");
+        assert_eq!(q.items[0].children[1].severity, Severity::Critical);
+    }
+
+    #[test]
+    fn push_notification_drain_clears_accumulator() {
+        let mut world = make_test_world();
+        call_push_notification(&world, r#"push_notification { message = "a" }"#);
+        run_drain(&mut world);
+        // Second drain with no new pushes must be a no-op.
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1, "no double-push after drain");
+    }
+
+    #[test]
+    fn push_notification_string_id_and_int_id_dont_collide() {
+        let mut world = make_test_world();
+        call_push_notification(
+            &world,
+            r#"
+            push_notification { event_id = 42, message = "int" }
+            push_notification { event_id = "42", message = "str" }
+        "#,
+        );
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        // The hash namespacing prevents the integer `42` and string
+        // `"42"` from colliding — both pushes should land.
+        assert_eq!(q.items.len(), 2);
+    }
+
+    #[test]
+    fn push_notification_malformed_entry_is_skipped() {
+        let mut world = make_test_world();
+        // Push a garbage non-table directly to the accumulator and a
+        // valid entry after it; the valid entry must still land.
+        {
+            let engine = world.resource::<ScriptEngine>();
+            let lua = engine.lua();
+            lua.load(
+                r#"
+                _pending_esc_notifications[#_pending_esc_notifications + 1] = 123
+                push_notification { message = "valid" }
+                "#,
+            )
+            .exec()
+            .expect("lua exec");
+        }
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(q.items[0].message, "valid");
+    }
+
+    #[test]
+    fn push_notification_title_and_message_combine() {
+        let mut world = make_test_world();
+        call_push_notification(
+            &world,
+            r#"push_notification { title = "Hostile", message = "detected" }"#,
+        );
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items[0].message, "Hostile: detected");
+    }
+
+    #[test]
+    fn push_notification_depth_limit_drops_overflow() {
+        let mut world = make_test_world();
+        // Build a depth-6 chain; the limit is 4, so depths 0..=3 survive
+        // and anything beyond is dropped.
+        call_push_notification(
+            &world,
+            r#"push_notification {
+                message = "d0",
+                children = {{
+                    message = "d1",
+                    children = {{
+                        message = "d2",
+                        children = {{
+                            message = "d3",
+                            children = {{
+                                message = "d4-dropped",
+                                children = {{ message = "d5-dropped" }}
+                            }}
+                        }}
+                    }}
+                }}
+            }"#,
+        );
+        run_drain(&mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.items.len(), 1);
+        let mut depth = 0;
+        let mut node: &Notification = &q.items[0];
+        while let Some(first) = node.children.first() {
+            depth += 1;
+            node = first;
+        }
+        // Depths 0,1,2,3 reachable → `depth` traversed = 3 edges.
+        assert_eq!(
+            depth, 3,
+            "depth limit caps the tree at {CHILD_DEPTH_LIMIT} levels"
+        );
+    }
+}

--- a/macrocosmo/src/scripting/globals.rs
+++ b/macrocosmo/src/scripting/globals.rs
@@ -1,8 +1,8 @@
 use mlua::prelude::*;
 use std::path::Path;
 
-use super::helpers::extract_id_from_lua_value;
 use super::effect_scope;
+use super::helpers::extract_id_from_lua_value;
 
 /// Configure global tables and functions available to all Lua scripts.
 pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
@@ -134,11 +134,7 @@ pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
 
     register_define_fn(lua, "faction", "_faction_definitions")?;
     register_define_fn(lua, "faction_type", "_faction_type_definitions")?;
-    register_define_fn(
-        lua,
-        "diplomatic_action",
-        "_diplomatic_action_definitions",
-    )?;
+    register_define_fn(lua, "diplomatic_action", "_diplomatic_action_definitions")?;
 
     // --- #160: Balance constants Lua binding ---
     // `define_balance { ... }` is expected to be called AT MOST ONCE from
@@ -442,6 +438,51 @@ pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
     })?;
     globals.set("show_notification", show_notification_fn)?;
 
+    // --- #345 ESC-2: ESC (Empire Situation Center) notification push API ---
+    //
+    // `push_notification { title, message, severity, source, event_id,
+    //                      timestamp, children? }` enqueues a *post-hoc*
+    // ack-able notification into `EscNotificationQueue` (see
+    // `crate::ui::situation_center::notifications_tab`).
+    //
+    // Distinct from `show_notification` — that API drives the top-banner
+    // stack (#151), which is a live TTL-based popup. `push_notification`
+    // targets the ESC Notifications tab: history + ack, not banners.
+    //
+    // Shape:
+    //   - title / message: strings (at least one should be non-empty;
+    //     the renderer uses `message` as the body, falling back to
+    //     `title` if `message` is absent).
+    //   - severity: "info" | "warn" | "critical" (default "info").
+    //   - source: optional table `{ kind = ..., id = <u64 Entity bits> }`
+    //     where `kind` is one of "none" | "empire" | "system" | "colony" |
+    //     "ship" | "fleet" | "faction" | "build_order". Unknown kinds
+    //     fall back to "none". Missing `source` is equivalent to `none`.
+    //   - event_id: optional string OR numeric. When supplied it is
+    //     routed through `#249 NotifiedEventIds::try_notify` by the Rust
+    //     drain so duplicate pushes for the same id are silently
+    //     suppressed (same mechanism the banner queue uses).
+    //   - timestamp: optional i64 game-hexadies. When absent the drain
+    //     reads the current `GameClock`.
+    //   - children: optional array of tables shaped like the outer push
+    //     (recursive; depth capped by Rust-side parser).
+    //
+    // The entry is appended to the global `_pending_esc_notifications`
+    // Lua table; the Rust-side `drain_pending_esc_notifications` system
+    // drains it every frame and applies the push to
+    // `EscNotificationQueue`.
+    globals.set("_pending_esc_notifications", lua.create_table()?)?;
+    let push_notification_fn = lua.create_function(|lua, params: mlua::Table| {
+        let pending: mlua::Table = lua.globals().get("_pending_esc_notifications")?;
+        let len = pending.len()?;
+        // We deliberately store the raw Lua table — the Rust side knows
+        // the shape and can surface clear errors for each malformed
+        // field instead of having Lua's `.get::<T>(...)` coerce silently.
+        pending.set(len + 1, params)?;
+        Ok(())
+    })?;
+    globals.set("push_notification", push_notification_fn)?;
+
     // --- #152: Player choice dialog API ---
 
     // Pending choice queue — drained by `drain_pending_choices`
@@ -464,10 +505,7 @@ pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
         // Derive a stable-ish id: prefer explicit `id`, else title slug, else
         // "choice". Always append a monotonically increasing counter to make
         // it unique even if the same title is shown repeatedly.
-        let next_counter: u64 = lua
-            .globals()
-            .get("_show_choice_counter")
-            .unwrap_or(0_u64);
+        let next_counter: u64 = lua.globals().get("_show_choice_counter").unwrap_or(0_u64);
         lua.globals()
             .set("_show_choice_counter", next_counter + 1)?;
 
@@ -476,7 +514,13 @@ pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
         } else if let Ok(title) = params.get::<String>("title") {
             let slug: String = title
                 .chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '_' })
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() {
+                        c.to_ascii_lowercase()
+                    } else {
+                        '_'
+                    }
+                })
                 .collect();
             format!("{slug}_{next_counter}")
         } else {
@@ -624,7 +668,11 @@ pub fn setup_globals(lua: &Lua, scripts_dir: &Path) -> Result<(), mlua::Error> {
 /// 1. Creates an accumulator table `_xxx_definitions`
 /// 2. Registers `define_xxx(table)` which appends to the accumulator and
 ///    tags the table with `_def_type = def_type`, then returns it as a reference.
-fn register_define_fn(lua: &Lua, def_type: &str, accumulator_name: &str) -> Result<(), mlua::Error> {
+fn register_define_fn(
+    lua: &Lua,
+    def_type: &str,
+    accumulator_name: &str,
+) -> Result<(), mlua::Error> {
     let globals = lua.globals();
 
     let acc = lua.create_table()?;

--- a/macrocosmo/src/scripting/mod.rs
+++ b/macrocosmo/src/scripting/mod.rs
@@ -4,6 +4,7 @@ pub mod condition_ctx;
 pub mod condition_parser;
 pub mod effect_scope;
 pub mod engine;
+pub mod esc_notifications;
 pub mod event_api;
 pub mod faction_api;
 pub mod galaxy_api;
@@ -140,6 +141,22 @@ impl Plugin for ScriptingPlugin {
                 knowledge_dispatch::dispatch_knowledge_observed
                     .after(crate::time_system::advance_game_time)
                     .after(crate::notifications::auto_notify_from_events),
+            )
+            // #345 ESC-2: drain the `_pending_esc_notifications` Lua
+            // accumulator populated by `push_notification { ... }`
+            // calls (typically from `scripts/notifications/default_bridge.lua`
+            // inside the `*@observed` subscriber chain). Ordered
+            // `.after(dispatch_knowledge_observed)` so subscribers
+            // that fire this tick land in `EscNotificationQueue`
+            // within the same frame. Also `.before(sweep_notified_event_ids)`
+            // so the dedup map still holds `try_notify` state when we
+            // read it.
+            .add_systems(
+                Update,
+                esc_notifications::drain_pending_esc_notifications
+                    .after(crate::time_system::advance_game_time)
+                    .after(knowledge_dispatch::dispatch_knowledge_observed)
+                    .before(crate::knowledge::sweep_notified_event_ids),
             );
     }
 }

--- a/macrocosmo/src/ui/situation_center/mod.rs
+++ b/macrocosmo/src/ui/situation_center/mod.rs
@@ -27,7 +27,10 @@ pub mod types;
 use bevy::prelude::*;
 
 pub use lua_adapter::{LuaOngoingTabAdapter, LuaTabRegistration};
-pub use notifications_tab::{EscNotificationQueue, NotificationsTab};
+pub use notifications_tab::{
+    EscNotificationQueue, NotificationsTab, PendingAck, PushOutcome, apply_pending_acks_system,
+    drain_pending_acks_for_tests, enqueue_pending_ack,
+};
 pub use panel::{TOGGLE_KEY, draw_situation_center_system, toggle_situation_center};
 pub use registry::{AppSituationExt, SituationTabRegistry};
 pub use state::{SituationCenterState, TabState};
@@ -60,7 +63,14 @@ impl Plugin for SituationCenterPlugin {
         app.init_resource::<SituationCenterState>()
             .init_resource::<SituationTabRegistry>()
             .init_resource::<EscNotificationQueue>()
-            .add_systems(Update, toggle_situation_center);
+            .add_systems(Update, toggle_situation_center)
+            // #345 ESC-2: drain ack intents emitted by the tab renderer
+            // each frame and apply them to the queue. Registered in
+            // `Update` rather than `EguiPrimaryContextPass` so the
+            // render path can fire ack buttons in frame N and the
+            // queue reflects them at the start of frame N+1's game
+            // systems (ordering mirrors `toggle_situation_center`).
+            .add_systems(Update, apply_pending_acks_system);
 
         // Register the framework-bundled Notifications tab. ESC-2
         // swaps the stub queue for the real pipeline but keeps this

--- a/macrocosmo/src/ui/situation_center/notifications_tab.rs
+++ b/macrocosmo/src/ui/situation_center/notifications_tab.rs
@@ -1,44 +1,164 @@
-//! ESC-internal Notifications tab + queue stub (#344 / ESC-1).
+//! ESC Notifications tab + queue (#344 ESC-1 stub → #345 ESC-2 real).
 //!
-//! The *queue* and its push / ack / dedupe / light-speed bridging is
-//! #345 (ESC-2) scope. ESC-1 only lands:
+//! This module hosts:
 //!
-//! 1. The [`EscNotificationQueue`] resource as an empty stub so the
-//!    framework compiles and other systems can depend on it.
-//! 2. The [`NotificationsTab`] concrete type, implementing
-//!    [`SituationTab`] directly (not `OngoingTab`) because its render
-//!    path needs to surface an "ack" button per row — the Event-tree
-//!    default renderer doesn't fit.
-//! 3. A minimal tree renderer that walks `Vec<Notification>` so the
-//!    tab shows *something* when entries are present.
+//! 1. [`EscNotificationQueue`] — the ack-able history queue backing the
+//!    Notifications tab. Each top-level entry carries a tree of
+//!    [`Notification`] children; `ack` cascades parent → children. Pushes
+//!    can optionally carry a `KnowledgeFact` [`EventId`] so the same
+//!    `#249 NotifiedEventIds` tri-state map the banner queue uses also
+//!    dedupes ESC entries. (#345 commit 1)
+//! 2. [`NotificationsTab`] — the [`SituationTab`] that renders the queue.
+//!    Custom render path (not `OngoingTab`) because each row needs an
+//!    ack button + a severity / ack-state filter UI. (#345 commit 2)
 //!
-//! The queue struct is deliberately **separate** from the pre-existing
-//! banner `NotificationQueue` in `crate::notifications` — the banner
-//! queue drives TTL-based pop-overs with Low/Medium/High priority and
-//! pause semantics, while ESC notifications are post-hoc, ack-gated,
-//! and tree-structured. Merging the two is out of scope for ESC-1; see
+//! The queue is deliberately **separate** from the pre-existing banner
+//! `crate::notifications::NotificationQueue` — the banner queue drives
+//! TTL-based pop-overs with Low/Medium/High priority and pause semantics,
+//! while ESC notifications are post-hoc, ack-gated, and tree-structured.
+//! Merging the two is out of scope for the ESC epic; see
 //! `docs/plan-326-esc.md` §"Existing NotificationQueue coexistence".
+//!
+//! # Push path
+//!
+//! Production pushes arrive from Lua via
+//! `scripts/notifications/default_bridge.lua`
+//! (an `on("*@observed", fn)` wildcard subscriber) calling the
+//! `push_notification { event_id, severity, message, source }` Lua API.
+//! The Rust-side drain system (`drain_pending_esc_notifications` in
+//! `crate::scripting::esc_notifications`) parses those entries and
+//! calls [`EscNotificationQueue::push`].
+//!
+//! [`EscNotificationQueue::push`] is also reachable from Rust for tests
+//! and future direct-write consumers; it performs id allocation + the
+//! `NotifiedEventIds` dedup handshake in a single call.
+//!
+//! # Ack routing (render → system)
+//!
+//! `SituationTab::render` only receives `&World`, so the tab cannot
+//! mutate the queue during render. The render path pushes ack requests
+//! into a process-wide `Mutex<Vec<PendingAck>>` buffer; the
+//! [`apply_pending_acks_system`] Bevy system drains the buffer in
+//! `Update` and applies each ack to the queue. Tests can drive this
+//! directly via [`enqueue_pending_ack`] and
+//! [`drain_pending_acks_for_tests`].
 
 use std::any::Any;
+use std::sync::Mutex;
 
 use bevy::prelude::*;
 use bevy_egui::egui;
 
 use super::state::TabState;
 use super::tab::{SituationTab, TabBadge, TabMeta};
-use super::types::{Notification, Severity, severity_max};
+use super::types::{Notification, NotificationId, Severity, severity_max};
+use crate::knowledge::{EventId, NotifiedEventIds};
 
-/// Stub queue for ESC notifications. ESC-2 replaces this with the real
-/// push / ack / cascade-ack implementation; the minimal shape here is
-/// just what the tab renderer needs (iterate + cascade-ack by id).
-#[derive(Resource, Default, Debug)]
+/// Outcome of [`EscNotificationQueue::push`] — a new entry was appended,
+/// or the push was suppressed because the event_id already fired.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PushOutcome {
+    /// The notification was appended with the returned id.
+    Pushed(NotificationId),
+    /// The notification was silently dropped because its `event_id` had
+    /// already fired (`#249 NotifiedEventIds::try_notify` returned
+    /// `false`).
+    DedupedByEventId,
+}
+
+/// ESC ack-able notification history queue.
+///
+/// Top-level entries are stored **newest-first** (index 0 is the most
+/// recently pushed). Children nest via [`Notification::children`].
+///
+/// ## Id allocation
+///
+/// Every successful push assigns a fresh [`NotificationId`] from a
+/// monotonically increasing counter (starts at 1). Ids are never reused
+/// even after an ack — so the tab strip badge, filter selection, and
+/// any future persistence layer can safely use them as stable keys.
+///
+/// ## Dedup
+///
+/// Pushes that carry an `event_id` are routed through
+/// [`NotifiedEventIds::try_notify`] before allocation. The first push
+/// for a given id wins; subsequent pushes return
+/// [`PushOutcome::DedupedByEventId`] with no mutation. Pushes without an
+/// `event_id` always succeed.
+///
+/// ## Ack
+///
+/// [`EscNotificationQueue::ack`] cascades to children via
+/// [`Notification::ack_cascade`] so the tree-level "ack all" semantics
+/// stay consistent with the ESC-1 `ack_cascade` unit tests. Ack only
+/// touches the entry and its descendants — siblings are untouched.
+#[derive(Resource, Debug, Default)]
 pub struct EscNotificationQueue {
-    /// Newest first. ESC-2 will seal the push API and add dedupe
-    /// against `NotifiedEventIds`.
+    /// Newest-first stack of top-level notifications.
     pub items: Vec<Notification>,
+    /// Monotonic id counter for new pushes. Never decreases.
+    next_id: NotificationId,
 }
 
 impl EscNotificationQueue {
+    /// Append a new notification. Optionally claim an `event_id` for
+    /// dedup via [`NotifiedEventIds`].
+    ///
+    /// Returns [`PushOutcome::Pushed`] with the allocated id on success.
+    /// Returns [`PushOutcome::DedupedByEventId`] when `event_id` is
+    /// `Some(id)` and the id has already been claimed (either by an
+    /// earlier ESC push or by the banner `auto_notify_from_events` path,
+    /// since the map is shared).
+    ///
+    /// The caller is responsible for building the [`Notification`] with
+    /// its `source`, `timestamp`, `severity`, `message`, and any
+    /// pre-built `children`. The queue overwrites `id` to guarantee
+    /// monotonicity — callers should not rely on whatever value they
+    /// pass in.
+    pub fn push(
+        &mut self,
+        mut notification: Notification,
+        event_id: Option<EventId>,
+        notified_ids: Option<&mut NotifiedEventIds>,
+    ) -> PushOutcome {
+        if let (Some(eid), Some(notified)) = (event_id, notified_ids)
+            && !notified.try_notify(eid)
+        {
+            return PushOutcome::DedupedByEventId;
+        }
+        self.next_id = self.next_id.saturating_add(1);
+        let id = self.next_id;
+        notification.id = id;
+        // Newest-first: prepend so the tab renders the most recent
+        // entry at the top without the renderer having to reverse-walk.
+        self.items.insert(0, notification);
+        PushOutcome::Pushed(id)
+    }
+
+    /// Ack the notification with `id` and cascade to all descendants.
+    /// Returns `true` if a matching entry was found (even if it was
+    /// already acked). Returns `false` if no entry with that id exists.
+    pub fn ack(&mut self, id: NotificationId) -> bool {
+        for top in self.items.iter_mut() {
+            if let Some(found) = find_mut_in_subtree(top, id) {
+                found.ack_cascade();
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Cascade-ack every top-level entry in the queue. Returns the
+    /// number of top-level entries that were touched (equal to
+    /// `items.len()`).
+    pub fn ack_all(&mut self) -> usize {
+        let n = self.items.len();
+        for top in self.items.iter_mut() {
+            top.ack_cascade();
+        }
+        n
+    }
+
     /// Total count of unacked entries across every tree in the queue.
     pub fn total_unacked(&self) -> usize {
         self.items.iter().map(Notification::unacked_count).sum()
@@ -52,13 +172,94 @@ impl EscNotificationQueue {
             .filter_map(Notification::highest_unacked_severity)
             .reduce(severity_max)
     }
+
+    /// Most recently allocated id (zero before the first push). Mostly
+    /// useful for tests / diagnostics.
+    pub fn last_id(&self) -> NotificationId {
+        self.next_id
+    }
+}
+
+/// Recursive helper that finds a mutable reference to the notification
+/// with `id` inside a notification tree.
+fn find_mut_in_subtree(root: &mut Notification, id: NotificationId) -> Option<&mut Notification> {
+    if root.id == id {
+        return Some(root);
+    }
+    for child in root.children.iter_mut() {
+        if let Some(found) = find_mut_in_subtree(child, id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Ack request emitted by the tab renderer and drained by
+/// [`apply_pending_acks_system`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PendingAck {
+    Single(NotificationId),
+    All,
+}
+
+// Shared render-path buffer. `SituationTab::render` only sees `&World`,
+// so we cannot route ack requests through a `ResMut` there. The render
+// path pushes into this process-wide mutex-protected buffer, and
+// `apply_pending_acks_system` drains it in `Update`. A `Mutex` (rather
+// than a thread-local) is required because the egui draw schedule and
+// the Bevy runner systems may run on different worker threads — a TLS
+// would be invisible to the drain system.
+//
+// Producer: `render_notification_leaf` / the "ack all" button branch
+// / the public [`enqueue_pending_ack`] helper (used by tests).
+// Consumer: [`apply_pending_acks_system`] (Bevy `Update`).
+static PENDING_ACK_BUFFER: Mutex<Vec<PendingAck>> = Mutex::new(Vec::new());
+
+/// Test helper + alternate entry: append an ack intent directly. The
+/// tab renderer calls this too; exposed so tests can drive the drain
+/// system without wiring egui.
+pub fn enqueue_pending_ack(action: PendingAck) {
+    if let Ok(mut buf) = PENDING_ACK_BUFFER.lock() {
+        buf.push(action);
+    }
+}
+
+/// Drain every ack intent emitted by the tab renderer since the last
+/// call. Public for tests only.
+pub fn drain_pending_acks_for_tests() -> Vec<PendingAck> {
+    match PENDING_ACK_BUFFER.lock() {
+        Ok(mut buf) => std::mem::take(&mut *buf),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Bevy system that drains the render-path ack intents and applies them
+/// to the queue. Runs in `Update` after the UI pass so the queue sees
+/// each ack exactly once per frame.
+pub fn apply_pending_acks_system(mut queue: ResMut<EscNotificationQueue>) {
+    let drained: Vec<PendingAck> = match PENDING_ACK_BUFFER.lock() {
+        Ok(mut buf) => std::mem::take(&mut *buf),
+        Err(_) => return,
+    };
+    for action in drained {
+        match action {
+            PendingAck::Single(id) => {
+                queue.ack(id);
+            }
+            PendingAck::All => {
+                queue.ack_all();
+            }
+        }
+    }
 }
 
 /// ESC tab that surfaces the [`EscNotificationQueue`].
 ///
 /// Implements [`SituationTab`] directly rather than [`super::tab::OngoingTab`]
-/// because its render path needs per-row ack buttons (and eventually
-/// filter UI in ESC-2) — the Event-tree default renderer doesn't fit.
+/// because its render path needs per-row ack buttons + a filter UI — the
+/// Event-tree default renderer doesn't fit. Filter state (severity floor,
+/// show-acked flag) lives on [`TabState`] so it persists across tab
+/// switches.
 pub struct NotificationsTab;
 
 impl NotificationsTab {
@@ -87,20 +288,39 @@ impl SituationTab for NotificationsTab {
         Some(TabBadge::new(count as u32, severity))
     }
 
-    fn render(&self, ui: &mut egui::Ui, world: &World, _state: &mut TabState) {
+    fn render(&self, ui: &mut egui::Ui, world: &World, state: &mut TabState) {
         let Some(queue) = world.get_resource::<EscNotificationQueue>() else {
             ui.label(egui::RichText::new("(EscNotificationQueue resource missing)").weak());
             return;
         };
+
+        render_filter_toolbar(ui, state);
+        ui.separator();
 
         if queue.items.is_empty() {
             ui.label(egui::RichText::new("(no notifications)").weak());
             return;
         }
 
-        for notif in &queue.items {
-            render_notification(ui, notif);
-        }
+        ui.horizontal(|ui| {
+            if ui.button("Ack all").clicked() {
+                enqueue_pending_ack(PendingAck::All);
+            }
+            ui.label(egui::RichText::new(format!("{} unacked", queue.total_unacked())).weak());
+        });
+        ui.separator();
+
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, true])
+            .max_height(360.0)
+            .show(ui, |ui| {
+                for notif in &queue.items {
+                    if !passes_filter(notif, state) {
+                        continue;
+                    }
+                    render_notification_row(ui, notif);
+                }
+            });
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -108,18 +328,103 @@ impl SituationTab for NotificationsTab {
     }
 }
 
-fn render_notification(ui: &mut egui::Ui, notif: &Notification) {
+/// Render the filter toolbar (severity floor + show-acked toggle). Both
+/// edits land on the shared [`TabState`]; the queue itself is not
+/// touched here.
+fn render_filter_toolbar(ui: &mut egui::Ui, state: &mut TabState) {
+    ui.horizontal(|ui| {
+        ui.label("Filter:");
+        egui::ComboBox::from_id_salt("esc_notif_severity_filter")
+            .selected_text(match state.severity_floor {
+                None => "All",
+                Some(Severity::Info) => "Info+",
+                Some(Severity::Warn) => "Warn+",
+                Some(Severity::Critical) => "Critical only",
+            })
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut state.severity_floor, None, "All");
+                ui.selectable_value(&mut state.severity_floor, Some(Severity::Info), "Info+");
+                ui.selectable_value(&mut state.severity_floor, Some(Severity::Warn), "Warn+");
+                ui.selectable_value(
+                    &mut state.severity_floor,
+                    Some(Severity::Critical),
+                    "Critical only",
+                );
+            });
+
+        // Show-acked toggle stored as a sentinel in `TabState::filter`
+        // so the shared state struct stays shape-compatible with other
+        // tabs (no dedicated `hide_acked` field).
+        let mut hide_acked = state.filter == HIDE_ACKED_SENTINEL;
+        if ui.checkbox(&mut hide_acked, "Hide acked").changed() {
+            state.filter = if hide_acked {
+                HIDE_ACKED_SENTINEL.into()
+            } else {
+                String::new()
+            };
+        }
+    });
+}
+
+/// Internal marker written to `TabState::filter` when the player toggles
+/// "Hide acked" in the notifications tab. Stored as a sentinel string so
+/// the shared `TabState` struct stays shape-compatible with other tabs
+/// (no dedicated `hide_acked` field).
+const HIDE_ACKED_SENTINEL: &str = "__esc_hide_acked__";
+
+/// Predicate that gates each top-level notification by the tab state.
+/// Tree descendants inherit the decision of their root — individual
+/// children are not re-filtered. This keeps the "parent ack cascades
+/// children" UX coherent: the root is the unit of filtering.
+fn passes_filter(notif: &Notification, state: &TabState) -> bool {
+    if let Some(floor) = state.severity_floor {
+        // Use the highest unacked severity when present so a fully-acked
+        // high-severity tree doesn't dominate the filter. Fall through
+        // to `notif.severity` when the subtree is fully acked so the
+        // entry is still reachable in the default view.
+        let sev = notif.highest_unacked_severity().unwrap_or(notif.severity);
+        if severity_rank(sev) < severity_rank(floor) {
+            return false;
+        }
+    }
+
+    if state.filter == HIDE_ACKED_SENTINEL && notif.unacked_count() == 0 {
+        return false;
+    }
+
+    true
+}
+
+fn severity_rank(s: Severity) -> u8 {
+    match s {
+        Severity::Info => 0,
+        Severity::Warn => 1,
+        Severity::Critical => 2,
+    }
+}
+
+/// Render a single top-level notification row (possibly with children)
+/// plus an ack button. Queues ack intents via [`enqueue_pending_ack`].
+fn render_notification_row(ui: &mut egui::Ui, notif: &Notification) {
     if notif.children.is_empty() {
         render_notification_leaf(ui, notif);
     } else {
-        let header = format!("{} ({} unacked)", notif.message, notif.unacked_count(),);
+        let header = format!(
+            "{} ({} unacked of {})",
+            notif.message,
+            notif.unacked_count(),
+            notif.tree_len(),
+        );
         egui::CollapsingHeader::new(header)
             .id_salt(("esc_notif", notif.id))
             .default_open(true)
             .show(ui, |ui| {
-                for c in &notif.children {
-                    render_notification(ui, c);
-                }
+                render_notification_leaf(ui, notif);
+                ui.indent(("esc_notif_children", notif.id), |ui| {
+                    for child in &notif.children {
+                        render_notification_row(ui, child);
+                    }
+                });
             });
     }
 }
@@ -139,6 +444,9 @@ fn render_notification_leaf(ui: &mut egui::Ui, notif: &Notification) {
         };
         ui.label(text);
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if !notif.acked && ui.small_button("ack").clicked() {
+                enqueue_pending_ack(PendingAck::Single(notif.id));
+            }
             ui.label(
                 egui::RichText::new(format!("t={}", notif.timestamp))
                     .weak()
@@ -171,23 +479,145 @@ mod tests {
     use super::*;
     use crate::ui::situation_center::types::NotificationSource;
 
-    fn notif(id: u64, sev: Severity, acked: bool) -> Notification {
+    fn notif(sev: Severity, acked: bool, message: &str) -> Notification {
         Notification {
-            id,
+            id: 0,
             source: NotificationSource::None,
             timestamp: 0,
             severity: sev,
-            message: format!("n{}", id),
+            message: message.into(),
             acked,
             children: Vec::new(),
         }
     }
 
     #[test]
+    fn push_assigns_monotonic_ids() {
+        let mut q = EscNotificationQueue::default();
+        let a = q.push(notif(Severity::Info, false, "a"), None, None);
+        let b = q.push(notif(Severity::Info, false, "b"), None, None);
+        let c = q.push(notif(Severity::Info, false, "c"), None, None);
+        match (a, b, c) {
+            (PushOutcome::Pushed(ia), PushOutcome::Pushed(ib), PushOutcome::Pushed(ic)) => {
+                assert!(ia < ib && ib < ic);
+            }
+            _ => panic!("pushes should succeed: {a:?} {b:?} {c:?}"),
+        }
+        assert_eq!(q.items.len(), 3);
+        // Newest-first invariant.
+        assert_eq!(q.items[0].message, "c");
+        assert_eq!(q.items[2].message, "a");
+    }
+
+    #[test]
+    fn push_deduplicates_by_event_id() {
+        let mut q = EscNotificationQueue::default();
+        let mut notified = NotifiedEventIds::default();
+        let eid = EventId(42);
+        notified.register(eid);
+
+        let first = q.push(
+            notif(Severity::Warn, false, "first"),
+            Some(eid),
+            Some(&mut notified),
+        );
+        let second = q.push(
+            notif(Severity::Warn, false, "second"),
+            Some(eid),
+            Some(&mut notified),
+        );
+
+        assert!(matches!(first, PushOutcome::Pushed(_)));
+        assert_eq!(second, PushOutcome::DedupedByEventId);
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(q.items[0].message, "first");
+    }
+
+    #[test]
+    fn push_without_event_id_never_dedupes() {
+        let mut q = EscNotificationQueue::default();
+        let mut notified = NotifiedEventIds::default();
+        for _ in 0..3 {
+            let outcome = q.push(notif(Severity::Info, false, "x"), None, Some(&mut notified));
+            assert!(matches!(outcome, PushOutcome::Pushed(_)));
+        }
+        assert_eq!(q.items.len(), 3);
+    }
+
+    #[test]
+    fn ack_cascades_to_children() {
+        let mut q = EscNotificationQueue::default();
+        let mut root = notif(Severity::Warn, false, "root");
+        root.children.push(notif(Severity::Info, false, "child1"));
+        root.children
+            .push(notif(Severity::Critical, false, "child2"));
+        let id = match q.push(root, None, None) {
+            PushOutcome::Pushed(id) => id,
+            _ => panic!(),
+        };
+
+        assert_eq!(q.total_unacked(), 3);
+        assert!(q.ack(id));
+        assert_eq!(q.total_unacked(), 0);
+        assert!(q.items[0].acked);
+        assert!(q.items[0].children.iter().all(|c| c.acked));
+    }
+
+    #[test]
+    fn ack_only_affects_matching_subtree() {
+        let mut q = EscNotificationQueue::default();
+        let mut a = notif(Severity::Warn, false, "a");
+        a.children.push(notif(Severity::Info, false, "a1"));
+        let id_a = match q.push(a, None, None) {
+            PushOutcome::Pushed(id) => id,
+            _ => panic!(),
+        };
+        let _id_b = q.push(notif(Severity::Critical, false, "b"), None, None);
+
+        assert!(q.ack(id_a));
+        assert_eq!(q.total_unacked(), 1);
+        let b = q
+            .items
+            .iter()
+            .find(|n| n.message == "b")
+            .expect("b present");
+        assert!(!b.acked);
+    }
+
+    #[test]
+    fn ack_missing_id_returns_false() {
+        let mut q = EscNotificationQueue::default();
+        q.push(notif(Severity::Info, false, "a"), None, None);
+        assert!(!q.ack(999_999));
+    }
+
+    #[test]
+    fn ack_all_cascades_everything() {
+        let mut q = EscNotificationQueue::default();
+        q.push(notif(Severity::Info, false, "a"), None, None);
+        q.push(notif(Severity::Warn, false, "b"), None, None);
+        q.push(notif(Severity::Critical, false, "c"), None, None);
+        let n = q.ack_all();
+        assert_eq!(n, 3);
+        assert_eq!(q.total_unacked(), 0);
+    }
+
+    #[test]
+    fn ack_is_idempotent() {
+        let mut q = EscNotificationQueue::default();
+        let id = match q.push(notif(Severity::Warn, false, "a"), None, None) {
+            PushOutcome::Pushed(id) => id,
+            _ => panic!(),
+        };
+        assert!(q.ack(id));
+        assert!(q.ack(id));
+        assert_eq!(q.total_unacked(), 0);
+    }
+
+    #[test]
     fn empty_queue_emits_no_badge() {
         let mut world = World::new();
         world.insert_resource(EscNotificationQueue::default());
-
         let tab = NotificationsTab;
         assert!(tab.badge(&world).is_none());
     }
@@ -196,11 +626,10 @@ mod tests {
     fn badge_counts_unacked_entries_and_reports_highest_severity() {
         let mut world = World::new();
         let mut queue = EscNotificationQueue::default();
-        queue.items.push(notif(1, Severity::Info, true));
-        queue.items.push(notif(2, Severity::Warn, false));
-        queue.items.push(notif(3, Severity::Critical, false));
-        // Extra acked Critical must not bump the severity.
-        queue.items.push(notif(4, Severity::Critical, true));
+        queue.push(notif(Severity::Info, true, "acked info"), None, None);
+        queue.push(notif(Severity::Warn, false, "warn"), None, None);
+        queue.push(notif(Severity::Critical, false, "crit"), None, None);
+        queue.push(notif(Severity::Critical, true, "acked crit"), None, None);
         world.insert_resource(queue);
 
         let tab = NotificationsTab;
@@ -214,5 +643,93 @@ mod tests {
         let world = World::new();
         let tab = NotificationsTab;
         assert!(tab.badge(&world).is_none());
+    }
+
+    #[test]
+    fn filter_severity_floor_hides_lower() {
+        let mut state = TabState::default();
+        state.severity_floor = Some(Severity::Warn);
+
+        let info = notif(Severity::Info, false, "info");
+        let warn = notif(Severity::Warn, false, "warn");
+        let crit = notif(Severity::Critical, false, "crit");
+
+        assert!(!passes_filter(&info, &state));
+        assert!(passes_filter(&warn, &state));
+        assert!(passes_filter(&crit, &state));
+    }
+
+    #[test]
+    fn filter_hide_acked_drops_fully_acked_tree() {
+        let mut state = TabState::default();
+        state.filter = HIDE_ACKED_SENTINEL.into();
+
+        let mut acked = notif(Severity::Warn, true, "acked");
+        acked.children.push(notif(Severity::Info, true, "c"));
+        let unacked = notif(Severity::Info, false, "unacked");
+
+        assert!(!passes_filter(&acked, &state));
+        assert!(passes_filter(&unacked, &state));
+    }
+
+    #[test]
+    fn push_outcome_bumps_last_id() {
+        let mut q = EscNotificationQueue::default();
+        assert_eq!(q.last_id(), 0);
+        q.push(notif(Severity::Info, false, "a"), None, None);
+        assert_eq!(q.last_id(), 1);
+        q.push(notif(Severity::Info, false, "b"), None, None);
+        assert_eq!(q.last_id(), 2);
+    }
+
+    /// Unit-level test for [`apply_pending_acks_system`] that calls
+    /// it directly rather than going through `App::update()`. Avoids
+    /// flakiness from the Bevy worker pool interleaving with the
+    /// global [`PENDING_ACK_BUFFER`] across concurrent tests in the
+    /// same process. The end-to-end (App::update) path is covered by
+    /// `tests/esc_notification_pipeline.rs` with explicit serialisation.
+    #[test]
+    fn apply_pending_acks_system_drains_buffer_and_acks_queue() {
+        let _guard = acquire_test_ack_serial();
+        // Clear leftover buffer state from any prior test run.
+        let _ = drain_pending_acks_for_tests();
+
+        let mut queue = EscNotificationQueue::default();
+        let id1 = match queue.push(notif(Severity::Warn, false, "a"), None, None) {
+            PushOutcome::Pushed(id) => id,
+            _ => unreachable!(),
+        };
+        let _id2 = queue.push(notif(Severity::Critical, false, "b"), None, None);
+
+        enqueue_pending_ack(PendingAck::Single(id1));
+
+        // Exercise the system function directly via a short-lived World
+        // so there's no worker-pool interleaving with other tests'
+        // queue resources.
+        let mut world = World::new();
+        world.insert_resource(queue);
+        let mut system = bevy::ecs::system::IntoSystem::into_system(apply_pending_acks_system);
+        system.initialize(&mut world);
+        system.run((), &mut world);
+
+        let q = world.resource::<EscNotificationQueue>();
+        let acked_ids: Vec<_> = q.items.iter().filter(|n| n.acked).map(|n| n.id).collect();
+        assert_eq!(acked_ids, vec![id1]);
+
+        enqueue_pending_ack(PendingAck::All);
+        system.run((), &mut world);
+        let q = world.resource::<EscNotificationQueue>();
+        assert_eq!(q.total_unacked(), 0);
+    }
+
+    /// Global mutex used by tests that touch [`PENDING_ACK_BUFFER`] so
+    /// they don't race each other. `cargo test` runs tests concurrently
+    /// by default; wrapping each buffer-touching test in
+    /// `acquire_test_ack_serial` keeps their effects isolated.
+    fn acquire_test_ack_serial() -> std::sync::MutexGuard<'static, ()> {
+        static TEST_ACK_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        TEST_ACK_SERIAL
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
     }
 }

--- a/macrocosmo/tests/esc_notification_pipeline.rs
+++ b/macrocosmo/tests/esc_notification_pipeline.rs
@@ -1,0 +1,425 @@
+//! #345 ESC-2 integration tests.
+//!
+//! End-to-end verification of the ESC Notifications path:
+//!
+//! 1. A `KnowledgeFact` variant lands in `PendingFactQueue` with
+//!    `arrives_at <= clock.elapsed`.
+//! 2. `dispatch_knowledge_observed` drains the queue, builds the
+//!    sealed `@observed` event table, and fires
+//!    `scripts/notifications/default_bridge.lua`'s wildcard
+//!    subscriber.
+//! 3. The bridge calls `push_notification { ... }`, which appends to
+//!    `_pending_esc_notifications`.
+//! 4. `drain_pending_esc_notifications` parses the accumulator and
+//!    pushes into `EscNotificationQueue`.
+//! 5. Ack intents routed through `enqueue_pending_ack` +
+//!    `apply_pending_acks_system` flip the entry `acked` without
+//!    touching the unrelated banner `NotificationQueue`.
+//!
+//! These tests do **not** assert egui render output — the UI layer is
+//! covered by the unit tests in
+//! `ui::situation_center::notifications_tab::tests`. Here we pin the
+//! wiring from `PendingFactQueue` through Lua and back to
+//! `EscNotificationQueue`.
+//!
+//! ## Parallelism + global state
+//!
+//! `apply_pending_acks_system` drains a process-wide
+//! `Mutex<Vec<PendingAck>>` populated from `enqueue_pending_ack`.
+//! Tests in this file serialise on `ACK_SERIAL` so one test's ack
+//! buffer can't bleed into another's drain. The esc bridge + the
+//! banner path never touch that buffer, so tests that don't use
+//! `enqueue_pending_ack` don't need the guard.
+
+use bevy::prelude::*;
+
+use macrocosmo::knowledge::{
+    CombatVictor, EventId, KnowledgeFact, NotifiedEventIds, ObservationSource, PendingFactQueue,
+    PerceivedFact, RelayNetwork,
+};
+use macrocosmo::notifications::NotificationQueue;
+use macrocosmo::player::PlayerEmpire;
+use macrocosmo::scripting::esc_notifications::drain_pending_esc_notifications;
+use macrocosmo::scripting::knowledge_dispatch::dispatch_knowledge_observed;
+use macrocosmo::scripting::knowledge_registry::{
+    KnowledgeSubscriptionRegistry, load_knowledge_subscriptions,
+};
+use macrocosmo::scripting::{GameRng, ScriptEngine};
+use macrocosmo::time_system::{GameClock, GameSpeed};
+use macrocosmo::ui::situation_center::{
+    EscNotificationQueue, PendingAck, Severity, apply_pending_acks_system,
+    drain_pending_acks_for_tests, enqueue_pending_ack,
+};
+
+/// Process-wide mutex that serialises tests which push to the
+/// shared ack buffer. See module-level doc.
+static ACK_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn acquire_ack_serial() -> std::sync::MutexGuard<'static, ()> {
+    ACK_SERIAL.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// Build a minimal headless app wired with the ESC + knowledge +
+/// scripting resources needed for the pipeline. Loads
+/// `macrocosmo/scripts/init.lua` (which now requires the default
+/// bridge) so the `*@observed` subscriber is live.
+fn make_integration_app() -> App {
+    let mut app = App::new();
+
+    // Knowledge + time + banner resources.
+    app.init_resource::<PendingFactQueue>()
+        .init_resource::<NotifiedEventIds>()
+        .init_resource::<RelayNetwork>()
+        .insert_resource(NotificationQueue::new())
+        .insert_resource(GameClock::new(0))
+        .insert_resource(GameSpeed::default());
+
+    // ESC resources.
+    app.init_resource::<EscNotificationQueue>()
+        .add_systems(Update, apply_pending_acks_system);
+
+    // Scripting — boot the engine with the crate-local scripts/ dir
+    // so `default_bridge.lua` is picked up by `require()`. We don't
+    // wire the full `ScriptingPlugin` because the integration test
+    // only needs the `init.lua` + knowledge subscription registry +
+    // the two drain systems (dispatch + esc drain). That keeps the
+    // app boot time tight and avoids pulling in Startup hooks that
+    // would try to allocate galaxy state we don't spawn here.
+    let rng = GameRng::default().handle();
+    let scripts_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts");
+    let engine = ScriptEngine::new_with_rng_and_dir(rng, scripts_dir.clone()).expect("engine");
+    // Mirror ScriptingPlugin's `init_scripting` globals setup path —
+    // the engine constructor runs `setup_globals` already via
+    // `new_with_rng_and_dir`, so we can proceed directly to
+    // `load_all_scripts`.
+    engine
+        .lua()
+        .load(r#"require("init")"#)
+        .exec()
+        .expect("init.lua");
+    app.insert_resource(engine);
+
+    // Drain `_pending_knowledge_subscriptions` (populated by `on(...)`
+    // calls inside default_bridge.lua during the `require("init")`
+    // pass above) into the bucketed registry so the dispatcher can
+    // walk them.
+    app.init_resource::<KnowledgeSubscriptionRegistry>();
+    let mut sys = bevy::ecs::system::IntoSystem::into_system(load_knowledge_subscriptions);
+    sys.initialize(app.world_mut());
+    sys.run((), app.world_mut());
+
+    // Hook the two drain systems we need. `dispatch_knowledge_observed`
+    // fires the wildcard subscriber, which calls `push_notification`;
+    // `drain_pending_esc_notifications` consumes the Lua accumulator.
+    app.add_systems(
+        Update,
+        (dispatch_knowledge_observed, drain_pending_esc_notifications).chain(),
+    );
+
+    // The dispatcher iterates `PlayerEmpire`-tagged entities as
+    // observer empires — spawn one so the observed path actually
+    // runs (otherwise the subscriber never fires and the test gives
+    // a false pass).
+    app.world_mut().spawn(PlayerEmpire);
+    app
+}
+
+fn enqueue_hostile_fact(app: &mut App, target_bits: u64, description: &str) {
+    let target = Entity::from_bits(target_bits);
+    let detector = app.world_mut().spawn_empty().id();
+    let mut queue = app.world_mut().resource_mut::<PendingFactQueue>();
+    queue.record(PerceivedFact {
+        fact: KnowledgeFact::HostileDetected {
+            event_id: None,
+            target,
+            detector,
+            target_pos: [0.0, 0.0, 0.0],
+            description: description.into(),
+        },
+        observed_at: 0,
+        arrives_at: 0,
+        source: ObservationSource::Direct,
+        origin_pos: [0.0, 0.0, 0.0],
+        related_system: None,
+    });
+}
+
+#[test]
+fn hostile_detected_flows_through_bridge_to_esc_queue() {
+    let mut app = make_integration_app();
+    enqueue_hostile_fact(&mut app, 42, "Warship sighted");
+
+    app.update();
+
+    let q = app.world().resource::<EscNotificationQueue>();
+    assert_eq!(q.items.len(), 1, "bridge should land one notification");
+    let n = &q.items[0];
+    assert_eq!(n.severity, Severity::Warn);
+    assert!(
+        n.message.contains("Warship sighted"),
+        "message should include payload description, got: {:?}",
+        n.message,
+    );
+}
+
+#[test]
+fn repeated_hostile_for_same_target_dedupes_via_event_id() {
+    let mut app = make_integration_app();
+    // Two independent facts for the same target entity. The bridge
+    // synthesises `event_id = "core:hostile:<target>"` so the second
+    // push is suppressed.
+    enqueue_hostile_fact(&mut app, 99, "alpha");
+    enqueue_hostile_fact(&mut app, 99, "beta");
+
+    app.update();
+
+    let q = app.world().resource::<EscNotificationQueue>();
+    assert_eq!(q.items.len(), 1, "event_id dedup should collapse to one");
+    // First-push-wins ordering: "alpha" lands, "beta" is suppressed.
+    assert!(
+        q.items[0].message.contains("alpha"),
+        "first push wins: {:?}",
+        q.items[0].message
+    );
+}
+
+#[test]
+fn distinct_targets_do_not_dedupe() {
+    let mut app = make_integration_app();
+    enqueue_hostile_fact(&mut app, 11, "a");
+    enqueue_hostile_fact(&mut app, 22, "b");
+    enqueue_hostile_fact(&mut app, 33, "c");
+
+    app.update();
+
+    let q = app.world().resource::<EscNotificationQueue>();
+    assert_eq!(q.items.len(), 3);
+}
+
+#[test]
+fn ack_affects_esc_queue_only_not_banner() {
+    let _guard = acquire_ack_serial();
+    let _ = drain_pending_acks_for_tests(); // clean leftover buffer
+
+    let mut app = make_integration_app();
+
+    // Enqueue a fact that produces BOTH an ESC notification (via
+    // the Lua bridge) AND a banner (via the K-5 inline core:* bridge
+    // in `dispatch_knowledge_observed`). We verify the two queues
+    // are independent: acking one does not touch the other.
+    let target = app.world_mut().spawn_empty().id();
+    let detector = app.world_mut().spawn_empty().id();
+    let mut queue = app.world_mut().resource_mut::<PendingFactQueue>();
+    queue.record(PerceivedFact {
+        fact: KnowledgeFact::HostileDetected {
+            event_id: Some(EventId(777)),
+            target,
+            detector,
+            target_pos: [0.0, 0.0, 0.0],
+            description: "Combined push".into(),
+        },
+        observed_at: 0,
+        arrives_at: 0,
+        source: ObservationSource::Direct,
+        origin_pos: [0.0, 0.0, 0.0],
+        related_system: None,
+    });
+    // Register the banner-side event id so the K-5 bridge's
+    // `try_notify` admits the banner push (mirrors `FactSysParam::
+    // allocate_event_id` + auto-pause contract).
+    app.world_mut()
+        .resource_mut::<NotifiedEventIds>()
+        .register(EventId(777));
+
+    app.update();
+
+    // Both queues populated.
+    let esc_id = {
+        let esc = app.world().resource::<EscNotificationQueue>();
+        assert_eq!(esc.items.len(), 1, "ESC got the Lua-bridge push");
+        esc.items[0].id
+    };
+    let banner_len_before = app.world().resource::<NotificationQueue>().items.len();
+    assert!(banner_len_before >= 1, "banner path also fired");
+
+    // Ack the ESC entry through the render-path thread-local.
+    enqueue_pending_ack(PendingAck::Single(esc_id));
+    app.update();
+
+    let esc = app.world().resource::<EscNotificationQueue>();
+    assert_eq!(esc.total_unacked(), 0, "ESC ack propagated");
+    assert!(
+        esc.items.iter().find(|n| n.id == esc_id).unwrap().acked,
+        "matching ESC entry marked acked"
+    );
+    let banner_len_after = app.world().resource::<NotificationQueue>().items.len();
+    assert_eq!(
+        banner_len_before, banner_len_after,
+        "banner queue unaffected by ESC ack",
+    );
+}
+
+#[test]
+fn cascade_ack_propagates_to_children() {
+    let _guard = acquire_ack_serial();
+    let _ = drain_pending_acks_for_tests();
+
+    let mut app = make_integration_app();
+
+    // Manually push a parent-with-children notification into the
+    // queue so we can exercise cascade ack end-to-end. The Lua
+    // bridge emits flat notifications today, but the queue / ack
+    // contract supports tree structures for future bridges.
+    let mut esc = app.world_mut().resource_mut::<EscNotificationQueue>();
+    use macrocosmo::ui::situation_center::{Notification, NotificationSource};
+    let parent = Notification {
+        id: 0,
+        source: NotificationSource::None,
+        timestamp: 0,
+        severity: Severity::Warn,
+        message: "parent".into(),
+        acked: false,
+        children: vec![
+            Notification {
+                id: 0,
+                source: NotificationSource::None,
+                timestamp: 0,
+                severity: Severity::Info,
+                message: "c1".into(),
+                acked: false,
+                children: Vec::new(),
+            },
+            Notification {
+                id: 0,
+                source: NotificationSource::None,
+                timestamp: 0,
+                severity: Severity::Critical,
+                message: "c2".into(),
+                acked: false,
+                children: Vec::new(),
+            },
+        ],
+    };
+    match esc.push(parent, None, None) {
+        macrocosmo::ui::situation_center::PushOutcome::Pushed(id) => {
+            drop(esc);
+            enqueue_pending_ack(PendingAck::Single(id));
+        }
+        other => panic!("unexpected outcome: {other:?}"),
+    }
+
+    app.update();
+
+    let esc = app.world().resource::<EscNotificationQueue>();
+    assert_eq!(
+        esc.total_unacked(),
+        0,
+        "cascade ack should flatten the subtree"
+    );
+    assert!(esc.items[0].acked);
+    assert!(esc.items[0].children.iter().all(|c| c.acked));
+}
+
+#[test]
+fn bridge_does_not_touch_banner_queue_directly() {
+    // The ESC bridge goes Lua → `_pending_esc_notifications` →
+    // `EscNotificationQueue`. It must NEVER push into the banner
+    // queue itself — banners are driven by the separate inline
+    // K-5 bridge inside `dispatch_knowledge_observed`. This test
+    // pushes a `push_notification` directly without any fact, which
+    // should populate ONLY the ESC queue.
+    let mut app = make_integration_app();
+    {
+        let engine = app.world().resource::<ScriptEngine>();
+        engine
+            .lua()
+            .load(
+                r#"
+            push_notification {
+                message = "direct lua push",
+                severity = "info"
+            }
+        "#,
+            )
+            .exec()
+            .expect("lua exec");
+    }
+    app.update();
+
+    let esc = app.world().resource::<EscNotificationQueue>();
+    assert_eq!(esc.items.len(), 1);
+    let banner = app.world().resource::<NotificationQueue>();
+    assert_eq!(
+        banner.items.len(),
+        0,
+        "direct push_notification must not leak into banner queue",
+    );
+}
+
+#[test]
+fn sample_kinds_are_not_bridged_by_default() {
+    // The default bridge only maps `core:*`. A scripted fact with a
+    // `sample:*` kind should pass through `dispatch_knowledge_observed`
+    // without creating an ESC notification (the bridge's policy
+    // table returns `nil` → skip).
+    let mut app = make_integration_app();
+
+    use macrocosmo::knowledge::payload::PayloadSnapshot;
+    let snapshot = PayloadSnapshot {
+        fields: std::collections::HashMap::new(),
+    };
+    let mut queue = app.world_mut().resource_mut::<PendingFactQueue>();
+    queue.record(PerceivedFact {
+        fact: KnowledgeFact::Scripted {
+            event_id: None,
+            kind_id: "sample:combat_report".into(),
+            origin_system: None,
+            payload_snapshot: snapshot,
+            recorded_at: 0,
+        },
+        observed_at: 0,
+        arrives_at: 0,
+        source: ObservationSource::Direct,
+        origin_pos: [0.0, 0.0, 0.0],
+        related_system: None,
+    });
+
+    app.update();
+
+    let esc = app.world().resource::<EscNotificationQueue>();
+    assert_eq!(
+        esc.items.len(),
+        0,
+        "sample:* kinds intentionally not mapped by the default bridge"
+    );
+}
+
+#[test]
+fn combat_defeat_marked_critical_by_policy() {
+    let mut app = make_integration_app();
+    let system = app.world_mut().spawn_empty().id();
+    let mut queue = app.world_mut().resource_mut::<PendingFactQueue>();
+    queue.record(PerceivedFact {
+        fact: KnowledgeFact::CombatOutcome {
+            event_id: None,
+            system,
+            victor: CombatVictor::Hostile,
+            detail: "Fleet lost".into(),
+        },
+        observed_at: 0,
+        arrives_at: 0,
+        source: ObservationSource::Direct,
+        origin_pos: [0.0, 0.0, 0.0],
+        related_system: Some(system),
+    });
+    app.update();
+
+    let esc = app.world().resource::<EscNotificationQueue>();
+    assert_eq!(esc.items.len(), 1);
+    assert_eq!(
+        esc.items[0].severity,
+        Severity::Critical,
+        "defeat policy elevates to critical",
+    );
+    assert!(esc.items[0].message.contains("defeat"));
+}


### PR DESCRIPTION
Closes #345 (ESC-2). Part of #326 epic (ESC: Empire Situation Center).

## Summary

Wires the Empire Situation Center Notifications tab end-to-end, with
the push path implemented as a Lua-side wildcard subscriber
(`on(\"*@observed\", fn)`) over the #349 ScriptableKnowledge pipeline.
This replaces the K-6 \"write Rust throwaway bridge first, rewrite in
Lua later\" approach with the final shape on day one.

- Builds on #344 (ESC-1 framework land, PR #361) — trait / type
  shapes (`SituationTab`, `Notification`, `NotificationSource`,
  `Severity`, `NotificationsTab`, `EscNotificationQueue` stub) are
  unchanged; the stub queue is swapped for a real impl.
- Builds on #349 (ScriptableKnowledge K-1..K-5, landed):
  `*@observed` wildcard subscribers + `push_notification` + `core:*`
  kind preload are all consumed here.

## Scope

### Rust
- `ui/situation_center/notifications_tab.rs`: replace the ESC-1 stub
  with a real `EscNotificationQueue` — monotonic id allocation,
  cascade ack, ack-all, `NotifiedEventIds` dedup handshake, filter
  toolbar (severity floor + hide-acked), per-row ack buttons, scroll.
- `ui/situation_center/mod.rs`: register the new ack drain system.
- `scripting/globals.rs`: add `push_notification { ... }` Lua global
  + `_pending_esc_notifications` accumulator (distinct from
  `show_notification` which drives the top banner stack).
- `scripting/esc_notifications.rs` (new): permissive drain system
  that parses `_pending_esc_notifications` each frame and pushes
  into `EscNotificationQueue`. Handles severity/source/event_id/
  timestamp/children with the documented defaults and a
  `CHILD_DEPTH_LIMIT = 4` tree cap.
- `scripting/mod.rs`: register the drain
  `.after(dispatch_knowledge_observed).before(sweep_notified_event_ids)`.
- `notifications.rs`: update `notify_from_knowledge_facts` doc to
  make its test-only status + \"do not re-register\" contract
  explicit (the function is already unregistered in production since
  K-5).

### Lua
- `scripts/notifications/default_bridge.lua` (new): single
  `on(\"*@observed\", fn)` subscriber that dispatches a per-kind
  `KIND_POLICY` table covering every `core:*` kind (9 total):
  `hostile_detected`, `combat_outcome`, `survey_complete`,
  `anomaly_discovered`, `survey_discovery`, `structure_built`,
  `colony_established`, `colony_failed`, `ship_arrived`. Each
  policy formats the message, picks severity, synthesises a stable
  `event_id` for dedup, and appends `(lag N hd)` when the fact
  carries non-zero light-speed delay.
- `scripts/init.lua`: require the bridge after `knowledge.sample`
  and before `lifecycle`.

### Tests
- Unit: 14 new in `notifications_tab.rs` (queue contract, filter
  predicate, ack drain system) + 14 in `esc_notifications.rs`
  (field parsing, dedup, malformed-entry recovery).
- Integration: `tests/esc_notification_pipeline.rs` (8 tests) —
  PendingFactQueue → dispatch → Lua bridge → drain →
  EscNotificationQueue → ack propagation → banner-queue isolation.

## Test plan

- [x] `cargo test --workspace` green — 2419 passed / 0 failed (was
  2411 before the 8 new integration tests).
- [x] `cargo check --workspace --tests` clean.
- [x] `rustfmt --edition 2024 --check` on every touched file
  (7 files) clean.
- [x] `tests/smoke::all_systems_no_query_conflict` pass (B0001 guard).
- [x] `tests/fixtures_smoke::load_minimal_game_fixture_smoke` pass
  (save format stability — no postcard bump needed).
- [x] `tests/notification_knowledge_pipeline.rs` — K-5 regression
  matrix, all 17 tests still green with zero changes.
- [x] `cargo test -p macrocosmo --test esc_notification_pipeline`
  — 8/8 new integration tests pass.

## K-5 regression matrix

No change. All 17 tests in
`tests/notification_knowledge_pipeline.rs` pass unchanged:

| test                                                      | covers                                   |
|-----------------------------------------------------------|------------------------------------------|
| test_remote_detection_notification_light_speed_delayed    | HostileDetected banner via light-delay   |
| test_detection_via_relay_network_near_instant             | relay-path arrival (ObservationSource)   |
| test_player_respawn_notification_instant                  | legacy whitelist (PlayerRespawn)         |
| test_lua_notification_instant                             | Lua show_notification path               |
| test_survey_result_via_knowledge_store                    | SurveyComplete banner title / body       |
| test_combat_victory_notification_delayed                  | CombatOutcome banner title               |
| test_channel_autoselect_picks_fastest                     | compute_fact_arrival routing             |
| test_empire_comm_relay_inv_latency_increases_speed        | CommsParams plumbing                     |
| test_empire_comm_relay_range_extends_coverage             | RelayNetwork build                       |
| test_fleet_comm_relay_targets_routed_but_unused           | storage-only modifier                    |
| test_legacy_whitelist_split                               | whitelist surface (systems-2 only)       |
| test_survey_complete_fact_delayed_when_remote             | remote survey → banner gated by arrival  |
| test_survey_hostile_dual_write_no_double_banner           | #249 EventId dedupe (whitelist + fact)   |
| test_combat_defeat_per_ship_and_wipe_dedupe               | #249 shared EventId dedupe               |
| test_ship_arrived_low_priority_silent                     | Low priority = no banner                 |
| test_colony_established_remote_vs_local                   | local bypass vs remote delay             |
| test_structure_built_low_priority_logged_only             | Low priority + EventId dedupe tracking   |

## Covered `core:*` kinds in `default_bridge.lua`

All 9:

- `core:hostile_detected` → warn
- `core:combat_outcome` → info (victory) / critical (defeat)
- `core:survey_complete` → info
- `core:anomaly_discovered` → warn
- `core:survey_discovery` → info
- `core:structure_built` → info (built) / warn (destroyed)
- `core:colony_established` → info
- `core:colony_failed` → critical
- `core:ship_arrived` → info

Each policy synthesises a stable `event_id` scoped to the relevant
payload field (entity / name / observed_at) so duplicate fact
propagation through the relay network doesn't flood the tab.

## `notify_from_knowledge_facts` status

Retained (not deleted or feature-gated). The function is already
unregistered from `NotificationsPlugin` since K-5 landed; this PR
only tightens the doc-comment to make three points explicit:

1. The production `PendingFactQueue` drain lives in
   `dispatch_knowledge_observed` (K-5).
2. `notify_from_knowledge_facts` is retained as a regression
   harness for the 17 tests above, which wire it manually via
   `app.add_systems(Update, notify_from_knowledge_facts)`.
3. Re-registering it in any plugin is actively harmful — it would
   double-drain `PendingFactQueue`, starve the `@observed`
   subscriber chain (including this PR's ESC Lua bridge), and
   double-push banners.

## Plan deviations

- **Commit 2 (NotificationsTab render) merged into Commit 1** —
  the render code lives in the same file (`notifications_tab.rs`)
  and depends on the queue types + ack buffer added in the push
  implementation, so separating them would have produced a
  non-compiling intermediate state. All the scope-2 UX (filter
  toolbar, ack buttons, ack-all, scroll) is in Commit 1.
- **Ack routing uses a process-wide `Mutex<Vec<PendingAck>>`** —
  `SituationTab::render` only sees `&World`, which precludes a
  `ResMut` path. The earlier thread-local design was reverted
  after discovering Bevy's scheduler can move systems to worker
  threads separate from the egui draw thread. The mutex is drained
  by `apply_pending_acks_system` each `Update` frame.
- **`notify_from_knowledge_facts` not deleted** — tests in
  `notification_knowledge_pipeline.rs` depend on it. The issue
  says \"plan で判断\"; retaining + doc-tightening keeps the 17-test
  regression baseline intact.

## Related issues / epics

- Parent: #326 (ESC epic)
- Dep: #344 (ESC-1 framework, PR #361)
- Dep: #349 (ScriptableKnowledge K-1..K-5)
- Notable siblings: #346 (ESC-3, parallel). The two touch
  disjoint files — #346 adds four tabs via
  `register_ongoing_situation_tab`, this PR keeps
  `NotificationsTab` (bundled by ESC-1) and adds the bridge +
  drain. Merge order is order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)