### PR TITLE
fix(ui): situation_center ship_ops_tab uses ShipView projection (#491 PR-4)

### DIFF
--- a/macrocosmo/src/ui/ship_view.rs
+++ b/macrocosmo/src/ui/ship_view.rs
@@ -48,8 +48,12 @@ use crate::ui::params::system_name;
 // #491 (D-C-1): the data shape moved to `knowledge::ship_view`. Re-export
 // from this module so the existing `use crate::ui::ship_view::ShipView`
 // import sites keep working.
+//
+// #491 follow-up: also re-export `ship_view_with_timing` so panel callers
+// can drop their per-panel `(ShipView, ShipViewTiming)` ladders in favour
+// of the hoisted helper (#491 PR-2 / PR-4).
 pub use crate::knowledge::ship_view::{
-    ShipView, ShipViewTiming, realtime_state_to_snapshot, ship_view,
+    ShipView, ShipViewTiming, realtime_state_to_snapshot, ship_view, ship_view_with_timing,
 };
 
 /// #491 (D-M-12): Progress data for an in-flight or in-progress ship

--- a/macrocosmo/src/ui/situation_center/ship_ops_tab.rs
+++ b/macrocosmo/src/ui/situation_center/ship_ops_tab.rs
@@ -4,13 +4,28 @@
 //! Combat / Other). Category groups become root events; individual
 //! ships hang as children with `EventSource::Ship(entity)`.
 //!
-//! Category mapping:
-//! * **Travel** — `ShipState::SubLight` or `ShipState::InFTL`.
-//! * **Survey** — `ShipState::Surveying` or `ShipState::Scouting`.
+//! Category mapping is light-coherent (#491 PR-4): the classifier reads
+//! the viewing empire's `KnowledgeStore` projection (own ships) or
+//! snapshot (foreign ships), never the realtime ECS [`ShipState`]
+//! directly. The `ship_view` helper performs the projection /
+//! snapshot collapse and returns a [`ShipView`] carrying a
+//! [`ShipSnapshotState`]; this tab classifies on that.
+//!
+//! Category mapping (over [`ShipSnapshotState`]):
+//! * **Travel** — `InTransitSubLight` or `InTransitFTL`. The two
+//!   variants render distinct labels (`"sublight transit"` vs
+//!   `"in FTL"`) so the player can see whether the ship is
+//!   interceptable; FTL ships are not.
+//! * **Survey** — `Surveying`. (Realtime `Scouting` collapses to
+//!   `Surveying` at snapshot granularity per #217 — the player UI
+//!   does not distinguish them at this layer.)
 //! * **Combat** — any ship whose current system hosts a `Hostile`
-//!   entity. `resolve_combat` is tick-based (no persistent "in-combat"
-//!   flag), so co-location is the cleanest pure-read signal.
-//! * **Other** — `Docked`, `Loitering`, `Settling`, `Refitting`.
+//!   entity AND that is not currently in transit. `resolve_combat` is
+//!   tick-based (no persistent "in-combat" flag), so co-location is
+//!   the cleanest pure-read signal.
+//! * **Other** — `InSystem` (docked), `Loitering`, `Settling`,
+//!   `Refitting`. `Destroyed` and `Missing` are filtered out so the
+//!   tab does not surface ships the player can no longer command.
 //!
 //! Badge surface: Combat count → `Severity::Warn` (ships engaged).
 
@@ -19,8 +34,11 @@ use std::collections::{HashMap, HashSet};
 use bevy::prelude::*;
 
 use crate::galaxy::{AtSystem, Hostile, StarSystem};
-use crate::ship::{Ship, ShipState};
+use crate::knowledge::{KnowledgeStore, ShipProjection, ShipSnapshot, ShipSnapshotState};
+use crate::player::PlayerEmpire;
+use crate::ship::{Owner, Ship, ShipState};
 use crate::time_system::GameClock;
+use crate::ui::ship_view::{ShipView, ShipViewTiming, ship_view};
 
 use super::tab::{OngoingTab, TabBadge, TabMeta};
 use super::types::{Event, EventKind, EventSource, Severity};
@@ -121,10 +139,130 @@ fn hostile_systems(world: &World) -> HashSet<Entity> {
     out
 }
 
+/// Resolve the player empire entity (= viewing empire). Returns `None`
+/// if no `PlayerEmpire` exists yet (early Startup before the spawn
+/// system runs); callers fall back to the realtime ECS path.
+fn resolve_player_empire(world: &World) -> Option<Entity> {
+    let mut q = world.try_query::<(Entity, &PlayerEmpire)>()?;
+    q.iter(world).next().map(|(e, _)| e)
+}
+
+/// Build a `ShipViewTiming` from an own-empire `ShipProjection`.
+///
+/// `origin_tick = projection.dispatched_at` (= dispatcher's command
+/// tick, light-coherent with the player UI). `expected_tick =
+/// projection.expected_arrival_at`.
+fn timing_from_projection(projection: &ShipProjection) -> ShipViewTiming {
+    ShipViewTiming {
+        origin_tick: projection.dispatched_at,
+        expected_tick: projection.expected_arrival_at,
+    }
+}
+
+/// Build a `ShipViewTiming` from a foreign-empire `ShipSnapshot`.
+///
+/// `origin_tick = snapshot.observed_at` (= the tick at which the
+/// viewing empire first / last learned of this state). `ShipSnapshot`
+/// does not carry an explicit ETA today; the foreign-ship progress
+/// bar therefore stays open-ended (`expected_tick = None`). When a
+/// future light-coherent ETA propagation lands this is the helper to
+/// update.
+fn timing_from_snapshot(snapshot: &ShipSnapshot) -> ShipViewTiming {
+    ShipViewTiming {
+        origin_tick: snapshot.observed_at,
+        expected_tick: None,
+    }
+}
+
+/// Build a `ShipViewTiming` from the realtime ECS `ShipState` for the
+/// no-`KnowledgeStore` fallback path (early Startup before empires are
+/// wired). Equivalent to the pre-#491 behaviour.
+fn timing_from_realtime(state: &ShipState) -> ShipViewTiming {
+    match state {
+        ShipState::SubLight {
+            departed_at,
+            arrival_at,
+            ..
+        }
+        | ShipState::InFTL {
+            departed_at,
+            arrival_at,
+            ..
+        } => ShipViewTiming {
+            origin_tick: *departed_at,
+            expected_tick: Some(*arrival_at),
+        },
+        ShipState::Surveying {
+            started_at,
+            completes_at,
+            ..
+        }
+        | ShipState::Scouting {
+            started_at,
+            completes_at,
+            ..
+        }
+        | ShipState::Settling {
+            started_at,
+            completes_at,
+            ..
+        }
+        | ShipState::Refitting {
+            started_at,
+            completes_at,
+            ..
+        } => ShipViewTiming {
+            origin_tick: *started_at,
+            expected_tick: Some(*completes_at),
+        },
+        ShipState::InSystem { .. } | ShipState::Loitering { .. } => ShipViewTiming {
+            origin_tick: 0,
+            expected_tick: None,
+        },
+    }
+}
+
+/// Resolve the timing for a ship from its ShipView source path.
+///
+/// * Own ship + projection present → `timing_from_projection`
+/// * Foreign ship + snapshot present → `timing_from_snapshot`
+/// * No `KnowledgeStore` (early Startup) → `timing_from_realtime`
+///
+/// Returns `None` only when the projection / snapshot is absent in a
+/// path that should have one (caller already filters those via
+/// `ship_view` returning `None`); callers can default to "no ETA"
+/// when this happens.
+fn ship_view_timing(
+    ship_entity: Entity,
+    ship: &Ship,
+    state: &ShipState,
+    viewing_knowledge: Option<&KnowledgeStore>,
+    viewing_empire: Option<Entity>,
+) -> ShipViewTiming {
+    let Some(store) = viewing_knowledge else {
+        return timing_from_realtime(state);
+    };
+    if let Owner::Empire(owner) = ship.owner
+        && Some(owner) == viewing_empire
+    {
+        return store
+            .get_projection(ship_entity)
+            .map(timing_from_projection)
+            .unwrap_or_else(|| timing_from_realtime(state));
+    }
+    store
+        .get_ship(ship_entity)
+        .map(timing_from_snapshot)
+        .unwrap_or_else(|| timing_from_realtime(state))
+}
+
 fn collect_ship_events(world: &World) -> Vec<Event> {
     let clock = world.resource::<GameClock>();
     let now = clock.elapsed;
     let hostiles = hostile_systems(world);
+
+    let viewing_empire = resolve_player_empire(world);
+    let viewing_knowledge = viewing_empire.and_then(|e| world.entity(e).get::<KnowledgeStore>());
 
     let mut buckets: HashMap<Category, Vec<Event>> = HashMap::new();
 
@@ -134,9 +272,28 @@ fn collect_ship_events(world: &World) -> Vec<Event> {
             if ship.is_immobile() {
                 continue;
             }
-            let current_system = ship_current_system(state);
-            let (category, state_label, eta, started_at) =
-                classify_ship(state, current_system, &hostiles, now);
+
+            // #491 PR-4: route the ship through the viewing empire's
+            // KnowledgeStore. Own = projection, foreign = snapshot,
+            // no-store = realtime fallback.
+            let Some(view) = ship_view(ship_entity, ship, state, viewing_knowledge, viewing_empire)
+            else {
+                // No projection / snapshot for this ship — skip rather
+                // than render stale realtime ECS state. Mirrors the
+                // outline-tree contract (#487).
+                continue;
+            };
+
+            let timing =
+                ship_view_timing(ship_entity, ship, state, viewing_knowledge, viewing_empire);
+
+            let Some((category, state_label, eta, started_at)) =
+                classify_view(&view, &timing, &hostiles, now)
+            else {
+                // Destroyed / Missing — filter out of the tab.
+                continue;
+            };
+
             let label = format!("{} — {}", ship.name, state_label);
             buckets.entry(category).or_default().push(Event {
                 id: ship_entity.to_bits(),
@@ -187,14 +344,29 @@ fn summarise_ships(world: &World) -> ShipSummary {
     let mut summary = ShipSummary::default();
     let clock = world.resource::<GameClock>();
     let now = clock.elapsed;
-    if let Some(mut q) = world.try_query::<(&Ship, &ShipState)>() {
-        for (ship, state) in q.iter(world) {
+
+    let viewing_empire = resolve_player_empire(world);
+    let viewing_knowledge = viewing_empire.and_then(|e| world.entity(e).get::<KnowledgeStore>());
+
+    if let Some(mut q) = world.try_query::<(Entity, &Ship, &ShipState)>() {
+        for (ship_entity, ship, state) in q.iter(world) {
             // #389: Exclude immobile ships (stations) from summary
             if ship.is_immobile() {
                 continue;
             }
-            let current_system = ship_current_system(state);
-            let (category, _, _, _) = classify_ship(state, current_system, &hostiles, now);
+
+            let Some(view) = ship_view(ship_entity, ship, state, viewing_knowledge, viewing_empire)
+            else {
+                continue;
+            };
+
+            let timing =
+                ship_view_timing(ship_entity, ship, state, viewing_knowledge, viewing_empire);
+
+            let Some((category, _, _, _)) = classify_view(&view, &timing, &hostiles, now) else {
+                continue;
+            };
+
             match category {
                 Category::Travel => summary.travel += 1,
                 Category::Survey => summary.survey += 1,
@@ -206,103 +378,72 @@ fn summarise_ships(world: &World) -> ShipSummary {
     summary
 }
 
-fn ship_current_system(state: &ShipState) -> Option<Entity> {
-    match state {
-        ShipState::InSystem { system } => Some(*system),
-        ShipState::Settling { system, .. } => Some(*system),
-        ShipState::Refitting { system, .. } => Some(*system),
-        ShipState::Surveying { target_system, .. } => Some(*target_system),
-        ShipState::Scouting { target_system, .. } => Some(*target_system),
-        ShipState::SubLight { target_system, .. } => *target_system,
-        ShipState::InFTL {
-            destination_system, ..
-        } => Some(*destination_system),
-        ShipState::Loitering { .. } => None,
-    }
-}
-
-fn classify_ship(
-    state: &ShipState,
-    current_system: Option<Entity>,
+/// #491 PR-4: Classify a [`ShipView`] (= projection / snapshot
+/// derived) into a UI category, plus the labels and timing payload.
+///
+/// Returns `None` for `Destroyed` / `Missing` — the player has no
+/// command surface for those ships, so they are filtered out of the
+/// Ship Operations tab. Callers `continue` on `None`.
+fn classify_view(
+    view: &ShipView,
+    timing: &ShipViewTiming,
     hostiles: &HashSet<Entity>,
     now: i64,
-) -> (Category, String, Option<i64>, i64) {
+) -> Option<(Category, String, Option<i64>, i64)> {
     // Combat override: if the ship is currently resident in a system
-    // containing a hostile entity AND it's not in transit, classify as
-    // Combat regardless of the other state bits. A ship in InFTL to a
-    // hostile-occupied system is still "travelling" — it's not yet
-    // engaged.
-    let in_transit = matches!(state, ShipState::InFTL { .. } | ShipState::SubLight { .. });
+    // containing a hostile entity AND it's not in transit, classify
+    // as Combat regardless of the other state bits. A ship in
+    // InTransitFTL / InTransitSubLight to a hostile-occupied system
+    // is still "travelling" — it's not yet engaged.
+    let in_transit = view.state.is_in_transit();
     if !in_transit
-        && let Some(sys) = current_system
+        && let Some(sys) = view.system
         && hostiles.contains(&sys)
     {
-        return (Category::Combat, "engaging hostiles".into(), None, now);
+        return Some((Category::Combat, "engaging hostiles".into(), None, now));
     }
 
-    match state {
-        ShipState::SubLight {
-            departed_at,
-            arrival_at,
-            ..
-        } => (
+    match &view.state {
+        ShipSnapshotState::InTransitSubLight => Some((
             Category::Travel,
             "sublight transit".into(),
-            Some(*arrival_at),
-            *departed_at,
-        ),
-        ShipState::InFTL {
-            departed_at,
-            arrival_at,
-            ..
-        } => (
+            timing.expected_tick,
+            timing.origin_tick,
+        )),
+        ShipSnapshotState::InTransitFTL => Some((
             Category::Travel,
             "in FTL".into(),
-            Some(*arrival_at),
-            *departed_at,
-        ),
-        ShipState::Surveying {
-            started_at,
-            completes_at,
-            ..
-        } => (
+            timing.expected_tick,
+            timing.origin_tick,
+        )),
+        ShipSnapshotState::Surveying => Some((
             Category::Survey,
             "surveying".into(),
-            Some(*completes_at),
-            *started_at,
-        ),
-        ShipState::Scouting {
-            started_at,
-            completes_at,
-            ..
-        } => (
-            Category::Survey,
-            "scouting".into(),
-            Some(*completes_at),
-            *started_at,
-        ),
-        ShipState::Settling {
-            started_at,
-            completes_at,
-            ..
-        } => (
+            timing.expected_tick,
+            timing.origin_tick,
+        )),
+        ShipSnapshotState::Settling => Some((
             Category::Other,
             "settling colony".into(),
-            Some(*completes_at),
-            *started_at,
-        ),
-        ShipState::Refitting {
-            started_at,
-            completes_at,
-            ..
-        } => (
+            timing.expected_tick,
+            timing.origin_tick,
+        )),
+        ShipSnapshotState::Refitting => Some((
             Category::Other,
             "refitting".into(),
-            Some(*completes_at),
-            *started_at,
-        ),
-        ShipState::InSystem { .. } => (Category::Other, "docked".into(), None, now),
-        ShipState::Loitering { .. } => (Category::Other, "loitering".into(), None, now),
+            timing.expected_tick,
+            timing.origin_tick,
+        )),
+        ShipSnapshotState::InSystem => Some((Category::Other, "docked".into(), None, now)),
+        ShipSnapshotState::Loitering { .. } => {
+            Some((Category::Other, "loitering".into(), None, now))
+        }
+        // Destroyed / Missing: filtered out of the tab. The player
+        // cannot act on these ships — `Destroyed` is a terminal
+        // state, `Missing` (#409) is "presumed lost". Letting them
+        // through would inflate the badge count for non-actionable
+        // entries.
+        ShipSnapshotState::Destroyed | ShipSnapshotState::Missing => None,
     }
 }
 
@@ -440,6 +581,9 @@ mod tests {
         let p = leaf.progress.expect("progress computed");
         // 50 is 40% of the way from 10 to 110.
         assert!((p - 0.4).abs() < 0.001, "unexpected progress {}", p);
+        // #491 PR-4: InTransitFTL must surface as "in FTL" — distinct
+        // from sublight transit.
+        assert!(leaf.label.contains("in FTL"));
     }
 
     #[test]

--- a/macrocosmo/src/ui/situation_center/ship_ops_tab.rs
+++ b/macrocosmo/src/ui/situation_center/ship_ops_tab.rs
@@ -34,11 +34,12 @@ use std::collections::{HashMap, HashSet};
 use bevy::prelude::*;
 
 use crate::galaxy::{AtSystem, Hostile, StarSystem};
-use crate::knowledge::{KnowledgeStore, ShipProjection, ShipSnapshot, ShipSnapshotState};
+use crate::knowledge::{KnowledgeStore, ShipSnapshotState};
+use crate::observer::ObserverMode;
 use crate::player::PlayerEmpire;
-use crate::ship::{Owner, Ship, ShipState};
+use crate::ship::{Ship, ShipState};
 use crate::time_system::GameClock;
-use crate::ui::ship_view::{ShipView, ShipViewTiming, ship_view};
+use crate::ui::ship_view::{ShipView, ShipViewTiming, ship_view_with_timing};
 
 use super::tab::{OngoingTab, TabBadge, TabMeta};
 use super::types::{Event, EventKind, EventSource, Severity};
@@ -147,113 +148,34 @@ fn resolve_player_empire(world: &World) -> Option<Entity> {
     q.iter(world).next().map(|(e, _)| e)
 }
 
-/// Build a `ShipViewTiming` from an own-empire `ShipProjection`.
-///
-/// `origin_tick = projection.dispatched_at` (= dispatcher's command
-/// tick, light-coherent with the player UI). `expected_tick =
-/// projection.expected_arrival_at`.
-fn timing_from_projection(projection: &ShipProjection) -> ShipViewTiming {
-    ShipViewTiming {
-        origin_tick: projection.dispatched_at,
-        expected_tick: projection.expected_arrival_at,
-    }
+/// #491 PR-4 follow-up: source-resolved viewing context. The
+/// situation_center collects events from the player empire's
+/// perspective by default; in observer mode we want ground truth
+/// (= realtime ECS), so we pass `None` for both the `KnowledgeStore`
+/// and the viewing empire — `ship_view_with_timing` then falls
+/// through to `realtime_state_to_snapshot`.
+struct ViewingContext<'a> {
+    knowledge: Option<&'a KnowledgeStore>,
+    empire: Option<Entity>,
 }
 
-/// Build a `ShipViewTiming` from a foreign-empire `ShipSnapshot`.
-///
-/// `origin_tick = snapshot.observed_at` (= the tick at which the
-/// viewing empire first / last learned of this state). `ShipSnapshot`
-/// does not carry an explicit ETA today; the foreign-ship progress
-/// bar therefore stays open-ended (`expected_tick = None`). When a
-/// future light-coherent ETA propagation lands this is the helper to
-/// update.
-fn timing_from_snapshot(snapshot: &ShipSnapshot) -> ShipViewTiming {
-    ShipViewTiming {
-        origin_tick: snapshot.observed_at,
-        expected_tick: None,
+fn resolve_viewing_context(world: &World) -> ViewingContext<'_> {
+    let observer_mode_enabled = world
+        .get_resource::<ObserverMode>()
+        .map(|o| o.enabled)
+        .unwrap_or(false);
+    if observer_mode_enabled {
+        // Observer mode: omniscient view = realtime ECS = ground truth.
+        // Mirrors the gate pattern in outline-tree (#487), ship-panel
+        // (#491 PR-2), and map tooltip (#491 PR-6) observer paths.
+        return ViewingContext {
+            knowledge: None,
+            empire: None,
+        };
     }
-}
-
-/// Build a `ShipViewTiming` from the realtime ECS `ShipState` for the
-/// no-`KnowledgeStore` fallback path (early Startup before empires are
-/// wired). Equivalent to the pre-#491 behaviour.
-fn timing_from_realtime(state: &ShipState) -> ShipViewTiming {
-    match state {
-        ShipState::SubLight {
-            departed_at,
-            arrival_at,
-            ..
-        }
-        | ShipState::InFTL {
-            departed_at,
-            arrival_at,
-            ..
-        } => ShipViewTiming {
-            origin_tick: *departed_at,
-            expected_tick: Some(*arrival_at),
-        },
-        ShipState::Surveying {
-            started_at,
-            completes_at,
-            ..
-        }
-        | ShipState::Scouting {
-            started_at,
-            completes_at,
-            ..
-        }
-        | ShipState::Settling {
-            started_at,
-            completes_at,
-            ..
-        }
-        | ShipState::Refitting {
-            started_at,
-            completes_at,
-            ..
-        } => ShipViewTiming {
-            origin_tick: *started_at,
-            expected_tick: Some(*completes_at),
-        },
-        ShipState::InSystem { .. } | ShipState::Loitering { .. } => ShipViewTiming {
-            origin_tick: 0,
-            expected_tick: None,
-        },
-    }
-}
-
-/// Resolve the timing for a ship from its ShipView source path.
-///
-/// * Own ship + projection present → `timing_from_projection`
-/// * Foreign ship + snapshot present → `timing_from_snapshot`
-/// * No `KnowledgeStore` (early Startup) → `timing_from_realtime`
-///
-/// Returns `None` only when the projection / snapshot is absent in a
-/// path that should have one (caller already filters those via
-/// `ship_view` returning `None`); callers can default to "no ETA"
-/// when this happens.
-fn ship_view_timing(
-    ship_entity: Entity,
-    ship: &Ship,
-    state: &ShipState,
-    viewing_knowledge: Option<&KnowledgeStore>,
-    viewing_empire: Option<Entity>,
-) -> ShipViewTiming {
-    let Some(store) = viewing_knowledge else {
-        return timing_from_realtime(state);
-    };
-    if let Owner::Empire(owner) = ship.owner
-        && Some(owner) == viewing_empire
-    {
-        return store
-            .get_projection(ship_entity)
-            .map(timing_from_projection)
-            .unwrap_or_else(|| timing_from_realtime(state));
-    }
-    store
-        .get_ship(ship_entity)
-        .map(timing_from_snapshot)
-        .unwrap_or_else(|| timing_from_realtime(state))
+    let empire = resolve_player_empire(world);
+    let knowledge = empire.and_then(|e| world.entity(e).get::<KnowledgeStore>());
+    ViewingContext { knowledge, empire }
 }
 
 fn collect_ship_events(world: &World) -> Vec<Event> {
@@ -261,8 +183,7 @@ fn collect_ship_events(world: &World) -> Vec<Event> {
     let now = clock.elapsed;
     let hostiles = hostile_systems(world);
 
-    let viewing_empire = resolve_player_empire(world);
-    let viewing_knowledge = viewing_empire.and_then(|e| world.entity(e).get::<KnowledgeStore>());
+    let ctx = resolve_viewing_context(world);
 
     let mut buckets: HashMap<Category, Vec<Event>> = HashMap::new();
 
@@ -276,16 +197,20 @@ fn collect_ship_events(world: &World) -> Vec<Event> {
             // #491 PR-4: route the ship through the viewing empire's
             // KnowledgeStore. Own = projection, foreign = snapshot,
             // no-store = realtime fallback.
-            let Some(view) = ship_view(ship_entity, ship, state, viewing_knowledge, viewing_empire)
+            //
+            // #491 PR-4 follow-up: replaced the local
+            // `(ship_view + ship_view_timing)` two-step with the
+            // hoisted `ship_view_with_timing` helper so the ladder
+            // cannot drift from the canonical implementation in
+            // `crate::knowledge::ship_view`.
+            let Some((view, timing)) =
+                ship_view_with_timing(ship_entity, ship, state, ctx.knowledge, ctx.empire)
             else {
                 // No projection / snapshot for this ship — skip rather
                 // than render stale realtime ECS state. Mirrors the
                 // outline-tree contract (#487).
                 continue;
             };
-
-            let timing =
-                ship_view_timing(ship_entity, ship, state, viewing_knowledge, viewing_empire);
 
             let Some((category, state_label, eta, started_at)) =
                 classify_view(&view, &timing, &hostiles, now)
@@ -345,8 +270,7 @@ fn summarise_ships(world: &World) -> ShipSummary {
     let clock = world.resource::<GameClock>();
     let now = clock.elapsed;
 
-    let viewing_empire = resolve_player_empire(world);
-    let viewing_knowledge = viewing_empire.and_then(|e| world.entity(e).get::<KnowledgeStore>());
+    let ctx = resolve_viewing_context(world);
 
     if let Some(mut q) = world.try_query::<(Entity, &Ship, &ShipState)>() {
         for (ship_entity, ship, state) in q.iter(world) {
@@ -355,13 +279,14 @@ fn summarise_ships(world: &World) -> ShipSummary {
                 continue;
             }
 
-            let Some(view) = ship_view(ship_entity, ship, state, viewing_knowledge, viewing_empire)
+            // #491 PR-4 follow-up: same hoisted-helper rewire as
+            // `collect_ship_events` so the badge count and the tree
+            // contents cannot drift.
+            let Some((view, timing)) =
+                ship_view_with_timing(ship_entity, ship, state, ctx.knowledge, ctx.empire)
             else {
                 continue;
             };
-
-            let timing =
-                ship_view_timing(ship_entity, ship, state, viewing_knowledge, viewing_empire);
 
             let Some((category, _, _, _)) = classify_view(&view, &timing, &hostiles, now) else {
                 continue;

--- a/macrocosmo/tests/situation_center_ftl_leak.rs
+++ b/macrocosmo/tests/situation_center_ftl_leak.rs
@@ -536,3 +536,106 @@ fn ship_ops_tab_summary_reflects_projection() {
     let badge = tab.badge(app.world()).expect("badge");
     assert_eq!(badge.count, 3);
 }
+
+// ---------------------------------------------------------------------------
+// 6. Observer mode — ground truth (= realtime ECS) drives the classifier
+// ---------------------------------------------------------------------------
+
+/// In observer mode the player has omniscient view: the situation_center
+/// must classify ships from the realtime ECS state (ground truth), NOT
+/// the player empire's lagging projection. Mirrors the gate pattern in
+/// the outline tree (#487), ship-panel (#491 PR-2), and map tooltip
+/// (#491 PR-6) observer paths.
+///
+/// Setup: own ship dispatched to a remote system. Projection still says
+/// `InSystem`; realtime ECS already has `InFTL`. With observer mode
+/// **disabled** the tab shows "docked" (= projection); with observer
+/// mode **enabled** the tab shows "in FTL" (= realtime).
+#[test]
+fn ship_ops_tab_observer_mode_uses_realtime() {
+    use macrocosmo::observer::ObserverMode;
+
+    let mut app = test_app();
+    let empire = spawn_minimal_player_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [50.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    // Lagging projection: still believed at home.
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(10),
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::InSystem,
+            projected_system: Some(home),
+            intended_state: None,
+            intended_system: None,
+            intended_takes_effect_at: None,
+        });
+    }
+
+    // Realtime: ship has actually entered FTL.
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::InFTL {
+            origin_system: home,
+            destination_system: frontier,
+            departed_at: 0,
+            arrival_at: 5,
+        },
+    );
+
+    let tab = ShipOperationsTab;
+
+    // 1) Observer mode disabled (default = absent resource): classifier
+    //    follows projection. Ship is "docked" (Other), not "in FTL"
+    //    (Travel).
+    {
+        let leaves = flatten_ship_leaves(&tab.collect(app.world()));
+        let kinds: Vec<EventKind> = leaves.iter().map(|(_, k)| *k).collect();
+        assert!(
+            kinds.contains(&EventKind::Other),
+            "player-mode classifier must surface projection (Other / docked). Got: {:?}",
+            leaves
+        );
+        assert!(
+            !kinds.contains(&EventKind::Travel),
+            "player-mode classifier must NOT surface realtime FTL. Got: {:?}",
+            leaves
+        );
+    }
+
+    // 2) Observer mode enabled: classifier falls through to realtime
+    //    ECS. Ship is "in FTL" (Travel), not "docked" (Other).
+    app.world_mut().insert_resource(ObserverMode {
+        enabled: true,
+        ..Default::default()
+    });
+    {
+        let leaves = flatten_ship_leaves(&tab.collect(app.world()));
+        let kinds: Vec<EventKind> = leaves.iter().map(|(_, k)| *k).collect();
+        assert!(
+            kinds.contains(&EventKind::Travel),
+            "observer-mode classifier must surface realtime FTL (Travel / 'in FTL'). Got: {:?}",
+            leaves
+        );
+        assert!(
+            !kinds.contains(&EventKind::Other),
+            "observer-mode classifier must NOT use the lagging projection. Got: {:?}",
+            leaves
+        );
+    }
+}

--- a/macrocosmo/tests/situation_center_ftl_leak.rs
+++ b/macrocosmo/tests/situation_center_ftl_leak.rs
@@ -1,0 +1,538 @@
+//! #491 PR-4: The Situation Center "Ship Operations" tab must not leak
+//! the realtime ECS [`ShipState`] for own-empire ships. The classifier
+//! routes through the viewing empire's [`KnowledgeStore`] — projections
+//! for own ships, snapshots for foreign ships — exactly the way the
+//! outline tree does (#487, `outline_tree_ftl_leak.rs`).
+//!
+//! These tests pin the **classifier** layer
+//! (`ShipOperationsTab::collect` / `badge`) by spawning ships +
+//! projections / snapshots and asserting the produced
+//! [`crate::ui::situation_center::Event`] tree.
+
+mod common;
+
+use bevy::prelude::*;
+
+use macrocosmo::knowledge::{
+    KnowledgeStore, ObservationSource, ShipProjection, ShipSnapshot, ShipSnapshotState,
+};
+use macrocosmo::player::{Empire, Faction, PlayerEmpire};
+use macrocosmo::ship::fleet::{Fleet, FleetMembers};
+use macrocosmo::ship::{
+    Cargo, CommandQueue, Owner, RulesOfEngagement, Ship, ShipHitpoints, ShipModifiers, ShipState,
+};
+use macrocosmo::ui::situation_center::{EventKind, OngoingTab, ShipOperationsTab};
+
+use common::{spawn_test_system, test_app};
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror the outline_tree_ftl_leak fixtures)
+// ---------------------------------------------------------------------------
+
+fn spawn_minimal_player_empire(app: &mut App) -> Entity {
+    app.world_mut()
+        .spawn((
+            Empire {
+                name: "Test".into(),
+            },
+            PlayerEmpire,
+            Faction {
+                id: "ship_ops_test".into(),
+                name: "Test".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+            KnowledgeStore::default(),
+            macrocosmo::knowledge::SystemVisibilityMap::default(),
+        ))
+        .id()
+}
+
+fn spawn_foreign_empire(app: &mut App) -> Entity {
+    app.world_mut()
+        .spawn((
+            Empire {
+                name: "Foreign".into(),
+            },
+            Faction {
+                id: "foreign".into(),
+                name: "Foreign".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+            KnowledgeStore::default(),
+            macrocosmo::knowledge::SystemVisibilityMap::default(),
+        ))
+        .id()
+}
+
+/// Hand-rolled ship spawn — avoids pulling in the design registry. Only
+/// the `Ship`/`ShipState`/owner Components matter for the classifier.
+fn spawn_test_ship(world: &mut World, name: &str, owner: Entity, system: Entity) -> Entity {
+    let ship_entity = world.spawn_empty().id();
+    let fleet_entity = world.spawn_empty().id();
+    world.entity_mut(ship_entity).insert((
+        Ship {
+            name: name.into(),
+            design_id: "explorer_mk1".into(),
+            hull_id: "frigate".into(),
+            modules: Vec::new(),
+            owner: Owner::Empire(owner),
+            sublight_speed: 1.0,
+            ftl_range: 5.0,
+            ruler_aboard: false,
+            home_port: system,
+            design_revision: 0,
+            fleet: Some(fleet_entity),
+        },
+        ShipState::InSystem { system },
+        ShipHitpoints {
+            hull: 100.0,
+            hull_max: 100.0,
+            armor: 0.0,
+            armor_max: 0.0,
+            shield: 0.0,
+            shield_max: 0.0,
+            shield_regen: 0.0,
+        },
+        CommandQueue::default(),
+        Cargo::default(),
+        ShipModifiers::default(),
+        macrocosmo::ship::ShipStats::default(),
+        RulesOfEngagement::default(),
+    ));
+    world.entity_mut(fleet_entity).insert((
+        Fleet {
+            name: name.into(),
+            flagship: Some(ship_entity),
+        },
+        FleetMembers(vec![ship_entity]),
+    ));
+    ship_entity
+}
+
+fn set_ship_state(world: &mut World, ship: Entity, new_state: ShipState) {
+    *world.get_mut::<ShipState>(ship).unwrap() = new_state;
+}
+
+/// Recursively flatten an event tree to all leaves with a non-`None` source.
+/// Returns `(label, kind)` tuples. Used for assertions that don't care
+/// about the per-category roll-up structure.
+fn flatten_ship_leaves(
+    events: &[macrocosmo::ui::situation_center::Event],
+) -> Vec<(String, EventKind)> {
+    let mut out = Vec::new();
+    for e in events {
+        if e.children.is_empty() {
+            if matches!(
+                e.source,
+                macrocosmo::ui::situation_center::EventSource::Ship(_)
+            ) {
+                out.push((e.label.clone(), e.kind));
+            }
+        } else {
+            out.extend(flatten_ship_leaves(&e.children));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// 1. FTL leak regression — own ship, projection InSystem, realtime SubLight
+// ---------------------------------------------------------------------------
+
+/// At dispatcher tick T+1 after dispatching a sublight move at T, the
+/// realtime ECS state has the ship in `SubLight` — but the projection
+/// still says `InSystem`. The Ship Operations tab must classify the
+/// ship as `Other` ("docked"), NOT `Travel` ("sublight transit").
+#[test]
+fn ship_ops_tab_classifier_uses_projection() {
+    let mut app = test_app();
+    let empire = spawn_minimal_player_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [50.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+
+    let ship = spawn_test_ship(app.world_mut(), "Explorer-1", empire, home);
+
+    // Projection: ship still believed at home (= dispatcher's tick has
+    // not yet reached the ship from its POV).
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(10),
+            expected_return_at: Some(20),
+            projected_state: ShipSnapshotState::InSystem,
+            projected_system: Some(home),
+            intended_state: Some(ShipSnapshotState::InTransitSubLight),
+            intended_system: Some(frontier),
+            intended_takes_effect_at: Some(5),
+        });
+    }
+
+    // Realtime ECS advances ahead of the projection (the FTL leak window).
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::SubLight {
+            origin: [0.0, 0.0, 0.0],
+            destination: [50.0, 0.0, 0.0],
+            target_system: Some(frontier),
+            departed_at: 0,
+            arrival_at: 50,
+        },
+    );
+
+    let tab = ShipOperationsTab;
+    let events = tab.collect(app.world());
+    let leaves = flatten_ship_leaves(&events);
+
+    assert_eq!(leaves.len(), 1, "exactly one ship leaf expected");
+    let (label, kind) = &leaves[0];
+    assert_eq!(
+        *kind,
+        EventKind::Other,
+        "FTL leak regression: projection says InSystem → Other category, got {:?} (label={})",
+        kind,
+        label
+    );
+    assert!(
+        label.contains("docked"),
+        "leaf must read 'docked', not 'sublight transit'. label={}",
+        label
+    );
+    assert!(
+        !label.contains("sublight") && !label.contains("FTL"),
+        "leaf must not surface realtime transit terms. label={}",
+        label
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. InTransitFTL classifier — distinct label
+// ---------------------------------------------------------------------------
+
+/// Once `poll_pending_routes` upgrades the projection to `InTransitFTL`,
+/// the classifier must surface "in FTL" — distinct from sublight
+/// transit so the player can see the FTL/SubLight distinction.
+#[test]
+fn ship_ops_tab_classifies_intransit_ftl_distinctly() {
+    let mut app = test_app();
+    let empire = spawn_minimal_player_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [50.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+
+    let ship = spawn_test_ship(app.world_mut(), "FTL-Cruiser", empire, home);
+
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: Some(10),
+            expected_return_at: Some(20),
+            projected_state: ShipSnapshotState::InTransitFTL,
+            projected_system: Some(frontier),
+            intended_state: Some(ShipSnapshotState::Surveying),
+            intended_system: Some(frontier),
+            intended_takes_effect_at: Some(10),
+        });
+    }
+    // Realtime: actually in FTL (= confluent with projection).
+    set_ship_state(
+        app.world_mut(),
+        ship,
+        ShipState::InFTL {
+            origin_system: home,
+            destination_system: frontier,
+            departed_at: 0,
+            arrival_at: 10,
+        },
+    );
+
+    let tab = ShipOperationsTab;
+    let events = tab.collect(app.world());
+    let leaves = flatten_ship_leaves(&events);
+
+    assert_eq!(leaves.len(), 1);
+    let (label, kind) = &leaves[0];
+    assert_eq!(*kind, EventKind::Travel);
+    assert!(
+        label.contains("in FTL"),
+        "InTransitFTL must surface 'in FTL', got {:?}",
+        label
+    );
+    assert!(
+        !label.contains("sublight"),
+        "FTL ship must not be labelled sublight, got {:?}",
+        label
+    );
+
+    // ETA lifted from projection.expected_arrival_at.
+    let leaf = events
+        .iter()
+        .flat_map(|e| e.children.iter())
+        .next()
+        .expect("travel leaf");
+    assert_eq!(leaf.eta, Some(10), "ETA must come from projection");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Foreign ship — uses snapshot
+// ---------------------------------------------------------------------------
+
+/// Foreign ships flow through `ship_snapshots`. The classifier must
+/// surface the snapshot's `last_known_state`, not the realtime ECS.
+#[test]
+fn ship_ops_tab_foreign_ship_uses_snapshot() {
+    let mut app = test_app();
+    let viewing = spawn_minimal_player_empire(&mut app);
+    let foreign = spawn_foreign_empire(&mut app);
+
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let foreign_sys = spawn_test_system(
+        app.world_mut(),
+        "ForeignSys",
+        [100.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+
+    let foreign_ship = spawn_test_ship(app.world_mut(), "EnemyScout", foreign, foreign_sys);
+
+    // Viewing empire's snapshot says "surveying".
+    {
+        let mut em = app.world_mut().entity_mut(viewing);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_ship(ShipSnapshot {
+            entity: foreign_ship,
+            name: "EnemyScout".into(),
+            design_id: "explorer_mk1".into(),
+            last_known_state: ShipSnapshotState::Surveying,
+            last_known_system: Some(foreign_sys),
+            observed_at: 0,
+            hp: 100.0,
+            hp_max: 100.0,
+            source: ObservationSource::Direct,
+        });
+    }
+
+    // Realtime moves on — snapshot must dominate.
+    set_ship_state(
+        app.world_mut(),
+        foreign_ship,
+        ShipState::InSystem { system: home },
+    );
+
+    let tab = ShipOperationsTab;
+    let events = tab.collect(app.world());
+    let leaves = flatten_ship_leaves(&events);
+
+    assert_eq!(leaves.len(), 1, "foreign ship must surface via snapshot");
+    let (label, kind) = &leaves[0];
+    assert_eq!(*kind, EventKind::Survey);
+    assert!(
+        label.contains("surveying"),
+        "snapshot says Surveying, got {:?}",
+        label
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Destroyed projection — filtered out
+// ---------------------------------------------------------------------------
+
+/// `Destroyed` and `Missing` are non-actionable terminal states — the
+/// classifier filters them out so they don't inflate the badge count.
+#[test]
+fn ship_ops_tab_destroyed_ship_filtered_out() {
+    let mut app = test_app();
+    let empire = spawn_minimal_player_empire(&mut app);
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+
+    let ship = spawn_test_ship(app.world_mut(), "Doomed", empire, home);
+
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: ship,
+            dispatched_at: 0,
+            expected_arrival_at: None,
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::Destroyed,
+            projected_system: None,
+            intended_state: None,
+            intended_system: None,
+            intended_takes_effect_at: None,
+        });
+    }
+
+    let tab = ShipOperationsTab;
+    let events = tab.collect(app.world());
+    let leaves = flatten_ship_leaves(&events);
+
+    assert!(
+        leaves.is_empty(),
+        "Destroyed projection must not surface in Ship Operations tab. Leaves: {:?}",
+        leaves
+    );
+
+    // Badge must also drop the Destroyed ship — total count = 0 → no badge.
+    assert!(
+        tab.badge(app.world()).is_none(),
+        "badge must be None when only ship is Destroyed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Mixed fleet — summary reflects projection-mediated view
+// ---------------------------------------------------------------------------
+
+/// Three ships across own/foreign/destroyed paths. The summary
+/// (= badge counts) must match the projection-/snapshot-mediated
+/// classification, not the realtime ECS state.
+#[test]
+fn ship_ops_tab_summary_reflects_projection() {
+    let mut app = test_app();
+    let player = spawn_minimal_player_empire(&mut app);
+    let foreign = spawn_foreign_empire(&mut app);
+
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [50.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let foreign_sys = spawn_test_system(
+        app.world_mut(),
+        "ForeignSys",
+        [100.0, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+
+    // Own ship #1: projection says InTransitFTL → Travel.
+    let own_ftl = spawn_test_ship(app.world_mut(), "Own-FTL", player, home);
+    // Own ship #2: projection says InSystem (= docked, despite realtime SubLight).
+    let own_docked = spawn_test_ship(app.world_mut(), "Own-Docked", player, home);
+    // Own ship #3: Destroyed projection — filtered out.
+    let own_destroyed = spawn_test_ship(app.world_mut(), "Own-Doomed", player, home);
+    // Foreign ship: snapshot says Surveying → Survey.
+    let foreign_ship = spawn_test_ship(app.world_mut(), "Foreign-Scout", foreign, foreign_sys);
+
+    {
+        let mut em = app.world_mut().entity_mut(player);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update_projection(ShipProjection {
+            entity: own_ftl,
+            dispatched_at: 0,
+            expected_arrival_at: Some(10),
+            expected_return_at: Some(20),
+            projected_state: ShipSnapshotState::InTransitFTL,
+            projected_system: Some(frontier),
+            intended_state: None,
+            intended_system: None,
+            intended_takes_effect_at: None,
+        });
+        store.update_projection(ShipProjection {
+            entity: own_docked,
+            dispatched_at: 0,
+            expected_arrival_at: None,
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::InSystem,
+            projected_system: Some(home),
+            intended_state: None,
+            intended_system: None,
+            intended_takes_effect_at: None,
+        });
+        store.update_projection(ShipProjection {
+            entity: own_destroyed,
+            dispatched_at: 0,
+            expected_arrival_at: None,
+            expected_return_at: None,
+            projected_state: ShipSnapshotState::Destroyed,
+            projected_system: None,
+            intended_state: None,
+            intended_system: None,
+            intended_takes_effect_at: None,
+        });
+        store.update_ship(ShipSnapshot {
+            entity: foreign_ship,
+            name: "Foreign-Scout".into(),
+            design_id: "explorer_mk1".into(),
+            last_known_state: ShipSnapshotState::Surveying,
+            last_known_system: Some(foreign_sys),
+            observed_at: 0,
+            hp: 100.0,
+            hp_max: 100.0,
+            source: ObservationSource::Direct,
+        });
+    }
+
+    // Realtime ECS leaks — own-docked is actually SubLight, own-ftl
+    // realtime says InSystem (= reconcile lag). Classifier must read
+    // projection.
+    set_ship_state(
+        app.world_mut(),
+        own_docked,
+        ShipState::SubLight {
+            origin: [0.0, 0.0, 0.0],
+            destination: [50.0, 0.0, 0.0],
+            target_system: Some(frontier),
+            departed_at: 0,
+            arrival_at: 50,
+        },
+    );
+
+    let tab = ShipOperationsTab;
+    let events = tab.collect(app.world());
+    let leaves = flatten_ship_leaves(&events);
+
+    // 4 ships spawned, 1 destroyed → 3 visible leaves.
+    assert_eq!(
+        leaves.len(),
+        3,
+        "expect 3 leaves (FTL + docked + foreign survey); destroyed filtered. Got: {:?}",
+        leaves
+    );
+
+    let by_kind: Vec<EventKind> = leaves.iter().map(|(_, k)| *k).collect();
+    let travel_count = by_kind.iter().filter(|k| **k == EventKind::Travel).count();
+    let survey_count = by_kind.iter().filter(|k| **k == EventKind::Survey).count();
+    let other_count = by_kind.iter().filter(|k| **k == EventKind::Other).count();
+    assert_eq!(travel_count, 1, "1 Travel leaf (Own-FTL via projection)");
+    assert_eq!(
+        survey_count, 1,
+        "1 Survey leaf (Foreign-Scout via snapshot)"
+    );
+    assert_eq!(
+        other_count, 1,
+        "1 Other leaf (Own-Docked via projection InSystem)"
+    );
+
+    let badge = tab.badge(app.world()).expect("badge");
+    assert_eq!(badge.count, 3);
+}


### PR DESCRIPTION
## Summary

- Replace realtime `ShipState` classifier in `collect_ship_events` / `summarise_ships` with projection-mediated `ShipView`
- New `classify_view` operates on `ShipSnapshotState` instead of `ShipState`
- `InTransitSubLight` / `InTransitFTL` rendered as distinct categories
- own = projection, foreign = snapshot, no-store = realtime fallback

Closes #491 (sub-PR 4 of 5).

## Test plan

- [x] New `tests/situation_center_ftl_leak.rs` (5 cases)
- [x] `cargo test` 全 green
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)