### PR TITLE
fix(ui): ship_panel.rs uses ShipView projection (#491 PR-2)

### DIFF
--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -1306,6 +1306,20 @@ fn draw_main_panels_system(
             .unwrap_or(false)
     });
 
+    // #491 PR-2: Light-coherent ShipView routing — pass the viewing
+    // empire's `KnowledgeStore` (own ship → projection, foreign ship →
+    // snapshot) and entity to the panel. Observer mode currently passes
+    // `None` for the store to fall through to realtime ECS (= ground
+    // truth); see #499 for the staged migration to empire-view-as-light-
+    // coherent. Mirrors the pattern already in
+    // `draw_outline_and_tooltips_system` where the `knowledge` resolution
+    // applies the same observer-mode → None gate before passing through
+    // to outline / tooltip helpers.
+    let ship_panel_knowledge: Option<&KnowledgeStore> = if selection.observer_mode.enabled {
+        None
+    } else {
+        Some(knowledge)
+    };
     let ship_panel_actions = ship_panel::draw_ship_panel(
         ctx,
         &mut selection.selected_ship,
@@ -1337,6 +1351,8 @@ fn draw_main_panels_system(
         &registries.hull_registry,
         &world.ship_modifiers,
         selected_ship_is_own,
+        ship_panel_knowledge,
+        Some(empire_entity),
     );
 
     // #398: In observer read-only mode, suppress all ship panel actions

--- a/macrocosmo/src/ui/ship_panel.rs
+++ b/macrocosmo/src/ui/ship_panel.rs
@@ -13,14 +13,14 @@ use crate::knowledge::{KnowledgeStore, ShipSnapshotState};
 use crate::modifier::ModifiedValue;
 use crate::player::{AboardShip, Player, StationedAt};
 use crate::ship::{
-    Cargo, CommandQueue, CourierMode, CourierRoute, DockedAt, Owner, PendingShipCommand,
-    QueuedCommand, RulesOfEngagement, Ship, ShipHitpoints, ShipModifiers, ShipState, ShipStats,
-    SurveyData,
+    Cargo, CommandQueue, CourierMode, CourierRoute, DockedAt, PendingShipCommand, QueuedCommand,
+    RulesOfEngagement, Ship, ShipHitpoints, ShipModifiers, ShipState, ShipStats, SurveyData,
 };
 use crate::ship_design::{HullRegistry, ShipDesignRegistry};
 use crate::time_system::GameClock;
 use crate::ui::ship_view::{
     ShipView, ShipViewProgress, ShipViewTiming, ship_view, ship_view_status_label,
+    ship_view_with_timing,
 };
 use crate::ui::{draw_modifier_breakdown, modified_value_label_with_tooltip};
 use crate::visualization::{SelectedShip, SelectedShips};
@@ -162,112 +162,6 @@ pub struct ShipStatusInfo {
     /// `ProgressBar` overlay; `fraction` is clamped to `[0.0, 1.0]` so
     /// stale clocks past `expected_tick` do not over-extend the bar.
     pub progress: Option<(i64, i64, f32)>,
-}
-
-/// #491 PR-2: Derive [`ShipViewTiming`] from a ship's projection /
-/// snapshot / realtime ECS, gated by the same own-empire / foreign /
-/// no-store ladder as [`ship_view`].
-///
-/// * **Own ship + KnowledgeStore present** → projection's
-///   `dispatched_at` / `expected_arrival_at`.
-/// * **Foreign ship + KnowledgeStore present** → snapshot's
-///   `observed_at`; `expected_tick` is `None` (snapshots don't carry
-///   remote ETAs), so progress collapses for foreign ships in transit.
-/// * **No KnowledgeStore** (early Startup) → realtime ECS departed/started
-///   tick + arrival/completion tick, matched against the view variant.
-///
-/// Mirrors the contract `ship_view` enforces — callers MUST drive
-/// `ShipView` and `ShipViewTiming` through the same data path.
-fn ship_panel_view_timing(
-    ship_entity: Entity,
-    ship: &Ship,
-    state: &ShipState,
-    view: &ShipView,
-    viewing_knowledge: Option<&KnowledgeStore>,
-    viewing_empire: Option<Entity>,
-) -> Option<ShipViewTiming> {
-    if let (Some(store), Some(viewing)) = (viewing_knowledge, viewing_empire) {
-        if let Owner::Empire(owner) = ship.owner {
-            if owner == viewing {
-                let p = store.get_projection(ship_entity)?;
-                return Some(ShipViewTiming {
-                    origin_tick: p.dispatched_at,
-                    expected_tick: p.expected_arrival_at,
-                });
-            }
-        }
-        // Foreign-ship snapshot path. `expected_tick` is unknown — the
-        // helper layer's progress gate already returns `None` when the
-        // expected tick is missing.
-        let snap = store.get_ship(ship_entity)?;
-        return Some(ShipViewTiming {
-            origin_tick: snap.observed_at,
-            expected_tick: None,
-        });
-    }
-    // Realtime ECS fallback (= no KnowledgeStore resolved). Match against
-    // the view variant so the right ECS field pair is selected.
-    match (&view.state, state) {
-        (
-            ShipSnapshotState::InTransitSubLight,
-            ShipState::SubLight {
-                departed_at,
-                arrival_at,
-                ..
-            },
-        )
-        | (
-            ShipSnapshotState::InTransitFTL,
-            ShipState::InFTL {
-                departed_at,
-                arrival_at,
-                ..
-            },
-        ) => Some(ShipViewTiming {
-            origin_tick: *departed_at,
-            expected_tick: Some(*arrival_at),
-        }),
-        (
-            ShipSnapshotState::Surveying,
-            ShipState::Surveying {
-                started_at,
-                completes_at,
-                ..
-            }
-            | ShipState::Scouting {
-                started_at,
-                completes_at,
-                ..
-            },
-        ) => Some(ShipViewTiming {
-            origin_tick: *started_at,
-            expected_tick: Some(*completes_at),
-        }),
-        (
-            ShipSnapshotState::Settling,
-            ShipState::Settling {
-                started_at,
-                completes_at,
-                ..
-            },
-        ) => Some(ShipViewTiming {
-            origin_tick: *started_at,
-            expected_tick: Some(*completes_at),
-        }),
-        (
-            ShipSnapshotState::Refitting,
-            ShipState::Refitting {
-                started_at,
-                completes_at,
-                ..
-            },
-        ) => Some(ShipViewTiming {
-            origin_tick: *started_at,
-            expected_tick: Some(*completes_at),
-        }),
-        // Steady-state / terminal — no progress timing.
-        _ => None,
-    }
 }
 
 /// #491 PR-2: Build status info from a [`ShipView`] + [`ShipViewTiming`].
@@ -678,21 +572,20 @@ pub fn draw_ship_panel(
         // empire has no entry for this ship at all" (e.g. own-ship before
         // its seed projection lands per #481), which we treat the same
         // way the outline tree does: skip the panel entirely.
-        let view = ship_view(
+        // #491 follow-up: replaced the local per-panel ladder
+        // (resolve view → resolve timing source → build timing) with the
+        // hoisted [`ship_view_with_timing`] helper. Same source-selection
+        // contract as before (own → projection, foreign → snapshot,
+        // no-store → realtime ECS), centralized in
+        // [`crate::knowledge::ship_view`].
+        let (view, view_timing_resolved) = ship_view_with_timing(
             ship_entity,
             &ship,
             &state,
             viewing_knowledge,
             viewing_empire,
         )?;
-        let view_timing = ship_panel_view_timing(
-            ship_entity,
-            &ship,
-            &state,
-            &view,
-            viewing_knowledge,
-            viewing_empire,
-        );
+        let view_timing: Option<ShipViewTiming> = Some(view_timing_resolved);
         let docked_system = if matches!(view.state, ShipSnapshotState::InSystem) {
             view.system
         } else {
@@ -730,16 +623,24 @@ pub fn draw_ship_panel(
                 }
             })
         });
