### PR TITLE
fix(ui): #499 observer mode honours empire-view contract via viewing empire's KnowledgeStore

### DIFF
--- a/macrocosmo/src/knowledge/ship_view.rs
+++ b/macrocosmo/src/knowledge/ship_view.rs
@@ -301,22 +301,19 @@ pub fn realtime_state_to_snapshot(state: &ShipState) -> (ShipSnapshotState, Opti
 ///   the viewing empire's [`KnowledgeStore::ship_snapshots`]. Unchanged
 ///   from the pre-#487 contract (it was already snapshot-mediated).
 /// * **Observer mode** (= empire-view, viewing as another empire): the
-///   *intended* contract is "treat identically to own-empire normal
-///   play — projection / snapshot of the **viewing empire**" (= the
-///   observed empire whose perspective the player is borrowing). The
-///   caller would pass the observed empire as `viewing_empire`. A
-///   separate omniscient (god-view) mode is the right way to expose
-///   realtime ground truth (#490, follow-up).
+///   contract is "treat identically to own-empire normal play —
+///   projection / snapshot of the **viewing empire**" (= the observed
+///   empire whose perspective the player is borrowing). The caller
+///   MUST pass the `ObserverView.viewing` empire as `viewing_empire`
+///   and its `KnowledgeStore` as `viewing_knowledge`; passing `None`
+///   in observer mode is reserved for the future omniscient (god-view)
+///   mode (#490), not "ground-truth fallback".
 ///
-///   **Production drift**: the current `ui::mod::draw_outline_and_tooltips_system`
-///   caller passes `viewing_knowledge = None` whenever observer mode is
-///   active, which falls through to the realtime ECS path below
-///   (= ground-truth, not the empire-view contract above). This is
-///   tracked as a follow-up to #440 (observer mode design); the helper
-///   itself supports both contracts via the no-store fallback, so
-///   migrating the call site is a one-line change once the design is
-///   finalised. Tests that pin the empire-view contract still pass
-///   because they construct `viewing_knowledge = Some(...)` explicitly.
+///   Callers resolve the empire via `ui::mod::resolve_ui_empire` (Query)
+///   or `crate::observer::resolve_viewing_empire` (`&World`), and pipe
+///   the store through `ui::mod::resolve_viewing_knowledge` /
+///   `empire_view_knowledge` to enforce the invariant at a single
+///   change point.
 /// * **No `KnowledgeStore` resolved** (early Startup frames before
 ///   empires are wired): fall back to realtime ECS state — there's no
 ///   light-coherent view to use yet.

--- a/macrocosmo/src/observer/mod.rs
+++ b/macrocosmo/src/observer/mod.rs
@@ -40,14 +40,20 @@ pub struct ObserverMode {
     pub read_only: bool,
 }
 
-/// Current faction the observer is inspecting. One-way mirrored to
+/// Current empire the observer is inspecting. One-way mirrored to
 /// `AiDebugUi::governor::GovernorState::faction` so the F10 panel follows
 /// the top-bar selector.
 #[derive(Resource, Debug, Clone, Default, Reflect)]
 #[reflect(Resource)]
 pub struct ObserverView {
-    /// The `Faction` entity being focused. `None` until the selector has
+    /// The `Empire` entity being focused. `None` until the selector has
     /// been initialised from the spawned empire list.
+    ///
+    /// Despite the historical naming (the field outlived an earlier
+    /// design where focus was stored as a `Faction` entity), the
+    /// initialiser (`setup::init_observer_view`) queries
+    /// `With<Empire>` and the top-bar selector iterates `With<Empire>`,
+    /// so consumers can dereference this as an Empire entity.
     pub viewing: Option<Entity>,
 }
 
@@ -56,6 +62,28 @@ pub struct ObserverView {
 #[derive(Resource, Debug, Clone, Copy, Default, Reflect)]
 #[reflect(Resource)]
 pub struct RngSeed(pub Option<u64>);
+
+/// #499: Resolve the viewing empire entity from a `&World`. Returns
+/// the `ObserverView`-selected empire when observer mode is enabled,
+/// otherwise the (singleton) `PlayerEmpire`. Returns `None` during
+/// early Startup before either is wired.
+///
+/// This is the single source of truth for the empire-view contract
+/// across `&World`-accessing call sites (e.g. `situation_center`
+/// tabs). The Query-based mirror is `ui::mod::resolve_ui_empire_raw`,
+/// kept identical in spirit; if the contract changes (e.g. #490 adds
+/// an `Omniscient` mode), update both in lockstep.
+pub fn resolve_viewing_empire(world: &World) -> Option<Entity> {
+    let observer_enabled = world
+        .get_resource::<ObserverMode>()
+        .map(|o| o.enabled)
+        .unwrap_or(false);
+    if observer_enabled {
+        return world.get_resource::<ObserverView>()?.viewing;
+    }
+    let mut q = world.try_query::<(Entity, &crate::player::PlayerEmpire)>()?;
+    q.iter(world).next().map(|(e, _)| e)
+}
 
 /// Run-condition: observer mode is active.
 pub fn in_observer_mode(o: Res<ObserverMode>) -> bool {

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -344,6 +344,89 @@ mod font_tests {
     }
 }
 
+#[cfg(test)]
+mod empire_view_tests {
+    use super::{empire_view_knowledge, resolve_viewing_knowledge};
+    use crate::knowledge::KnowledgeStore;
+    use crate::player::{Empire, Faction, PlayerEmpire};
+    use bevy::ecs::system::SystemState;
+    use bevy::prelude::*;
+
+    fn spawn_empire(world: &mut World, name: &str, is_player: bool) -> Entity {
+        let mut e = world.spawn((
+            Empire {
+                name: name.into(),
+            },
+            Faction {
+                id: name.to_lowercase(),
+                name: name.into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+            KnowledgeStore::default(),
+        ));
+        if is_player {
+            e.insert(PlayerEmpire);
+        }
+        e.id()
+    }
+
+    /// #499 invariant: `resolve_viewing_knowledge(Some(empire), q)`
+    /// returns the `KnowledgeStore` of THAT empire, even if multiple
+    /// `Empire` entities exist. Same store regardless of whether the
+    /// entity is the `PlayerEmpire` or a non-player observed empire.
+    #[test]
+    fn resolves_to_passed_empires_knowledge_store_in_observer_mode() {
+        let mut world = World::new();
+        let _player = spawn_empire(&mut world, "Player", true);
+        let observed = spawn_empire(&mut world, "Observed", false);
+
+        let mut state: SystemState<Query<&KnowledgeStore, With<Empire>>> =
+            SystemState::new(&mut world);
+        let q = state.get(&world);
+
+        let resolved = resolve_viewing_knowledge(Some(observed), &q);
+        assert!(
+            resolved.is_some(),
+            "viewing the observed empire must surface its KnowledgeStore"
+        );
+
+        // Sanity: the resolved store is the SAME memory the observed
+        // empire holds (pointer equality through deref).
+        let observed_store = world
+            .entity(observed)
+            .get::<KnowledgeStore>()
+            .expect("observed has store");
+        assert!(std::ptr::eq(resolved.unwrap(), observed_store));
+    }
+
+    /// #499: `None` empire (= no `PlayerEmpire`, no `ObserverView`
+    /// selection yet) yields `None` knowledge — the helper's safe
+    /// early-Startup escape.
+    #[test]
+    fn empty_empire_yields_none() {
+        let mut world = World::new();
+        let _ = spawn_empire(&mut world, "Lonely", false);
+        let mut state: SystemState<Query<&KnowledgeStore, With<Empire>>> =
+            SystemState::new(&mut world);
+        let q = state.get(&world);
+        assert!(resolve_viewing_knowledge(None, &q).is_none());
+    }
+
+    /// #499: `empire_view_knowledge` is the sibling helper for callers
+    /// that have already resolved the `KnowledgeStore` via a multi-
+    /// component query. Today it just wraps in `Some(_)`; the test
+    /// pins the contract so a future omniscient (#490) branch lands
+    /// exclusively in this helper.
+    #[test]
+    fn empire_view_knowledge_wraps_in_some() {
+        let store = KnowledgeStore::default();
+        let resolved = empire_view_knowledge(&store);
+        assert!(resolved.is_some());
+        assert!(std::ptr::eq(resolved.unwrap(), &store));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // #417: Helper to resolve the "active empire" entity for UI purposes.
 // In normal play this is the PlayerEmpire entity; in observer mode it is
@@ -365,6 +448,48 @@ fn resolve_ui_empire_raw(
 /// Convenience wrapper that extracts the active empire from an [`ObserverUiState`].
 fn resolve_ui_empire(obs: &ObserverUiState) -> Option<Entity> {
     resolve_ui_empire_raw(&obs.player_empire_q, &obs.observer_mode, &obs.observer_view)
+}
+
+/// #499: Resolve the viewing empire's `KnowledgeStore` from a query of
+/// all empire stores (e.g. `draw_outline_and_tooltips_system`). The
+/// produced `Option<&KnowledgeStore>` feeds straight into
+/// [`crate::knowledge::ship_view::ship_view`]'s `viewing_knowledge`
+/// argument.
+///
+/// **Caller invariant**: pass `empire` as the entity returned by
+/// [`resolve_ui_empire`] / [`resolve_ui_empire_raw`] (= the
+/// `PlayerEmpire` in normal play, the `ObserverView`-selected empire
+/// in observer mode).
+///
+/// **Future-mode hook (#490 Omniscient)**: when the omniscient
+/// (god-view) mode lands, this helper is one of two single change
+/// points (sibling: [`empire_view_knowledge`]) where the empire-view
+/// contract branches to return `None` for omniscient callers (=
+/// realtime ECS ground truth).
+pub(crate) fn resolve_viewing_knowledge<'a>(
+    empire: Option<Entity>,
+    q: &'a Query<&KnowledgeStore, With<crate::player::Empire>>,
+) -> Option<&'a KnowledgeStore> {
+    empire.and_then(|e| q.get(e).ok())
+}
+
+/// #499: Wrap a pre-resolved viewing-empire `KnowledgeStore` in the
+/// `Option<&KnowledgeStore>` shape expected by panel helpers.
+///
+/// Used by `draw_main_panels_system`, where the viewing empire's
+/// `KnowledgeStore` is already destructured out of a multi-component
+/// `empire_q.get(empire_entity)` and passed to multiple panels
+/// (ship-panel / context-menu / camera-centering). The wrapper is
+/// trivial today (`Some(knowledge)`); its job is to pin the linkage
+/// between those panel call sites and the empire-view contract so a
+/// future re-introduction of an observer-mode gate is centralised.
+///
+/// **Future-mode hook (#490 Omniscient)**: sibling to
+/// [`resolve_viewing_knowledge`]. The omniscient branch lands here
+/// when the panels are reached with a resolved knowledge already in
+/// hand.
+pub(crate) fn empire_view_knowledge(knowledge: &KnowledgeStore) -> Option<&KnowledgeStore> {
+    Some(knowledge)
 }
 
 // ---------------------------------------------------------------------------
@@ -950,14 +1075,14 @@ fn draw_outline_and_tooltips_system(
     let Ok(ctx) = contexts.ctx_mut() else {
         return;
     };
-    // #417: In observer mode, show ground truth (no KnowledgeStore delay).
-    // In normal play, use the PlayerEmpire's KnowledgeStore.
+    // #499: Empire-view contract — observer mode borrows the viewing
+    // empire's `KnowledgeStore` so projection / snapshot reads stay
+    // light-coherent (= same path as `PlayerEmpire` normal play, just a
+    // different `viewing_empire`). Ground-truth realtime peeks belong to
+    // the future omniscient (god-view) mode (#490). In normal play this
+    // resolves to the `PlayerEmpire`'s store as before.
     let empire_entity = resolve_ui_empire(&obs);
-    let knowledge = if obs.observer_mode.enabled {
-        None // ground truth in observer mode
-    } else {
-        empire_entity.and_then(|e| knowledge_q.get(e).ok())
-    };
+    let knowledge = resolve_viewing_knowledge(empire_entity, &knowledge_q);
     let player_system = ui_state.player_system;
 
     // Resolve the viewed empire's home system for capital checks.
@@ -983,10 +1108,10 @@ fn draw_outline_and_tooltips_system(
         empire_entity,
         obs.observer_mode.enabled,
         home_system_entity,
-        // #487: Pass the viewing empire's KnowledgeStore so the outline
-        // tree's ship-state queries flow through the projection table.
-        // `None` in observer mode (= ground truth) matches the existing
-        // tooltip data path on line above.
+        // #487 / #499: Pass the viewing empire's KnowledgeStore so the
+        // outline tree's ship-state queries flow through the projection
+        // table. Observer mode resolves to the observed empire's store
+        // (= light-coherent empire-view), not realtime ground truth.
         knowledge,
     );
 
@@ -1265,22 +1390,12 @@ fn draw_main_panels_system(
             // InSystem. Loitering coordinates flow through
             // `ShipView::position()`.
             //
-            // #491 PR-6 follow-up: in observer mode we want ground truth
-            // (= realtime ECS) so the omniscient view's camera centers on
-            // where the ship *actually* is, not where the player empire
-            // believes it is. Mirrors the gate pattern used in the
-            // outline-tree (#487) and ship-panel (#491 PR-2)
-            // observer-mode passes.
-            let ship_view_knowledge: Option<&KnowledgeStore> = if selection.observer_mode.enabled {
-                None
-            } else {
-                Some(knowledge)
-            };
-            let ship_view_empire: Option<Entity> = if selection.observer_mode.enabled {
-                None
-            } else {
-                Some(empire_entity)
-            };
+            // #491 PR-6 / #499: Camera centering reads through the
+            // viewing empire's `ShipView` so observer mode tracks where
+            // the observed empire *believes* the ship is, matching the
+            // outline tree (#487) and ship panel (#491 PR-2). Routed
+            // through `empire_view_knowledge` so the empire-view
+            // contract is pinned at a single change point.
             let ship_pos = ships_query
                 .get(ship_e)
                 .ok()
@@ -1289,8 +1404,8 @@ fn draw_main_panels_system(
                         ship_e,
                         ship,
                         &state,
-                        ship_view_knowledge,
-                        ship_view_empire,
+                        empire_view_knowledge(knowledge),
+                        Some(empire_entity),
                     )?;
                     if let Some(pos) = view.position() {
                         return Some(Position::from(pos));
@@ -1336,20 +1451,12 @@ fn draw_main_panels_system(
             .unwrap_or(false)
     });
 
-    // #491 PR-2: Light-coherent ShipView routing — pass the viewing
-    // empire's `KnowledgeStore` (own ship → projection, foreign ship →
-    // snapshot) and entity to the panel. Observer mode currently passes
-    // `None` for the store to fall through to realtime ECS (= ground
-    // truth); see #499 for the staged migration to empire-view-as-light-
-    // coherent. Mirrors the pattern already in
-    // `draw_outline_and_tooltips_system` where the `knowledge` resolution
-    // applies the same observer-mode → None gate before passing through
-    // to outline / tooltip helpers.
-    let ship_panel_knowledge: Option<&KnowledgeStore> = if selection.observer_mode.enabled {
-        None
-    } else {
-        Some(knowledge)
-    };
+    // #491 PR-2 / #499: Light-coherent ShipView routing — pass the
+    // viewing empire's `KnowledgeStore` (own ship → projection, foreign
+    // ship → snapshot) and entity to the panel. Observer mode resolves
+    // to the observed empire's store via `resolve_ui_empire_raw`, then
+    // `empire_view_knowledge` pins the contract single change point.
+    let ship_panel_knowledge: Option<&KnowledgeStore> = empire_view_knowledge(knowledge);
     let ship_panel_actions = ship_panel::draw_ship_panel(
         ctx,
         &mut selection.selected_ship,
@@ -1743,19 +1850,12 @@ fn draw_main_panels_system(
     if !selected_ship_is_own {
         selection.context_menu.open = false;
     }
-    // #491 (PR-3) Stage-2: Light-coherent ShipView routing — pass the
-    // viewing empire's `KnowledgeStore` (own ship → projection, foreign
-    // ship → snapshot) and entity to the context menu. Observer mode
-    // currently passes `None` for the store to fall through to realtime
-    // ECS (= ground truth); see #499 for the staged migration to
-    // empire-view-as-light-coherent. Mirrors the gate pattern used in
-    // `draw_outline_and_tooltips_system` and the ship-panel sub-PR
-    // (#491 PR-2).
-    let context_menu_knowledge: Option<&KnowledgeStore> = if selection.observer_mode.enabled {
-        None
-    } else {
-        Some(knowledge)
-    };
+    // #491 (PR-3) Stage-2 / #499: Light-coherent ShipView routing — pass
+    // the viewing empire's `KnowledgeStore` (own ship → projection,
+    // foreign ship → snapshot) and entity to the context menu. Routed
+    // through `empire_view_knowledge` so the empire-view contract is
+    // pinned at a single change point (#490 future-mode hook).
+    let context_menu_knowledge: Option<&KnowledgeStore> = empire_view_knowledge(knowledge);
     let ctx_menu_actions = context_menu::draw_context_menu(
         ctx,
         &mut selection.context_menu,

--- a/macrocosmo/src/ui/situation_center/ship_ops_tab.rs
+++ b/macrocosmo/src/ui/situation_center/ship_ops_tab.rs
@@ -35,8 +35,6 @@ use bevy::prelude::*;
 
 use crate::galaxy::{AtSystem, Hostile, StarSystem};
 use crate::knowledge::{KnowledgeStore, ShipSnapshotState};
-use crate::observer::ObserverMode;
-use crate::player::PlayerEmpire;
 use crate::ship::{Ship, ShipState};
 use crate::time_system::GameClock;
 use crate::ui::ship_view::{ShipView, ShipViewTiming, ship_view_with_timing};
@@ -140,40 +138,19 @@ fn hostile_systems(world: &World) -> HashSet<Entity> {
     out
 }
 
-/// Resolve the player empire entity (= viewing empire). Returns `None`
-/// if no `PlayerEmpire` exists yet (early Startup before the spawn
-/// system runs); callers fall back to the realtime ECS path.
-fn resolve_player_empire(world: &World) -> Option<Entity> {
-    let mut q = world.try_query::<(Entity, &PlayerEmpire)>()?;
-    q.iter(world).next().map(|(e, _)| e)
-}
-
-/// #491 PR-4 follow-up: source-resolved viewing context. The
-/// situation_center collects events from the player empire's
-/// perspective by default; in observer mode we want ground truth
-/// (= realtime ECS), so we pass `None` for both the `KnowledgeStore`
-/// and the viewing empire — `ship_view_with_timing` then falls
-/// through to `realtime_state_to_snapshot`.
+/// #491 PR-4 / #499: source-resolved viewing context. The situation
+/// center collects events from the viewing empire's perspective — own
+/// ships flow through `KnowledgeStore::projections`, foreign ships
+/// through `ship_snapshots`. The empire is resolved via
+/// `crate::observer::resolve_viewing_empire` so the empire-view
+/// contract stays in lockstep with `ui::mod::resolve_ui_empire`.
 struct ViewingContext<'a> {
     knowledge: Option<&'a KnowledgeStore>,
     empire: Option<Entity>,
 }
 
 fn resolve_viewing_context(world: &World) -> ViewingContext<'_> {
-    let observer_mode_enabled = world
-        .get_resource::<ObserverMode>()
-        .map(|o| o.enabled)
-        .unwrap_or(false);
-    if observer_mode_enabled {
-        // Observer mode: omniscient view = realtime ECS = ground truth.
-        // Mirrors the gate pattern in outline-tree (#487), ship-panel
-        // (#491 PR-2), and map tooltip (#491 PR-6) observer paths.
-        return ViewingContext {
-            knowledge: None,
-            empire: None,
-        };
-    }
-    let empire = resolve_player_empire(world);
+    let empire = crate::observer::resolve_viewing_empire(world);
     let knowledge = empire.and_then(|e| world.entity(e).get::<KnowledgeStore>());
     ViewingContext { knowledge, empire }
 }
@@ -567,6 +544,113 @@ mod tests {
         let badge = tab.badge(&world).expect("combat badge");
         assert_eq!(badge.severity, Severity::Warn);
         assert_eq!(badge.count, 1);
+    }
+
+    /// #499 regression: in observer mode the ship-ops tab must read
+    /// through the **observed empire**'s `KnowledgeStore`, not realtime
+    /// ECS. Prior to #499, `resolve_viewing_context` returned
+    /// `(knowledge=None, empire=None)` whenever `ObserverMode.enabled`,
+    /// which fell through to the realtime ECS path inside
+    /// `ship_view_with_timing`. With the migrated contract,
+    /// `ObserverView.viewing` is honoured and the projection becomes
+    /// the canonical source — same path as `PlayerEmpire` normal play.
+    #[test]
+    fn observer_mode_routes_through_observed_empire_knowledge() {
+        use crate::knowledge::{KnowledgeStore, ShipProjection, ShipSnapshotState};
+        use crate::observer::{ObserverMode, ObserverView};
+        use crate::player::{Empire, Faction};
+
+        let mut world = World::new();
+        setup_clock(&mut world, 50);
+
+        // Observer mode active, viewing an empire that is NOT a
+        // PlayerEmpire (= the empire-view contract: borrow another
+        // empire's perspective).
+        world.insert_resource(ObserverMode {
+            enabled: true,
+            ..Default::default()
+        });
+
+        let observed_empire = world
+            .spawn((
+                Empire {
+                    name: "Observed".into(),
+                },
+                Faction {
+                    id: "observed".into(),
+                    name: "Observed".into(),
+                    can_diplomacy: false,
+                    allowed_diplomatic_options: Default::default(),
+                },
+                KnowledgeStore::default(),
+            ))
+            .id();
+        world.insert_resource(ObserverView {
+            viewing: Some(observed_empire),
+        });
+
+        // Realtime ECS: ship is mid-FTL towards a frontier system.
+        let home = spawn_system(&mut world, "Home");
+        let frontier = spawn_system(&mut world, "Frontier");
+        let ship = world
+            .spawn((
+                Ship {
+                    name: "Pinned".into(),
+                    design_id: "corvette".into(),
+                    hull_id: "corvette".into(),
+                    modules: Vec::<EquippedModule>::new(),
+                    owner: Owner::Empire(observed_empire),
+                    sublight_speed: 1.0,
+                    ftl_range: 5.0,
+                    ruler_aboard: false,
+                    home_port: home,
+                    design_revision: 0,
+                    fleet: None,
+                },
+                ShipState::InFTL {
+                    origin_system: home,
+                    destination_system: frontier,
+                    departed_at: 10,
+                    arrival_at: 110,
+                },
+            ))
+            .id();
+
+        // The observed empire's projection says the ship is still
+        // docked at home — the dispatch order has not yet propagated
+        // along light-speed lines. The empire-view contract requires
+        // the tab to honour this stale belief, not the realtime FTL.
+        {
+            let mut em = world.entity_mut(observed_empire);
+            let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+            store.update_projection(ShipProjection {
+                entity: ship,
+                dispatched_at: 0,
+                expected_arrival_at: None,
+                expected_return_at: None,
+                projected_state: ShipSnapshotState::InSystem,
+                projected_system: Some(home),
+                intended_state: None,
+                intended_system: None,
+                intended_takes_effect_at: None,
+            });
+        }
+
+        let events = collect_ship_events(&world);
+
+        // Steady-state per projection ⇒ Docked / Idle, NOT Travel.
+        assert!(
+            events.iter().all(|e| e.kind != EventKind::Travel),
+            "observer mode must hide realtime ECS FTL when the observed empire's \
+             projection says InSystem — events: {:?}",
+            events.iter().map(|e| e.kind).collect::<Vec<_>>()
+        );
+        let other = events
+            .iter()
+            .find(|e| e.kind == EventKind::Other)
+            .expect("docked ship surfaces under Other category");
+        assert!(other.children.iter().any(|c| c.label.contains("Pinned")));
+        assert!(other.children.iter().any(|c| c.label.contains("docked")));
     }
 
     #[test]

--- a/macrocosmo/tests/outline_tree_ftl_leak.rs
+++ b/macrocosmo/tests/outline_tree_ftl_leak.rs
@@ -450,6 +450,12 @@ fn outline_foreign_ship_uses_snapshot() {
 ///
 /// Verify by setting up a situation where the projection and realtime
 /// disagree, then asserting observer mode reads the **projection** side.
+///
+/// #499 closed the production drift that previously routed observer
+/// mode through `viewing_knowledge=None` (= realtime fallback). The
+/// `ui::mod::draw_outline_and_tooltips_system` caller now resolves the
+/// store from the observed empire, matching the contract this test
+/// pinned.
 #[test]
 fn outline_observer_mode_is_light_coherent_via_projection() {
     let mut app = test_app();


### PR DESCRIPTION
## Summary

Pre-#499, 5 UI callsites passed `viewing_knowledge=None` whenever `ObserverMode.enabled`, falling through to realtime ECS ground truth. This contradicted the helper's documented empire-view contract — the player should borrow the observed empire's perspective, **light-coherent**.

This PR migrates 5 callsites to resolve `viewing_knowledge` from the observed empire's `KnowledgeStore`, completing the contract migration tracked by Round 14 handoff.

### Changes

- **outline tree / map tooltip** (`ui/mod.rs`) — gate removed; routed through new `resolve_viewing_knowledge(empire, query)` helper
- **ship-panel / context-menu / camera-centering** (`ui/mod.rs`) — gate removed; routed through new sibling `empire_view_knowledge(store)` helper
- **situation_center ship_ops_tab** — `resolve_player_empire` replaced by hoisted `observer::resolve_viewing_empire(&World)` (single `&World` source of truth, mirrors `ui::mod::resolve_ui_empire_raw`'s Query path)
- **`knowledge::ship_view`** docstring rewritten from history narration to caller-invariant: "Callers MUST pass the observed empire's `KnowledgeStore`"
- **`ObserverView.viewing`** doc-comment corrected: "Faction entity" → "Empire entity" (drifted since #417)

### #490 future-mode hook

Both new helpers document the Omniscient (god-view) mode change point. When #490 lands as a 3-variant `ObserverMode` enum, these two helpers are the single change points that branch to return `None` for omniscient callers.

### Adversarial review

Bug + design lens reviewed in parallel before commit. Findings folded in:

| Severity | Finding | Resolution |
|---|---|---|
| HIGH | Duplicated viewing-empire resolver | Hoisted `observer::resolve_viewing_empire` |
| HIGH | Inline `Some(knowledge)` × 4 fragile under #490 | Routed via 2 sibling helpers |
| HIGH | 4 callsites lacked production-path regression test | Added `empire_view_tests` module (3 tests) |
| MEDIUM | Docstring narrated history, not invariant | Rewrote as caller invariant |
| NIT | `ObserverView.viewing` doc said "Faction" but value is Empire | Fixed |

## Test plan

- [x] `cargo test --workspace --tests -- --test-threads=1` → **3557 passed / 0 failed**
- [x] New regression tests:
  - `ui::empire_view_tests::resolves_to_passed_empires_knowledge_store_in_observer_mode`
  - `ui::empire_view_tests::empty_empire_yields_none`
  - `ui::empire_view_tests::empire_view_knowledge_wraps_in_some`
  - `situation_center::ship_ops_tab::tests::observer_mode_routes_through_observed_empire_knowledge`
- [x] `cargo check -p macrocosmo` clean
- [ ] CI green

Closes #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)