### PR TITLE
#364: Re-enable bevy_gizmos_render so galaxy map ships render

### DIFF
--- a/macrocosmo/Cargo.toml
+++ b/macrocosmo/Cargo.toml
@@ -9,11 +9,17 @@ edition.workspace = true
 # bevy_scene / bevy_text / bevy_ui / bevy_state / bevy_input_focus / bevy_picking +
 # picking backends / png / vorbis / webgl2 / hdr / tonemapping_luts / smaa_luts /
 # custom_cursor / zstd_rust。egui で UI / text を担当するため bevy_ui 系は不要。
+#
+# IMPORTANT: `bevy_gizmos` は API レイヤ (Gizmos SystemParam, gizmos.circle_2d 等)
+# のみを提供し、実際に画面へ描画するレンダリングは `bevy_gizmos_render` 側にある。
+# 両方 enable しないと gizmo 呼び出しは silent no-op になり、map 上の船・経路・
+# overlay 等がすべて invisible になる (#364 regression)。
 bevy = { version = "0.18.1", default-features = false, features = [
     "bevy_asset",
     "bevy_color",
     "bevy_core_pipeline",
     "bevy_gizmos",
+    "bevy_gizmos_render",
     "bevy_log",
     "bevy_render",
     "bevy_sprite",

--- a/macrocosmo/src/visualization/mod.rs
+++ b/macrocosmo/src/visualization/mod.rs
@@ -471,4 +471,16 @@ mod tests {
         let target = resolve_deploy_target(None, cursor, 0.0);
         assert_eq!(target, [3.0, 4.0, 0.0]);
     }
+
+    /// #364 regression guard: `bevy_gizmos` enables only the `Gizmos`
+    /// SystemParam / API surface; the actual GPU rendering pipeline lives in
+    /// `bevy_gizmos_render::GizmoRenderPlugin`. If the `bevy_gizmos_render`
+    /// feature is dropped from `Cargo.toml`, gizmo draw calls (ships, deploy
+    /// preview, system overlays, etc.) become silent no-ops and the galaxy
+    /// map appears blank. Referencing the type here makes the build fail
+    /// instead of silently producing an invisible ship layer.
+    #[test]
+    fn bevy_gizmos_render_feature_is_enabled() {
+        let _: bevy::gizmos_render::GizmoRenderPlugin = bevy::gizmos_render::GizmoRenderPlugin;
+    }
 }


### PR DESCRIPTION
Closes #364.

## Summary

- The recent Bevy feature prune listed `bevy_gizmos` but dropped `bevy_gizmos_render`. In Bevy 0.18 those are two separate features:
  - `bevy_gizmos` — API only (`Gizmos` SystemParam, `gizmos.circle_2d`, etc.)
  - `bevy_gizmos_render` — `GizmoRenderPlugin`, the actual GPU pipeline
- Without `bevy_gizmos_render`, `DefaultPlugins` skips `GizmoRenderPlugin`, every `gizmos.*` call becomes a silent no-op, and the galaxy map loses ships, movement paths, deploy preview, and all overlay markers.
- This is the actual root cause of #364, **not** the `Owner` / `FactionOwner` resolution path the issue body suspected. Confirmed via a debug print in `draw_ships`: 4 ships were being seen every frame but nothing reached the screen.

## What changed

- `macrocosmo/Cargo.toml`: add `bevy_gizmos_render` to the Bevy feature list, with a comment explaining why both are required to avoid this regression.
- `macrocosmo/src/visualization/mod.rs`: new unit test `bevy_gizmos_render_feature_is_enabled` references `bevy::gizmos_render::GizmoRenderPlugin`, so dropping the feature again breaks the build instead of silently producing an invisible ship layer.

## Test plan

- [x] `cargo test --workspace`: 2467 passed / 0 failed (with the new regression test)
- [x] `cargo run --bin macrocosmo` from workspace root — game launches, no new warnings besides the pre-existing `bevy_egui/picking` and `CARGO_MANIFEST_DIR` ones
- [x] In-game galaxy map shows ship markers + dashed paths again

🤖 Generated with [Claude Code](https://claude.com/claude-code)