+        // #491 follow-up: Master action gate. Terminal projection states
+        // ([`ShipSnapshotState::Destroyed`] / [`ShipSnapshotState::Missing`])
+        // must not surface ScrapShip / SetHomePort / Refit / Cancel actions —
+        // the player should not be able to act on a ship the empire already
+        // believes is gone. Mirrors the gate pattern used in `context_menu`
+        // (PR-3) and uses the canonical [`ShipView::is_actionable`] predicate.
+        let is_actionable = view.is_actionable();
         // #491 PR-2: Cancellation is gated on the player's *belief*
         // (= projection state). The cancel command itself still travels
         // light-delayed to the ship; this guard only decides whether the
         // button is shown. Reading realtime ECS would let the player see
         // a "Cancel" button before the projection has caught up — that's
         // the FTL leak this PR closes.
-        let is_cancellable = matches!(
-            view.state,
-            ShipSnapshotState::Surveying | ShipSnapshotState::Settling
-        );
+        let is_cancellable = is_actionable
+            && matches!(
+                view.state,
+                ShipSnapshotState::Surveying | ShipSnapshotState::Settling
+            );
         // #103: Check if ship carries unreported survey data
         let has_survey_data = survey_data.is_some();
         let survey_data_system = survey_data.map(|sd| sd.system_name.clone());
