### PR TITLE
fix(ai): #468 PR-1 survey_system courier delay = Ruler→ship (proof of concept)

### DIFF
--- a/macrocosmo/src/ai/command_consumer.rs
+++ b/macrocosmo/src/ai/command_consumer.rs
@@ -142,7 +142,6 @@ pub struct CommandStamp<'w> {
 
 /// Drain AI commands from the bus and apply them to the game world.
 pub fn drain_ai_commands(
-    mut commands_buf: Commands,
     mut drainer: AiBusDrainer,
     ships: Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
     sovereignty: Query<(Entity, &Sovereignty), With<StarSystem>>,
@@ -188,18 +187,16 @@ pub fn drain_ai_commands(
                 now,
             );
         } else if kind_str == cmd_ids::survey_system().as_str() {
-            if let Some(ref mut w) = stamp.survey_writer {
-                handle_survey_system(
-                    &cmd.issuer,
-                    &cmd.params,
-                    &ships,
-                    &empires,
-                    w,
-                    &mut stamp.next_cmd_id,
-                    now,
-                    &mut commands_buf,
-                );
-            }
+            // #468 PR-1: `survey_system` is now produced via the new
+            // `PendingAiShipCommand` pipeline and consumed by
+            // `drain_ai_ship_commands` — it must never reach this arm.
+            // If a stale command slips in via the old outbox path,
+            // drop it with a `debug!` rather than re-dispatch.
+            debug!(
+                "drain_ai_commands: stale survey_system from faction {:?} hit legacy \
+                 dispatch; expected `drain_ai_ship_commands` to handle this",
+                cmd.issuer
+            );
         } else if kind_str == cmd_ids::colonize_system().as_str() {
             if let Some(ref mut w) = stamp.colonize_writer {
                 handle_colonize_system(
@@ -346,7 +343,7 @@ fn find_empire_entity(
 
 /// Extract ship entity list from indexed command params (`ship_count`,
 /// `ship_0`, `ship_1`, ...).
-fn extract_ship_list(params: &macrocosmo_ai::CommandParams) -> Vec<Entity> {
+pub(crate) fn extract_ship_list(params: &macrocosmo_ai::CommandParams) -> Vec<Entity> {
     let count = match params.get("ship_count") {
         Some(CommandValue::I64(n)) => *n as usize,
         _ => return vec![],
@@ -428,78 +425,6 @@ fn handle_attack_target(
     if dispatched > 0 {
         info!(
             "attack_target: dispatched {} ships from faction {:?} to system {:?}",
-            dispatched, issuer, target_system
-        );
-    }
-}
-
-/// Handle `survey_system`: dispatch the specified survey ship to the target system.
-///
-/// Stamps each dispatched ship with a [`crate::ai::assignments::PendingAssignment`]
-/// so subsequent NPC decision ticks can dedup against in-flight surveys
-/// (Round 9 PR #2 Step 4). The marker is removed by
-/// [`crate::ship::handlers::handle_survey_requested`] on terminal Rejected
-/// results and by [`crate::ai::assignments::sweep_resolved_survey_assignments`]
-/// once the issuing empire's `KnowledgeStore` learns the target is surveyed.
-/// Bevy's automatic component cleanup handles ship despawn (combat loss).
-#[allow(clippy::too_many_arguments)]
-fn handle_survey_system(
-    issuer: &macrocosmo_ai::FactionId,
-    params: &macrocosmo_ai::CommandParams,
-    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
-    empires: &Query<(Entity, &Faction), With<Empire>>,
-    survey_writer: &mut MessageWriter<SurveyRequested>,
-    next_cmd_id: &mut NextCommandId,
-    now: i64,
-    commands_buf: &mut Commands,
-) {
-    use crate::ai::assignments::PendingAssignment;
-
-    let target_system = match params.get("target_system") {
-        Some(CommandValue::System(sys_ref)) => from_ai_system(*sys_ref),
-        _ => {
-            warn!("survey_system command missing target_system param");
-            return;
-        }
-    };
-
-    let empire_entity = match find_empire_entity(issuer, empires) {
-        Some(e) => e,
-        None => return,
-    };
-
-    let selected_ships = extract_ship_list(params);
-    let mut dispatched = 0;
-    for ship_entity in selected_ships {
-        let Ok((_, ship, state, queue)) = ships.get(ship_entity) else {
-            continue;
-        };
-        if ship.owner != Owner::Empire(empire_entity) {
-            continue;
-        }
-        if !matches!(state, ShipState::InSystem { .. }) || !queue.commands.is_empty() {
-            continue;
-        }
-
-        survey_writer.write(SurveyRequested {
-            command_id: next_cmd_id.allocate(),
-            ship: ship_entity,
-            target_system,
-            issued_at: now,
-        });
-        commands_buf
-            .entity(ship_entity)
-            .insert(PendingAssignment::survey_system(
-                empire_entity,
-                target_system,
-                now,
-            ));
-        dispatched += 1;
-    }
-
-    if dispatched > 0 {
-        info!(
-            "survey_system: dispatched {} ships from faction {:?} to system {:?}",
             dispatched, issuer, target_system
         );
     }
@@ -1769,6 +1694,190 @@ pub fn process_ruler_boarding(
             ship.ruler_aboard = true;
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// #468 PR-1: per-ship light-speed delayed AI command (survey_system only)
+// ---------------------------------------------------------------------------
+//
+// Background: the previous AI command light-speed shim computed `arrives_at`
+// from the issuer Ruler to the command's `target_system`. For ship-control
+// commands (survey_system / colonize_system / …) that's the wrong distance
+// — the order has to reach the *ship*, not the target. A Ruler at home A
+// dispatching a scout already at frontier B should incur ~0 light-delay
+// (the scout is "right next to" the system whose authority routes the
+// order, conceptually), not the round trip A→B that the old code paid.
+//
+// PR-1 migrates the `survey_system` arm as a proof of concept. PR-2 / PR-3
+// follow with the remaining ship-control kinds. The new wiring is:
+//
+//   `dispatch_ai_pending_commands`
+//     (sees `survey_system` from the bus)
+//     ↓ branches out: per ship_<i>, spawn `PendingAiShipCommand` with
+//       `arrives_at = sent_at + light_delay_ruler_to_ship(ruler, ship)`,
+//       insert `PendingAssignment` marker NOW (preserves dedup contract
+//       with `npc_decision.rs`'s outbox-scan).
+//   `drain_ai_ship_commands`   (runs at start of `AiTickSet::CommandDrain`,
+//                               before `drain_ai_commands`)
+//     ↓ for entries where `clock.elapsed >= arrives_at`: write
+//       `SurveyRequested`, despawn the holder entity.
+//
+// Runtime-only — not `Reflect`, not persisted. Mirrors `PendingScriptedCommand`
+// in `scripting::gamestate_scope`: in-flight commands are frame-transient
+// and surviving save/load is a non-goal for pre-alpha. SAVE_VERSION does
+// not bump.
+
+/// In-flight AI-issued ship command awaiting light-speed arrival.
+///
+/// Spawned by [`crate::ai::command_outbox::dispatch_ai_pending_commands`]
+/// at the moment the AI policy emits the command; drained by
+/// [`drain_ai_ship_commands`] once `clock.elapsed >= arrives_at`. The
+/// `PendingAssignment` marker on `ship` is inserted at the same time the
+/// holder is spawned, *not* at arrival — that keeps the dedup contract at
+/// `npc_decision.rs:566` intact across the courier window.
+#[derive(Component, Debug)]
+pub struct PendingAiShipCommand {
+    /// The AI bus command that produced this holder. Preserves the full
+    /// parameter map so the drain system can replay any per-arm logic.
+    pub command: macrocosmo_ai::Command,
+    /// The specific ship this holder targets. For multi-ship commands the
+    /// outbox spawns one `PendingAiShipCommand` per ship, each with its
+    /// own Ruler→ship `arrives_at`.
+    pub ship: Entity,
+    /// Empire entity that issued the command (= dispatcher empire).
+    pub issuer_empire: Entity,
+    /// Clock tick (hexadies) when the command was emitted.
+    pub sent_at: i64,
+    /// Clock tick at which this command becomes deliverable. Computed via
+    /// [`crate::physics::light_delay_ruler_to_ship`].
+    pub arrives_at: i64,
+}
+
+/// Start-of-`AiTickSet::CommandDrain` system: walk the
+/// [`PendingAiShipCommand`] entities and emit the corresponding typed
+/// `*Requested` message for any whose `arrives_at` has elapsed. Despawns
+/// the holder entity once dispatched.
+///
+/// PR-1 only handles `survey_system`. Other ship-kind holders are not
+/// produced yet (PR-2/3 follow); the function logs and despawns any
+/// unexpected kind defensively rather than re-queueing.
+pub fn drain_ai_ship_commands(
+    mut commands_buf: Commands,
+    mut pending_q: Query<(Entity, &mut PendingAiShipCommand)>,
+    ships: Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
+    clock: Res<GameClock>,
+    mut survey_writer: Option<MessageWriter<SurveyRequested>>,
+    mut next_cmd_id: ResMut<NextCommandId>,
+) {
+    let now = clock.elapsed;
+    let survey_kind = crate::ai::schema::ids::command::survey_system();
+
+    // Collect mature entries first so we can despawn while iterating
+    // without invalidating the query cursor.
+    let mut mature: Vec<(Entity, macrocosmo_ai::Command, Entity, Entity)> = Vec::new();
+    for (holder_entity, pending) in &mut pending_q {
+        if pending.arrives_at <= now {
+            mature.push((
+                holder_entity,
+                pending.command.clone(),
+                pending.ship,
+                pending.issuer_empire,
+            ));
+        }
+    }
+
+    for (holder_entity, cmd, ship_entity, empire_entity) in mature {
+        let kind_str = cmd.kind.as_str();
+
+        if kind_str == survey_kind.as_str() {
+            apply_survey_to_ship(
+                ship_entity,
+                empire_entity,
+                &cmd,
+                &ships,
+                survey_writer.as_mut(),
+                &mut next_cmd_id,
+                now,
+            );
+        } else {
+            // Defensive: PR-1 only spawns `survey_system` holders. Any
+            // other kind here means an upstream bug — log + drop rather
+            // than silently dispatch through an unknown path.
+            debug!(
+                "drain_ai_ship_commands: unexpected kind {} for ship {:?}; dropping",
+                kind_str, ship_entity
+            );
+        }
+
+        commands_buf.entity(holder_entity).despawn();
+    }
+}
+
+/// Apply a matured `survey_system` PendingAiShipCommand: validate the ship
+/// is still eligible (owned by the issuer, in-system, idle) and write the
+/// `SurveyRequested` message. The `PendingAssignment` marker is already
+/// in place — it was inserted at outbox-spawn time to preserve dedup.
+///
+/// Mirrors the per-ship body of the legacy `handle_survey_system` minus
+/// the marker insertion. Extracted as a free function so the outbox can
+/// reuse the eligibility shape if needed and so the drain system stays
+/// small.
+fn apply_survey_to_ship(
+    ship_entity: Entity,
+    empire_entity: Entity,
+    cmd: &macrocosmo_ai::Command,
+    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
+    survey_writer: Option<&mut MessageWriter<SurveyRequested>>,
+    next_cmd_id: &mut NextCommandId,
+    now: i64,
+) {
+    let Some(writer) = survey_writer else {
+        warn!("drain_ai_ship_commands: SurveyRequested writer unavailable");
+        return;
+    };
+
+    let target_system = match cmd.params.get("target_system") {
+        Some(CommandValue::System(sys_ref)) => from_ai_system(*sys_ref),
+        _ => {
+            warn!("drain_ai_ship_commands: survey_system holder missing target_system");
+            return;
+        }
+    };
+
+    let Ok((_, ship, state, queue)) = ships.get(ship_entity) else {
+        debug!(
+            "drain_ai_ship_commands: ship {:?} despawned before arrival",
+            ship_entity
+        );
+        return;
+    };
+    if ship.owner != Owner::Empire(empire_entity) {
+        debug!(
+            "drain_ai_ship_commands: ship {:?} no longer owned by empire {:?}",
+            ship_entity, empire_entity
+        );
+        return;
+    }
+    if !matches!(state, ShipState::InSystem { .. }) || !queue.commands.is_empty() {
+        debug!(
+            "drain_ai_ship_commands: ship {:?} not idle at arrival (queue_len={})",
+            ship_entity,
+            queue.commands.len(),
+        );
+        return;
+    }
+
+    writer.write(SurveyRequested {
+        command_id: next_cmd_id.allocate(),
+        ship: ship_entity,
+        target_system,
+        issued_at: now,
+    });
+
+    info!(
+        "drain_ai_ship_commands: survey_system delivered to ship {:?} → system {:?} for empire {:?}",
+        ship_entity, target_system, empire_entity
+    );
 }
 
 #[cfg(test)]

--- a/macrocosmo/src/ai/command_consumer.rs
+++ b/macrocosmo/src/ai/command_consumer.rs
@@ -1735,11 +1735,23 @@ pub fn process_ruler_boarding(
 /// `PendingAssignment` marker on `ship` is inserted at the same time the
 /// holder is spawned, *not* at arrival — that keeps the dedup contract at
 /// `npc_decision.rs:566` intact across the courier window.
+///
+/// Fields the drain side actually consumes are stored directly rather
+/// than the full [`macrocosmo_ai::Command`] — the `params` map (for an
+/// N-ship multi-target survey) is ~hundreds of bytes per holder and the
+/// drain only reads `target_system`. PR-2/3 extends this struct with
+/// kind-specific extras (e.g. `target_planet: Option<Entity>` for
+/// `colonize_planet`) rather than cloning the whole command.
 #[derive(Component, Debug)]
 pub struct PendingAiShipCommand {
-    /// The AI bus command that produced this holder. Preserves the full
-    /// parameter map so the drain system can replay any per-arm logic.
-    pub command: macrocosmo_ai::Command,
+    /// Which AI command kind this holder represents. Drain dispatch
+    /// branches on this string-interned id (cheap `Arc<str>` clone).
+    pub kind: macrocosmo_ai::CommandKindId,
+    /// Star system the order targets (= the `target_system` param the
+    /// AI command carried at emission). Used by both the drain
+    /// (for `SurveyRequested.target_system`) and the dedup scan in
+    /// `npc_decision.rs`.
+    pub target_system: Entity,
     /// The specific ship this holder targets. For multi-ship commands the
     /// outbox spawns one `PendingAiShipCommand` per ship, each with its
     /// own Ruler→ship `arrives_at`.
@@ -1763,7 +1775,7 @@ pub struct PendingAiShipCommand {
 /// unexpected kind defensively rather than re-queueing.
 pub fn drain_ai_ship_commands(
     mut commands_buf: Commands,
-    mut pending_q: Query<(Entity, &mut PendingAiShipCommand)>,
+    pending_q: Query<(Entity, &PendingAiShipCommand)>,
     ships: Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
     clock: Res<GameClock>,
     mut survey_writer: Option<MessageWriter<SurveyRequested>>,
@@ -1774,74 +1786,92 @@ pub fn drain_ai_ship_commands(
 
     // Collect mature entries first so we can despawn while iterating
     // without invalidating the query cursor.
-    let mut mature: Vec<(Entity, macrocosmo_ai::Command, Entity, Entity)> = Vec::new();
-    for (holder_entity, pending) in &mut pending_q {
+    let mut mature: Vec<(Entity, MaturedHolder)> = Vec::new();
+    for (holder_entity, pending) in &pending_q {
         if pending.arrives_at <= now {
             mature.push((
                 holder_entity,
-                pending.command.clone(),
-                pending.ship,
-                pending.issuer_empire,
+                MaturedHolder {
+                    kind: pending.kind.clone(),
+                    target_system: pending.target_system,
+                    ship: pending.ship,
+                    issuer_empire: pending.issuer_empire,
+                },
             ));
         }
     }
 
-    for (holder_entity, cmd, ship_entity, empire_entity) in mature {
-        let kind_str = cmd.kind.as_str();
-
-        if kind_str == survey_kind.as_str() {
+    for (holder_entity, m) in mature {
+        if m.kind.as_str() == survey_kind.as_str() {
             apply_survey_to_ship(
-                ship_entity,
-                empire_entity,
-                &cmd,
+                m.ship,
+                m.issuer_empire,
+                m.target_system,
                 &ships,
                 survey_writer.as_mut(),
                 &mut next_cmd_id,
+                &mut commands_buf,
                 now,
             );
         } else {
             // Defensive: PR-1 only spawns `survey_system` holders. Any
             // other kind here means an upstream bug — log + drop rather
-            // than silently dispatch through an unknown path.
+            // than silently dispatch through an unknown path. Also
+            // strip the stale `PendingAssignment` so the ship is not
+            // permanently excluded from future AI dispatches.
             debug!(
                 "drain_ai_ship_commands: unexpected kind {} for ship {:?}; dropping",
-                kind_str, ship_entity
+                m.kind, m.ship
             );
+            commands_buf
+                .entity(m.ship)
+                .remove::<crate::ai::assignments::PendingAssignment>();
         }
 
         commands_buf.entity(holder_entity).despawn();
     }
 }
 
+/// #468 PR-1: lightweight snapshot of a matured
+/// [`PendingAiShipCommand`] used inside [`drain_ai_ship_commands`] so the
+/// drain loop can despawn / mutate via `Commands` without holding a
+/// borrow on the source query.
+struct MaturedHolder {
+    kind: macrocosmo_ai::CommandKindId,
+    target_system: Entity,
+    ship: Entity,
+    issuer_empire: Entity,
+}
+
 /// Apply a matured `survey_system` PendingAiShipCommand: validate the ship
 /// is still eligible (owned by the issuer, in-system, idle) and write the
-/// `SurveyRequested` message. The `PendingAssignment` marker is already
-/// in place — it was inserted at outbox-spawn time to preserve dedup.
+/// `SurveyRequested` message.
 ///
-/// Mirrors the per-ship body of the legacy `handle_survey_system` minus
-/// the marker insertion. Extracted as a free function so the outbox can
-/// reuse the eligibility shape if needed and so the drain system stays
-/// small.
+/// The `PendingAssignment` marker was inserted at outbox-spawn time to
+/// preserve dedup across the courier window. On any early-return path
+/// here (ship despawned / owner-changed / non-idle / no writer) the
+/// marker MUST be removed — otherwise the ship is permanently excluded
+/// from future AI survey dispatches because the dedup scan at
+/// `npc_decision.rs:566` filters by `PendingAssignment`. Pre-#468 the
+/// legacy `handle_survey_requested` path cleared the marker on its own
+/// reject branches; on the new path, no `SurveyRequested` is even
+/// written when these gates fail, so we drop the marker ourselves.
 fn apply_survey_to_ship(
     ship_entity: Entity,
     empire_entity: Entity,
-    cmd: &macrocosmo_ai::Command,
+    target_system: Entity,
     ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
     survey_writer: Option<&mut MessageWriter<SurveyRequested>>,
     next_cmd_id: &mut NextCommandId,
+    commands_buf: &mut Commands,
     now: i64,
 ) {
     let Some(writer) = survey_writer else {
         warn!("drain_ai_ship_commands: SurveyRequested writer unavailable");
+        commands_buf
+            .entity(ship_entity)
+            .remove::<crate::ai::assignments::PendingAssignment>();
         return;
-    };
-
-    let target_system = match cmd.params.get("target_system") {
-        Some(CommandValue::System(sys_ref)) => from_ai_system(*sys_ref),
-        _ => {
-            warn!("drain_ai_ship_commands: survey_system holder missing target_system");
-            return;
-        }
     };
 
     let Ok((_, ship, state, queue)) = ships.get(ship_entity) else {
@@ -1849,6 +1879,8 @@ fn apply_survey_to_ship(
             "drain_ai_ship_commands: ship {:?} despawned before arrival",
             ship_entity
         );
+        // Ship is gone — the `PendingAssignment` was on its
+        // (despawned) entity, so no further cleanup is required.
         return;
     };
     if ship.owner != Owner::Empire(empire_entity) {
@@ -1856,6 +1888,9 @@ fn apply_survey_to_ship(
             "drain_ai_ship_commands: ship {:?} no longer owned by empire {:?}",
             ship_entity, empire_entity
         );
+        commands_buf
+            .entity(ship_entity)
+            .remove::<crate::ai::assignments::PendingAssignment>();
         return;
     }
     if !matches!(state, ShipState::InSystem { .. }) || !queue.commands.is_empty() {
@@ -1864,6 +1899,9 @@ fn apply_survey_to_ship(
             ship_entity,
             queue.commands.len(),
         );
+        commands_buf
+            .entity(ship_entity)
+            .remove::<crate::ai::assignments::PendingAssignment>();
         return;
     }
 

--- a/macrocosmo/src/ai/command_outbox.rs
+++ b/macrocosmo/src/ai/command_outbox.rs
@@ -742,8 +742,15 @@ fn dispatch_survey_per_ship(
         // a survey for the same target — if the marker waited until
         // arrival, the scan would still need a fallback into the
         // PendingAiShipCommand query (which it now has).
+        //
+        // Only the kind + target_system are stored — the full `cmd`
+        // (with its AHashMap of params and stale ship_<i> list) is not
+        // needed downstream. Per-ship multi-target surveys spawn N
+        // holders here; cloning the whole command would N× the
+        // param-map allocations for no benefit.
         commands_buf.spawn(PendingAiShipCommand {
-            command: cmd.clone(),
+            kind: cmd.kind.clone(),
+            target_system,
             ship: ship_entity,
             issuer_empire: empire_entity,
             sent_at: now,

--- a/macrocosmo/src/ai/command_outbox.rs
+++ b/macrocosmo/src/ai/command_outbox.rs
@@ -250,8 +250,13 @@ pub fn command_targets_system(kind: &str) -> bool {
         || s == cmd_ids::blockade().as_str()
         || s == cmd_ids::fortify_system().as_str()
         || s == cmd_ids::colonize_system().as_str()
-        || s == cmd_ids::survey_system().as_str()
         || s == cmd_ids::move_ruler().as_str()
+    // #468 PR-1: `survey_system` is no longer listed here. Ship-control
+    // commands now compute light-delay Ruler→ship (not Ruler→target_system)
+    // and flow through the `PendingAiShipCommand` per-ship holder; the
+    // outbox's capital/target-system routing only applies to the
+    // remaining (PR-2/3 pending) ship kinds. PR-2/3 will migrate the rest.
+    //
     // build_ship / build_structure may carry a target_system in some
     // policies but commonly route to the empire's preferred shipyard;
     // they fall through to capital-as-destination by default. The
@@ -485,6 +490,7 @@ pub fn dispatch_ai_pending_commands(
     mut bus: ResMut<crate::ai::plugin::AiBusResource>,
     mut outbox: ResMut<AiCommandOutbox>,
     clock: Res<crate::time_system::GameClock>,
+    mut commands_buf: Commands,
     mut params: DispatchParams,
 ) {
     let now = clock.elapsed;
@@ -502,6 +508,8 @@ pub fn dispatch_ai_pending_commands(
         .map(|n| n.relays.clone())
         .unwrap_or_default();
     let relays: &[crate::knowledge::RelaySnapshot] = &relays_owned;
+
+    let survey_kind = cmd_ids::survey_system();
 
     for cmd in drained {
         let issuer = cmd.issuer;
@@ -527,6 +535,25 @@ pub fn dispatch_ai_pending_commands(
             );
             continue;
         };
+
+        // #468 PR-1: `survey_system` branches onto the new
+        // per-ship `PendingAiShipCommand` pipeline. Light delay is
+        // Ruler→ship (not Ruler→target_system), and the marker insertion
+        // happens NOW (not at arrival) so the `npc_decision.rs`
+        // outbox-dedup scan still sees in-flight surveys during the
+        // courier window. PR-2/3 will migrate the rest of the
+        // ship-control kinds.
+        if cmd.kind == survey_kind {
+            dispatch_survey_per_ship(
+                &cmd,
+                empire_entity,
+                origin_pos,
+                now,
+                &mut commands_buf,
+                &mut params,
+            );
+            continue;
+        }
 
         let Some(destination_pos) = resolve_destination_pos(
             &cmd,
@@ -588,6 +615,147 @@ pub fn dispatch_ai_pending_commands(
         }
 
         outbox.entries.push(pending);
+    }
+}
+
+/// #468 PR-1: dispatch a `survey_system` command onto the per-ship
+/// `PendingAiShipCommand` pipeline.
+///
+/// For each `ship_<i>` in the command params:
+///   * read the ship's `Position` (= dispatcher's *real* idea of where
+///     the order has to travel — the snapshot fallback path is reserved
+///     for the projection write only)
+///   * compute `arrives_at = sent_at + light_delay_ruler_to_ship(ruler, ship)`
+///   * spawn `PendingAiShipCommand` with the per-ship arrival
+///   * insert `PendingAssignment::survey_system` on the ship NOW (the
+///     dedup contract at `npc_decision.rs:566` requires the marker be
+///     visible while the courier window is open)
+///   * write the dispatcher's `ShipProjection` belief — same contract
+///     as the pre-#468 path, just keyed per ship rather than once for
+///     the whole command.
+///
+/// Commands whose ship list is empty, whose target_system param is
+/// missing, or whose primary ship cannot be located fall through with
+/// a `debug!` — these were already no-ops in the previous handler.
+fn dispatch_survey_per_ship(
+    cmd: &Command,
+    empire_entity: Entity,
+    origin_pos: [f64; 3],
+    now: i64,
+    commands_buf: &mut Commands,
+    params: &mut DispatchParams,
+) {
+    use crate::ai::assignments::PendingAssignment;
+    use crate::ai::command_consumer::{PendingAiShipCommand, extract_ship_list};
+    use crate::physics::light_delay_ruler_to_ship;
+
+    // target_system is still required so the marker dedup + the eventual
+    // `SurveyRequested` write have somewhere to point. We log + drop a
+    // malformed survey command the same way `handle_survey_system` did.
+    let target_system = match extract_target_system(cmd) {
+        Some(t) => t,
+        None => {
+            warn!(
+                "survey_system dispatch: missing target_system for empire {:?}",
+                empire_entity
+            );
+            return;
+        }
+    };
+
+    let ship_list = extract_ship_list(&cmd.params);
+    if ship_list.is_empty() {
+        debug!(
+            "survey_system dispatch: no ships in command for empire {:?}",
+            empire_entity
+        );
+        return;
+    }
+
+    for ship_entity in ship_list {
+        // Ship position is ground-truth ECS `Position` — that's what the
+        // *order* has to physically reach. The snapshot-based projection
+        // belief still flows through `compute_ship_projection` below so
+        // the dispatcher's KnowledgeStore reflects what the empire
+        // *thinks* about the ship's state, not where the order travels.
+        let ship_pos = match params.positions.get(ship_entity) {
+            Ok(p) => p.as_array(),
+            Err(_) => {
+                debug!(
+                    "survey_system dispatch: ship {:?} has no Position (despawned?)",
+                    ship_entity
+                );
+                continue;
+            }
+        };
+
+        let arrives_at = now + light_delay_ruler_to_ship(origin_pos, ship_pos);
+
+        // #475 projection write — preserves the per-empire belief update
+        // moved out of the legacy `build_projection_inputs` site. The
+        // snapshot lookup and fallback chain mirror the old path; the
+        // only change is we now write one projection per ship in the
+        // command rather than just `ship_0`.
+        let snapshot = params
+            .knowledge_stores
+            .get(empire_entity)
+            .ok()
+            .and_then(|store| store.get_ship(ship_entity).cloned());
+        let fallback_system = params.ships.get(ship_entity).ok().map(|s| s.home_port);
+        let target_system_pos = params
+            .star_positions
+            .get(target_system)
+            .ok()
+            .map(|p| p.as_array());
+        let projection_ship_pos = match snapshot.as_ref().map(|s| &s.last_known_state) {
+            Some(crate::knowledge::ShipSnapshotState::Loitering { position }) => *position,
+            _ => snapshot
+                .as_ref()
+                .and_then(|s| s.last_known_system)
+                .or(fallback_system)
+                .and_then(|sys| params.star_positions.get(sys).ok().map(|p| p.as_array()))
+                .unwrap_or(origin_pos),
+        };
+        let intended_state = crate::knowledge::command_kind_to_intended_state(cmd.kind.as_str());
+        let has_return_leg = crate::knowledge::command_kind_has_return_leg(cmd.kind.as_str());
+
+        let projection = compute_ship_projection(
+            ship_entity,
+            snapshot.as_ref(),
+            origin_pos,
+            projection_ship_pos,
+            target_system_pos,
+            intended_state,
+            Some(target_system),
+            has_return_leg,
+            fallback_system,
+            now,
+        );
+        if let Ok(mut store) = params.knowledge_stores.get_mut(empire_entity) {
+            store.update_projection(projection);
+        }
+
+        // Spawn the in-flight holder and stamp the dedup marker.
+        // Stamping NOW (not at arrival) is load-bearing: the
+        // `npc_decision.rs:566` outbox scan reads
+        // `Query<&PendingAiShipCommand>` to decide whether to re-emit
+        // a survey for the same target — if the marker waited until
+        // arrival, the scan would still need a fallback into the
+        // PendingAiShipCommand query (which it now has).
+        commands_buf.spawn(PendingAiShipCommand {
+            command: cmd.clone(),
+            ship: ship_entity,
+            issuer_empire: empire_entity,
+            sent_at: now,
+            arrives_at,
+        });
+        commands_buf
+            .entity(ship_entity)
+            .insert(PendingAssignment::survey_system(
+                empire_entity,
+                target_system,
+                now,
+            ));
     }
 }
 
@@ -724,7 +892,11 @@ mod tests {
         // for must report `true` here, and at least one spatial-less
         // kind must report `false`.
         assert!(command_targets_system("attack_target"));
-        assert!(command_targets_system("survey_system"));
+        // #468 PR-1: `survey_system` no longer reports `true` here —
+        // it has been migrated off the Ruler→target_system outbox path
+        // onto the new `PendingAiShipCommand` per-ship pipeline.
+        // PR-2/3 will migrate the other ship-control kinds.
+        assert!(!command_targets_system("survey_system"));
         assert!(command_targets_system("colonize_system"));
         assert!(command_targets_system("move_ruler"));
         assert!(command_targets_system("reposition"));

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -530,20 +530,17 @@ pub fn npc_decision_tick(
     // dedup pass. With survey_system off `AiCommandOutbox`, this is the
     // only place the npc_decision tick can see in-flight surveys during
     // the Ruler→ship courier window. PR-2/3 will add more kinds here as
-    // they migrate.
+    // they migrate — until then the `kind` filter is a no-op (only
+    // survey_system holders exist) but kept so PR-2/3 can layer in
+    // colonize/attack/etc. without re-walking this scan shape.
     for pending in &dedup.pending_ai_ship_commands {
-        let cmd = &pending.command;
-        if cmd.kind.as_str() != survey_kind.as_str() {
+        if pending.kind.as_str() != survey_kind.as_str() {
             continue;
         }
-        let target = match cmd.params.get("target_system") {
-            Some(macrocosmo_ai::CommandValue::System(s)) => from_ai_system(*s),
-            _ => continue,
-        };
         outbox_survey_per_empire
             .entry(pending.issuer_empire)
             .or_default()
-            .insert(target);
+            .insert(pending.target_system);
     }
 
     // #449 PR2b: per-MidAgent loop. We resolve each MidAgent →

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -17,6 +17,7 @@
 //!
 //! [`AiTickSet::Reason`]: super::AiTickSet::Reason
 
+use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 
 use crate::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
@@ -28,6 +29,24 @@ use crate::knowledge::KnowledgeStore;
 use crate::player::{AboardShip, Empire, EmpireRuler, Faction, PlayerEmpire, Ruler, StationedAt};
 use crate::technology::ResearchQueue;
 use crate::time_system::GameClock;
+
+/// #468 PR-1: bundle of dedup-related queries / resources used by
+/// `npc_decision_tick` to avoid double-emitting `survey_system` /
+/// `colonize_system` commands. Centralised in one `SystemParam` so the
+/// outer function stays under Bevy's 16-param limit even as more
+/// dedup sources land (PR-2/3 will add migrated-kind ship pipelines).
+#[derive(SystemParam)]
+pub struct DedupParams<'w, 's> {
+    /// Per-faction in-flight assignment markers (handler-resolved path).
+    pub pending_assignments: Query<'w, 's, (Entity, &'static PendingAssignment)>,
+    /// Light-speed outbox for kinds that still flow through it
+    /// (colonize_system + non-survey ship kinds in PR-1).
+    pub outbox: Res<'w, AiCommandOutbox>,
+    /// #468 PR-1: `survey_system` lives here (one entry per ship) for the
+    /// Ruler→ship courier window. PR-2/3 will expand coverage.
+    pub pending_ai_ship_commands:
+        Query<'w, 's, &'static crate::ai::command_consumer::PendingAiShipCommand>,
+}
 
 /// Marker component: this empire's decisions are made by the AI policy.
 /// Applied to NPC empires automatically, and optionally to the player
@@ -389,18 +408,16 @@ pub fn npc_decision_tick(
     design_registry: Option<Res<crate::ship_design::ShipDesignRegistry>>,
     empire_rulers: Query<&EmpireRuler, With<Empire>>,
     ruler_q: Query<(&StationedAt, Option<&AboardShip>), With<Ruler>>,
-    // Round 9 PR #2 Step 4: dedup against in-flight survey dispatches so
-    // we don't double-assign two surveyors to the same target across
-    // overlapping decision ticks. Marker is per-faction.
-    pending_assignments: Query<(Entity, &PendingAssignment)>,
-    // Round 11 Bug A: also dedup against commands sitting in the
-    // light-speed outbox — between `bus.emit_command` (here) and
-    // handler insert (`drain_ai_commands` → `PendingAssignment`),
-    // a `survey_system` / `colonize_system` may live in
-    // `AiCommandOutbox.entries` for hundreds of hexadies. Without
-    // this, `mid_cadence=2` re-fires every other tick onto the same
-    // target. See `tests/ai_npc_outbox_dedup.rs` for the regression.
-    outbox: Res<AiCommandOutbox>,
+    // Round 9 PR #2 Step 4 + Round 11 Bug A + #468 PR-1: dedup against
+    // in-flight survey / colonize commands across THREE sources:
+    //   * `PendingAssignment` markers (handler-resolved path)
+    //   * `AiCommandOutbox.entries` (colonize_system + non-survey ship
+    //     kinds during the Ruler→target_system courier window)
+    //   * `PendingAiShipCommand` (survey_system during the Ruler→ship
+    //     courier window — added in #468 PR-1)
+    // Bundled into a `SystemParam` so the outer fn stays under Bevy's
+    // 16-param limit.
+    dedup: DedupParams,
     // #299 / #446 short-term loop fix: only systems hosting one of the
     // empire's own Cores are colonizable. Without this filter the AI
     // re-emits `colonize_system` every tick for systems where the
@@ -475,7 +492,7 @@ pub fn npc_decision_tick(
     > = std::collections::HashMap::new();
     // Both maps are mutated only inside the next block (single pass over
     // outbox.entries); the empire loop below reads via shared `&` only.
-    if !outbox.entries.is_empty() {
+    if !dedup.outbox.entries.is_empty() {
         // Build issuer FactionId → empire Entity once (faction_id
         // encodes only `Entity::index()`, see `to_ai_faction`); then
         // each entry is an O(1) hashmap lookup instead of an O(empires)
@@ -485,7 +502,7 @@ pub fn npc_decision_tick(
         for (entity, _, _, _) in &npcs {
             faction_to_empire.insert(to_ai_faction(entity), entity);
         }
-        for entry in &outbox.entries {
+        for entry in &dedup.outbox.entries {
             let cmd = &entry.command;
             let Some(&empire_entity) = faction_to_empire.get(&cmd.issuer) else {
                 continue;
@@ -507,6 +524,26 @@ pub fn npc_decision_tick(
                     .insert(from_ai_system(*s));
             }
         }
+    }
+
+    // #468 PR-1: union in `PendingAiShipCommand` entries for the same
+    // dedup pass. With survey_system off `AiCommandOutbox`, this is the
+    // only place the npc_decision tick can see in-flight surveys during
+    // the Ruler→ship courier window. PR-2/3 will add more kinds here as
+    // they migrate.
+    for pending in &dedup.pending_ai_ship_commands {
+        let cmd = &pending.command;
+        if cmd.kind.as_str() != survey_kind.as_str() {
+            continue;
+        }
+        let target = match cmd.params.get("target_system") {
+            Some(macrocosmo_ai::CommandValue::System(s)) => from_ai_system(*s),
+            _ => continue,
+        };
+        outbox_survey_per_empire
+            .entry(pending.issuer_empire)
+            .or_default()
+            .insert(target);
     }
 
     // #449 PR2b: per-MidAgent loop. We resolve each MidAgent →
@@ -566,7 +603,7 @@ pub fn npc_decision_tick(
             std::collections::HashSet::new();
         let mut pending_assigned_ships: std::collections::HashSet<Entity> =
             std::collections::HashSet::new();
-        for (ship_entity, pa) in &pending_assignments {
+        for (ship_entity, pa) in &dedup.pending_assignments {
             if pa.faction != entity {
                 continue;
             }

--- a/macrocosmo/src/ai/plugin.rs
+++ b/macrocosmo/src/ai/plugin.rs
@@ -256,8 +256,18 @@ impl Plugin for AiPlugin {
                 Update,
                 (
                     super::command_outbox::process_ai_pending_commands,
-                    super::command_consumer::drain_ai_commands
+                    // #468 PR-1: per-ship light-speed AI command drain
+                    // (survey_system only in PR-1; PR-2/3 extend coverage).
+                    // Runs BEFORE `drain_ai_commands` so a mature
+                    // `PendingAiShipCommand` writes its `SurveyRequested`
+                    // in the same tick the legacy outbox would have, and
+                    // the per-tick message ordering across the bus drain
+                    // is preserved.
+                    super::command_consumer::drain_ai_ship_commands
                         .after(super::command_outbox::process_ai_pending_commands),
+                    super::command_consumer::drain_ai_commands
+                        .after(super::command_outbox::process_ai_pending_commands)
+                        .after(super::command_consumer::drain_ai_ship_commands),
                     super::command_consumer::process_ruler_boarding
                         .after(super::command_consumer::drain_ai_commands),
                     super::assignments::sweep_resolved_survey_assignments,

--- a/macrocosmo/src/physics/mod.rs
+++ b/macrocosmo/src/physics/mod.rs
@@ -22,6 +22,21 @@ pub fn light_delay_hexadies(distance: f64) -> i64 {
     (distance / LIGHT_SPEED_LY_PER_HEXADIES).ceil() as i64
 }
 
+/// #468: Light-speed command delay from an issuer (Ruler) to a specific
+/// ship.
+///
+/// Centralises the "Ruler → ship" light-delay computation used by the
+/// player-issued command path (`ui::context_menu`), the Lua-scripted
+/// command path (`scripting::gamestate_scope::compute_request_light_delay`),
+/// and the AI ship-command dispatch path (`ai::command_outbox`). Prior to
+/// the #468 hoist each of those sites duplicated the
+/// `light_delay_hexadies(distance_ly_arr(...))` pair inline; collapsing
+/// them through a single helper makes the three paths share one
+/// definition of "command travel time".
+pub fn light_delay_ruler_to_ship(ruler_pos: [f64; 3], ship_pos: [f64; 3]) -> i64 {
+    light_delay_hexadies(distance_ly_arr(ruler_pos, ship_pos))
+}
+
 /// Travel time at sub-light speed in hexadies
 pub fn sublight_travel_hexadies(distance: f64, speed_fraction: f64) -> i64 {
     (distance / (LIGHT_SPEED_LY_PER_HEXADIES * speed_fraction)).ceil() as i64
@@ -78,5 +93,19 @@ mod tests {
         let a = [3.0, 4.0, 0.0];
         let b = [0.0, 0.0, 0.0];
         assert!((distance_ly_arr(a, b) - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn light_delay_ruler_to_ship_zero_when_coincident() {
+        let p = [1.0, 2.0, 3.0];
+        assert_eq!(light_delay_ruler_to_ship(p, p), 0);
+    }
+
+    #[test]
+    fn light_delay_ruler_to_ship_matches_light_delay_hexadies() {
+        let ruler = [0.0, 0.0, 0.0];
+        let ship = [5.0, 0.0, 0.0];
+        let expected = light_delay_hexadies(distance_ly_arr(ruler, ship));
+        assert_eq!(light_delay_ruler_to_ship(ruler, ship), expected);
     }
 }

--- a/macrocosmo/src/scripting/gamestate_scope.rs
+++ b/macrocosmo/src/scripting/gamestate_scope.rs
@@ -2025,8 +2025,10 @@ pub mod apply {
         // Target position: the ship's own `Position`.
         let target_pos = world.get::<Position>(target_ship).map(|p| p.as_array())?;
 
-        let distance = physics::distance_ly_arr(issuer_pos, target_pos);
-        Some(physics::light_delay_hexadies(distance))
+        // #468: route through the shared `light_delay_ruler_to_ship`
+        // helper so the player / Lua / AI command paths share one
+        // definition of "Ruler → ship" light-delay.
+        Some(physics::light_delay_ruler_to_ship(issuer_pos, target_pos))
     }
 
     // ==================================================================

--- a/macrocosmo/src/ui/context_menu.rs
+++ b/macrocosmo/src/ui/context_menu.rs
@@ -404,13 +404,19 @@ pub fn draw_context_menu(
     // ground-truth ECS timeline (which the player can't observe yet).
     // The `light_delay.max(remaining_travel)` envelope is preserved.
     let command_delay: i64 = {
+        // #468: hoist the Ruler → ship light-delay through the shared
+        // `physics::light_delay_ruler_to_ship` helper so the player,
+        // Lua-scripting, and AI paths converge on one definition of
+        // "command travel time".
         let light_delay: i64 = player_q
             .single()
             .ok()
             .and_then(|(_, stationed, _)| {
                 let player_pos = positions.get(stationed.system).ok()?;
-                let dist = physics::distance_ly(player_pos, &ship_pos);
-                Some(physics::light_delay_hexadies(dist))
+                Some(physics::light_delay_ruler_to_ship(
+                    player_pos.as_array(),
+                    ship_pos.as_array(),
+                ))
             })
             .unwrap_or(0);
 

--- a/macrocosmo/tests/ai_command_lightspeed.rs
+++ b/macrocosmo/tests/ai_command_lightspeed.rs
@@ -1,31 +1,44 @@
-//! Round 9 PR #3 regression: AI commands incur light-speed delay.
+//! Round 9 PR #3 / #468 PR-1 regression: AI commands incur light-speed delay.
 //!
-//! Before this PR, NPC AI commands flowed `bus.emit_command →
+//! Before Round 9 PR #3, NPC AI commands flowed `bus.emit_command →
 //! drain_ai_commands` in a single tick — NPCs had perfect
 //! instantaneous reach across the galaxy regardless of their Ruler's
-//! position. The fix interposes [`AiCommandOutbox`] between producer
+//! position. PR #3 interposed an [`AiCommandOutbox`] between producer
 //! (`npc_decision_tick`, `run_short_agents`) and consumer
 //! (`drain_ai_commands`), computing each command's `arrives_at` from
-//! the Ruler's position to the command's destination via the
-//! existing [`compute_fact_arrival`] knowledge-side helper.
+//! the Ruler to the command's *destination* (`target_system` for
+//! spatial commands, capital for spatial-less).
 //!
-//! These tests pin the contract:
+//! **#468 PR-1 update.** That arrival model was wrong for ship-control
+//! commands. The order has to reach the *ship*, not the target —
+//! a Ruler at home A dispatching a Scout already at frontier B (5 ly
+//! away) was paying ~300 hd delay before any survey could fire ("AI
+//! does nothing for years"). PR-1 migrates `survey_system` onto a new
+//! per-ship `PendingAiShipCommand` pipeline whose `arrives_at` is
+//! `light_delay_ruler_to_ship(ruler, ship)`. PR-2/3 will migrate the
+//! remaining ship-control kinds.
 //!
-//! 1. `survey_command_outbox_holds_until_light_delay_elapses` —
-//!    a survey command emitted with the Ruler at home and the
-//!    target several light-years away must NOT trigger a
-//!    `SurveyRequested` event before `light_delay_hexadies(d)`
-//!    elapses. After the window passes, the event fires.
-//! 2. `survey_command_with_ruler_at_target_lands_immediately` —
-//!    a Ruler stationed at the target system means origin ==
-//!    destination, light delay is zero, and the survey command
-//!    lands on the same tick the AI emitted it.
+//! These tests pin the new survey contract:
+//!
+//! 1. `survey_ai_scout_at_home_ruler_at_home_target_far_zero_delay` —
+//!    Ruler at A, Scout at A, frontier B 5 ly away. The Ruler→ship
+//!    distance is zero, so the survey must fire within 1–2 ticks
+//!    regardless of the target's distance. This is the core #468
+//!    regression: pre-PR-1, the AI would wait ~300 hd before firing.
+//! 2. `survey_ai_scout_remote_ruler_at_home_delays_by_ruler_to_ship` —
+//!    Ruler at A, Scout at B (5 ly), target C. Delay must equal
+//!    `light_delay_hexadies(5)` (~300 hd) — Ruler→ship distance, not
+//!    Ruler→target.
+//! 3. `survey_ai_scout_at_home_ruler_remote_delays_by_ruler_to_ship` —
+//!    Symmetric: Ruler at frontier (5 ly), Scout at home. Same delay.
 
 mod common;
 
 use bevy::prelude::*;
 
 use macrocosmo::ai::AiPlayerMode;
+use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+use macrocosmo::ai::schema::ids::command as cmd_ids;
 use macrocosmo::knowledge::{KnowledgeStore, SystemVisibilityMap, SystemVisibilityTier};
 use macrocosmo::player::{Empire, Faction, PlayerEmpire};
 use macrocosmo::ship::command_events::SurveyRequested;
@@ -35,13 +48,15 @@ use macrocosmo::time_system::GameClock;
 use common::{advance_time, spawn_test_ruler, spawn_test_ship, spawn_test_system, test_app};
 
 /// Spawn a self-sufficient AI-controlled empire with one Explorer at
-/// `home`, a Ruler stationed at `ruler_system`, and a single
+/// `scout_home`, a Ruler stationed at `ruler_system`, and a single
 /// frontier system the AI is expected to survey.
 ///
-/// `frontier_distance_ly` controls the spatial separation: putting
-/// the frontier far from the Ruler stretches the light-speed window
-/// so the test can resolve the dispatch-vs-process race cleanly.
-fn setup_one_target(app: &mut App, frontier_distance_ly: f64) -> (Entity, Entity, Entity) {
+/// Returns `(empire, home, frontier, scout)` so each test can pin
+/// per-empire setup (Ruler placement, Scout location, target system).
+fn setup_survey_world(
+    app: &mut App,
+    frontier_distance_ly: f64,
+) -> (Entity, Entity, Entity, Entity) {
     app.insert_resource(AiPlayerMode(true));
 
     let empire = app
@@ -72,9 +87,9 @@ fn setup_one_target(app: &mut App, frontier_distance_ly: f64) -> (Entity, Entity
         false,
     );
 
-    // Visibility tiers: home is Local (we live there), frontier is
-    // Catalogued (we know it exists, haven't surveyed). The AI
-    // policy looks for unsurveyed *catalogued* systems.
+    // Visibility tiers: home is Local, frontier is Catalogued (known to
+    // exist but not surveyed). The AI policy looks for unsurveyed
+    // catalogued systems.
     {
         let mut em = app.world_mut().entity_mut(empire);
         let mut vis = em.get_mut::<SystemVisibilityMap>().unwrap();
@@ -82,10 +97,7 @@ fn setup_one_target(app: &mut App, frontier_distance_ly: f64) -> (Entity, Entity
         vis.set(frontier, SystemVisibilityTier::Catalogued);
     }
 
-    // Seed the empire's KnowledgeStore so home is "known surveyed"
-    // from the empire's own perspective — without this the AI would
-    // mistake home for an unsurveyed candidate (see the comment in
-    // `tests/ai_npc_no_double_survey_assignment.rs`).
+    // Seed the empire's KnowledgeStore so home is "known surveyed".
     let home_pos = app
         .world()
         .entity(home)
@@ -109,7 +121,8 @@ fn setup_one_target(app: &mut App, frontier_distance_ly: f64) -> (Entity, Entity
         });
     }
 
-    // One Explorer ship parked at home, owned by the test empire.
+    // Scout at home initially — tests reposition by mutating
+    // `ShipState`/`Position` after this helper returns.
     let scout = spawn_test_ship(
         app.world_mut(),
         "Scout-1",
@@ -123,117 +136,42 @@ fn setup_one_target(app: &mut App, frontier_distance_ly: f64) -> (Entity, Entity
         .unwrap()
         .owner = Owner::Empire(empire);
 
-    (empire, home, frontier)
+    (empire, home, frontier, scout)
+}
+
+/// Mutate the Scout's location to be in `system` at world-space
+/// position `pos`. Used to set up the "Scout off at the frontier"
+/// fixture for the Ruler→ship delay assertions.
+fn place_ship_at(app: &mut App, ship: Entity, system: Entity, pos: [f64; 3]) {
+    let mut em = app.world_mut().entity_mut(ship);
+    if let Some(mut state) = em.get_mut::<macrocosmo::ship::ShipState>() {
+        *state = macrocosmo::ship::ShipState::InSystem { system };
+    }
+    if let Some(mut position) = em.get_mut::<macrocosmo::components::Position>() {
+        *position = macrocosmo::components::Position::from(pos);
+    }
 }
 
 /// Count `SurveyRequested` messages emitted this Update window.
-/// Uses Bevy 0.18's `iter_current_update_messages` so consumed
-/// messages are visible to later assertions without holding a
-/// long-lived cursor.
 fn survey_requested_count(app: &mut App) -> usize {
     let messages = app.world().resource::<Messages<SurveyRequested>>();
     messages.iter_current_update_messages().count()
 }
 
-/// A Ruler stationed `d` ly from the survey target should NOT
-/// produce a `SurveyRequested` event before `light_delay(d)` ticks
-/// have elapsed since the AI emitted the command. This is the core
-/// "Bug 2" regression: pre-PR-3 the event fired the same tick the
-/// AI policy decided.
-#[test]
-fn survey_command_outbox_holds_until_light_delay_elapses() {
-    use macrocosmo::physics::light_delay_hexadies;
-
-    let frontier_distance_ly = 5.0;
-    let mut app = test_app();
-    let (empire, home, frontier) = setup_one_target(&mut app, frontier_distance_ly);
-    spawn_test_ruler(app.world_mut(), empire, home);
-
-    // Required by Bevy's message reader bookkeeping in headless tests.
-    app.world_mut()
-        .resource_mut::<Messages<SurveyRequested>>()
-        .update();
-
-    // Run a couple of ticks so `npc_decision_tick` fires (it gates on
-    // `clock.elapsed > last_tick`) and the dispatcher stows the
-    // command in the outbox. We deliberately stay well below the
-    // light-speed window so the assertion catches the bug.
-    for _ in 0..3 {
-        advance_time(&mut app, 1);
-    }
-
-    // Drain whatever events accumulated during the early window.
-    // Then explicitly re-check `Messages` to confirm zero events
-    // fired across the most recent Update — the outbox is gating.
-    let _ = survey_requested_count(&mut app);
-    app.world_mut()
-        .resource_mut::<Messages<SurveyRequested>>()
-        .update();
-    advance_time(&mut app, 1);
-    let count_at_4 = survey_requested_count(&mut app);
-    assert_eq!(
-        count_at_4,
-        0,
-        "survey event fired {} hexadies before light-speed window — \
-         outbox failed to gate (bug 2 regression)",
-        light_delay_hexadies(frontier_distance_ly)
-    );
-
-    // Now drive enough ticks to clear the light-speed window. The
-    // dispatcher computes arrives_at = sent_at + light_delay; once
-    // that tick passes, `process_ai_pending_commands` releases the
-    // command and `drain_ai_commands` produces a SurveyRequested
-    // event. Add a small slack so the dispatch + process schedule
-    // boundary doesn't trip the assertion at the exact threshold.
-    // Step the clock 1 hexady at a time and accumulate
-    // `SurveyRequested` events as they fire. `iter_current_update_messages`
-    // only sees the most recent Update window's writes (Bevy 0.18
-    // double-buffer rotation), so a single check at the end of the
-    // loop misses any event that fired mid-loop. Accumulating tick by
-    // tick is the only deterministic observation strategy here.
-    //
-    // Also tracks outbox state across the threshold so a real
-    // over-gating regression (= command stuck in outbox) and a test
-    // observation miss (= count == 0 because event already drained)
-    // can be distinguished in failure messages.
-    let light_delay = light_delay_hexadies(frontier_distance_ly);
-    let mut survey_event_total = 0usize;
-    let mut released_at: Option<i64> = None;
-    for _ in 0..(light_delay + 5) {
-        advance_time(&mut app, 1);
-        survey_event_total += survey_requested_count(&mut app);
-        if released_at.is_none() && !outbox_holds_survey_for(&app, frontier) {
-            released_at = Some(app.world().resource::<GameClock>().elapsed);
-        }
-    }
-
-    assert!(
-        survey_event_total > 0,
-        "no SurveyRequested fired across {} post-threshold ticks (outbox \
-         released_at={:?}) — outbox is over-gating",
-        light_delay + 5,
-        released_at,
-    );
-    assert!(
-        released_at.is_some(),
-        "outbox never released the survey_system command across {} \
-         post-threshold ticks — direct over-gating regression",
-        light_delay + 5,
-    );
-}
-
-/// True iff `AiCommandOutbox` currently holds a `survey_system`
-/// command targeted at `target_system`. Used to distinguish
-/// "outbox over-gates" from "test observation missed the event"
-/// in the post-threshold accumulator loop.
-fn outbox_holds_survey_for(app: &App, target_system: Entity) -> bool {
-    let outbox = app.world().resource::<macrocosmo::ai::command_outbox::AiCommandOutbox>();
-    let kind = macrocosmo::ai::schema::ids::command::survey_system();
-    outbox.entries.iter().any(|entry| {
-        if entry.command.kind != kind {
+/// True iff a `PendingAiShipCommand` is in flight (= `arrives_at` > now)
+/// for a `survey_system` against `target_system`.
+fn pending_ship_command_holds_survey_for(app: &mut App, target_system: Entity) -> bool {
+    let now = app.world().resource::<GameClock>().elapsed;
+    let kind = cmd_ids::survey_system();
+    let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+    q.iter(app.world()).any(|p| {
+        if p.command.kind != kind {
             return false;
         }
-        match entry.command.params.get("target_system") {
+        if p.arrives_at <= now {
+            return false;
+        }
+        match p.command.params.get("target_system") {
             Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
                 target_system.to_bits() == sys_id.0
             }
@@ -242,38 +180,142 @@ fn outbox_holds_survey_for(app: &App, target_system: Entity) -> bool {
     })
 }
 
-/// Sanity counterpart: when origin == destination (Ruler at the
-/// survey target), the outbox computes arrives_at == sent_at and
-/// `process_ai_pending_commands` releases the command immediately.
-/// `drain_ai_commands` then produces the `SurveyRequested` event in
-/// the same Update.
-///
-/// This guards against an over-correction where every AI command
-/// pays at least one tick of artificial delay — the Ruler's local
-/// commands must remain instantaneous, mirroring the player path.
+/// #468 PR-1 core regression: Ruler at home, Scout at home, target
+/// far away. Pre-fix the AI paid Ruler→target light delay (~300 hd
+/// for 5 ly) before firing. Post-fix the delay is Ruler→ship = 0 so
+/// the survey fires within 1–2 ticks.
 #[test]
-fn survey_command_with_ruler_at_target_lands_immediately() {
+fn survey_ai_scout_at_home_ruler_at_home_target_far_zero_delay() {
+    let frontier_distance_ly = 5.0;
     let mut app = test_app();
-    // Set the Ruler at the *frontier* this time, not at home, so
-    // the survey command's destination matches the Ruler's
-    // StationedAt position. Light delay = 0.
-    let (empire, _home, frontier) = setup_one_target(&mut app, 5.0);
+    let (empire, home, frontier, _scout) = setup_survey_world(&mut app, frontier_distance_ly);
+    spawn_test_ruler(app.world_mut(), empire, home);
+
+    app.world_mut()
+        .resource_mut::<Messages<SurveyRequested>>()
+        .update();
+
+    // A handful of ticks is enough for `npc_decision_tick` to fire
+    // (gates on `clock.elapsed > last_tick`) AND for
+    // `drain_ai_ship_commands` to release the `PendingAiShipCommand`
+    // whose `arrives_at == sent_at` (Ruler at the ship → 0 light delay).
+    let mut survey_event_total = 0usize;
+    for _ in 0..5 {
+        advance_time(&mut app, 1);
+        survey_event_total += survey_requested_count(&mut app);
+    }
+
+    assert!(
+        survey_event_total > 0,
+        "Ruler at the ship's system must pay zero light-delay (Ruler→ship distance); \
+         expected SurveyRequested within 5 ticks for {} ly target but got 0 — #468 regression",
+        frontier_distance_ly,
+    );
+    let _ = frontier;
+}
+
+/// #468 PR-1: Ruler at home A, Scout at frontier B (5 ly), target C.
+/// The Ruler→ship distance is 5 ly, so the survey must NOT fire until
+/// `light_delay_hexadies(5)` ticks have elapsed.
+#[test]
+fn survey_ai_scout_remote_ruler_at_home_delays_by_ruler_to_ship() {
+    use macrocosmo::physics::light_delay_hexadies;
+
+    let mut app = test_app();
+    let (empire, home, frontier, scout) = setup_survey_world(&mut app, 5.0);
+    spawn_test_ruler(app.world_mut(), empire, home);
+
+    // Move the Scout to the frontier — Ruler→ship distance = 5 ly.
+    place_ship_at(&mut app, scout, frontier, [5.0, 0.0, 0.0]);
+
+    app.world_mut()
+        .resource_mut::<Messages<SurveyRequested>>()
+        .update();
+
+    // Drive a few ticks so the decision system emits a survey_system
+    // command and `dispatch_ai_pending_commands` spawns the
+    // `PendingAiShipCommand` holder.
+    for _ in 0..3 {
+        advance_time(&mut app, 1);
+    }
+
+    app.world_mut()
+        .resource_mut::<Messages<SurveyRequested>>()
+        .update();
+    advance_time(&mut app, 1);
+
+    // Pre-arrival sanity: no survey fired yet, holder still in flight.
+    let early_count = survey_requested_count(&mut app);
+    assert_eq!(
+        early_count, 0,
+        "survey fired before Ruler→ship light delay elapsed — #468 regression",
+    );
+    assert!(
+        pending_ship_command_holds_survey_for(&mut app, frontier),
+        "PendingAiShipCommand for survey of frontier should be in flight before light delay elapses",
+    );
+
+    // Accumulate survey events tick-by-tick across the rest of the
+    // light-delay window. `iter_current_update_messages` only sees the
+    // current Update, so we must observe each tick individually.
+    let light_delay = light_delay_hexadies(5.0);
+    let mut survey_event_total = 0usize;
+    let mut released_at: Option<i64> = None;
+    for _ in 0..(light_delay + 5) {
+        advance_time(&mut app, 1);
+        survey_event_total += survey_requested_count(&mut app);
+        if released_at.is_none() && !pending_ship_command_holds_survey_for(&mut app, frontier) {
+            released_at = Some(app.world().resource::<GameClock>().elapsed);
+        }
+    }
+    assert!(
+        survey_event_total > 0,
+        "no SurveyRequested fired across {} post-threshold ticks (released_at={:?}) — #468 PR-1 over-gating regression",
+        light_delay + 5,
+        released_at,
+    );
+}
+
+/// #468 PR-1 symmetry: Ruler at frontier B (5 ly), Scout at home A,
+/// target wherever. Same Ruler→ship distance = 5 ly, same delay.
+/// Guards against the helper being asymmetric in one direction.
+#[test]
+fn survey_ai_scout_at_home_ruler_remote_delays_by_ruler_to_ship() {
+    use macrocosmo::physics::light_delay_hexadies;
+
+    let mut app = test_app();
+    // Frontier is the target system AND the Ruler's posting.
+    let (empire, _home, frontier, _scout) = setup_survey_world(&mut app, 5.0);
     spawn_test_ruler(app.world_mut(), empire, frontier);
 
     app.world_mut()
         .resource_mut::<Messages<SurveyRequested>>()
         .update();
 
-    // A handful of ticks is enough — both the AI cadence gate and
-    // the dispatch ↔ process schedule split fit inside this window.
-    for _ in 0..5 {
+    for _ in 0..3 {
         advance_time(&mut app, 1);
     }
 
-    let total_in_last_update = survey_requested_count(&mut app);
+    app.world_mut()
+        .resource_mut::<Messages<SurveyRequested>>()
+        .update();
+    advance_time(&mut app, 1);
+
+    let early_count = survey_requested_count(&mut app);
+    assert_eq!(
+        early_count, 0,
+        "survey fired before Ruler→ship light delay elapsed (symmetric case) — #468 regression",
+    );
+
+    let light_delay = light_delay_hexadies(5.0);
+    let mut survey_event_total = 0usize;
+    for _ in 0..(light_delay + 5) {
+        advance_time(&mut app, 1);
+        survey_event_total += survey_requested_count(&mut app);
+    }
     assert!(
-        total_in_last_update > 0 || app.world().resource::<Messages<SurveyRequested>>().len() > 0,
-        "Ruler at the survey target should pay no light-speed delay; \
-         expected at least one SurveyRequested within 5 ticks but got 0",
+        survey_event_total > 0,
+        "no SurveyRequested fired across {} post-threshold ticks — #468 PR-1 symmetric over-gating regression",
+        light_delay + 5,
     );
 }

--- a/macrocosmo/tests/ai_command_lightspeed.rs
+++ b/macrocosmo/tests/ai_command_lightspeed.rs
@@ -164,20 +164,8 @@ fn pending_ship_command_holds_survey_for(app: &mut App, target_system: Entity) -
     let now = app.world().resource::<GameClock>().elapsed;
     let kind = cmd_ids::survey_system();
     let mut q = app.world_mut().query::<&PendingAiShipCommand>();
-    q.iter(app.world()).any(|p| {
-        if p.command.kind != kind {
-            return false;
-        }
-        if p.arrives_at <= now {
-            return false;
-        }
-        match p.command.params.get("target_system") {
-            Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
-                target_system.to_bits() == sys_id.0
-            }
-            _ => false,
-        }
-    })
+    q.iter(app.world())
+        .any(|p| p.kind == kind && p.arrives_at > now && p.target_system == target_system)
 }
 
 /// #468 PR-1 core regression: Ruler at home, Scout at home, target
@@ -317,5 +305,135 @@ fn survey_ai_scout_at_home_ruler_remote_delays_by_ruler_to_ship() {
         survey_event_total > 0,
         "no SurveyRequested fired across {} post-threshold ticks — #468 PR-1 symmetric over-gating regression",
         light_delay + 5,
+    );
+}
+
+/// #468 PR-1 BLOCKER regression (adversarial review HIGH #1): when a
+/// matured `PendingAiShipCommand` is rejected at drain time (ship no
+/// longer idle, owner changed, despawned), the `PendingAssignment`
+/// marker stamped at outbox-spawn time must be removed too — otherwise
+/// the ship is permanently excluded from future AI dispatches because
+/// the dedup scan at `npc_decision.rs::dedup_pending_assignments`
+/// filters by `PendingAssignment`.
+///
+/// Pre-fix: `apply_survey_to_ship` early-returned without touching the
+/// marker on any of the reject branches, since no `SurveyRequested`
+/// fired and `handle_survey_requested` (the legacy cleaner) never ran.
+/// Post-fix: the drain explicitly strips the marker on every reject.
+///
+/// Test shape: we don't want the AI to keep re-emitting `survey_system`
+/// in subsequent ticks (that would re-stamp the marker after every
+/// removal). So we set up the holder + marker manually, set the ship
+/// to a non-idle state, then drive the drain to maturity and assert
+/// the marker is gone. The dispatcher path is exercised by the other
+/// tests in this file.
+#[test]
+fn rejected_survey_at_drain_time_releases_pending_assignment() {
+    use macrocosmo::ai::AiBusResource;
+    use macrocosmo::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    use macrocosmo::ai::schema::ids::command as cmd_ids;
+    use macrocosmo::ship::{CommandQueue, QueuedCommand};
+
+    let mut app = test_app();
+    // Disable AI policy emission so the test exclusively exercises the
+    // drain reject path — without this the next NPC tick would
+    // re-stamp the marker after we observe its removal.
+    app.insert_resource(AiPlayerMode(false));
+    app.insert_resource(AiBusResource::default());
+
+    let empire = app
+        .world_mut()
+        .spawn((
+            Empire {
+                name: "Reject Test".into(),
+            },
+            Faction {
+                id: "reject_test".into(),
+                name: "Reject Test".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+        ))
+        .id();
+
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [5.0, 0.0, 0.0],
+        1.0,
+        false,
+        false,
+    );
+    let scout = spawn_test_ship(
+        app.world_mut(),
+        "Scout-1",
+        "explorer_mk1",
+        home,
+        [0.0, 0.0, 0.0],
+    );
+    app.world_mut()
+        .entity_mut(scout)
+        .get_mut::<Ship>()
+        .unwrap()
+        .owner = Owner::Empire(empire);
+
+    // Set the ship's CommandQueue to non-empty so apply_survey_to_ship
+    // takes the "queue.commands.is_empty()" reject branch on maturity.
+    {
+        let mut em = app.world_mut().entity_mut(scout);
+        if let Some(mut queue) = em.get_mut::<CommandQueue>() {
+            queue.commands.push(QueuedCommand::MoveTo { system: home });
+        }
+    }
+
+    // Manually spawn the in-flight holder + stamp the marker — same
+    // shape the dispatcher would produce on the survey path.
+    let now = app.world().resource::<GameClock>().elapsed;
+    app.world_mut().spawn(PendingAiShipCommand {
+        kind: cmd_ids::survey_system(),
+        target_system: frontier,
+        ship: scout,
+        issuer_empire: empire,
+        sent_at: now,
+        arrives_at: now + 1,
+    });
+    app.world_mut()
+        .entity_mut(scout)
+        .insert(PendingAssignment {
+            faction: empire,
+            kind: AssignmentKind::Survey,
+            target: AssignmentTarget::System(frontier),
+            since: now,
+        });
+
+    // Sanity: the marker is stamped before the drain runs.
+    assert!(
+        app.world().entity(scout).get::<PendingAssignment>().is_some(),
+        "PendingAssignment must be present pre-drain (test setup invariant)",
+    );
+
+    // Walk the clock so drain_ai_ship_commands fires. arrives_at = now+1,
+    // so a couple of ticks is plenty.
+    for _ in 0..3 {
+        advance_time(&mut app, 1);
+    }
+
+    // After rejection: the holder is despawned AND the marker is
+    // removed. Pre-fix this assertion failed — the marker stayed
+    // forever, locking the scout out of future surveys.
+    let holder_remains = {
+        let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+        q.iter(app.world()).any(|p| p.ship == scout)
+    };
+    assert!(
+        !holder_remains,
+        "Holder must be drained even on reject path",
+    );
+    assert!(
+        app.world().entity(scout).get::<PendingAssignment>().is_none(),
+        "PendingAssignment must be removed when survey is rejected at drain time \
+         (otherwise the ship is permanently excluded from AI dispatches)",
     );
 }

--- a/macrocosmo/tests/ai_npc_avoid_hostile_systems.rs
+++ b/macrocosmo/tests/ai_npc_avoid_hostile_systems.rs
@@ -122,17 +122,39 @@ fn setup_hostile_known_scenario(app: &mut App, target_surveyed: bool) -> (Entity
 }
 
 fn outbox_has_command_for(
-    app: &App,
+    app: &mut App,
     kind: macrocosmo_ai::CommandKindId,
     target_system: Entity,
 ) -> bool {
-    let outbox = app.world().resource::<AiCommandOutbox>();
-    outbox.entries.iter().any(|entry| {
-        let cmd = &entry.command;
-        if cmd.kind != kind {
+    let outbox_hit = {
+        let outbox = app.world().resource::<AiCommandOutbox>();
+        outbox.entries.iter().any(|entry| {
+            let cmd = &entry.command;
+            if cmd.kind != kind {
+                return false;
+            }
+            match cmd.params.get("target_system") {
+                Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
+                    target_system.to_bits() == sys_id.0
+                }
+                _ => false,
+            }
+        })
+    };
+    if outbox_hit {
+        return true;
+    }
+    // #468 PR-1: `survey_system` no longer flows through
+    // `AiCommandOutbox` — check the per-ship pipeline too. Folded into
+    // the same helper so the "did the AI emit X?" question stays a
+    // single call across both pipelines as PR-2/3 migrate more kinds.
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+    q.iter(app.world()).any(|p| {
+        if p.command.kind != kind {
             return false;
         }
-        match cmd.params.get("target_system") {
+        match p.command.params.get("target_system") {
             Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
                 target_system.to_bits() == sys_id.0
             }
@@ -228,7 +250,7 @@ fn ai_does_not_dispatch_survey_to_known_hostile_system() {
     }
 
     assert!(
-        !outbox_has_command_for(&app, cmd_ids::survey_system(), target),
+        !outbox_has_command_for(&mut app, cmd_ids::survey_system(), target),
         "AI emitted survey_system for a system flagged has_hostile=true \
          in its own KnowledgeStore — Bug B regression (the lost-scout \
          loop)."
@@ -280,7 +302,7 @@ fn ai_does_not_dispatch_colonize_to_known_hostile_system() {
     }
 
     assert!(
-        !outbox_has_command_for(&app, cmd_ids::colonize_system(), target),
+        !outbox_has_command_for(&mut app, cmd_ids::colonize_system(), target),
         "AI emitted colonize_system for a system flagged has_hostile=true \
          in its own KnowledgeStore — Bug B regression (settlers into the \
          meat grinder)."

--- a/macrocosmo/tests/ai_npc_avoid_hostile_systems.rs
+++ b/macrocosmo/tests/ai_npc_avoid_hostile_systems.rs
@@ -150,17 +150,8 @@ fn outbox_has_command_for(
     // single call across both pipelines as PR-2/3 migrate more kinds.
     use macrocosmo::ai::command_consumer::PendingAiShipCommand;
     let mut q = app.world_mut().query::<&PendingAiShipCommand>();
-    q.iter(app.world()).any(|p| {
-        if p.command.kind != kind {
-            return false;
-        }
-        match p.command.params.get("target_system") {
-            Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
-                target_system.to_bits() == sys_id.0
-            }
-            _ => false,
-        }
-    })
+    q.iter(app.world())
+        .any(|p| p.kind == kind && p.target_system == target_system)
 }
 
 fn pending_survey_targets(app: &mut App, empire: Entity) -> Vec<Entity> {

--- a/macrocosmo/tests/ai_npc_outbox_dedup.rs
+++ b/macrocosmo/tests/ai_npc_outbox_dedup.rs
@@ -77,17 +77,7 @@ fn count_outbox_for(
         use macrocosmo::ai::command_consumer::PendingAiShipCommand;
         let mut q = app.world_mut().query::<&PendingAiShipCommand>();
         q.iter(app.world())
-            .filter(|p| {
-                if p.command.kind != kind {
-                    return false;
-                }
-                match p.command.params.get("target_system") {
-                    Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
-                        target_system.to_bits() == sys_id.0
-                    }
-                    _ => false,
-                }
-            })
+            .filter(|p| p.kind == kind && p.target_system == target_system)
             .count()
     };
 

--- a/macrocosmo/tests/ai_npc_outbox_dedup.rs
+++ b/macrocosmo/tests/ai_npc_outbox_dedup.rs
@@ -43,24 +43,55 @@ use macrocosmo::ship::{CoreShip, Owner, Ship};
 
 use common::{advance_time, spawn_test_ruler, spawn_test_ship, spawn_test_system, test_app};
 
-fn count_outbox_for(app: &App, kind: macrocosmo_ai::CommandKindId, target_system: Entity) -> usize {
-    let outbox = app.world().resource::<AiCommandOutbox>();
-    outbox
-        .entries
-        .iter()
-        .filter(|entry| {
-            let cmd = &entry.command;
-            if cmd.kind != kind {
-                return false;
-            }
-            match cmd.params.get("target_system") {
-                Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
-                    target_system.to_bits() == sys_id.0
+fn count_outbox_for(
+    app: &mut App,
+    kind: macrocosmo_ai::CommandKindId,
+    target_system: Entity,
+) -> usize {
+    let outbox_count = {
+        let outbox = app.world().resource::<AiCommandOutbox>();
+        outbox
+            .entries
+            .iter()
+            .filter(|entry| {
+                let cmd = &entry.command;
+                if cmd.kind != kind {
+                    return false;
                 }
-                _ => false,
-            }
-        })
-        .count()
+                match cmd.params.get("target_system") {
+                    Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
+                        target_system.to_bits() == sys_id.0
+                    }
+                    _ => false,
+                }
+            })
+            .count()
+    };
+
+    // #468 PR-1: `survey_system` migrated off `AiCommandOutbox` onto
+    // `PendingAiShipCommand` (one entry per ship). The dedup test
+    // cares about "is there *any* in-flight survey to this target?"
+    // — fold both sources together so the assertion stays valid as
+    // PR-2/3 migrate other kinds.
+    let ship_command_count = {
+        use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+        let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+        q.iter(app.world())
+            .filter(|p| {
+                if p.command.kind != kind {
+                    return false;
+                }
+                match p.command.params.get("target_system") {
+                    Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
+                        target_system.to_bits() == sys_id.0
+                    }
+                    _ => false,
+                }
+            })
+            .count()
+    };
+
+    outbox_count + ship_command_count
 }
 
 /// Spawn an AI-controlled empire at `home` (capital, surveyed in its
@@ -206,27 +237,41 @@ fn place_core_at(world: &mut World, empire: Entity, system: Entity, position: [f
 
 /// Bug A regression (survey path): with two idle scouts, one
 /// frontier target, and a far-away placement (so the light-speed
-/// outbox window spans many decision ticks), only ONE
-/// `survey_system` command may live in the outbox at any point
-/// before the first one arrives.
+/// courier window spans many decision ticks), only ONE
+/// `survey_system` command may live in flight at any point before
+/// the first one arrives.
+///
+/// #468 PR-1: `survey_system` now flows through `PendingAiShipCommand`
+/// keyed on Ruler→ship distance, not Ruler→target. To keep the
+/// courier window open across multiple decision ticks the scouts are
+/// staged at a remote loitering system 5 ly away from the Ruler's
+/// home — placing them at home would give a 0 light-delay and the
+/// command would mature instantly. The dedup contract under test is
+/// unchanged: only ONE in-flight + marker pair may exist for the
+/// same target while the courier window is open.
 #[test]
 fn outbox_dedups_survey_system_during_light_delay_window() {
-    // 5 ly frontier → light delay is many tens of hexadies, more than
-    // enough for `mid_cadence=2` `npc_decision_tick` to fire several
-    // times during the window.
     let mut app = test_app();
-    let (empire, home, frontier) = setup_far_target(&mut app, "Vesk", 5.0, false);
+    let (empire, _home, frontier) = setup_far_target(&mut app, "Vesk", 5.0, false);
 
-    // Two idle scouts at home — the bug needs more than one candidate
-    // ship to manifest (Rule 2 zips ships×targets and would happily
-    // dispatch the second scout if dedup misses the in-flight one).
+    // Stage the scouts at a remote loitering system (the same 5-ly
+    // frontier system would also work, but spinning a dedicated
+    // "Loiter" system avoids any survey-the-system-you're-in edge
+    // case in the policy). Scouts at 5 ly from Ruler keep the
+    // Ruler→ship light-delay window open.
+    let loiter = spawn_test_system(app.world_mut(), "Loiter", [0.0, 5.0, 0.0], 1.0, true, false);
+
+    // Two idle scouts at the remote loitering system — the bug needs
+    // more than one candidate ship to manifest (Rule 2 zips
+    // ships×targets and would happily dispatch the second scout if
+    // dedup misses the in-flight one).
     for i in 0..2 {
         let s = spawn_test_ship(
             app.world_mut(),
             &format!("Scout-{}", i),
             "explorer_mk1",
-            home,
-            [0.0, 0.0, 0.0],
+            loiter,
+            [0.0, 5.0, 0.0],
         );
         app.world_mut()
             .entity_mut(s)
@@ -236,14 +281,14 @@ fn outbox_dedups_survey_system_during_light_delay_window() {
     }
 
     // First batch: enough ticks for `npc_decision_tick` to fire once
-    // (it gates on `clock.elapsed > last_tick`) and the dispatcher to
-    // park the command in the outbox. Stay well under the 5-ly light
-    // delay so the entry hasn't matured yet.
+    // and the dispatcher to spawn the `PendingAiShipCommand` holder.
+    // Stay well under the 5-ly light delay so the holder is still
+    // in flight.
     for _ in 0..3 {
         advance_time(&mut app, 1);
     }
 
-    let after_first = count_outbox_for(&app, cmd_ids::survey_system(), frontier);
+    let after_first = count_outbox_for(&mut app, cmd_ids::survey_system(), frontier);
     assert_eq!(
         after_first, 1,
         "expected exactly 1 in-flight survey command after first decision \
@@ -252,19 +297,19 @@ fn outbox_dedups_survey_system_during_light_delay_window() {
     );
 
     // Second batch: drive several more decision ticks while the
-    // outbox entry is still in flight. The pre-fix code would let the
+    // holder is still in flight. The pre-fix code would let the
     // second scout fire onto the same target — the assertion checks
-    // the outbox count stays at 1.
+    // the in-flight count stays at 1.
     for _ in 0..6 {
         advance_time(&mut app, 1);
     }
 
-    let after_second = count_outbox_for(&app, cmd_ids::survey_system(), frontier);
+    let after_second = count_outbox_for(&mut app, cmd_ids::survey_system(), frontier);
     assert_eq!(
         after_second, 1,
-        "expected outbox to still hold exactly 1 survey command for the \
-         frontier (the light-speed window has not elapsed); got {} — \
-         Bug A regression",
+        "expected exactly 1 in-flight survey command for the frontier \
+         (the light-speed window has not elapsed); got {} — \
+         Bug A + #468 PR-1 regression",
         after_second,
     );
 }
@@ -303,7 +348,7 @@ fn outbox_dedups_colonize_system_during_light_delay_window() {
         advance_time(&mut app, 1);
     }
 
-    let after_first = count_outbox_for(&app, cmd_ids::colonize_system(), frontier);
+    let after_first = count_outbox_for(&mut app, cmd_ids::colonize_system(), frontier);
     assert_eq!(
         after_first, 1,
         "expected exactly 1 in-flight colonize command after first decision \
@@ -315,7 +360,7 @@ fn outbox_dedups_colonize_system_during_light_delay_window() {
         advance_time(&mut app, 1);
     }
 
-    let after_second = count_outbox_for(&app, cmd_ids::colonize_system(), frontier);
+    let after_second = count_outbox_for(&mut app, cmd_ids::colonize_system(), frontier);
     assert_eq!(
         after_second, 1,
         "expected outbox to still hold exactly 1 colonize command for the \

--- a/macrocosmo/tests/short_rules_cutover_sentinel.rs
+++ b/macrocosmo/tests/short_rules_cutover_sentinel.rs
@@ -45,16 +45,18 @@ fn find_outbox(app: &App, kind: macrocosmo_ai::CommandKindId) -> Option<macrocos
 /// #468 PR-1: ship-kind commands (currently just `survey_system`) flow
 /// through the per-ship `PendingAiShipCommand` pipeline instead of the
 /// faction-wide `AiCommandOutbox`. Find the first such holder whose
-/// command kind matches.
+/// command kind matches and return its (kind, target_system, ship,
+/// issuer_empire) — enough to pin the cutover wire shape without
+/// holding a borrow on the world.
 fn find_ship_pending(
     app: &mut App,
     kind: macrocosmo_ai::CommandKindId,
-) -> Option<macrocosmo_ai::Command> {
+) -> Option<(macrocosmo_ai::CommandKindId, Entity, Entity, Entity)> {
     use macrocosmo::ai::command_consumer::PendingAiShipCommand;
     let mut q = app.world_mut().query::<&PendingAiShipCommand>();
     q.iter(app.world())
-        .find(|p| p.command.kind == kind)
-        .map(|p| p.command.clone())
+        .find(|p| p.kind == kind)
+        .map(|p| (p.kind.clone(), p.target_system, p.ship, p.issuer_empire))
 }
 
 // ---- Rule 2 (survey) — Fleet-scope ShortAgent ---------------------------
@@ -154,35 +156,23 @@ fn short_emits_survey_system_after_cutover() {
         advance_time(&mut app, 1);
     }
 
-    let cmd = find_ship_pending(&mut app, cmd_ids::survey_system())
-        .expect("Short must emit survey_system");
+    let (kind, target_system, ship, issuer_empire) =
+        find_ship_pending(&mut app, cmd_ids::survey_system())
+            .expect("Short must emit survey_system");
     assert_eq!(
-        cmd.kind.as_str(),
+        kind.as_str(),
         "survey_system",
         "wire kind must match the deleted Mid Rule 2"
     );
-    // issuer is FactionId derived from the empire entity.
     assert_eq!(
-        cmd.issuer,
-        macrocosmo_ai::FactionId(empire.index().index()),
-        "issuer must remain the empire FactionId",
+        target_system, frontier,
+        "target_system must be the unsurveyed frontier"
     );
-    match cmd.params.get("target_system") {
-        Some(macrocosmo_ai::CommandValue::System(sys)) => {
-            assert_eq!(sys.0, frontier.to_bits(), "target_system param");
-        }
-        other => panic!("expected target_system = SystemRef; got {:?}", other),
-    }
-    match cmd.params.get("ship_count") {
-        Some(macrocosmo_ai::CommandValue::I64(n)) => assert_eq!(*n, 1, "ship_count"),
-        other => panic!("expected ship_count=1; got {:?}", other),
-    }
-    match cmd.params.get("ship_0") {
-        Some(macrocosmo_ai::CommandValue::Entity(eref)) => {
-            assert_eq!(eref.0, scout.to_bits(), "ship_0 = scout");
-        }
-        other => panic!("expected ship_0 entity; got {:?}", other),
-    }
+    assert_eq!(ship, scout, "ship must be the spawned scout (= ship_0)");
+    assert_eq!(
+        issuer_empire, empire,
+        "issuer_empire must be the empire that owns the scout"
+    );
 }
 
 // ---- Rule 5b (slot fill) — ColonizedSystem-scope ShortAgent --------------

--- a/macrocosmo/tests/short_rules_cutover_sentinel.rs
+++ b/macrocosmo/tests/short_rules_cutover_sentinel.rs
@@ -42,6 +42,21 @@ fn find_outbox(app: &App, kind: macrocosmo_ai::CommandKindId) -> Option<macrocos
         .map(|entry| entry.command.clone())
 }
 
+/// #468 PR-1: ship-kind commands (currently just `survey_system`) flow
+/// through the per-ship `PendingAiShipCommand` pipeline instead of the
+/// faction-wide `AiCommandOutbox`. Find the first such holder whose
+/// command kind matches.
+fn find_ship_pending(
+    app: &mut App,
+    kind: macrocosmo_ai::CommandKindId,
+) -> Option<macrocosmo_ai::Command> {
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+    q.iter(app.world())
+        .find(|p| p.command.kind == kind)
+        .map(|p| p.command.clone())
+}
+
 // ---- Rule 2 (survey) — Fleet-scope ShortAgent ---------------------------
 
 /// Short cutover sentinel: with one idle surveyor + one unsurveyed
@@ -111,12 +126,20 @@ fn short_emits_survey_system_after_cutover() {
         });
     }
 
+    // #468 PR-1: stage the scout at a remote loitering system 5 ly
+    // away so the Ruler→ship light-delay keeps the
+    // `PendingAiShipCommand` holder around long enough for the test
+    // to inspect it. Placing the scout at home (= Ruler's system)
+    // would give a zero light-delay and `drain_ai_ship_commands`
+    // would dispatch + despawn the holder in the same tick the
+    // Short layer emitted the command.
+    let loiter = spawn_test_system(app.world_mut(), "Loiter", [0.0, 5.0, 0.0], 1.0, true, false);
     let scout = spawn_test_ship(
         app.world_mut(),
         "Scout-1",
         "explorer_mk1",
-        home,
-        [0.0, 0.0, 0.0],
+        loiter,
+        [0.0, 5.0, 0.0],
     );
     app.world_mut()
         .entity_mut(scout)
@@ -125,13 +148,14 @@ fn short_emits_survey_system_after_cutover() {
         .owner = Owner::Empire(empire);
 
     // Walk a few ticks: `npc_decision_tick` populates the per-empire
-    // scratch, `run_short_agents` reads it, the dispatcher parks the
-    // command in the outbox.
+    // scratch, `run_short_agents` reads it, the dispatcher spawns
+    // the `PendingAiShipCommand` holder.
     for _ in 0..3 {
         advance_time(&mut app, 1);
     }
 
-    let cmd = find_outbox(&app, cmd_ids::survey_system()).expect("Short must emit survey_system");
+    let cmd = find_ship_pending(&mut app, cmd_ids::survey_system())
+        .expect("Short must emit survey_system");
     assert_eq!(
         cmd.kind.as_str(),
         "survey_system",


### PR DESCRIPTION
## Summary

- **Bug fixed (partially):** AI ship-control commands paid Ruler→target_system light delay instead of Ruler→ship. A Ruler at home A dispatching a Scout already at frontier B (5 ly) was waiting ~300 hexadies before *any* survey fired — the "NPC does nothing for years" symptom in #468.
- **Scope:** `survey_system` only (proof of concept). PR-2/3 will migrate `colonize_system`, `reposition`, `blockade`, `attack_target`, `load_deliverable`, `unload_deliverable`, `colonize_planet`, `move_ruler`, and the `fortify_system` mis-categorisation.
- **Wire shape preserved:** `SurveyRequested` events / `PendingAssignment` markers / `ShipProjection` writes all keep their existing contracts. SAVE_VERSION does **not** bump.

## Changes

1. **Hoist `physics::light_delay_ruler_to_ship`** alongside `light_delay_hexadies`. Player (`ui::context_menu`), Lua scripting (`scripting::gamestate_scope::compute_request_light_delay`), and AI dispatch paths now share one helper.
2. **New `PendingAiShipCommand` component** in `ai::command_consumer` (runtime-only, not `Reflect`, not persisted — mirrors `PendingScriptedCommand`). Carries `{command, ship, issuer_empire, sent_at, arrives_at}`.
3. **New `drain_ai_ship_commands` system** registered before `drain_ai_commands` in `AiTickSet::CommandDrain`. On maturity (`clock.elapsed ≥ arrives_at`) it writes `SurveyRequested` and despawns the holder.
4. **`dispatch_ai_pending_commands` branches** on `survey_system`: spawns one `PendingAiShipCommand` per `ship_<i>` with its own Ruler→ship delay, inserts `PendingAssignment` immediately (preserves dedup), and writes the per-ship `ShipProjection`. `command_targets_system()` no longer lists `survey_system`.
5. **`handle_survey_system` deleted** from `drain_ai_commands`; its body lives in `apply_survey_to_ship` called from the new drain.
6. **`npc_decision_tick` dedup extended** to walk `Query<&PendingAiShipCommand>` for `survey_system`. Three queries (`PendingAssignment`, `AiCommandOutbox`, `PendingAiShipCommand`) bundled into a new `DedupParams` `SystemParam` so the function stays under Bevy's 16-param limit.

## Tests

- **3 new regression tests** in `tests/ai_command_lightspeed.rs`:
  - `survey_ai_scout_at_home_ruler_at_home_target_far_zero_delay` — the #468 regression.
  - `survey_ai_scout_remote_ruler_at_home_delays_by_ruler_to_ship` — Ruler→ship delay applies when scout is remote.
  - `survey_ai_scout_at_home_ruler_remote_delays_by_ruler_to_ship` — symmetric case (Ruler campaigning).
- **Updated existing tests** in `ai_npc_outbox_dedup`, `short_rules_cutover_sentinel`, `ai_npc_avoid_hostile_systems` to query both `AiCommandOutbox` and `PendingAiShipCommand` so the "in-flight" check stays a single call across the two pipelines.

## Test plan

- [x] `cargo check -p macrocosmo` clean
- [x] `cargo test -p macrocosmo --test ai_command_lightspeed -- --test-threads=1` — 3 pass
- [x] `cargo test -p macrocosmo --test ai_npc_outbox_dedup -- --test-threads=1` — 2 pass
- [x] `cargo test -p macrocosmo --test fixtures_smoke -- --test-threads=1` — 1 pass (SAVE_VERSION unchanged)
- [x] `cargo test --workspace --tests -- --test-threads=1` — **3562 pass / 0 fail** (+5 above 3557 baseline)

## Follow-ups

- **PR-2 / PR-3** — migrate `colonize_system`, `reposition`, `blockade`, `attack_target`, `load_deliverable`, `unload_deliverable`, `colonize_planet`, `move_ruler`.
- **PR-3** — also fix the `fortify_system` mis-categorisation (Plan Step 4 last paragraph).
- Issue #468 stays open until PR-3 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)