### PR TITLE
fix(ui): context_menu.rs uses ShipView projection (#491 PR-3)

### DIFF
--- a/macrocosmo/src/ui/context_menu.rs
+++ b/macrocosmo/src/ui/context_menu.rs
@@ -4,6 +4,7 @@ use bevy_egui::egui;
 use crate::colony::{Colony, SlotAssignment};
 use crate::components::Position;
 use crate::galaxy::{Planet, StarSystem, SystemAttributes};
+use crate::knowledge::{KnowledgeStore, ShipSnapshotState};
 use crate::physics;
 use crate::player::{AboardShip, Player, StationedAt};
 use crate::ship::{
@@ -13,6 +14,7 @@ use crate::ship_design::ShipDesignRegistry;
 use crate::technology::GlobalParams;
 use crate::time_system::GameClock;
 use crate::ui::UiElementRegistry;
+use crate::ui::ship_view::ship_view;
 use crate::visualization::{SelectedShip, SelectedShips};
 
 /// #482: Map a [`QueuedCommand`] to the equivalent [`crate::ship::ShipCommand`]
@@ -41,6 +43,117 @@ pub struct HarbourInfo {
     pub entity: Entity,
     pub name: String,
     pub can_dock: bool,
+}
+
+/// #491 (PR-3): Light-coherent context-menu inputs derived from a ship's
+/// `ShipView` instead of the realtime ECS `ShipState`.
+///
+/// Returned by [`compute_context_menu_ship_data`]. All fields are derived
+/// from the viewing empire's projection (own ship) / snapshot (foreign
+/// ship) / realtime fallback (no-store) — never the ship's realtime
+/// `ShipState` directly. This collapses the FTL leak surface in the
+/// context-menu path to a single helper.
+///
+/// `remaining_travel` is the *projection-mediated* time-to-arrival —
+/// `expected_arrival_at - clock.elapsed`, clamped at zero. For non-transit
+/// projection states (e.g. steady-state `InSystem`, or projections with
+/// `expected_arrival_at = None`) this is `0`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ContextMenuShipData {
+    /// `Some(system)` when the ship's *projected* state is `InSystem`.
+    pub docked_system: Option<Entity>,
+    /// The ship's projected target / current system, when the ship is
+    /// in transit / surveying / settling / refitting. `None` for
+    /// `InSystem` / `Loitering` / terminal states.
+    pub current_destination_system: Option<Entity>,
+    /// Deep-space coordinate when the projection reports `Loitering`.
+    /// `None` for all other states.
+    pub loitering_pos: Option<[f64; 3]>,
+    /// Projected time-to-arrival in hexadies. `0` when the ship is
+    /// `is_docked` or has no in-flight expected arrival.
+    pub remaining_travel: i64,
+    /// `true` iff the projection reports `InSystem`.
+    pub is_docked: bool,
+}
+
+/// #491 (PR-3): Compute the projection-mediated context-menu data for a
+/// ship. Routes own-empire ships through `ShipProjection` and foreign
+/// ships through `ShipSnapshot` via the [`ship_view`] helper, eliminating
+/// the realtime `ShipState` reads that previously leaked FTL/transit
+/// state into the context menu (#491).
+///
+/// # Semantics
+///
+/// * `docked_system` / `is_docked` — derived from `ShipView::state` via
+///   `ShipSnapshotState::InSystem`. The ship's *projected* docking
+///   state, not its realtime ECS state.
+/// * `current_destination_system` — derived from `ShipView::system` for
+///   transit / survey / settle / refit projection states.
+/// * `loitering_pos` — extracted via `ShipView::position()`.
+/// * `remaining_travel` — `ShipProjection.expected_arrival_at -
+///   clock.elapsed`, clamped at zero. Light-coherent with the dispatcher's
+///   timeline (= what the player believes about the ship's arrival).
+///
+/// # Fallback
+///
+/// When `ship_view` returns `None` (= the viewing empire has no
+/// projection / snapshot for the ship — e.g. before a seed projection
+/// lands), this returns `None`. The caller treats that as "close menu".
+pub fn compute_context_menu_ship_data(
+    ship_entity: Entity,
+    ship: &Ship,
+    realtime_state: &ShipState,
+    clock: &GameClock,
+    viewing_knowledge: Option<&KnowledgeStore>,
+    viewing_empire: Option<Entity>,
+) -> Option<ContextMenuShipData> {
+    let view = ship_view(
+        ship_entity,
+        ship,
+        realtime_state,
+        viewing_knowledge,
+        viewing_empire,
+    )?;
+    let docked_system = match view.state {
+        ShipSnapshotState::InSystem => view.system,
+        _ => None,
+    };
+    // For non-`InSystem` states, the `view.system` is the destination /
+    // target / planet-bearing system. `Loitering` / `Destroyed` /
+    // `Missing` carry `view.system = None`, so this naturally yields
+    // `None` for those. `InSystem` is handled via `docked_system` above
+    // (current_destination_system stays `None`).
+    let current_destination_system = match view.state {
+        ShipSnapshotState::InSystem | ShipSnapshotState::Destroyed | ShipSnapshotState::Missing => {
+            None
+        }
+        ShipSnapshotState::Loitering { .. } => None,
+        _ => view.system,
+    };
+    let loitering_pos = view.position();
+    let is_docked = matches!(view.state, ShipSnapshotState::InSystem);
+    // #491 (PR-3): `remaining_travel` is the dispatcher's projected
+    // time-to-arrival. For docked ships it's irrelevant (forced to 0).
+    // For projections with no `expected_arrival_at` (e.g. steady-state
+    // `InSystem`, or spatial-less commands) it's also 0. This replaces
+    // the previous realtime-`ShipState`-driven `arrival_at` /
+    // `completes_at` reads.
+    let remaining_travel = if is_docked {
+        0
+    } else {
+        viewing_knowledge
+            .and_then(|k| k.get_projection(ship_entity))
+            .and_then(|p| p.expected_arrival_at)
+            .map(|eta| (eta - clock.elapsed).max(0))
+            .unwrap_or(0)
+    };
+    Some(ContextMenuShipData {
+        docked_system,
+        current_destination_system,
+        loitering_pos,
+        remaining_travel,
+        is_docked,
+    })
 }
 
 /// Apply a command directly to a ship's [`ShipState`].
@@ -159,6 +272,17 @@ pub fn draw_context_menu(
     target_harbours: &[HarbourInfo],
     // #389: Whether the selected ship is already docked at a harbour.
     ship_is_docked_at_harbour: bool,
+    // #491 (PR-3): Viewing empire's KnowledgeStore for projection-mediated
+    // ship-state reads. `None` falls back to realtime ECS (= early Startup
+    // before empires are wired, observer god-view future work). The
+    // existing #432 caller-side guard suppresses the menu for non-owned
+    // ships, so the realistic `Some(...)` case is `viewing_empire ==
+    // ship.owner` (= projection-driven path).
+    viewing_knowledge: Option<&KnowledgeStore>,
+    // #491 (PR-3): Empire whose perspective the player is currently
+    // viewing — `PlayerEmpire` in normal play, observed empire in
+    // observer mode. Resolved at the call site (`ui/mod.rs`).
+    viewing_empire: Option<Entity>,
 ) -> ContextMenuActions {
     let mut ctx_actions = ContextMenuActions {
         dock_at: None,
@@ -178,53 +302,13 @@ pub fn draw_context_menu(
         return ctx_actions;
     };
 
-    // Collect ship data
-    let ship_data = {
-        let Ok((_, ship, state, _, _, _)) = ships_query.get(ship_entity) else {
-            context_menu.open = false;
-            return ctx_actions;
-        };
-        let docked_system = if let ShipState::InSystem { system } = &*state {
-            Some(*system)
-        } else {
-            None
-        };
-        // For non-docked ships, determine origin position from current state.
-        // #266: Loitering ships have no associated system but DO have a known
-        // deep-space position — carry it as a fallback so context menu can
-        // still compute light delay and open properly.
-        let current_destination_system = match &*state {
-            ShipState::SubLight { target_system, .. } => *target_system,
-            ShipState::InFTL {
-                destination_system, ..
-            } => Some(*destination_system),
-            ShipState::Surveying { target_system, .. } => Some(*target_system),
-            ShipState::Settling { system, .. } => Some(*system),
-            ShipState::InSystem { .. } => None, // handled via docked_system
-            ShipState::Refitting { system, .. } => Some(*system),
-            ShipState::Loitering { .. } => None,
-            ShipState::Scouting { target_system, .. } => Some(*target_system),
-        };
-        let loitering_pos: Option<[f64; 3]> = match &*state {
-            ShipState::Loitering { position } => Some(*position),
-            _ => None,
-        };
-        (
-            ship.name.clone(),
-            ship.design_id.clone(),
-            ship.ftl_range,
-            ship.sublight_speed,
-            docked_system,
-            current_destination_system,
-            loitering_pos,
-            // #296: cache immobility so the MoveTo guard below stays a
-            // simple boolean.
-            ship.is_immobile(),
-            // #299 (S-5): ship faction for Core-presence check.
-            ship.owner,
-        )
-    };
-
+    // Collect ship data — projection-mediated per #491 (PR-3): own-empire
+    // ships read `ShipProjection`, foreign ships read `ShipSnapshot`,
+    // no-store falls back to realtime ECS state. The previous realtime
+    // `ShipState` reads (`InFTL { arrival_at }` / `SubLight {
+    // target_system }` / etc.) are gone — they were the FTL-leak surface
+    // this PR closes. See [`compute_context_menu_ship_data`] for the
+    // helper contract.
     let (
         ship_name,
         design_id,
@@ -235,9 +319,43 @@ pub fn draw_context_menu(
         loitering_pos,
         ship_immobile,
         ship_owner,
-    ) = ship_data;
-
-    let is_docked = docked_system.is_some();
+        remaining_travel,
+        is_docked,
+    ) = {
+        let Ok((_, ship, state, _, _, _)) = ships_query.get(ship_entity) else {
+            context_menu.open = false;
+            return ctx_actions;
+        };
+        let Some(view_data) = compute_context_menu_ship_data(
+            ship_entity,
+            &ship,
+            &state,
+            clock,
+            viewing_knowledge,
+            viewing_empire,
+        ) else {
+            // No projection / snapshot resolvable for this ship — close
+            // the menu rather than fall through with stale realtime data.
+            context_menu.open = false;
+            return ctx_actions;
+        };
+        (
+            ship.name.clone(),
+            ship.design_id.clone(),
+            ship.ftl_range,
+            ship.sublight_speed,
+            view_data.docked_system,
+            view_data.current_destination_system,
+            view_data.loitering_pos,
+            // #296: cache immobility so the MoveTo guard below stays a
+            // simple boolean.
+            ship.is_immobile(),
+            // #299 (S-5): ship faction for Core-presence check.
+            ship.owner,
+            view_data.remaining_travel,
+            view_data.is_docked,
+        )
+    };
 
     // For docked ships, the origin is the docked system.
     // For non-docked ships, the origin is either the current destination
@@ -266,8 +384,16 @@ pub fn draw_context_menu(
     let same_system = is_docked && origin_system == Some(target_entity);
 
     // #76: Calculate light-speed delay from player to ship's location.
-    // For in-transit ships, the command must also wait for the ship to arrive
-    // at its destination (it can't receive commands mid-FTL).
+    // For in-transit ships, the command must also wait for the ship to
+    // arrive at its destination (it can't receive commands mid-FTL).
+    //
+    // #491 (PR-3): `remaining_travel` is now the dispatcher's projected
+    // ETA (= `ShipProjection.expected_arrival_at - clock.elapsed`) instead
+    // of the realtime `arrival_at` / `completes_at`. The semantic shift
+    // is intentional: the player's command travel time should align with
+    // *what the player believes* about the ship's arrival, not the
+    // ground-truth ECS timeline (which the player can't observe yet).
+    // The `light_delay.max(remaining_travel)` envelope is preserved.
     let command_delay: i64 = {
         let light_delay: i64 = player_q
             .single()
@@ -278,30 +404,6 @@ pub fn draw_context_menu(
                 Some(physics::light_delay_hexadies(dist))
             })
             .unwrap_or(0);
-
-        // For non-docked ships, also account for remaining travel time
-        let remaining_travel: i64 = if !is_docked {
-            if let Ok((_, _, state, _, _, _)) = ships_query.get(ship_entity) {
-                match &*state {
-                    ShipState::InFTL { arrival_at, .. } => (*arrival_at - clock.elapsed).max(0),
-                    ShipState::SubLight { arrival_at, .. } => (*arrival_at - clock.elapsed).max(0),
-                    ShipState::Surveying { completes_at, .. } => {
-                        (*completes_at - clock.elapsed).max(0)
-                    }
-                    ShipState::Settling { completes_at, .. } => {
-                        (*completes_at - clock.elapsed).max(0)
-                    }
-                    ShipState::Refitting { completes_at, .. } => {
-                        (*completes_at - clock.elapsed).max(0)
-                    }
-                    _ => 0,
-                }
-            } else {
-                0
-            }
-        } else {
-            0
-        };
 
         light_delay.max(remaining_travel)
     };

--- a/macrocosmo/src/ui/context_menu.rs
+++ b/macrocosmo/src/ui/context_menu.rs
@@ -114,6 +114,15 @@ pub fn compute_context_menu_ship_data(
         viewing_knowledge,
         viewing_empire,
     )?;
+    // #491 Stage-2 follow-up: terminal projections (Destroyed / Missing)
+    // must not surface a context menu — the player should not be able to
+    // dispatch MoveTo / Survey / Colonize against a ship the empire
+    // already believes is gone. Return `None` so the caller closes the
+    // menu, the same outcome as a missing projection (= "menu has no
+    // valid target, bail").
+    if !view.is_actionable() {
+        return None;
+    }
     let docked_system = match view.state {
         ShipSnapshotState::InSystem => view.system,
         _ => None,

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -1719,6 +1719,12 @@ fn draw_main_panels_system(
         selection.ui_registry.as_mut().map(|r| &mut **r),
         &target_harbours,
         ship_is_docked_at_harbour,
+        // #491 (PR-3): Pass the viewing empire's KnowledgeStore so the
+        // context menu's ship-state reads flow through the projection
+        // (own ship) / snapshot (foreign ship) helper, mirroring the
+        // outline-tree fix #487 / #491 PR #2.
+        Some(knowledge),
+        Some(empire_entity),
     );
     // #389: Handle dock action from context menu
     if let Some((ship_entity, harbour_entity)) = ctx_menu_actions.dock_at {

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -1697,6 +1697,19 @@ fn draw_main_panels_system(
     if !selected_ship_is_own {
         selection.context_menu.open = false;
     }
+    // #491 (PR-3) Stage-2: Light-coherent ShipView routing — pass the
+    // viewing empire's `KnowledgeStore` (own ship → projection, foreign
+    // ship → snapshot) and entity to the context menu. Observer mode
+    // currently passes `None` for the store to fall through to realtime
+    // ECS (= ground truth); see #499 for the staged migration to
+    // empire-view-as-light-coherent. Mirrors the gate pattern used in
+    // `draw_outline_and_tooltips_system` and the ship-panel sub-PR
+    // (#491 PR-2).
+    let context_menu_knowledge: Option<&KnowledgeStore> = if selection.observer_mode.enabled {
+        None
+    } else {
+        Some(knowledge)
+    };
     let ctx_menu_actions = context_menu::draw_context_menu(
         ctx,
         &mut selection.context_menu,
@@ -1723,7 +1736,7 @@ fn draw_main_panels_system(
         // context menu's ship-state reads flow through the projection
         // (own ship) / snapshot (foreign ship) helper, mirroring the
         // outline-tree fix #487 / #491 PR #2.
-        Some(knowledge),
+        context_menu_knowledge,
         Some(empire_entity),
     );
     // #389: Handle dock action from context menu

--- a/macrocosmo/tests/context_menu_ftl_leak.rs
+++ b/macrocosmo/tests/context_menu_ftl_leak.rs
@@ -1,0 +1,416 @@
+//! #491 (PR-3): Context menu must not leak realtime ECS `ShipState` for
+//! own-empire ships. The `docked_system` / `current_destination_system` /
+//! `loitering_pos` fields and the `remaining_travel` derivation in
+//! `compute_context_menu_ship_data` flow through the viewing empire's
+//! `KnowledgeStore::projections` (own ship) / `ship_snapshots` (foreign
+//! ship), mirroring the outline-tree fix #487 / #491 PR #2 and the
+//! Galaxy Map fix #477.
+//!
+//! These tests pin the **data extraction layer**
+//! ([`compute_context_menu_ship_data`]) — the egui-driven
+//! `draw_context_menu` itself is not invoked since egui systems are
+//! excluded from `test_app()`. Bare `World::new()` is sufficient because
+//! the helper is pure-data over `KnowledgeStore` + `Ship` + `ShipState`,
+//! with no Bevy plugin / system / resource dependency.
+
+use bevy::prelude::*;
+
+use macrocosmo::knowledge::{
+    KnowledgeStore, ObservationSource, ShipProjection, ShipSnapshot, ShipSnapshotState,
+};
+use macrocosmo::ship::{Owner, Ship, ShipState};
+use macrocosmo::time_system::GameClock;
+use macrocosmo::ui::context_menu::compute_context_menu_ship_data;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_ship(name: &str, owner: Entity, home: Entity) -> Ship {
+    Ship {
+        name: name.into(),
+        design_id: "explorer_mk1".into(),
+        hull_id: "frigate".into(),
+        modules: Vec::new(),
+        owner: Owner::Empire(owner),
+        sublight_speed: 1.0,
+        ftl_range: 5.0,
+        ruler_aboard: false,
+        home_port: home,
+        design_revision: 0,
+        fleet: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. docked_system uses projection (FTL leak regression)
+// ---------------------------------------------------------------------------
+
+/// Own-ship dispatched to a remote system. Realtime ECS already advanced
+/// to `SubLight`, but the projection has not yet caught up — `projected_state`
+/// is still `InSystem` at home. The context menu's `docked_system` field
+/// must reflect the *projection*, not the realtime state.
+#[test]
+fn context_menu_docked_system_uses_projection() {
+    let mut world = World::new();
+    let empire = world.spawn_empty().id();
+    let home = world.spawn_empty().id();
+    let frontier = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("Explorer-1", empire, home);
+
+    // Realtime: SubLight (= dispatcher's command has propagated to the
+    // ship at the engine level, but the dispatcher hasn't yet observed
+    // it — that's the FTL leak window).
+    let realtime = ShipState::SubLight {
+        origin: [0.0, 0.0, 0.0],
+        destination: [50.0, 0.0, 0.0],
+        target_system: Some(frontier),
+        departed_at: 0,
+        arrival_at: 5,
+    };
+
+    let mut store = KnowledgeStore::default();
+    store.update_projection(ShipProjection {
+        entity: ship_entity,
+        dispatched_at: 0,
+        expected_arrival_at: Some(10),
+        expected_return_at: None,
+        projected_state: ShipSnapshotState::InSystem,
+        projected_system: Some(home),
+        intended_state: Some(ShipSnapshotState::InTransitSubLight),
+        intended_system: Some(frontier),
+        intended_takes_effect_at: Some(5),
+    });
+
+    let clock = GameClock::new(1);
+    let data = compute_context_menu_ship_data(
+        ship_entity,
+        &ship,
+        &realtime,
+        &clock,
+        Some(&store),
+        Some(empire),
+    )
+    .expect("projection-driven path produces data");
+
+    assert_eq!(
+        data.docked_system,
+        Some(home),
+        "FTL leak regression: docked_system must reflect the projection \
+         (= still home), not realtime SubLight"
+    );
+    assert!(
+        data.is_docked,
+        "is_docked must mirror docked_system.is_some"
+    );
+    assert_eq!(
+        data.current_destination_system, None,
+        "InSystem projection has no destination",
+    );
+
+    // The previously-attached helper used in the production code derives
+    // `origin_system` as `docked_system.or(current_destination_system)`,
+    // so let's pin that the reconstructed origin is `home`.
+    let origin_system = data.docked_system.or(data.current_destination_system);
+    assert_eq!(origin_system, Some(home));
+}
+
+// ---------------------------------------------------------------------------
+// 2. remaining_travel uses ShipProjection.expected_arrival_at
+// ---------------------------------------------------------------------------
+
+/// Once the projection is in transit (`InTransitFTL`) with a known
+/// `expected_arrival_at`, the context menu's `remaining_travel` is
+/// `expected_arrival_at - clock.elapsed`, NOT the realtime
+/// `arrival_at - clock.elapsed`. Pins the dispatcher-timeline contract
+/// from #491.
+#[test]
+fn context_menu_remaining_travel_uses_projection_eta() {
+    let mut world = World::new();
+    let empire = world.spawn_empty().id();
+    let home = world.spawn_empty().id();
+    let frontier = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("Explorer-1", empire, home);
+
+    // Realtime: ship has already arrived (= ground truth). Projection
+    // still says InTransitFTL — the dispatcher hasn't observed it yet.
+    let realtime = ShipState::InSystem { system: frontier };
+
+    let mut store = KnowledgeStore::default();
+    let now: i64 = 5;
+    let projected_arrival = now + 100;
+    store.update_projection(ShipProjection {
+        entity: ship_entity,
+        dispatched_at: 0,
+        expected_arrival_at: Some(projected_arrival),
+        expected_return_at: None,
+        projected_state: ShipSnapshotState::InTransitFTL,
+        projected_system: Some(frontier),
+        intended_state: Some(ShipSnapshotState::InTransitFTL),
+        intended_system: Some(frontier),
+        intended_takes_effect_at: Some(2),
+    });
+
+    let clock = GameClock::new(now);
+    let data = compute_context_menu_ship_data(
+        ship_entity,
+        &ship,
+        &realtime,
+        &clock,
+        Some(&store),
+        Some(empire),
+    )
+    .expect("projection-driven path produces data");
+
+    assert!(
+        !data.is_docked,
+        "InTransitFTL projection must not mark ship as docked"
+    );
+    assert_eq!(
+        data.remaining_travel, 100,
+        "remaining_travel must be projection.expected_arrival_at - clock \
+         (= 100), NOT a realtime-derived value"
+    );
+    assert_eq!(
+        data.current_destination_system,
+        Some(frontier),
+        "InTransitFTL projection's view.system is the destination",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. loitering_pos extracted via ShipView::position()
+// ---------------------------------------------------------------------------
+
+/// An own-ship loitering at a deep-space coordinate exposes that
+/// coordinate via `ShipView::position()`. The context menu's
+/// `loitering_pos` field must mirror the projection's loitering
+/// coordinate, not pull from realtime ECS.
+#[test]
+fn context_menu_loitering_pos_extracted_via_view_accessor() {
+    let mut world = World::new();
+    let empire = world.spawn_empty().id();
+    let home = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("Explorer-1", empire, home);
+
+    // Realtime: anything — projection should win.
+    let realtime = ShipState::InSystem { system: home };
+
+    let loiter_pos = [1.0, 2.0, 3.0];
+    let mut store = KnowledgeStore::default();
+    store.update_projection(ShipProjection {
+        entity: ship_entity,
+        dispatched_at: 0,
+        expected_arrival_at: None,
+        expected_return_at: None,
+        projected_state: ShipSnapshotState::Loitering {
+            position: loiter_pos,
+        },
+        projected_system: None,
+        intended_state: None,
+        intended_system: None,
+        intended_takes_effect_at: None,
+    });
+
+    let clock = GameClock::new(0);
+    let data = compute_context_menu_ship_data(
+        ship_entity,
+        &ship,
+        &realtime,
+        &clock,
+        Some(&store),
+        Some(empire),
+    )
+    .expect("projection-driven path produces data");
+
+    assert_eq!(
+        data.loitering_pos,
+        Some(loiter_pos),
+        "Loitering projection must surface its coordinate via \
+         ShipView::position() accessor"
+    );
+    assert_eq!(data.docked_system, None);
+    assert_eq!(data.current_destination_system, None);
+    assert_eq!(
+        data.remaining_travel, 0,
+        "Loitering with expected_arrival_at = None => remaining_travel 0",
+    );
+    assert!(!data.is_docked);
+}
+
+// ---------------------------------------------------------------------------
+// 4. No projection — own ship returns None (skip menu)
+// ---------------------------------------------------------------------------
+
+/// An own-ship with no projection (= edge case: spawn before #481's
+/// seed-projection lands, or test setup that didn't dispatch a command)
+/// produces `None` so the caller knows to close the menu rather than
+/// fall through with stale realtime data.
+#[test]
+fn context_menu_own_ship_no_projection_returns_none() {
+    let mut world = World::new();
+    let empire = world.spawn_empty().id();
+    let home = world.spawn_empty().id();
+    let frontier = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("Explorer-1", empire, home);
+
+    let realtime = ShipState::InFTL {
+        origin_system: home,
+        destination_system: frontier,
+        departed_at: 0,
+        arrival_at: 5,
+    };
+
+    let store = KnowledgeStore::default(); // no projection seeded
+    let clock = GameClock::new(2);
+    let data = compute_context_menu_ship_data(
+        ship_entity,
+        &ship,
+        &realtime,
+        &clock,
+        Some(&store),
+        Some(empire),
+    );
+    assert!(
+        data.is_none(),
+        "own-ship with no projection must return None — caller closes menu \
+         instead of using realtime FTL state"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. No KnowledgeStore — realtime fallback
+// ---------------------------------------------------------------------------
+
+/// When `viewing_knowledge` is `None` (= early Startup before empires
+/// are wired, or future omniscient observer mode), the helper falls
+/// back to realtime ECS state via `ship_view`'s no-store branch. This
+/// pins the existing fallback behaviour so the egui pipeline doesn't
+/// crash before the projection table is available.
+#[test]
+fn context_menu_no_knowledge_store_realtime_fallback() {
+    let mut world = World::new();
+    let empire = world.spawn_empty().id();
+    let home = world.spawn_empty().id();
+    let frontier = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("Explorer-1", empire, home);
+
+    // Realtime is in-transit sublight to frontier.
+    let realtime = ShipState::SubLight {
+        origin: [0.0, 0.0, 0.0],
+        destination: [50.0, 0.0, 0.0],
+        target_system: Some(frontier),
+        departed_at: 0,
+        arrival_at: 5,
+    };
+
+    let clock = GameClock::new(1);
+    // No KnowledgeStore => realtime fallback.
+    let data = compute_context_menu_ship_data(ship_entity, &ship, &realtime, &clock, None, None)
+        .expect("no-store fallback must produce data");
+
+    assert!(!data.is_docked, "SubLight realtime must not mark as docked");
+    assert_eq!(data.docked_system, None);
+    assert_eq!(
+        data.current_destination_system,
+        Some(frontier),
+        "no-store fallback derives destination from realtime SubLight"
+    );
+    assert_eq!(data.loitering_pos, None);
+    // No KnowledgeStore => no projection => remaining_travel 0.
+    assert_eq!(data.remaining_travel, 0);
+}
+
+/// `Loitering` realtime state in the no-store fallback path surfaces the
+/// position via `ShipView::position()` even when there's no projection
+/// to consult.
+#[test]
+fn context_menu_no_knowledge_store_loitering_realtime_fallback() {
+    let mut world = World::new();
+    let empire = world.spawn_empty().id();
+    let home = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("Explorer-1", empire, home);
+
+    let pos = [7.0, -3.0, 4.5];
+    let realtime = ShipState::Loitering { position: pos };
+
+    let clock = GameClock::new(0);
+    let data = compute_context_menu_ship_data(ship_entity, &ship, &realtime, &clock, None, None)
+        .expect("no-store fallback must produce data");
+    assert_eq!(data.loitering_pos, Some(pos));
+    assert_eq!(data.docked_system, None);
+    assert_eq!(data.current_destination_system, None);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Foreign ship — snapshot path
+// ---------------------------------------------------------------------------
+
+/// Foreign ships flow through `ship_snapshots` — the existing #175
+/// light-delayed visibility — and the context menu's view of them is
+/// snapshot-driven. While the production caller suppresses the menu for
+/// non-owned ships (#432), the data extraction must still respect the
+/// snapshot when invoked, so the contract is uniform across panels.
+#[test]
+fn context_menu_foreign_ship_uses_snapshot() {
+    let mut world = World::new();
+    let viewing_empire = world.spawn_empty().id();
+    let foreign_empire = world.spawn_empty().id();
+    let last_known_sys = world.spawn_empty().id();
+    let realtime_dest = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("EnemyShip", foreign_empire, last_known_sys);
+
+    // Realtime: post-snapshot ground truth (FTL). The viewing empire
+    // must NOT see this — the snapshot path is mandatory.
+    let realtime = ShipState::InFTL {
+        origin_system: last_known_sys,
+        destination_system: realtime_dest,
+        departed_at: 1,
+        arrival_at: 5,
+    };
+
+    let mut store = KnowledgeStore::default();
+    store.update_ship(ShipSnapshot {
+        entity: ship_entity,
+        name: "EnemyShip".into(),
+        design_id: "explorer_mk1".into(),
+        last_known_state: ShipSnapshotState::InTransitFTL,
+        last_known_system: Some(last_known_sys),
+        observed_at: 0,
+        hp: 100.0,
+        hp_max: 100.0,
+        source: ObservationSource::Direct,
+    });
+
+    let clock = GameClock::new(2);
+    let data = compute_context_menu_ship_data(
+        ship_entity,
+        &ship,
+        &realtime,
+        &clock,
+        Some(&store),
+        Some(viewing_empire),
+    )
+    .expect("foreign snapshot path must produce data");
+
+    assert!(
+        !data.is_docked,
+        "InTransitFTL snapshot must not mark ship as docked"
+    );
+    assert_eq!(data.docked_system, None);
+    assert_eq!(
+        data.current_destination_system,
+        Some(last_known_sys),
+        "foreign-ship view.system from snapshot is last_known_system"
+    );
+    // Foreign ship has no projection on the viewing empire's store, so
+    // remaining_travel is 0 — projection-mediated only.
+    assert_eq!(data.remaining_travel, 0);
+}

--- a/macrocosmo/tests/context_menu_ftl_leak.rs
+++ b/macrocosmo/tests/context_menu_ftl_leak.rs
@@ -414,3 +414,139 @@ fn context_menu_foreign_ship_uses_snapshot() {
     // remaining_travel is 0 — projection-mediated only.
     assert_eq!(data.remaining_travel, 0);
 }
+
+// ---------------------------------------------------------------------------
+// #491 Stage-2 follow-up: terminal-state guard via ShipView::is_actionable
+// ---------------------------------------------------------------------------
+
+/// Own-ship whose projection has collapsed to `Destroyed` must not surface
+/// a context menu — the player should not be able to dispatch MoveTo /
+/// Survey / Colonize against a ship the empire already believes is gone.
+/// `compute_context_menu_ship_data` returns `None` for terminal projection
+/// states, mirroring the missing-projection contract (= caller closes
+/// the menu).
+#[test]
+fn context_menu_destroyed_ship_returns_none() {
+    let mut world = World::new();
+    let empire = world.spawn_empty().id();
+    let home = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("Explorer-1", empire, home);
+
+    // Realtime ECS state is irrelevant — projection drives the gate.
+    let realtime = ShipState::InSystem { system: home };
+
+    let mut store = KnowledgeStore::default();
+    store.update_projection(ShipProjection {
+        entity: ship_entity,
+        dispatched_at: 0,
+        expected_arrival_at: None,
+        expected_return_at: None,
+        projected_state: ShipSnapshotState::Destroyed,
+        projected_system: None,
+        intended_state: None,
+        intended_system: None,
+        intended_takes_effect_at: None,
+    });
+
+    let clock = GameClock::new(5);
+    let data = compute_context_menu_ship_data(
+        ship_entity,
+        &ship,
+        &realtime,
+        &clock,
+        Some(&store),
+        Some(empire),
+    );
+
+    assert!(
+        data.is_none(),
+        "Destroyed projection must close the context menu (None), not \
+         surface a dispatchable target"
+    );
+}
+
+/// Same contract for `Missing` — the other terminal `ShipSnapshotState`
+/// variant. Covers the case where a ship has been lost from the empire's
+/// observation horizon (e.g. observation timed out).
+#[test]
+fn context_menu_missing_ship_returns_none() {
+    let mut world = World::new();
+    let empire = world.spawn_empty().id();
+    let home = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("Explorer-1", empire, home);
+
+    let realtime = ShipState::InSystem { system: home };
+
+    let mut store = KnowledgeStore::default();
+    store.update_projection(ShipProjection {
+        entity: ship_entity,
+        dispatched_at: 0,
+        expected_arrival_at: None,
+        expected_return_at: None,
+        projected_state: ShipSnapshotState::Missing,
+        projected_system: None,
+        intended_state: None,
+        intended_system: None,
+        intended_takes_effect_at: None,
+    });
+
+    let clock = GameClock::new(5);
+    let data = compute_context_menu_ship_data(
+        ship_entity,
+        &ship,
+        &realtime,
+        &clock,
+        Some(&store),
+        Some(empire),
+    );
+
+    assert!(
+        data.is_none(),
+        "Missing projection must close the context menu (None)"
+    );
+}
+
+/// Foreign ship whose snapshot has collapsed to `Destroyed` (= the
+/// viewing empire observed the ship's destruction). Same guard.
+#[test]
+fn context_menu_foreign_destroyed_ship_returns_none() {
+    let mut world = World::new();
+    let viewing_empire = world.spawn_empty().id();
+    let foreign_empire = world.spawn_empty().id();
+    let foreign_sys = world.spawn_empty().id();
+    let ship_entity = world.spawn_empty().id();
+    let ship = make_ship("EnemyScout", foreign_empire, foreign_sys);
+
+    let realtime = ShipState::InSystem {
+        system: foreign_sys,
+    };
+    let mut store = KnowledgeStore::default();
+    store.update_ship(ShipSnapshot {
+        entity: ship_entity,
+        name: "EnemyScout".into(),
+        design_id: "explorer_mk1".into(),
+        last_known_state: ShipSnapshotState::Destroyed,
+        last_known_system: None,
+        observed_at: 1,
+        hp: 0.0,
+        hp_max: 100.0,
+        source: ObservationSource::Direct,
+    });
+
+    let clock = GameClock::new(2);
+    let data = compute_context_menu_ship_data(
+        ship_entity,
+        &ship,
+        &realtime,
+        &clock,
+        Some(&store),
+        Some(viewing_empire),
+    );
+
+    assert!(
+        data.is_none(),
+        "Foreign-ship Destroyed snapshot must close the context menu"
+    );
+}


### PR DESCRIPTION
## Summary

- Replace realtime `ShipState` reads in `compute_context_menu_actions` with projection-mediated `ShipView`
- `docked_system` / `current_destination_system` / `loitering_pos` derived from `ShipView` (#498)
- `remaining_travel` uses `ShipProjection.expected_arrival_at` (= dispatcher's belief, light-coherent)
- own = projection, foreign = snapshot, no-store = realtime fallback

Closes #491 (sub-PR 3 of 5).

## Test plan

- [x] New `tests/context_menu_ftl_leak.rs` (7 cases — docked/in-transit/loitering projection paths plus no-projection / foreign-snapshot / no-store realtime fallback)
- [x] `cargo test` 全 green (3479 passed, 0 failed; 7 new)
- [x] `cargo fmt --check` clean for touched files
- [x] `cargo clippy -p macrocosmo -- -D warnings` clean (only pre-existing macrocosmo-ai baseline errors remain, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)