@@ -760,31 +661,47 @@ pub fn draw_ship_panel(
         // #123: Pre-compute design-based refit eligibility / cost / time so the
         // panel can present a one-button "Apply Refit" once the design has
         // moved ahead of the ship.
-        let refit_info: Option<RefitInfo> = (|| {
-            let design = design_registry.get(&ship.design_id)?;
-            if design.revision <= ship.design_revision {
-                return None;
-            }
-            let hull = hull_registry.get(&ship.hull_id)?;
-            let (cost_m, cost_e, time) = crate::ship_design::refit_cost_to_design(
-                &ship.modules,
-                design,
-                hull,
-                module_registry,
-            );
-            Some(RefitInfo {
-                target_revision: design.revision,
-                current_revision: ship.design_revision,
-                design_name: design.name.clone(),
-                cost_minerals: cost_m,
-                cost_energy: cost_e,
-                refit_time: time,
-            })
-        })();
+        //
+        // #491 follow-up: Gate computation on `is_actionable` so a terminal
+        // projection (Destroyed / Missing) skips the entire refit pipeline.
+        let refit_info: Option<RefitInfo> = if !is_actionable {
+            None
+        } else {
+            (|| {
+                let design = design_registry.get(&ship.design_id)?;
+                if design.revision <= ship.design_revision {
+                    return None;
+                }
+                let hull = hull_registry.get(&ship.hull_id)?;
+                let (cost_m, cost_e, time) = crate::ship_design::refit_cost_to_design(
+                    &ship.modules,
+                    design,
+                    hull,
+                    module_registry,
+                );
+                Some(RefitInfo {
+                    target_revision: design.revision,
+                    current_revision: ship.design_revision,
+                    design_name: design.name.clone(),
+                    cost_minerals: cost_m,
+                    cost_energy: cost_e,
+                    refit_time: time,
+                })
+            })()
+        };
         // #123: Fleet membership + per-fleet refit summary (if applicable).
         // #287 (γ-1): membership is read from `Ship.fleet` and the peer
         // `FleetMembers` component on the fleet entity.
-        let fleet_refit_summary: Option<FleetRefitSummary> = ship.fleet.and_then(|fleet_entity| {
+        //
+        // #491 follow-up: gated on `is_actionable` — a destroyed/missing
+        // flagship's panel should not present a "Refit Fleet" button even
+        // if surviving members are docked. If the player wants to refit
+        // the surviving members, they can open one of those members'
+        // panels directly.
+        let fleet_refit_summary: Option<FleetRefitSummary> = (is_actionable
+            .then_some(()))
+        .and_then(|()| ship.fleet)
+        .and_then(|fleet_entity| {
             let fleet = fleets.get(fleet_entity).ok()?;
             let members = fleet_members.get(fleet_entity).ok()?;
             let mut eligible = 0usize;

--- a/macrocosmo/src/ui/ship_panel.rs
+++ b/macrocosmo/src/ui/ship_panel.rs
@@ -9,15 +9,19 @@ use crate::colony::{
 };
 use crate::components::Position;
 use crate::galaxy::{Planet, StarSystem, SystemAttributes};
+use crate::knowledge::{KnowledgeStore, ShipSnapshotState};
 use crate::modifier::ModifiedValue;
-use crate::physics;
 use crate::player::{AboardShip, Player, StationedAt};
 use crate::ship::{
-    Cargo, CommandQueue, CourierMode, CourierRoute, DockedAt, PendingShipCommand, QueuedCommand,
-    RulesOfEngagement, Ship, ShipHitpoints, ShipModifiers, ShipState, ShipStats, SurveyData,
+    Cargo, CommandQueue, CourierMode, CourierRoute, DockedAt, Owner, PendingShipCommand,
+    QueuedCommand, RulesOfEngagement, Ship, ShipHitpoints, ShipModifiers, ShipState, ShipStats,
+    SurveyData,
 };
 use crate::ship_design::{HullRegistry, ShipDesignRegistry};
 use crate::time_system::GameClock;
+use crate::ui::ship_view::{
+    ShipView, ShipViewProgress, ShipViewTiming, ship_view, ship_view_status_label,
+};
 use crate::ui::{draw_modifier_breakdown, modified_value_label_with_tooltip};
 use crate::visualization::{SelectedShip, SelectedShips};
 
@@ -145,154 +149,147 @@ pub struct NearbyStructure {
 pub(super) use crate::ui::params::system_name;
 
 /// Collected status information for the ship panel UI.
-struct ShipStatusInfo {
-    label: String,
-    /// Progress fraction 0.0..=1.0, if applicable.
-    progress: Option<(i64, i64, f32)>, // (elapsed, total, fraction)
+///
+/// #491 PR-2: Public-in-crate so the FTL-leak regression tests can read
+/// the extracted label / progress without driving the egui pipeline.
+#[derive(Clone, Debug)]
+pub struct ShipStatusInfo {
+    pub label: String,
+    /// Progress (elapsed, total, fraction). `None` for steady-state /
+    /// terminal states (InSystem / Loitering / Destroyed / Missing).
+    ///
+    /// `elapsed` and `total` are surfaced in raw form for the egui
+    /// `ProgressBar` overlay; `fraction` is clamped to `[0.0, 1.0]` so
+    /// stale clocks past `expected_tick` do not over-extend the bar.
+    pub progress: Option<(i64, i64, f32)>,
 }
 
-/// Build a detailed status string (and optional progress) from a ShipState.
-fn build_status_info(
+/// #491 PR-2: Derive [`ShipViewTiming`] from a ship's projection /
+/// snapshot / realtime ECS, gated by the same own-empire / foreign /
+/// no-store ladder as [`ship_view`].
+///
+/// * **Own ship + KnowledgeStore present** → projection's
+///   `dispatched_at` / `expected_arrival_at`.
+/// * **Foreign ship + KnowledgeStore present** → snapshot's
+///   `observed_at`; `expected_tick` is `None` (snapshots don't carry
+///   remote ETAs), so progress collapses for foreign ships in transit.
+/// * **No KnowledgeStore** (early Startup) → realtime ECS departed/started
+///   tick + arrival/completion tick, matched against the view variant.
+///
+/// Mirrors the contract `ship_view` enforces — callers MUST drive
+/// `ShipView` and `ShipViewTiming` through the same data path.
+fn ship_panel_view_timing(
+    ship_entity: Entity,
+    ship: &Ship,
     state: &ShipState,
+    view: &ShipView,
+    viewing_knowledge: Option<&KnowledgeStore>,
+    viewing_empire: Option<Entity>,
+) -> Option<ShipViewTiming> {
+    if let (Some(store), Some(viewing)) = (viewing_knowledge, viewing_empire) {
+        if let Owner::Empire(owner) = ship.owner {
+            if owner == viewing {
+                let p = store.get_projection(ship_entity)?;
+                return Some(ShipViewTiming {
+                    origin_tick: p.dispatched_at,
+                    expected_tick: p.expected_arrival_at,
+                });
+            }
+        }
+        // Foreign-ship snapshot path. `expected_tick` is unknown — the
+        // helper layer's progress gate already returns `None` when the
+        // expected tick is missing.
+        let snap = store.get_ship(ship_entity)?;
+        return Some(ShipViewTiming {
+            origin_tick: snap.observed_at,
+            expected_tick: None,
+        });
+    }
+    // Realtime ECS fallback (= no KnowledgeStore resolved). Match against
+    // the view variant so the right ECS field pair is selected.
+    match (&view.state, state) {
+        (
+            ShipSnapshotState::InTransitSubLight,
+            ShipState::SubLight {
+                departed_at,
+                arrival_at,
+                ..
+            },
+        )
+        | (
+            ShipSnapshotState::InTransitFTL,
+            ShipState::InFTL {
+                departed_at,
+                arrival_at,
+                ..
+            },
+        ) => Some(ShipViewTiming {
+            origin_tick: *departed_at,
+            expected_tick: Some(*arrival_at),
+        }),
+        (
+            ShipSnapshotState::Surveying,
+            ShipState::Surveying {
+                started_at,
+                completes_at,
+                ..
+            }
+            | ShipState::Scouting {
+                started_at,
+                completes_at,
+                ..
+            },
+        ) => Some(ShipViewTiming {
+            origin_tick: *started_at,
+            expected_tick: Some(*completes_at),
+        }),
+        (
+            ShipSnapshotState::Settling,
+            ShipState::Settling {
+                started_at,
+                completes_at,
+                ..
+            },
+        ) => Some(ShipViewTiming {
+            origin_tick: *started_at,
+            expected_tick: Some(*completes_at),
+        }),
+        (
+            ShipSnapshotState::Refitting,
+            ShipState::Refitting {
+                started_at,
+                completes_at,
+                ..
+            },
+        ) => Some(ShipViewTiming {
+            origin_tick: *started_at,
+            expected_tick: Some(*completes_at),
+        }),
+        // Steady-state / terminal — no progress timing.
+        _ => None,
+    }
+}
+
+/// #491 PR-2: Build status info from a [`ShipView`] + [`ShipViewTiming`].
+///
+/// Replaces the legacy `build_status_info`'s realtime [`ShipState`]
+/// match with the projection-mediated `ship_view_status_label` helper.
+/// The label no longer carries the legacy `(a/b hd, p%)` suffix —
+/// progress digits are rendered exclusively by the egui
+/// `ProgressBar`'s `text(...)` overlay (#491 D-H-8 / D-M-10).
+///
+/// Visible to crate-internal tests so the FTL-leak regression suite can
+/// assert label / progress without driving the egui pipeline.
+pub fn build_status_info_from_view(
+    view: &ShipView,
+    timing: Option<ShipViewTiming>,
     clock: &GameClock,
     stars: &Query<(Entity, &StarSystem, &Position, Option<&SystemAttributes>)>,
 ) -> ShipStatusInfo {
-    match state {
-        ShipState::InSystem { system } => ShipStatusInfo {
-            label: format!("Docked at {}", system_name(*system, stars)),
-            progress: None,
-        },
-        ShipState::SubLight {
-            target_system,
-            departed_at,
-            arrival_at,
-            ..
-        } => {
-            let total = (arrival_at - departed_at).max(1);
-            let elapsed = (clock.elapsed - departed_at).clamp(0, total);
-            let pct = elapsed as f32 / total as f32;
-            let dest_name = target_system
-                .map(|e| system_name(e, stars))
-                .unwrap_or_else(|| "deep space".to_string());
-            ShipStatusInfo {
-                label: format!(
-                    "Moving to {} ({}/{} hd, {:.0}%)",
-                    dest_name,
-                    elapsed,
-                    total,
-                    pct * 100.0
-                ),
-                progress: Some((elapsed, total, pct)),
-            }
-        }
-        ShipState::InFTL {
-            destination_system,
-            departed_at,
-            arrival_at,
-            ..
-        } => {
-            let total = (arrival_at - departed_at).max(1);
-            let elapsed = (clock.elapsed - departed_at).clamp(0, total);
-            let pct = elapsed as f32 / total as f32;
-            ShipStatusInfo {
-                label: format!(
-                    "FTL to {} ({}/{} hd, {:.0}%)",
-                    system_name(*destination_system, stars),
-                    elapsed,
-                    total,
-                    pct * 100.0
-                ),
-                progress: Some((elapsed, total, pct)),
-            }
-        }
-        ShipState::Surveying {
-            target_system,
-            started_at,
-            completes_at,
-        } => {
-            let total = (completes_at - started_at).max(1);
-            let elapsed = (clock.elapsed - started_at).clamp(0, total);
-            let pct = elapsed as f32 / total as f32;
-            ShipStatusInfo {
-                label: format!(
-                    "Surveying {} ({}/{} hd, {:.0}%)",
-                    system_name(*target_system, stars),
-                    elapsed,
-                    total,
-                    pct * 100.0
-                ),
-                progress: Some((elapsed, total, pct)),
-            }
-        }
-        ShipState::Settling {
-            system,
-            started_at,
-            completes_at,
-            ..
-        } => {
-            let total = (completes_at - started_at).max(1);
-            let elapsed = (clock.elapsed - started_at).clamp(0, total);
-            let pct = elapsed as f32 / total as f32;
-            ShipStatusInfo {
-                label: format!(
-                    "Settling {} ({}/{} hd, {:.0}%)",
-                    system_name(*system, stars),
-                    elapsed,
-                    total,
-                    pct * 100.0
-                ),
-                progress: Some((elapsed, total, pct)),
-            }
-        }
-        ShipState::Refitting {
-            system,
-            started_at,
-            completes_at,
-            ..
-        } => {
-            let total = (completes_at - started_at).max(1);
-            let elapsed = (clock.elapsed - started_at).clamp(0, total);
-            let pct = elapsed as f32 / total as f32;
-            ShipStatusInfo {
-                label: format!(
-                    "Refitting at {} ({}/{} hd, {:.0}%)",
-                    system_name(*system, stars),
-                    elapsed,
-                    total,
-                    pct * 100.0
-                ),
-                progress: Some((elapsed, total, pct)),
-            }
-        }
-        // #185: Loitering at deep-space coordinates.
-        ShipState::Loitering { position } => ShipStatusInfo {
-            label: format!(
-                "Loitering at ({:.2}, {:.2}, {:.2})",
-                position[0], position[1], position[2]
-            ),
-            progress: None,
-        },
-        // #217: Scouting — display like Surveying but labelled "Scouting".
-        ShipState::Scouting {
-            target_system,
-            started_at,
-            completes_at,
-            ..
-        } => {
-            let total = (completes_at - started_at).max(1);
-            let elapsed = (clock.elapsed - started_at).clamp(0, total);
-            let pct = elapsed as f32 / total as f32;
-            ShipStatusInfo {
-                label: format!(
-                    "Scouting {} ({}/{} hd, {:.0}%)",
-                    system_name(*target_system, stars),
-                    elapsed,
-                    total,
-                    pct * 100.0
-                ),
-                progress: Some((elapsed, total, pct)),
-            }
-        }
+    let (label, progress) = ship_view_status_label(view, timing, clock, stars);
+    ShipStatusInfo {
+        label,
+        progress: progress.map(|p: ShipViewProgress| (p.elapsed, p.total, p.fraction)),
     }
 }
 
@@ -645,6 +642,13 @@ pub fn draw_ship_panel(
     ship_modifiers_query: &Query<&ShipModifiers>,
     // #432: When `false`, command buttons are suppressed (foreign ship).
     is_own_ship: bool,
+    // #491 PR-2: Light-coherent rendering — own-empire ships flow through
+    // the viewing empire's projection table, foreign ships through
+    // snapshots, and the no-store fallback (early Startup) reads realtime
+    // ECS. `viewing_knowledge` / `viewing_empire` form the same
+    // (store, empire) pair that `outline.rs` already routes through.
+    viewing_knowledge: Option<&KnowledgeStore>,
+    viewing_empire: Option<Entity>,
 ) -> ShipPanelActions {
     // #407: Multi-select panel — when 2+ ships selected, show aggregate view
     // instead of individual ship details.
@@ -662,8 +666,35 @@ pub fn draw_ship_panel(
     // Collect ship data into locals first, then draw UI, then apply mutations
     let ship_data = selected_ship.0.and_then(|ship_entity| {
         let (_, ship, state, cargo, ship_hp, survey_data) = ships_query.get(ship_entity).ok()?;
-        let docked_system = if let ShipState::InSystem { system } = &*state {
-            Some(*system)
+        // #491 PR-2: Resolve the light-coherent view of the ship up front.
+        // All downstream `docked_system` / `is_cancellable` / `is_refitting`
+        // / fleet refit gating reads through this view rather than the
+        // realtime ECS [`ShipState`], closing the FTL-leak window in the
+        // ship panel (epic #473 / sibling fixes #477 + #487).
+        //
+        // Falls back to a realtime collapse when no projection / snapshot
+        // exists — the `ship_view` helper handles that case via
+        // `realtime_state_to_snapshot`. `None` here means "the viewing
+        // empire has no entry for this ship at all" (e.g. own-ship before
+        // its seed projection lands per #481), which we treat the same
+        // way the outline tree does: skip the panel entirely.
+        let view = ship_view(
+            ship_entity,
+            &ship,
+            &state,
+            viewing_knowledge,
+            viewing_empire,
+        )?;
+        let view_timing = ship_panel_view_timing(
+            ship_entity,
+            &ship,
+            &state,
+            &view,
+            viewing_knowledge,
+            viewing_empire,
+        );
+        let docked_system = if matches!(view.state, ShipSnapshotState::InSystem) {
+            view.system
         } else {
             None
         };
@@ -672,7 +703,7 @@ pub fn draw_ship_panel(
         // item without re-borrowing cargo mutably.
         let cargo_items: Vec<crate::ship::CargoItem> =
             cargo.map(|c| c.items.clone()).unwrap_or_default();
-        let status_info = build_status_info(&state, clock, stars);
+        let status_info = build_status_info_from_view(&view, view_timing, clock, stars);
         let queued_cmds: Vec<String> = command_queues
             .get(ship_entity)
             .ok()
@@ -699,10 +730,15 @@ pub fn draw_ship_panel(
                 }
             })
         });
-        // Check if ship is in a cancellable state (surveying or settling)
+        // #491 PR-2: Cancellation is gated on the player's *belief*
+        // (= projection state). The cancel command itself still travels
+        // light-delayed to the ship; this guard only decides whether the
+        // button is shown. Reading realtime ECS would let the player see
+        // a "Cancel" button before the projection has caught up — that's
+        // the FTL leak this PR closes.
         let is_cancellable = matches!(
-            &*state,
-            ShipState::Surveying { .. } | ShipState::Settling { .. }
+            view.state,
+            ShipSnapshotState::Surveying | ShipSnapshotState::Settling
         );
         // #103: Check if ship carries unreported survey data
         let has_survey_data = survey_data.is_some();
@@ -717,7 +753,10 @@ pub fn draw_ship_panel(
         let ship_hull_id = ship.hull_id.clone();
         let ship_modules: Vec<crate::ship::EquippedModule> = ship.modules.clone();
         // #98: Is the ship refitting?
-        let is_refitting = matches!(&*state, ShipState::Refitting { .. });
+        // #491 PR-2: Routed through the view (= projection / snapshot) so
+        // the "Refitting in progress" UX matches what the player believes
+        // is happening, not the realtime ECS.
+        let is_refitting = matches!(view.state, ShipSnapshotState::Refitting);
         // #123: Pre-compute design-based refit eligibility / cost / time so the
         // panel can present a one-button "Apply Refit" once the design has
         // moved ahead of the ship.
@@ -762,7 +801,21 @@ pub fn draw_ship_panel(
                 if m_design.revision <= m_ship.design_revision {
                     continue;
                 }
-                if !matches!(&*m_state, ShipState::InSystem { .. }) {
+                // #491 PR-2: Per-member docked filter routed through the
+                // projection view — own-ship eligibility is decided on
+                // the player's belief, not realtime ECS. A member with no
+                // projection / snapshot is skipped (mirrors the outline
+                // tree's no-store / pre-seed handling).
+                let Some(m_view) = ship_view(
+                    *member,
+                    &m_ship,
+                    &m_state,
+                    viewing_knowledge,
+                    viewing_empire,
+                ) else {
+                    continue;
+                };
+                if !matches!(m_view.state, ShipSnapshotState::InSystem) {
                     continue;
                 }
                 let Some(m_hull) = hull_registry.get(&m_ship.hull_id) else {
@@ -792,18 +845,24 @@ pub fn draw_ship_panel(
         });
         // #57: Current ROE
         let current_roe = roe_query.get(ship_entity).copied().unwrap_or_default();
-        // #57: Command delay for ROE changes
+        // #57: Command delay for ROE changes.
+        //
+        // #491 PR-2: The ship's location is taken from the view —
+        // `view.system` covers both docked (= InSystem.system) and
+        // in-flight (= destination from projection's `projected_system` /
+        // snapshot's `last_known_system`) cases. Loitering / unknown
+        // collapses to `None`, matching the legacy fallback's `_ => None`.
+        //
+        // TODO (#491 follow-up): For in-flight own ships, an
+        // `estimated_position(timing, clock, origin, dest)` lerp would
+        // give a tighter light-delay estimate than treating the ship as
+        // already-at-destination. The helper is in
+        // `ShipView::estimated_position`; wiring it here requires looking
+        // up the projection's origin system (or `ship.home_port` as a
+        // proxy) and is out of scope for the panel rewire. The current
+        // semantics match the pre-rewire behaviour.
         let roe_command_delay: i64 = {
-            // Determine the system the ship is at (or heading to)
-            let ship_system = docked_system.or_else(|| match &*state {
-                ShipState::SubLight { target_system, .. } => *target_system,
-                ShipState::InFTL {
-                    destination_system, ..
-                } => Some(*destination_system),
-                ShipState::Surveying { target_system, .. } => Some(*target_system),
-                ShipState::Settling { system, .. } => Some(*system),
-                _ => None,
-            });
+            let ship_system = view.system;
             player_stationed
                 .and_then(|player_sys| {
                     let player_pos = positions.get(player_sys).ok()?;

--- a/macrocosmo/src/ui/ship_view.rs
+++ b/macrocosmo/src/ui/ship_view.rs
@@ -48,8 +48,12 @@ use crate::ui::params::system_name;
 // #491 (D-C-1): the data shape moved to `knowledge::ship_view`. Re-export
 // from this module so the existing `use crate::ui::ship_view::ShipView`
 // import sites keep working.
+//
+// #491 follow-up: also re-export `ship_view_with_timing` so panel callers
+// can drop their per-panel `(ShipView, ShipViewTiming)` ladders in favour
+// of the hoisted helper (#491 PR-2 / PR-4).
 pub use crate::knowledge::ship_view::{
-    ShipView, ShipViewTiming, realtime_state_to_snapshot, ship_view,
+    ShipView, ShipViewTiming, realtime_state_to_snapshot, ship_view, ship_view_with_timing,
 };
 
 /// #491 (D-M-12): Progress data for an in-flight or in-progress ship

--- a/macrocosmo/tests/ship_panel_ftl_leak.rs
+++ b/macrocosmo/tests/ship_panel_ftl_leak.rs
@@ -1,0 +1,590 @@
+//! #491 PR-2: Ship panel must not leak realtime ECS `ShipState` for
+//! own-empire ships. Status label, docked-system derivation, cancel /
+//! refit gating all flow through the viewing empire's
+//! `KnowledgeStore::projections` (own ships) or `ship_snapshots`
+//! (foreign ships), mirroring the Galaxy Map fix #477 and the outline
+//! tree fix #487.
+//!
+//! Pins the **data extraction layer** — `ship_view` /
+//! `build_status_info_from_view` — exercised through `test_app()`
+//! (egui systems are excluded so the egui-driven `draw_ship_panel`
+//! itself is not invoked).
+
+mod common;
+
+use bevy::ecs::system::SystemState;
+use bevy::prelude::*;
+
+use macrocosmo::components::Position;
+use macrocosmo::galaxy::{StarSystem, SystemAttributes};
+use macrocosmo::knowledge::{
+    KnowledgeStore, ObservationSource, ShipProjection, ShipSnapshot, ShipSnapshotState,
+};
+use macrocosmo::player::{Empire, Faction, PlayerEmpire};
+use macrocosmo::ship::fleet::{Fleet, FleetMembers};
+use macrocosmo::ship::{
+    Cargo, CommandQueue, Owner, RulesOfEngagement, Ship, ShipHitpoints, ShipModifiers, ShipState,
+};
+use macrocosmo::time_system::GameClock;
+use macrocosmo::ui::ship_panel::build_status_info_from_view;
+use macrocosmo::ui::ship_view::ship_view;
+
+use common::{spawn_test_system, test_app};
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror outline_tree_ftl_leak.rs setup so the regression suite
+// stays consistent across panel rewires).
+// ---------------------------------------------------------------------------
+
+fn spawn_minimal_empire(app: &mut App) -> Entity {
+    app.world_mut()
+        .spawn((
+            Empire {
+                name: "Test".into(),
+            },
+            PlayerEmpire,
+            Faction {
+                id: "ship_panel_test".into(),
+                name: "Test".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+            KnowledgeStore::default(),
+            macrocosmo::knowledge::SystemVisibilityMap::default(),
+        ))
+        .id()
+}
+
+fn spawn_test_ship(world: &mut World, name: &str, owner: Entity, system: Entity) -> Entity {
+    let ship_entity = world.spawn_empty().id();
+    let fleet_entity = world.spawn_empty().id();
+    world.entity_mut(ship_entity).insert((
+        Ship {
+            name: name.into(),
+            design_id: "explorer_mk1".into(),
+            hull_id: "frigate".into(),
+            modules: Vec::new(),
+            owner: Owner::Empire(owner),
+            sublight_speed: 1.0,
+            ftl_range: 5.0,
+            ruler_aboard: false,
+            home_port: system,
+            design_revision: 0,
+            fleet: Some(fleet_entity),
+        },
+        ShipState::InSystem { system },
+        ShipHitpoints {
+            hull: 100.0,
+            hull_max: 100.0,
+            armor: 0.0,
+            armor_max: 0.0,
+            shield: 0.0,
+            shield_max: 0.0,
+            shield_regen: 0.0,
+        },
+        CommandQueue::default(),
+        Cargo::default(),
+        ShipModifiers::default(),
+        macrocosmo::ship::ShipStats::default(),
+        RulesOfEngagement::default(),
+    ));
+    world.entity_mut(fleet_entity).insert((
+        Fleet {
+            name: name.into(),
+            flagship: Some(ship_entity),
+        },
+        FleetMembers(vec![ship_entity]),
+    ));
+    ship_entity
+}
+
+fn set_ship_state(world: &mut World, ship: Entity, new_state: ShipState) {
+    *world.get_mut::<ShipState>(ship).unwrap() = new_state;
+}
+
+fn snapshot_knowledge(app: &App, empire: Entity) -> KnowledgeStore {
+    let src = app
+        .world()
+        .entity(empire)
+        .get::<KnowledgeStore>()
+        .expect("KnowledgeStore");
+    let mut out = KnowledgeStore::default();
+    for (_, projection) in src.iter_projections() {
+        out.update_projection(projection.clone());
+    }
+    for (_, snapshot) in src.iter_ships() {
+        out.update_ship(snapshot.clone());
+    }
+    out
+}
+
+/// Run `build_status_info_from_view` against the world's star query the
+/// way `draw_ship_panel` does. `timing` is constructed by the caller to
+/// match the path-under-test (= projection / snapshot / realtime).
+fn run_status_label(
+    app: &mut App,
+    view: &macrocosmo::ui::ship_view::ShipView,
+    timing: Option<macrocosmo::ui::ship_view::ShipViewTiming>,
+    clock_elapsed: i64,
+) -> macrocosmo::ui::ship_panel::ShipStatusInfo {
+    let mut state: SystemState<Query<(Entity, &StarSystem, &Position, Option<&SystemAttributes>)>> =
+        SystemState::new(app.world_mut());
+    let stars = state.get(app.world_mut());
+    let clock = GameClock::new(clock_elapsed);
+    build_status_info_from_view(view, timing, &clock, &stars)
+}
+
+// ---------------------------------------------------------------------------
+// 1. Status label uses projection (FTL-leak regression)
+// ---------------------------------------------------------------------------
+
+/// Right after dispatching a survey, the realtime ECS has the ship in
+/// FTL/Surveying — but the projection still says `InSystem` (the
+/// dispatch hasn't propagated to the ship yet). The ship panel's status
+/// label MUST read the projection ("Docked at Home"), not realtime
+/// ("FTL to Frontier" / "Surveying Frontier").
+#[test]
+fn ship_panel_status_label_uses_projection_after_dispatch() {
+    let mut app = test_app();
+    let empire = spawn_minimal_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [50.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(10),
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::InSystem,
+            projected_system: Some(home),
+            intended_state: Some(ShipSnapshotState::Surveying),
+            intended_system: Some(frontier),
+            intended_takes_effect_at: Some(5),
+        });
+    }
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::InFTL {
+            origin_system: home,
+            destination_system: frontier,
+            departed_at: 0,
+            arrival_at: 5,
+        },
+    );
+
+    // Build the view the same way the panel does.
+    let store = snapshot_knowledge(&app, empire);
+    let ship_ref = app.world().entity(ship);
+    let ship_comp = ship_ref.get::<Ship>().expect("Ship Component").clone();
+    let state = ship_ref.get::<ShipState>().expect("ShipState").clone();
+    let view = ship_view(ship, &ship_comp, &state, Some(&store), Some(empire))
+        .expect("own-ship projection must produce a view");
+    // Projection-anchored timing.
+    let timing = {
+        let p = store.get_projection(ship).expect("projection");
+        macrocosmo::ui::ship_view::ShipViewTiming {
+            origin_tick: p.dispatched_at,
+            expected_tick: p.expected_arrival_at,
+        }
+    };
+
+    let info = run_status_label(&mut app, &view, Some(timing), 1);
+    assert!(
+        info.label.contains("Docked"),
+        "FTL-leak regression: status label must reflect projection (Docked) \
+         not realtime FTL. Got: {:?}",
+        info.label
+    );
+    assert!(
+        info.label.contains("Home"),
+        "label must name the projected system (Home). Got: {:?}",
+        info.label
+    );
+    assert!(
+        !info.label.contains("FTL"),
+        "label must not surface the realtime FTL state. Got: {:?}",
+        info.label
+    );
+    assert!(
+        !info.label.contains("Surveying"),
+        "label must not surface the intended Surveying state until the \
+         projection reconciles. Got: {:?}",
+        info.label
+    );
+    // Steady-state (InSystem) — no progress bar.
+    assert_eq!(info.progress, None);
+}
+
+// ---------------------------------------------------------------------------
+// 2. docked_system derivation uses projection
+// ---------------------------------------------------------------------------
+
+/// `docked_system` (used downstream for colony lookup, scrap, set-home-port,
+/// refit eligibility, harbour interactions) MUST be `Some(home)` per the
+/// projection — not `None` per the realtime InFTL state.
+#[test]
+fn ship_panel_docked_system_uses_projection() {
+    let mut app = test_app();
+    let empire = spawn_minimal_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [50.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(10),
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::InSystem,
+            projected_system: Some(home),
+            intended_state: Some(ShipSnapshotState::Surveying),
+            intended_system: Some(frontier),
+            intended_takes_effect_at: Some(5),
+        });
+    }
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::InFTL {
+            origin_system: home,
+            destination_system: frontier,
+            departed_at: 0,
+            arrival_at: 5,
+        },
+    );
+
+    let store = snapshot_knowledge(&app, empire);
+    let ship_ref = app.world().entity(ship);
+    let ship_comp = ship_ref.get::<Ship>().expect("Ship").clone();
+    let state = ship_ref.get::<ShipState>().expect("ShipState").clone();
+    let view = ship_view(ship, &ship_comp, &state, Some(&store), Some(empire)).expect("view");
+    // Mirrors `draw_ship_panel`'s derivation:
+    //   docked_system = (view.state == InSystem) ? view.system : None
+    let docked_system = if matches!(view.state, ShipSnapshotState::InSystem) {
+        view.system
+    } else {
+        None
+    };
+    assert_eq!(
+        docked_system,
+        Some(home),
+        "docked_system must come from projection (Some(home)), not realtime InFTL (None)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. is_cancellable uses projection
+// ---------------------------------------------------------------------------
+
+/// Cancel button visibility is the player's *belief* — the projection
+/// state. Realtime says Surveying, but the projection still says InSystem
+/// (= the player hasn't been told the survey started yet). The Cancel
+/// button must NOT appear until the projection reconciles.
+#[test]
+fn ship_panel_is_cancellable_uses_projection() {
+    let mut app = test_app();
+    let empire = spawn_minimal_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [50.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(10),
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::InSystem,
+            projected_system: Some(home),
+            intended_state: Some(ShipSnapshotState::Surveying),
+            intended_system: Some(frontier),
+            intended_takes_effect_at: Some(5),
+        });
+    }
+    // Realtime advances ahead — survey has begun.
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::Surveying {
+            target_system: frontier,
+            started_at: 0,
+            completes_at: 10,
+        },
+    );
+
+    // Helper closure: snapshot knowledge, look up ship+state, build view,
+    // and return the projection-mediated cancel-button predicate.
+    fn is_cancellable_now(app: &App, ship: Entity, empire: Entity) -> bool {
+        let store = snapshot_knowledge(app, empire);
+        let ship_ref = app.world().entity(ship);
+        let ship_comp = ship_ref.get::<Ship>().expect("Ship");
+        let state = ship_ref.get::<ShipState>().expect("ShipState");
+        let view = ship_view(ship, ship_comp, state, Some(&store), Some(empire)).expect("view");
+        matches!(
+            view.state,
+            ShipSnapshotState::Surveying | ShipSnapshotState::Settling
+        )
+    }
+
+    assert!(
+        !is_cancellable_now(&app, ship, empire),
+        "FTL-leak regression: cancel button must not be shown while \
+         projection still says InSystem (the player has not yet been \
+         informed the survey started)."
+    );
+
+    // Once the projection reconciles to Surveying, cancel becomes available.
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(10),
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::Surveying,
+            projected_system: Some(frontier),
+            intended_state: Some(ShipSnapshotState::Surveying),
+            intended_system: Some(frontier),
+            intended_takes_effect_at: Some(5),
+        });
+    }
+    assert!(
+        is_cancellable_now(&app, ship, empire),
+        "cancel button must appear once projection reconciles to Surveying"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. No projection — falls through to realtime ECS
+// ---------------------------------------------------------------------------
+
+/// Edge case: own-empire ship without a projection (= early Startup
+/// before #481's spawn-time seed lands). `ship_view` returns `None` for
+/// the projection path — but the same ship through the realtime
+/// fallback (no KnowledgeStore at all) must use the ECS state.
+///
+/// Production caller (= `draw_ship_panel`) skips the panel entirely
+/// when `ship_view` returns `None` — that is the safer behaviour and
+/// matches the outline tree's no-projection contract. This test
+/// verifies the fallback path itself produces a sensible label so the
+/// helper layer's contract is preserved.
+#[test]
+fn ship_panel_no_projection_falls_through_to_realtime() {
+    let mut app = test_app();
+    let empire = spawn_minimal_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [50.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    // No projection populated. Realtime says InFTL.
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::InFTL {
+            origin_system: home,
+            destination_system: frontier,
+            departed_at: 0,
+            arrival_at: 5,
+        },
+    );
+
+    // First check the production path: with KnowledgeStore but no
+    // projection, `ship_view` returns None and the panel skips the ship.
+    let store = snapshot_knowledge(&app, empire);
+    let ship_ref = app.world().entity(ship);
+    let ship_comp = ship_ref.get::<Ship>().expect("Ship").clone();
+    let state = ship_ref.get::<ShipState>().expect("ShipState").clone();
+    let view_with_store = ship_view(ship, &ship_comp, &state, Some(&store), Some(empire));
+    assert!(
+        view_with_store.is_none(),
+        "own-ship without projection must produce no view — caller skips panel"
+    );
+
+    // Now the realtime fallback path: no KnowledgeStore at all
+    // (= early Startup). The view collapses from realtime ECS, and the
+    // status label uses the realtime arrival tick.
+    let view_no_store =
+        ship_view(ship, &ship_comp, &state, None, Some(empire)).expect("realtime fallback view");
+    assert_eq!(view_no_store.state, ShipSnapshotState::InTransitFTL);
+    assert_eq!(view_no_store.system, Some(frontier));
+
+    // Realtime-anchored timing — matches what the panel constructs.
+    let timing = macrocosmo::ui::ship_view::ShipViewTiming {
+        origin_tick: 0,
+        expected_tick: Some(5),
+    };
+    let info = run_status_label(&mut app, &view_no_store, Some(timing), 2);
+    assert!(
+        info.label.contains("FTL"),
+        "realtime fallback must reflect ECS InFTL state. Got: {:?}",
+        info.label
+    );
+    assert!(
+        info.label.contains("Frontier"),
+        "label must name the realtime destination. Got: {:?}",
+        info.label
+    );
+    let progress = info.progress.expect("InTransitFTL must surface progress");
+    assert_eq!(progress.0, 2, "elapsed = clock - departed");
+    assert_eq!(progress.1, 5, "total = arrival - departed");
+}
+
+// ---------------------------------------------------------------------------
+// 5. Foreign ship reads snapshot
+// ---------------------------------------------------------------------------
+
+/// Foreign ships are rendered through the viewing empire's
+/// `ship_snapshots` — observer mode (when `viewing_empire` points at a
+/// non-owner empire) MUST NOT see realtime ECS ground truth.
+#[test]
+fn ship_panel_foreign_ship_uses_snapshot() {
+    let mut app = test_app();
+    let viewing_empire = spawn_minimal_empire(&mut app);
+
+    let foreign_empire = app
+        .world_mut()
+        .spawn((
+            Empire {
+                name: "Foreign".into(),
+            },
+            Faction {
+                id: "foreign".into(),
+                name: "Foreign".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+            KnowledgeStore::default(),
+            macrocosmo::knowledge::SystemVisibilityMap::default(),
+        ))
+        .id();
+
+    let last_known = spawn_test_system(
+        app.world_mut(),
+        "LastKnown",
+        [10.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let realtime_dest = spawn_test_system(
+        app.world_mut(),
+        "RealtimeDest",
+        [200.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+
+    let ship = spawn_test_ship(app.world_mut(), "EnemyShip", foreign_empire, last_known);
+
+    // Snapshot: viewing empire saw the foreign ship in sub-light transit.
+    {
+        let mut em = app.world_mut().entity_mut(viewing_empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_ship(ShipSnapshot {
+            entity: ship,
+            name: "EnemyShip".into(),
+            design_id: "explorer_mk1".into(),
+            last_known_state: ShipSnapshotState::InTransitSubLight,
+            last_known_system: Some(last_known),
+            observed_at: 0,
+            hp: 100.0,
+            hp_max: 100.0,
+            source: ObservationSource::Direct,
+        });
+    }
+    // Realtime advances ahead — the ship has actually entered FTL. The
+    // viewing empire must NOT see this.
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::InFTL {
+            origin_system: last_known,
+            destination_system: realtime_dest,
+            departed_at: 1,
+            arrival_at: 5,
+        },
+    );
+
+    let store = snapshot_knowledge(&app, viewing_empire);
+    let ship_ref = app.world().entity(ship);
+    let ship_comp = ship_ref.get::<Ship>().expect("Ship").clone();
+    let state = ship_ref.get::<ShipState>().expect("ShipState").clone();
+    let view = ship_view(ship, &ship_comp, &state, Some(&store), Some(viewing_empire))
+        .expect("foreign-ship snapshot must produce a view");
+    assert_eq!(
+        view.state,
+        ShipSnapshotState::InTransitSubLight,
+        "foreign ship view must reflect snapshot (sublight), not realtime FTL"
+    );
+    assert_eq!(view.system, Some(last_known));
+
+    // Foreign ship snapshot timing has no expected_tick — progress
+    // collapses to None even though the state is in-transit.
+    let timing = {
+        let snap = store.get_ship(ship).expect("snapshot");
+        macrocosmo::ui::ship_view::ShipViewTiming {
+            origin_tick: snap.observed_at,
+            expected_tick: None,
+        }
+    };
+    let info = run_status_label(&mut app, &view, Some(timing), 5);
+    assert!(
+        info.label.contains("Moving") || info.label.contains("Transit"),
+        "label must reflect sublight transit. Got: {:?}",
+        info.label
+    );
+    assert!(
+        info.label.contains("LastKnown"),
+        "label must name snapshot's last-known system. Got: {:?}",
+        info.label
+    );
+    assert!(
+        !info.label.contains("FTL"),
+        "label must not leak the realtime FTL state. Got: {:?}",
+        info.label
+    );
+    assert_eq!(
+        info.progress, None,
+        "foreign-ship snapshot has no expected_tick — progress must be None"
+    );
+}

--- a/macrocosmo/tests/ship_panel_ftl_leak.rs
+++ b/macrocosmo/tests/ship_panel_ftl_leak.rs
@@ -588,3 +588,242 @@ fn ship_panel_foreign_ship_uses_snapshot() {
         "foreign-ship snapshot has no expected_tick — progress must be None"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 6. Refitting projection drives ship-panel UX (FTL-leak parity)
+// ---------------------------------------------------------------------------
+
+/// Right after dispatching a Refit command the realtime ECS may already
+/// be in `Refitting`, but the player's *belief* (= projection) still
+/// says `InSystem` until the dispatcher reconciles. The ship panel's
+/// `is_refitting` predicate (which gates the "Refitting in progress…"
+/// banner and hides the "Apply Refit" button) must read the projection,
+/// not the realtime ECS — the same FTL-leak semantics #491 closes for
+/// status-label / docked-system / cancellable.
+#[test]
+fn ship_panel_is_refitting_uses_projection() {
+    let mut app = test_app();
+    let empire = spawn_minimal_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    // Pre-reconcile: projection still says InSystem (player believes ship
+    // is docked; refit hasn't visibly started yet).
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(8),
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::InSystem,
+            projected_system: Some(home),
+            intended_state: Some(ShipSnapshotState::Refitting),
+            intended_system: Some(home),
+            intended_takes_effect_at: Some(2),
+        });
+    }
+    // Realtime advances ahead — refit has begun.
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::Refitting {
+            system: home,
+            started_at: 0,
+            completes_at: 8,
+            new_modules: Vec::new(),
+            target_revision: 1,
+        },
+    );
+
+    fn is_refitting_now(app: &App, ship: Entity, empire: Entity) -> bool {
+        let store = snapshot_knowledge(app, empire);
+        let ship_ref = app.world().entity(ship);
+        let ship_comp = ship_ref.get::<Ship>().expect("Ship");
+        let state = ship_ref.get::<ShipState>().expect("ShipState");
+        let view = ship_view(ship, ship_comp, state, Some(&store), Some(empire)).expect("view");
+        matches!(view.state, ShipSnapshotState::Refitting)
+    }
+
+    assert!(
+        !is_refitting_now(&app, ship, empire),
+        "FTL-leak regression: 'Refitting in progress' banner must not show \
+         while projection still says InSystem"
+    );
+
+    // Once the projection reconciles to Refitting, the panel switches over.
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(8),
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::Refitting,
+            projected_system: Some(home),
+            intended_state: Some(ShipSnapshotState::Refitting),
+            intended_system: Some(home),
+            intended_takes_effect_at: Some(2),
+        });
+    }
+    assert!(
+        is_refitting_now(&app, ship, empire),
+        "Refitting banner must appear once projection reconciles to Refitting"
+    );
+
+    // While in Refitting, the status label says "Refitting at <home>" with
+    // a meaningful progress bar driven by the projection's dispatch /
+    // arrival ticks.
+    let store = snapshot_knowledge(&app, empire);
+    let ship_ref = app.world().entity(ship);
+    let ship_comp = ship_ref.get::<Ship>().expect("Ship").clone();
+    let state = ship_ref.get::<ShipState>().expect("ShipState").clone();
+    let view = ship_view(ship, &ship_comp, &state, Some(&store), Some(empire)).expect("view");
+    let timing = {
+        let p = store.get_projection(ship).expect("projection");
+        macrocosmo::ui::ship_view::ShipViewTiming {
+            origin_tick: p.dispatched_at,
+            expected_tick: p.expected_arrival_at,
+        }
+    };
+    let info = run_status_label(&mut app, &view, Some(timing), 4);
+    assert!(
+        info.label.contains("Refitting"),
+        "label must reflect Refitting state. Got: {:?}",
+        info.label
+    );
+    assert!(
+        info.label.contains("Home"),
+        "label must name the refit system. Got: {:?}",
+        info.label
+    );
+    let progress = info.progress.expect("Refitting must produce progress");
+    assert_eq!(progress.0, 4, "elapsed = clock(4) - dispatched_at(0)");
+    assert_eq!(progress.1, 8, "total = expected_arrival(8) - dispatched_at(0)");
+    assert!(
+        (progress.2 - 0.5).abs() < 1e-6,
+        "fraction = elapsed / total = 0.5"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Terminal-state actionable guard via ShipView::is_actionable
+// ---------------------------------------------------------------------------
+
+/// A ship whose own-empire projection has collapsed to `Destroyed` must
+/// not surface ScrapShip / SetHomePort / Refit / Cancel actions —
+/// `ShipView::is_actionable()` is the canonical predicate panels gate
+/// on. This test pins that the projection-driven view returns `false`
+/// from `is_actionable` for terminal states, which is the one input
+/// `ship_panel` reads to disable the entire actions block.
+#[test]
+fn ship_panel_destroyed_projection_is_not_actionable() {
+    let mut app = test_app();
+    let empire = spawn_minimal_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: None,
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::Destroyed,
+            projected_system: None,
+            intended_state: None,
+            intended_system: None,
+            intended_takes_effect_at: None,
+        });
+    }
+    // Realtime ECS state is irrelevant — the projection drives the gate.
+    set_ship_state(app.world_mut(), ship, ShipState::InSystem { system: home });
+
+    let store = snapshot_knowledge(&app, empire);
+    let ship_ref = app.world().entity(ship);
+    let ship_comp = ship_ref.get::<Ship>().expect("Ship").clone();
+    let state = ship_ref.get::<ShipState>().expect("ShipState").clone();
+    let view =
+        ship_view(ship, &ship_comp, &state, Some(&store), Some(empire)).expect("Destroyed view");
+
+    assert!(
+        !view.is_actionable(),
+        "Destroyed projection must report is_actionable() == false; \
+         ship_panel uses this to skip ScrapShip / SetHomePort / Refit / \
+         Cancel buttons."
+    );
+}
+
+#[test]
+fn ship_panel_missing_projection_is_not_actionable() {
+    let mut app = test_app();
+    let empire = spawn_minimal_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: None,
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::Missing,
+            projected_system: None,
+            intended_state: None,
+            intended_system: None,
+            intended_takes_effect_at: None,
+        });
+    }
+    let store = snapshot_knowledge(&app, empire);
+    let ship_ref = app.world().entity(ship);
+    let ship_comp = ship_ref.get::<Ship>().expect("Ship").clone();
+    let state = ship_ref.get::<ShipState>().expect("ShipState").clone();
+    let view = ship_view(ship, &ship_comp, &state, Some(&store), Some(empire)).expect("view");
+
+    assert!(
+        !view.is_actionable(),
+        "Missing projection must report is_actionable() == false"
+    );
+}
+
+/// Sanity: a healthy `InSystem` projection IS actionable — the panel
+/// must surface ScrapShip / SetHomePort / Refit / Cancel as usual.
+#[test]
+fn ship_panel_in_system_projection_is_actionable() {
+    let mut app = test_app();
+    let empire = spawn_minimal_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: None,
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::InSystem,
+            projected_system: Some(home),
+            intended_state: None,
+            intended_system: None,
+            intended_takes_effect_at: None,
+        });
+    }
+    let store = snapshot_knowledge(&app, empire);
+    let ship_ref = app.world().entity(ship);
+    let ship_comp = ship_ref.get::<Ship>().expect("Ship").clone();
+    let state = ship_ref.get::<ShipState>().expect("ShipState").clone();
+    let view = ship_view(ship, &ship_comp, &state, Some(&store), Some(empire)).expect("view");
+
+    assert!(
+        view.is_actionable(),
+        "InSystem projection must report is_actionable() == true"
+    );
+}


### PR DESCRIPTION
## Summary

- Replace `ship_panel::build_status_info` with `ship_view_status_label` helper (#498)
- `docked_system` / `is_cancellable` / `is_refitting` / fleet refit filter / ROE command delay derived from projection-mediated `ShipView` instead of realtime `ShipState`
- own-empire ships go through projection, foreign ships through snapshot, observer mode follows existing contract (= #499 follow-up)

Closes #491 (sub-PR 2 of 5).

## Notable design notes

- Status label no longer carries the legacy `(a/b hd, p%)` suffix — progress digits are rendered exclusively by the egui `ProgressBar` overlay (per #491 D-H-8 / D-M-10).
- ROE command_delay was simplified to read `view.system` (covers both docked and in-flight cases). A `TODO` comment marks the `estimated_position` lerp as a follow-up — the helper exists in `ShipView::estimated_position` but wiring it requires looking up the projection's origin system, which expands scope past the panel rewire.
- `view = None` (own-empire ship without a projection / snapshot) makes the panel skip rendering, matching the outline tree's no-store / pre-seed handling.

## Test plan

- [x] New `tests/ship_panel_ftl_leak.rs` (5 cases): projection-mediated label / docked / is_cancellable, no-projection realtime fallback, foreign-ship snapshot
- [x] `cargo test --workspace --tests` 全 green (3477 total tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` baseline 24 errors (no new errors from this PR)
- [x] `cargo build -p macrocosmo --lib` clean (`--features remote` build verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)