### PR TITLE
fix(ai): #468 PR-2 colonize/reposition/blockade courier delay = Ruler→ship

### DIFF
--- a/macrocosmo/src/ai/assignments.rs
+++ b/macrocosmo/src/ai/assignments.rs
@@ -24,7 +24,7 @@
 //! 1. `handle_survey_requested` Rejected (start_survey failed at handler
 //!    time, e.g. ship gone) — immediate remove (emit failed; AI is free
 //!    to re-emit next tick).
-//! 2. [`sweep_resolved_survey_assignments`] — every tick, checks the
+//! 2. [`sweep_resolved_assignments`] — every tick, checks the
 //!    issuing empire's `KnowledgeStore`. If the target system is now
 //!    `surveyed = true` from that empire's perspective (success arrived
 //!    via fact propagation) → remove.
@@ -125,17 +125,21 @@ impl PendingAssignment {
 /// surveyor loops every 30 hexadies.
 ///
 /// #468 PR-2: covers both `Survey` (target's `surveyed` flag) and
-/// `Colonize` (target's `colonized` flag). The function name retains the
-/// `survey` lead for historical continuity; the body branches on
-/// `AssignmentKind` to pick the relevant resolution predicate.
+/// `Colonize` (target's `colonized` flag). The body branches on
+/// `AssignmentKind` to pick the relevant resolution predicate; PR-3
+/// will extend with further kinds.
 ///
-/// Failure path (ship lost to hostiles before completion) is currently
-/// handled by Bevy's automatic component cleanup on `despawn`. A future
-/// extension may also drop the marker when `KnowledgeStore` records a
-/// `ShipDestroyed` fact for the carrying ship — then the NPC explicitly
-/// knows "scout was lost" and can re-emit immediately rather than waiting
-/// for the ship entity itself to vanish.
-pub fn sweep_resolved_survey_assignments(
+/// Failure path (ship lost to hostiles before completion) is handled
+/// by Bevy's automatic component cleanup on `despawn` for the survey
+/// kind, and explicitly by `handle_colonize_requested`'s reject-branch
+/// marker removal for the colonize kind (the colonize handler runs
+/// after a Ruler→ship courier window so the ship is still alive when
+/// rejections happen). A future extension may also drop the marker
+/// when `KnowledgeStore` records a `ShipDestroyed` fact for the
+/// carrying ship — then the NPC explicitly knows "scout was lost" and
+/// can re-emit immediately rather than waiting for the ship entity
+/// itself to vanish.
+pub fn sweep_resolved_assignments(
     mut commands: Commands,
     assignments: Query<(Entity, &PendingAssignment)>,
     knowledge: Query<&crate::knowledge::KnowledgeStore>,

--- a/macrocosmo/src/ai/assignments.rs
+++ b/macrocosmo/src/ai/assignments.rs
@@ -46,13 +46,17 @@
 use bevy::prelude::*;
 
 /// What kind of work has been queued. Reserved for future expansion (#189
-/// follow-up: Colonize, Scout, Repair, etc.).
+/// follow-up: Scout, Repair, etc.).
 #[derive(Debug, Clone, Copy, Reflect, PartialEq, Eq, Hash)]
 pub enum AssignmentKind {
     /// `survey_system` command issued — handler will read the
     /// `SurveyRequested` message and either start the survey or auto-insert
     /// a `MoveTo` first (Deferred).
     Survey,
+    /// `colonize_system` command issued — #468 PR-2 added. Drained by
+    /// `apply_colonize_to_ship` which emits `ColonizeRequested`. Marker
+    /// dedup keyed in `npc_decision.rs::outbox_colonize_per_empire`.
+    Colonize,
 }
 
 /// Where the assignment is targeted. Reserved for future expansion (planet-
@@ -95,15 +99,35 @@ impl PendingAssignment {
             since: now,
         }
     }
+
+    /// #468 PR-2: convenience constructor for a colonize-system
+    /// assignment. Same shape as [`survey_system`] but tags the marker
+    /// with `AssignmentKind::Colonize` so the dedup scan in
+    /// `npc_decision.rs` can distinguish "this ship is on a survey"
+    /// from "this ship is on a colonize" when both lookups need to
+    /// avoid double-tasking a candidate ship.
+    pub fn colonize_system(faction: Entity, target: Entity, now: i64) -> Self {
+        Self {
+            faction,
+            kind: AssignmentKind::Colonize,
+            target: AssignmentTarget::System(target),
+            since: now,
+        }
+    }
 }
 
 /// Knowledge-driven cleanup: remove a `PendingAssignment` once the issuing
-/// empire's `KnowledgeStore` reflects the survey completion. This is the
+/// empire's `KnowledgeStore` reflects the work's completion. This is the
 /// AI memory dissolving as the empire *learns* the result, not when the
 /// handler fires (which is too eager — the success fact still has to
 /// propagate at light speed back to the issuing Ruler). Without this, NPC
 /// AI re-emits the same target for the entire propagation window and the
 /// surveyor loops every 30 hexadies.
+///
+/// #468 PR-2: covers both `Survey` (target's `surveyed` flag) and
+/// `Colonize` (target's `colonized` flag). The function name retains the
+/// `survey` lead for historical continuity; the body branches on
+/// `AssignmentKind` to pick the relevant resolution predicate.
 ///
 /// Failure path (ship lost to hostiles before completion) is currently
 /// handled by Bevy's automatic component cleanup on `despawn`. A future
@@ -117,20 +141,23 @@ pub fn sweep_resolved_survey_assignments(
     knowledge: Query<&crate::knowledge::KnowledgeStore>,
 ) {
     for (ship_entity, pa) in &assignments {
-        if !matches!(pa.kind, AssignmentKind::Survey) {
-            continue;
-        }
         let target = match pa.target {
             AssignmentTarget::System(t) => t,
         };
         let Ok(store) = knowledge.get(pa.faction) else {
             continue;
         };
-        if store
-            .get(target)
-            .map(|sk| sk.data.surveyed)
-            .unwrap_or(false)
-        {
+        let snapshot = store.get(target);
+        // #468 PR-2: extended to drop the marker when the kind's
+        // target-state has been learned by the issuing empire. For
+        // `Survey` that's `surveyed = true`; for `Colonize` that's
+        // `colonized = true`. Either flag becoming true means the AI no
+        // longer needs the marker to dedup against in-flight work.
+        let resolved = match pa.kind {
+            AssignmentKind::Survey => snapshot.map(|sk| sk.data.surveyed).unwrap_or(false),
+            AssignmentKind::Colonize => snapshot.map(|sk| sk.data.colonized).unwrap_or(false),
+        };
+        if resolved {
             commands.entity(ship_entity).remove::<PendingAssignment>();
         }
     }
@@ -151,5 +178,18 @@ mod tests {
             AssignmentTarget::System(e) => assert_eq!(e, target),
         }
         assert_eq!(pa.since, 100);
+    }
+
+    #[test]
+    fn colonize_system_constructor_sets_fields() {
+        let faction = Entity::from_raw_u32(3).unwrap();
+        let target = Entity::from_raw_u32(4).unwrap();
+        let pa = PendingAssignment::colonize_system(faction, target, 200);
+        assert_eq!(pa.faction, faction);
+        assert!(matches!(pa.kind, AssignmentKind::Colonize));
+        match pa.target {
+            AssignmentTarget::System(e) => assert_eq!(e, target),
+        }
+        assert_eq!(pa.since, 200);
     }
 }

--- a/macrocosmo/src/ai/command_consumer.rs
+++ b/macrocosmo/src/ai/command_consumer.rs
@@ -198,17 +198,16 @@ pub fn drain_ai_commands(
                 cmd.issuer
             );
         } else if kind_str == cmd_ids::colonize_system().as_str() {
-            if let Some(ref mut w) = stamp.colonize_writer {
-                handle_colonize_system(
-                    &cmd.issuer,
-                    &cmd.params,
-                    &ships,
-                    &empires,
-                    w,
-                    &mut stamp.next_cmd_id,
-                    now,
-                );
-            }
+            // #468 PR-2: `colonize_system` is now produced via the new
+            // `PendingAiShipCommand` pipeline and consumed by
+            // `drain_ai_ship_commands` — it must never reach this arm.
+            // If a stale command slips in via the old outbox path, drop
+            // it with a `debug!` rather than re-dispatch.
+            debug!(
+                "drain_ai_commands: stale colonize_system from faction {:?} hit legacy \
+                 dispatch; expected `drain_ai_ship_commands` to handle this",
+                cmd.issuer
+            );
         } else if kind_str == cmd_ids::build_ship().as_str() {
             handle_build_ship(
                 &cmd.issuer,
@@ -236,14 +235,14 @@ pub fn drain_ai_commands(
                 &mut build_research,
             );
         } else if kind_str == cmd_ids::reposition().as_str() {
-            handle_reposition(
-                &cmd.issuer,
-                &cmd.params,
-                &ships,
-                &empires,
-                &mut stamp.move_writer,
-                &mut stamp.next_cmd_id,
-                now,
+            // #468 PR-2: `reposition` migrated to the per-ship
+            // `PendingAiShipCommand` pipeline (consumed by
+            // `drain_ai_ship_commands`). Stale legacy emissions drop
+            // with a `debug!`.
+            debug!(
+                "drain_ai_commands: stale reposition from faction {:?} hit legacy \
+                 dispatch; expected `drain_ai_ship_commands` to handle this",
+                cmd.issuer
             );
         } else if kind_str == cmd_ids::move_ruler().as_str() {
             handle_move_ruler(
@@ -259,14 +258,14 @@ pub fn drain_ai_commands(
                 now,
             );
         } else if kind_str == cmd_ids::blockade().as_str() {
-            handle_blockade(
-                &cmd.issuer,
-                &cmd.params,
-                &ships,
-                &empires,
-                &mut stamp.move_writer,
-                &mut stamp.next_cmd_id,
-                now,
+            // #468 PR-2: `blockade` migrated to the per-ship
+            // `PendingAiShipCommand` pipeline (consumed by
+            // `drain_ai_ship_commands`). Stale legacy emissions drop
+            // with a `debug!`.
+            debug!(
+                "drain_ai_commands: stale blockade from faction {:?} hit legacy \
+                 dispatch; expected `drain_ai_ship_commands` to handle this",
+                cmd.issuer
             );
         } else if kind_str == cmd_ids::build_deliverable().as_str() {
             handle_build_deliverable(
@@ -430,59 +429,10 @@ fn handle_attack_target(
     }
 }
 
-/// Handle `colonize_system`: dispatch the specified colony ship to the target system.
-fn handle_colonize_system(
-    issuer: &macrocosmo_ai::FactionId,
-    params: &macrocosmo_ai::CommandParams,
-    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
-    empires: &Query<(Entity, &Faction), With<Empire>>,
-    colonize_writer: &mut MessageWriter<ColonizeRequested>,
-    next_cmd_id: &mut NextCommandId,
-    now: i64,
-) {
-    let target_system = match params.get("target_system") {
-        Some(CommandValue::System(sys_ref)) => from_ai_system(*sys_ref),
-        _ => {
-            warn!("colonize_system command missing target_system param");
-            return;
-        }
-    };
-
-    let empire_entity = match find_empire_entity(issuer, empires) {
-        Some(e) => e,
-        None => return,
-    };
-
-    let selected_ships = extract_ship_list(params);
-    let mut dispatched = 0;
-    for ship_entity in selected_ships {
-        let Ok((_, ship, state, queue)) = ships.get(ship_entity) else {
-            continue;
-        };
-        if ship.owner != Owner::Empire(empire_entity) {
-            continue;
-        }
-        if !matches!(state, ShipState::InSystem { .. }) || !queue.commands.is_empty() {
-            continue;
-        }
-
-        colonize_writer.write(ColonizeRequested {
-            command_id: next_cmd_id.allocate(),
-            ship: ship_entity,
-            target_system,
-            planet: None, // Let the handler pick the best planet
-            issued_at: now,
-        });
-        dispatched += 1;
-    }
-
-    if dispatched > 0 {
-        info!(
-            "colonize_system: dispatched {} ships from faction {:?} to system {:?}",
-            dispatched, issuer, target_system
-        );
-    }
-}
+// #468 PR-2: `handle_colonize_system` removed — the colonize_system arm
+// of `drain_ai_commands` now logs and drops stale legacy emissions; the
+// canonical dispatch path is the per-ship `PendingAiShipCommand`
+// pipeline + `apply_colonize_to_ship`.
 
 /// Queue a ship build order at a system owned by the faction that has a
 /// shipyard. Returns true if the order was queued successfully.
@@ -927,57 +877,12 @@ fn handle_build_structure(
     }
 }
 
-/// Handle `reposition`: move specified ships to a target system.
-///
-/// Params:
-/// - `target_system` (System): destination system.
-/// - `ship_count` / `ship_N` (indexed list): ships to move.
-fn handle_reposition(
-    issuer: &macrocosmo_ai::FactionId,
-    params: &macrocosmo_ai::CommandParams,
-    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
-    empires: &Query<(Entity, &Faction), With<Empire>>,
-    move_writer: &mut MessageWriter<MoveRequested>,
-    next_cmd_id: &mut NextCommandId,
-    now: i64,
-) {
-    dispatch_ships_to_target(
-        "reposition",
-        issuer,
-        params,
-        ships,
-        empires,
-        move_writer,
-        next_cmd_id,
-        now,
-    );
-}
-
-/// Handle `blockade`: move specified ships to a target system (tactical positioning).
-///
-/// Params:
-/// - `target_system` (System): destination system.
-/// - `ship_count` / `ship_N` (indexed list): ships to move.
-fn handle_blockade(
-    issuer: &macrocosmo_ai::FactionId,
-    params: &macrocosmo_ai::CommandParams,
-    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
-    empires: &Query<(Entity, &Faction), With<Empire>>,
-    move_writer: &mut MessageWriter<MoveRequested>,
-    next_cmd_id: &mut NextCommandId,
-    now: i64,
-) {
-    dispatch_ships_to_target(
-        "blockade",
-        issuer,
-        params,
-        ships,
-        empires,
-        move_writer,
-        next_cmd_id,
-        now,
-    );
-}
+// #468 PR-2: `handle_reposition` and `handle_blockade` removed — both
+// kinds are now produced via the per-ship `PendingAiShipCommand`
+// pipeline and consumed by `apply_reposition_to_ship` /
+// `apply_blockade_to_ship`. The shared helper `dispatch_ships_to_target`
+// is retained — PR-3 will use it for `attack_target` and
+// `fortify_system` until those kinds also migrate.
 
 // ---------------------------------------------------------------------------
 // Deliverable family handlers (#446)
@@ -1398,8 +1303,16 @@ fn handle_colonize_planet(
     );
 }
 
-/// Shared logic for reposition / blockade: dispatch listed ships to a
-/// target system (same pattern as `handle_attack_target`).
+/// Shared logic for "dispatch listed ships to a target system" — the
+/// same pattern as `handle_attack_target`.
+///
+/// #468 PR-2 note: this helper used to be called by `handle_reposition`
+/// and `handle_blockade`; both kinds have since moved to the per-ship
+/// `PendingAiShipCommand` pipeline (`apply_*_to_ship`). The helper is
+/// retained for PR-3 — `attack_target` and `fortify_system` will share
+/// the same shape when they migrate. Marked `#[allow(dead_code)]` so
+/// the PR-2 build doesn't warn while the helper is dormant.
+#[allow(dead_code)]
 fn dispatch_ships_to_target(
     cmd_name: &str,
     issuer: &macrocosmo_ai::FactionId,
@@ -1770,8 +1683,9 @@ pub struct PendingAiShipCommand {
 /// `*Requested` message for any whose `arrives_at` has elapsed. Despawns
 /// the holder entity once dispatched.
 ///
-/// PR-1 only handles `survey_system`. Other ship-kind holders are not
-/// produced yet (PR-2/3 follow); the function logs and despawns any
+/// PR-1 handled `survey_system`; PR-2 adds `colonize_system`,
+/// `reposition`, and `blockade`. Other ship-kind holders are not
+/// produced yet (PR-3 follows); the function logs and despawns any
 /// unexpected kind defensively rather than re-queueing.
 pub fn drain_ai_ship_commands(
     mut commands_buf: Commands,
@@ -1779,10 +1693,15 @@ pub fn drain_ai_ship_commands(
     ships: Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
     clock: Res<GameClock>,
     mut survey_writer: Option<MessageWriter<SurveyRequested>>,
+    mut colonize_writer: Option<MessageWriter<ColonizeRequested>>,
+    mut move_writer: Option<MessageWriter<MoveRequested>>,
     mut next_cmd_id: ResMut<NextCommandId>,
 ) {
     let now = clock.elapsed;
     let survey_kind = crate::ai::schema::ids::command::survey_system();
+    let colonize_kind = crate::ai::schema::ids::command::colonize_system();
+    let reposition_kind = crate::ai::schema::ids::command::reposition();
+    let blockade_kind = crate::ai::schema::ids::command::blockade();
 
     // Collect mature entries first so we can despawn while iterating
     // without invalidating the query cursor.
@@ -1802,7 +1721,8 @@ pub fn drain_ai_ship_commands(
     }
 
     for (holder_entity, m) in mature {
-        if m.kind.as_str() == survey_kind.as_str() {
+        let kind_str = m.kind.as_str();
+        if kind_str == survey_kind.as_str() {
             apply_survey_to_ship(
                 m.ship,
                 m.issuer_empire,
@@ -1813,12 +1733,44 @@ pub fn drain_ai_ship_commands(
                 &mut commands_buf,
                 now,
             );
+        } else if kind_str == colonize_kind.as_str() {
+            apply_colonize_to_ship(
+                m.ship,
+                m.issuer_empire,
+                m.target_system,
+                &ships,
+                colonize_writer.as_mut(),
+                &mut next_cmd_id,
+                &mut commands_buf,
+                now,
+            );
+        } else if kind_str == reposition_kind.as_str() {
+            apply_reposition_to_ship(
+                m.ship,
+                m.issuer_empire,
+                m.target_system,
+                &ships,
+                move_writer.as_mut(),
+                &mut next_cmd_id,
+                now,
+            );
+        } else if kind_str == blockade_kind.as_str() {
+            apply_blockade_to_ship(
+                m.ship,
+                m.issuer_empire,
+                m.target_system,
+                &ships,
+                move_writer.as_mut(),
+                &mut next_cmd_id,
+                now,
+            );
         } else {
-            // Defensive: PR-1 only spawns `survey_system` holders. Any
-            // other kind here means an upstream bug — log + drop rather
-            // than silently dispatch through an unknown path. Also
-            // strip the stale `PendingAssignment` so the ship is not
-            // permanently excluded from future AI dispatches.
+            // Defensive: only kinds migrated through `dispatch_ship_command_per_ship`
+            // should produce holders. Any other kind here means an
+            // upstream bug — log + drop rather than silently dispatch
+            // through an unknown path. Also strip the stale
+            // `PendingAssignment` so the ship is not permanently
+            // excluded from future AI dispatches.
             debug!(
                 "drain_ai_ship_commands: unexpected kind {} for ship {:?}; dropping",
                 m.kind, m.ship
@@ -1915,6 +1867,201 @@ fn apply_survey_to_ship(
     info!(
         "drain_ai_ship_commands: survey_system delivered to ship {:?} → system {:?} for empire {:?}",
         ship_entity, target_system, empire_entity
+    );
+}
+
+/// #468 PR-2: Apply a matured `colonize_system` PendingAiShipCommand.
+///
+/// Mirrors `apply_survey_to_ship`: validate the ship is still eligible
+/// (owned by the issuer, in-system, idle) and write the
+/// `ColonizeRequested` message. The `PendingAssignment` marker was
+/// inserted at outbox-spawn time with `AssignmentKind::Colonize`; on
+/// every reject branch we strip the marker so the ship is not
+/// permanently excluded from future AI colonize dispatches (the dedup
+/// scan in `npc_decision.rs` filters by `PendingAssignment`).
+///
+/// `planet = None` — the consumer-side colonization handler picks the
+/// best planet in the target system. Same convention the legacy
+/// `handle_colonize_system` used.
+fn apply_colonize_to_ship(
+    ship_entity: Entity,
+    empire_entity: Entity,
+    target_system: Entity,
+    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
+    colonize_writer: Option<&mut MessageWriter<ColonizeRequested>>,
+    next_cmd_id: &mut NextCommandId,
+    commands_buf: &mut Commands,
+    now: i64,
+) {
+    let Some(writer) = colonize_writer else {
+        warn!("drain_ai_ship_commands: ColonizeRequested writer unavailable");
+        commands_buf
+            .entity(ship_entity)
+            .remove::<crate::ai::assignments::PendingAssignment>();
+        return;
+    };
+
+    let Ok((_, ship, state, queue)) = ships.get(ship_entity) else {
+        debug!(
+            "drain_ai_ship_commands: colonize ship {:?} despawned before arrival",
+            ship_entity
+        );
+        return;
+    };
+    if ship.owner != Owner::Empire(empire_entity) {
+        debug!(
+            "drain_ai_ship_commands: colonize ship {:?} no longer owned by empire {:?}",
+            ship_entity, empire_entity
+        );
+        commands_buf
+            .entity(ship_entity)
+            .remove::<crate::ai::assignments::PendingAssignment>();
+        return;
+    }
+    if !matches!(state, ShipState::InSystem { .. }) || !queue.commands.is_empty() {
+        debug!(
+            "drain_ai_ship_commands: colonize ship {:?} not idle at arrival (queue_len={})",
+            ship_entity,
+            queue.commands.len(),
+        );
+        commands_buf
+            .entity(ship_entity)
+            .remove::<crate::ai::assignments::PendingAssignment>();
+        return;
+    }
+
+    writer.write(ColonizeRequested {
+        command_id: next_cmd_id.allocate(),
+        ship: ship_entity,
+        target_system,
+        planet: None,
+        issued_at: now,
+    });
+
+    info!(
+        "drain_ai_ship_commands: colonize_system delivered to ship {:?} → system {:?} for empire {:?}",
+        ship_entity, target_system, empire_entity
+    );
+}
+
+/// #468 PR-2: Apply a matured `reposition` PendingAiShipCommand.
+///
+/// Reposition is a pure movement order — no `PendingAssignment` marker
+/// is involved (the dispatcher passes `None` for `assignment_factory`),
+/// so reject branches simply early-return without marker bookkeeping.
+/// Also skips ships already at `target_system` (legacy
+/// `dispatch_ships_to_target` no-op).
+fn apply_reposition_to_ship(
+    ship_entity: Entity,
+    empire_entity: Entity,
+    target_system: Entity,
+    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
+    move_writer: Option<&mut MessageWriter<MoveRequested>>,
+    next_cmd_id: &mut NextCommandId,
+    now: i64,
+) {
+    apply_move_to_ship(
+        "reposition",
+        ship_entity,
+        empire_entity,
+        target_system,
+        ships,
+        move_writer,
+        next_cmd_id,
+        now,
+    );
+}
+
+/// #468 PR-2: Apply a matured `blockade` PendingAiShipCommand.
+///
+/// Same shape as `apply_reposition_to_ship` — both are pure movement
+/// orders that write `MoveRequested` after validating ship eligibility.
+fn apply_blockade_to_ship(
+    ship_entity: Entity,
+    empire_entity: Entity,
+    target_system: Entity,
+    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
+    move_writer: Option<&mut MessageWriter<MoveRequested>>,
+    next_cmd_id: &mut NextCommandId,
+    now: i64,
+) {
+    apply_move_to_ship(
+        "blockade",
+        ship_entity,
+        empire_entity,
+        target_system,
+        ships,
+        move_writer,
+        next_cmd_id,
+        now,
+    );
+}
+
+/// #468 PR-2: shared movement-order delivery for `reposition` and
+/// `blockade`. Both kinds are bus-of-MoveRequested writes after the
+/// idle / owned / not-already-there gates, so the body is the same; the
+/// `cmd_name` argument keeps the `info!` line distinguishable in logs.
+fn apply_move_to_ship(
+    cmd_name: &str,
+    ship_entity: Entity,
+    empire_entity: Entity,
+    target_system: Entity,
+    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
+    move_writer: Option<&mut MessageWriter<MoveRequested>>,
+    next_cmd_id: &mut NextCommandId,
+    now: i64,
+) {
+    let Some(writer) = move_writer else {
+        warn!(
+            "drain_ai_ship_commands: MoveRequested writer unavailable for {}",
+            cmd_name
+        );
+        return;
+    };
+
+    let Ok((_, ship, state, queue)) = ships.get(ship_entity) else {
+        debug!(
+            "drain_ai_ship_commands: {} ship {:?} despawned before arrival",
+            cmd_name, ship_entity
+        );
+        return;
+    };
+    if ship.owner != Owner::Empire(empire_entity) {
+        debug!(
+            "drain_ai_ship_commands: {} ship {:?} no longer owned by empire {:?}",
+            cmd_name, ship_entity, empire_entity
+        );
+        return;
+    }
+    if !matches!(state, ShipState::InSystem { .. }) || !queue.commands.is_empty() {
+        debug!(
+            "drain_ai_ship_commands: {} ship {:?} not idle at arrival (queue_len={})",
+            cmd_name,
+            ship_entity,
+            queue.commands.len(),
+        );
+        return;
+    }
+    if let ShipState::InSystem { system } = state {
+        if *system == target_system {
+            debug!(
+                "drain_ai_ship_commands: {} ship {:?} already at target {:?}; skipping",
+                cmd_name, ship_entity, target_system
+            );
+            return;
+        }
+    }
+
+    writer.write(MoveRequested {
+        command_id: next_cmd_id.allocate(),
+        ship: ship_entity,
+        target: target_system,
+        issued_at: now,
+    });
+
+    info!(
+        "drain_ai_ship_commands: {} delivered to ship {:?} → system {:?} for empire {:?}",
+        cmd_name, ship_entity, target_system, empire_entity
     );
 }
 
@@ -2495,6 +2642,11 @@ mod tests {
         assert!(found, "should have queued a building order");
     }
 
+    /// #468 PR-2: `reposition` is dispatched through the per-ship
+    /// `PendingAiShipCommand` pipeline. We construct a matured holder
+    /// directly and assert `drain_ai_ship_commands` emits one
+    /// `MoveRequested` — same wire shape as the legacy
+    /// `handle_reposition` path that this test replaced.
     #[test]
     fn reposition_dispatches_ships() {
         let mut app = test_app();
@@ -2509,8 +2661,6 @@ mod tests {
             ))
             .id();
 
-        let faction_id = to_ai_faction(empire_entity);
-
         let origin = world
             .spawn((
                 StarSystem {
@@ -2522,7 +2672,6 @@ mod tests {
                 Position::from([0.0, 0.0, 0.0]),
             ))
             .id();
-
         let target = world
             .spawn((
                 StarSystem {
@@ -2534,7 +2683,6 @@ mod tests {
                 Position::from([10.0, 0.0, 0.0]),
             ))
             .id();
-
         let ship_entity = world
             .spawn((
                 Ship {
@@ -2555,22 +2703,30 @@ mod tests {
             ))
             .id();
 
-        let target_ref = crate::ai::convert::to_ai_system(target);
-        let ship_ref = crate::ai::convert::to_ai_entity(ship_entity);
-        let cmd = Command::new(cmd_ids::reposition(), faction_id, 10)
-            .with_param("target_system", CommandValue::System(target_ref))
-            .with_param("ship_count", CommandValue::I64(1))
-            .with_param("ship_0", CommandValue::Entity(ship_ref));
-        world.resource_mut::<AiBusResource>().0.emit_command(cmd);
+        // Spawn a matured holder (arrives_at = sent_at = 0) so the very
+        // next drain pass picks it up.
+        world.spawn(PendingAiShipCommand {
+            kind: cmd_ids::reposition(),
+            target_system: target,
+            ship: ship_entity,
+            issuer_empire: empire_entity,
+            sent_at: 0,
+            arrives_at: 0,
+        });
 
         app.insert_resource(MoveCount(0));
-        app.add_systems(Update, (drain_ai_commands, count_moves).chain());
+        app.add_systems(Update, (drain_ai_ship_commands, count_moves).chain());
         app.update();
 
         let count = app.world().resource::<MoveCount>().0;
-        assert_eq!(count, 1, "reposition should emit 1 MoveRequested");
+        assert_eq!(
+            count, 1,
+            "reposition should emit 1 MoveRequested through drain_ai_ship_commands"
+        );
     }
 
+    /// #468 PR-2: same shape as `reposition_dispatches_ships` but for
+    /// the `blockade` kind. Both share `apply_move_to_ship` underneath.
     #[test]
     fn blockade_dispatches_ships() {
         let mut app = test_app();
@@ -2585,8 +2741,6 @@ mod tests {
             ))
             .id();
 
-        let faction_id = to_ai_faction(empire_entity);
-
         let origin = world
             .spawn((
                 StarSystem {
@@ -2598,7 +2752,6 @@ mod tests {
                 Position::from([0.0, 0.0, 0.0]),
             ))
             .id();
-
         let target = world
             .spawn((
                 StarSystem {
@@ -2610,7 +2763,6 @@ mod tests {
                 Position::from([10.0, 0.0, 0.0]),
             ))
             .id();
-
         let ship_entity = world
             .spawn((
                 Ship {
@@ -2631,20 +2783,24 @@ mod tests {
             ))
             .id();
 
-        let target_ref = crate::ai::convert::to_ai_system(target);
-        let ship_ref = crate::ai::convert::to_ai_entity(ship_entity);
-        let cmd = Command::new(cmd_ids::blockade(), faction_id, 10)
-            .with_param("target_system", CommandValue::System(target_ref))
-            .with_param("ship_count", CommandValue::I64(1))
-            .with_param("ship_0", CommandValue::Entity(ship_ref));
-        world.resource_mut::<AiBusResource>().0.emit_command(cmd);
+        world.spawn(PendingAiShipCommand {
+            kind: cmd_ids::blockade(),
+            target_system: target,
+            ship: ship_entity,
+            issuer_empire: empire_entity,
+            sent_at: 0,
+            arrives_at: 0,
+        });
 
         app.insert_resource(MoveCount(0));
-        app.add_systems(Update, (drain_ai_commands, count_moves).chain());
+        app.add_systems(Update, (drain_ai_ship_commands, count_moves).chain());
         app.update();
 
         let count = app.world().resource::<MoveCount>().0;
-        assert_eq!(count, 1, "blockade should emit 1 MoveRequested");
+        assert_eq!(
+            count, 1,
+            "blockade should emit 1 MoveRequested through drain_ai_ship_commands"
+        );
     }
 
     #[test]

--- a/macrocosmo/src/ai/command_consumer.rs
+++ b/macrocosmo/src/ai/command_consumer.rs
@@ -880,9 +880,10 @@ fn handle_build_structure(
 // #468 PR-2: `handle_reposition` and `handle_blockade` removed — both
 // kinds are now produced via the per-ship `PendingAiShipCommand`
 // pipeline and consumed by `apply_reposition_to_ship` /
-// `apply_blockade_to_ship`. The shared helper `dispatch_ships_to_target`
-// is retained — PR-3 will use it for `attack_target` and
-// `fortify_system` until those kinds also migrate.
+// `apply_blockade_to_ship`. `dispatch_ships_to_target` was deleted in
+// the PR-2 review fold-in (it had no live callers); PR-3 will choose
+// between `apply_move_to_ship` and a freshly-extracted helper for
+// `attack_target` / `fortify_system` based on whichever shape fits.
 
 // ---------------------------------------------------------------------------
 // Deliverable family handlers (#446)
@@ -1301,85 +1302,6 @@ fn handle_colonize_planet(
         "colonize_planet: ship {:?} → planet {:?} (system {:?}) for faction {:?}",
         ship_entity, target_planet, target_system, issuer
     );
-}
-
-/// Shared logic for "dispatch listed ships to a target system" — the
-/// same pattern as `handle_attack_target`.
-///
-/// #468 PR-2 note: this helper used to be called by `handle_reposition`
-/// and `handle_blockade`; both kinds have since moved to the per-ship
-/// `PendingAiShipCommand` pipeline (`apply_*_to_ship`). The helper is
-/// retained for PR-3 — `attack_target` and `fortify_system` will share
-/// the same shape when they migrate. Marked `#[allow(dead_code)]` so
-/// the PR-2 build doesn't warn while the helper is dormant.
-#[allow(dead_code)]
-fn dispatch_ships_to_target(
-    cmd_name: &str,
-    issuer: &macrocosmo_ai::FactionId,
-    params: &macrocosmo_ai::CommandParams,
-    ships: &Query<(Entity, &Ship, &ShipState, &CommandQueue)>,
-    empires: &Query<(Entity, &Faction), With<Empire>>,
-    move_writer: &mut MessageWriter<MoveRequested>,
-    next_cmd_id: &mut NextCommandId,
-    now: i64,
-) {
-    let target_system = match params.get("target_system") {
-        Some(CommandValue::System(sys_ref)) => from_ai_system(*sys_ref),
-        _ => {
-            warn!("{} command missing target_system param", cmd_name);
-            return;
-        }
-    };
-
-    let empire_entity = match find_empire_entity(issuer, empires) {
-        Some(e) => e,
-        None => {
-            warn!("{}: no empire found for faction {:?}", cmd_name, issuer);
-            return;
-        }
-    };
-
-    let selected_ships = extract_ship_list(params);
-    if selected_ships.is_empty() {
-        debug!(
-            "{}: no ships specified by policy for faction {:?}",
-            cmd_name, issuer
-        );
-        return;
-    }
-
-    let mut dispatched = 0;
-    for ship_entity in selected_ships {
-        let Ok((_, ship, state, queue)) = ships.get(ship_entity) else {
-            continue;
-        };
-        if ship.owner != Owner::Empire(empire_entity) {
-            continue;
-        }
-        if !matches!(state, ShipState::InSystem { .. }) || !queue.commands.is_empty() {
-            continue;
-        }
-        if let ShipState::InSystem { system } = state {
-            if *system == target_system {
-                continue;
-            }
-        }
-
-        move_writer.write(MoveRequested {
-            command_id: next_cmd_id.allocate(),
-            ship: ship_entity,
-            target: target_system,
-            issued_at: now,
-        });
-        dispatched += 1;
-    }
-
-    if dispatched > 0 {
-        info!(
-            "{}: dispatched {} ships from faction {:?} to system {:?}",
-            cmd_name, dispatched, issuer, target_system
-        );
-    }
 }
 
 /// Handle `retreat`: find ships in systems with hostiles and send them
@@ -1949,8 +1871,7 @@ fn apply_colonize_to_ship(
 /// Reposition is a pure movement order — no `PendingAssignment` marker
 /// is involved (the dispatcher passes `None` for `assignment_factory`),
 /// so reject branches simply early-return without marker bookkeeping.
-/// Also skips ships already at `target_system` (legacy
-/// `dispatch_ships_to_target` no-op).
+/// Also skips ships already at `target_system` (= move-to-self no-op).
 fn apply_reposition_to_ship(
     ship_entity: Entity,
     empire_entity: Entity,

--- a/macrocosmo/src/ai/command_outbox.rs
+++ b/macrocosmo/src/ai/command_outbox.rs
@@ -246,16 +246,14 @@ pub fn resolve_capital_system(
 pub fn command_targets_system(kind: &str) -> bool {
     let s = kind;
     s == cmd_ids::attack_target().as_str()
-        || s == cmd_ids::reposition().as_str()
-        || s == cmd_ids::blockade().as_str()
         || s == cmd_ids::fortify_system().as_str()
-        || s == cmd_ids::colonize_system().as_str()
         || s == cmd_ids::move_ruler().as_str()
-    // #468 PR-1: `survey_system` is no longer listed here. Ship-control
-    // commands now compute light-delay Ruler→ship (not Ruler→target_system)
-    // and flow through the `PendingAiShipCommand` per-ship holder; the
+    // #468 PR-1/PR-2: `survey_system`, `colonize_system`, `reposition`,
+    // and `blockade` are no longer listed here. Ship-control commands
+    // now compute light-delay Ruler→ship (not Ruler→target_system) and
+    // flow through the `PendingAiShipCommand` per-ship holder; the
     // outbox's capital/target-system routing only applies to the
-    // remaining (PR-2/3 pending) ship kinds. PR-2/3 will migrate the rest.
+    // remaining (PR-3 pending) ship kinds.
     //
     // build_ship / build_structure may carry a target_system in some
     // policies but commonly route to the empire's preferred shipyard;
@@ -510,6 +508,9 @@ pub fn dispatch_ai_pending_commands(
     let relays: &[crate::knowledge::RelaySnapshot] = &relays_owned;
 
     let survey_kind = cmd_ids::survey_system();
+    let colonize_kind = cmd_ids::colonize_system();
+    let reposition_kind = cmd_ids::reposition();
+    let blockade_kind = cmd_ids::blockade();
 
     for cmd in drained {
         let issuer = cmd.issuer;
@@ -536,21 +537,53 @@ pub fn dispatch_ai_pending_commands(
             continue;
         };
 
-        // #468 PR-1: `survey_system` branches onto the new
+        // #468 PR-1/PR-2: ship-control commands branch onto the new
         // per-ship `PendingAiShipCommand` pipeline. Light delay is
         // Ruler→ship (not Ruler→target_system), and the marker insertion
-        // happens NOW (not at arrival) so the `npc_decision.rs`
-        // outbox-dedup scan still sees in-flight surveys during the
-        // courier window. PR-2/3 will migrate the rest of the
-        // ship-control kinds.
+        // (when applicable) happens NOW (not at arrival) so the
+        // `npc_decision.rs` outbox-dedup scan still sees in-flight
+        // commands during the courier window. PR-3 will migrate the
+        // remaining ship-control kinds (`attack_target`, `move_ruler`,
+        // `load_deliverable`, `unload_deliverable`, `colonize_planet`).
+        //
+        // Survey + Colonize stamp `PendingAssignment` for empire-level
+        // dedup. Reposition + Blockade are pure movement orders — a
+        // duplicate dispatch to the same target is idempotent (the
+        // apply path skips already-in-system ships and ships with a
+        // non-empty queue), so no marker is needed.
         if cmd.kind == survey_kind {
-            dispatch_survey_per_ship(
+            dispatch_ship_command_per_ship(
                 &cmd,
                 empire_entity,
                 origin_pos,
                 now,
                 &mut commands_buf,
                 &mut params,
+                Some(crate::ai::assignments::PendingAssignment::survey_system),
+            );
+            continue;
+        }
+        if cmd.kind == colonize_kind {
+            dispatch_ship_command_per_ship(
+                &cmd,
+                empire_entity,
+                origin_pos,
+                now,
+                &mut commands_buf,
+                &mut params,
+                Some(crate::ai::assignments::PendingAssignment::colonize_system),
+            );
+            continue;
+        }
+        if cmd.kind == reposition_kind || cmd.kind == blockade_kind {
+            dispatch_ship_command_per_ship(
+                &cmd,
+                empire_entity,
+                origin_pos,
+                now,
+                &mut commands_buf,
+                &mut params,
+                None,
             );
             continue;
         }
@@ -618,8 +651,22 @@ pub fn dispatch_ai_pending_commands(
     }
 }
 
-/// #468 PR-1: dispatch a `survey_system` command onto the per-ship
-/// `PendingAiShipCommand` pipeline.
+/// #468 PR-2: generic per-ship dispatcher for AI ship-control commands.
+///
+/// PR-1 introduced this shape for `survey_system`; PR-2 generalises it so
+/// `colonize_system`, `reposition`, and `blockade` flow through the same
+/// path. The kind-specific bits are isolated to two arguments:
+///
+/// * `assignment_factory` — `Some(fn)` for kinds that participate in the
+///   per-faction "don't double-dispatch" dedup contract (Survey,
+///   Colonize); `None` for kinds that don't (Reposition, Blockade —
+///   movement orders aren't "decisions" the AI needs to remember it
+///   already made; a second dispatch to the same target is idempotent
+///   because `apply_*_to_ship` no-ops on already-in-system ships).
+/// * Everything else (intended_state, has_return_leg, projection
+///   computation) is read from `cmd.kind` via the existing
+///   `command_kind_to_intended_state` / `command_kind_has_return_leg`
+///   helpers — no kind-specific branching here.
 ///
 /// For each `ship_<i>` in the command params:
 ///   * read the ship's `Position` (= dispatcher's *real* idea of where
@@ -627,37 +674,38 @@ pub fn dispatch_ai_pending_commands(
 ///     for the projection write only)
 ///   * compute `arrives_at = sent_at + light_delay_ruler_to_ship(ruler, ship)`
 ///   * spawn `PendingAiShipCommand` with the per-ship arrival
-///   * insert `PendingAssignment::survey_system` on the ship NOW (the
-///     dedup contract at `npc_decision.rs:566` requires the marker be
+///   * optionally insert a `PendingAssignment` on the ship NOW (the
+///     dedup contract at `npc_decision.rs` requires the marker be
 ///     visible while the courier window is open)
-///   * write the dispatcher's `ShipProjection` belief — same contract
-///     as the pre-#468 path, just keyed per ship rather than once for
-///     the whole command.
+///   * write the dispatcher's `ShipProjection` belief
 ///
 /// Commands whose ship list is empty, whose target_system param is
 /// missing, or whose primary ship cannot be located fall through with
-/// a `debug!` — these were already no-ops in the previous handler.
-fn dispatch_survey_per_ship(
+/// a `debug!` — these were already no-ops in the legacy handlers.
+fn dispatch_ship_command_per_ship(
     cmd: &Command,
     empire_entity: Entity,
     origin_pos: [f64; 3],
     now: i64,
     commands_buf: &mut Commands,
     params: &mut DispatchParams,
+    assignment_factory: Option<
+        fn(Entity, Entity, i64) -> crate::ai::assignments::PendingAssignment,
+    >,
 ) {
-    use crate::ai::assignments::PendingAssignment;
     use crate::ai::command_consumer::{PendingAiShipCommand, extract_ship_list};
     use crate::physics::light_delay_ruler_to_ship;
 
-    // target_system is still required so the marker dedup + the eventual
-    // `SurveyRequested` write have somewhere to point. We log + drop a
-    // malformed survey command the same way `handle_survey_system` did.
+    let kind_str = cmd.kind.as_str();
+
+    // target_system is required for every ship-control kind we route here;
+    // the marker dedup + the eventual `*Requested` write both need it.
     let target_system = match extract_target_system(cmd) {
         Some(t) => t,
         None => {
             warn!(
-                "survey_system dispatch: missing target_system for empire {:?}",
-                empire_entity
+                "{} dispatch: missing target_system for empire {:?}",
+                kind_str, empire_entity
             );
             return;
         }
@@ -666,8 +714,8 @@ fn dispatch_survey_per_ship(
     let ship_list = extract_ship_list(&cmd.params);
     if ship_list.is_empty() {
         debug!(
-            "survey_system dispatch: no ships in command for empire {:?}",
-            empire_entity
+            "{} dispatch: no ships in command for empire {:?}",
+            kind_str, empire_entity
         );
         return;
     }
@@ -682,8 +730,8 @@ fn dispatch_survey_per_ship(
             Ok(p) => p.as_array(),
             Err(_) => {
                 debug!(
-                    "survey_system dispatch: ship {:?} has no Position (despawned?)",
-                    ship_entity
+                    "{} dispatch: ship {:?} has no Position (despawned?)",
+                    kind_str, ship_entity
                 );
                 continue;
             }
@@ -693,9 +741,8 @@ fn dispatch_survey_per_ship(
 
         // #475 projection write — preserves the per-empire belief update
         // moved out of the legacy `build_projection_inputs` site. The
-        // snapshot lookup and fallback chain mirror the old path; the
-        // only change is we now write one projection per ship in the
-        // command rather than just `ship_0`.
+        // snapshot lookup and fallback chain mirror the old path; we
+        // write one projection per ship in the command.
         let snapshot = params
             .knowledge_stores
             .get(empire_entity)
@@ -716,8 +763,8 @@ fn dispatch_survey_per_ship(
                 .and_then(|sys| params.star_positions.get(sys).ok().map(|p| p.as_array()))
                 .unwrap_or(origin_pos),
         };
-        let intended_state = crate::knowledge::command_kind_to_intended_state(cmd.kind.as_str());
-        let has_return_leg = crate::knowledge::command_kind_has_return_leg(cmd.kind.as_str());
+        let intended_state = crate::knowledge::command_kind_to_intended_state(kind_str);
+        let has_return_leg = crate::knowledge::command_kind_has_return_leg(kind_str);
 
         let projection = compute_ship_projection(
             ship_entity,
@@ -735,17 +782,15 @@ fn dispatch_survey_per_ship(
             store.update_projection(projection);
         }
 
-        // Spawn the in-flight holder and stamp the dedup marker.
-        // Stamping NOW (not at arrival) is load-bearing: the
-        // `npc_decision.rs:566` outbox scan reads
+        // Spawn the in-flight holder and (for dedup-aware kinds) stamp
+        // the marker. Stamping NOW (not at arrival) is load-bearing: the
+        // `npc_decision.rs` outbox scan reads
         // `Query<&PendingAiShipCommand>` to decide whether to re-emit
-        // a survey for the same target — if the marker waited until
-        // arrival, the scan would still need a fallback into the
-        // PendingAiShipCommand query (which it now has).
+        // a command for the same target during the courier window.
         //
         // Only the kind + target_system are stored — the full `cmd`
         // (with its AHashMap of params and stale ship_<i> list) is not
-        // needed downstream. Per-ship multi-target surveys spawn N
+        // needed downstream. Per-ship multi-target commands spawn N
         // holders here; cloning the whole command would N× the
         // param-map allocations for no benefit.
         commands_buf.spawn(PendingAiShipCommand {
@@ -756,13 +801,11 @@ fn dispatch_survey_per_ship(
             sent_at: now,
             arrives_at,
         });
-        commands_buf
-            .entity(ship_entity)
-            .insert(PendingAssignment::survey_system(
-                empire_entity,
-                target_system,
-                now,
-            ));
+        if let Some(factory) = assignment_factory {
+            commands_buf
+                .entity(ship_entity)
+                .insert(factory(empire_entity, target_system, now));
+        }
     }
 }
 
@@ -895,19 +938,20 @@ mod tests {
 
     #[test]
     fn command_targets_system_lists_spatial_kinds() {
-        // Sanity: every kind that the consumer reads `target_system`
-        // for must report `true` here, and at least one spatial-less
-        // kind must report `false`.
+        // Sanity: every kind still routed through the outbox's
+        // Ruler→target_system path must report `true` here; every kind
+        // migrated to the `PendingAiShipCommand` per-ship pipeline
+        // (PR-1: survey_system; PR-2: colonize_system, reposition,
+        // blockade) must report `false`. Spatial-less kinds also
+        // report `false`.
         assert!(command_targets_system("attack_target"));
-        // #468 PR-1: `survey_system` no longer reports `true` here —
-        // it has been migrated off the Ruler→target_system outbox path
-        // onto the new `PendingAiShipCommand` per-ship pipeline.
-        // PR-2/3 will migrate the other ship-control kinds.
+        // #468 PR-1: survey_system migrated.
         assert!(!command_targets_system("survey_system"));
-        assert!(command_targets_system("colonize_system"));
+        // #468 PR-2: colonize_system / reposition / blockade migrated.
+        assert!(!command_targets_system("colonize_system"));
+        assert!(!command_targets_system("reposition"));
+        assert!(!command_targets_system("blockade"));
         assert!(command_targets_system("move_ruler"));
-        assert!(command_targets_system("reposition"));
-        assert!(command_targets_system("blockade"));
         assert!(command_targets_system("fortify_system"));
         assert!(!command_targets_system("research_focus"));
         assert!(!command_targets_system("retreat"));

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -526,18 +526,27 @@ pub fn npc_decision_tick(
         }
     }
 
-    // #468 PR-1: union in `PendingAiShipCommand` entries for the same
-    // dedup pass. With survey_system off `AiCommandOutbox`, this is the
-    // only place the npc_decision tick can see in-flight surveys during
-    // the Ruler→ship courier window. PR-2/3 will add more kinds here as
-    // they migrate — until then the `kind` filter is a no-op (only
-    // survey_system holders exist) but kept so PR-2/3 can layer in
-    // colonize/attack/etc. without re-walking this scan shape.
+    // #468 PR-1/PR-2: union in `PendingAiShipCommand` entries for the
+    // same dedup pass. With survey_system + colonize_system off
+    // `AiCommandOutbox`, this is the only place the npc_decision tick
+    // can see in-flight survey / colonize during the Ruler→ship
+    // courier window. PR-3 will add more kinds here as they migrate.
+    //
+    // `reposition` / `blockade` holders also exist but they don't
+    // participate in a per-empire dedup map — movement orders aren't
+    // "decisions" the AI remembers it already made, so we ignore them
+    // here (the marker-less dispatch path means there's no
+    // double-dispatch problem to dedup against in the first place).
     for pending in &dedup.pending_ai_ship_commands {
-        if pending.kind.as_str() != survey_kind.as_str() {
+        let kind_str = pending.kind.as_str();
+        let target_set = if kind_str == survey_kind.as_str() {
+            &mut outbox_survey_per_empire
+        } else if kind_str == colonize_kind.as_str() {
+            &mut outbox_colonize_per_empire
+        } else {
             continue;
-        }
-        outbox_survey_per_empire
+        };
+        target_set
             .entry(pending.issuer_empire)
             .or_default()
             .insert(pending.target_system);
@@ -598,6 +607,8 @@ pub fn npc_decision_tick(
         // but the marker covers the same-tick race).
         let mut pending_survey_targets: std::collections::HashSet<Entity> =
             std::collections::HashSet::new();
+        let mut pending_colonize_targets: std::collections::HashSet<Entity> =
+            std::collections::HashSet::new();
         let mut pending_assigned_ships: std::collections::HashSet<Entity> =
             std::collections::HashSet::new();
         for (ship_entity, pa) in &dedup.pending_assignments {
@@ -605,9 +616,16 @@ pub fn npc_decision_tick(
                 continue;
             }
             pending_assigned_ships.insert(ship_entity);
-            if pa.kind == AssignmentKind::Survey {
-                if let AssignmentTarget::System(sys) = pa.target {
-                    pending_survey_targets.insert(sys);
+            match pa.kind {
+                AssignmentKind::Survey => {
+                    if let AssignmentTarget::System(sys) = pa.target {
+                        pending_survey_targets.insert(sys);
+                    }
+                }
+                AssignmentKind::Colonize => {
+                    if let AssignmentTarget::System(sys) = pa.target {
+                        pending_colonize_targets.insert(sys);
+                    }
                 }
             }
         }
@@ -618,11 +636,9 @@ pub fn npc_decision_tick(
         if let Some(set) = outbox_survey_per_empire.get(&entity) {
             pending_survey_targets.extend(set.iter().copied());
         }
-        let pending_colonize_targets: std::collections::HashSet<Entity> =
-            outbox_colonize_per_empire
-                .get(&entity)
-                .cloned()
-                .unwrap_or_default();
+        if let Some(set) = outbox_colonize_per_empire.get(&entity) {
+            pending_colonize_targets.extend(set.iter().copied());
+        }
 
         // Extract system intel. Hostile / colonizable signals still come
         // from the KnowledgeStore (those require detailed snapshots),

--- a/macrocosmo/src/ai/plugin.rs
+++ b/macrocosmo/src/ai/plugin.rs
@@ -248,7 +248,7 @@ impl Plugin for AiPlugin {
             // pulls from it.
             // `process_ruler_boarding` runs after `drain_ai_commands` to handle
             // deferred ruler boarding (needs mutable Ship access).
-            // `sweep_resolved_survey_assignments` runs alongside the consumer
+            // `sweep_resolved_assignments` runs alongside the consumer
             // in the same set so the sweep happens at the natural "AI command
             // resolution" boundary; it has no data dependency on
             // `drain_ai_commands`.
@@ -270,7 +270,7 @@ impl Plugin for AiPlugin {
                         .after(super::command_consumer::drain_ai_ship_commands),
                     super::command_consumer::process_ruler_boarding
                         .after(super::command_consumer::drain_ai_commands),
-                    super::assignments::sweep_resolved_survey_assignments,
+                    super::assignments::sweep_resolved_assignments,
                 )
                     .in_set(AiTickSet::CommandDrain)
                     .run_if(in_state(crate::game_state::GameState::InGame)),

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -1627,6 +1627,7 @@ impl SavedConqueredCore {
 ///
 /// `kind` is encoded as a `u8`:
 /// - `0` = `AssignmentKind::Survey`.
+/// - `1` = `AssignmentKind::Colonize` (#468 PR-2).
 ///
 /// `target` is encoded as a `(u8, u64)`:
 /// - tag `0` (`AssignmentTarget::System`) → entity bits.
@@ -1643,6 +1644,7 @@ impl SavedPendingAssignment {
     pub fn from_live(v: &crate::ai::assignments::PendingAssignment) -> Self {
         let kind = match v.kind {
             crate::ai::assignments::AssignmentKind::Survey => 0,
+            crate::ai::assignments::AssignmentKind::Colonize => 1,
         };
         let (target_tag, target_bits) = match v.target {
             crate::ai::assignments::AssignmentTarget::System(e) => (0u8, e.to_bits()),
@@ -1657,8 +1659,11 @@ impl SavedPendingAssignment {
     }
     pub fn into_live(self, map: &EntityMap) -> crate::ai::assignments::PendingAssignment {
         let kind = match self.kind {
-            // `Survey` is the only currently-defined kind; future variants
-            // will fan in additional match arms with explicit tags.
+            0 => crate::ai::assignments::AssignmentKind::Survey,
+            1 => crate::ai::assignments::AssignmentKind::Colonize,
+            // Unknown future tag from a forward-compatible save: fall back
+            // to `Survey` to keep the load path infallible. SAVE_VERSION
+            // bumps would have been blocked at the schema layer first.
             _ => crate::ai::assignments::AssignmentKind::Survey,
         };
         let target = match self.target_tag {

--- a/macrocosmo/src/persistence/savebag.rs
+++ b/macrocosmo/src/persistence/savebag.rs
@@ -1661,10 +1661,20 @@ impl SavedPendingAssignment {
         let kind = match self.kind {
             0 => crate::ai::assignments::AssignmentKind::Survey,
             1 => crate::ai::assignments::AssignmentKind::Colonize,
-            // Unknown future tag from a forward-compatible save: fall back
-            // to `Survey` to keep the load path infallible. SAVE_VERSION
-            // bumps would have been blocked at the schema layer first.
-            _ => crate::ai::assignments::AssignmentKind::Survey,
+            // Unknown tag — SAVE_VERSION should have blocked this at the
+            // schema layer, so reaching here means a forgotten version
+            // bump on a new variant. Warn loudly so the regression is
+            // visible in CI / playtest logs, then fall back to `Survey`
+            // to keep the load path infallible (the marker may dedup
+            // against the wrong target, but the game stays playable).
+            unknown => {
+                bevy::log::warn!(
+                    "SavedPendingAssignment: unknown kind tag {} — falling back to Survey. \
+                     This indicates a missed SAVE_VERSION bump.",
+                    unknown,
+                );
+                crate::ai::assignments::AssignmentKind::Survey
+            }
         };
         let target = match self.target_tag {
             // `System` is the only currently-defined target; same fan-in

--- a/macrocosmo/src/ship/handlers/settlement_handler.rs
+++ b/macrocosmo/src/ship/handlers/settlement_handler.rs
@@ -160,7 +160,7 @@ pub fn handle_survey_requested(
                 // outlive the dispatch and stay attached until the issuing
                 // empire's `KnowledgeStore` reflects the survey completion
                 // (success path) or the ship is despawned (failure path).
-                // `sweep_resolved_survey_assignments` clears the marker on
+                // `sweep_resolved_assignments` clears the marker on
                 // success once the survey fact reaches the issuer; Bevy's
                 // automatic component cleanup handles ship loss.
             }
@@ -185,6 +185,7 @@ pub fn handle_survey_requested(
 
 #[allow(clippy::too_many_arguments)]
 pub fn handle_colonize_requested(
+    mut commands_buf: Commands,
     clock: Res<GameClock>,
     balance: Res<crate::technology::GameBalance>,
     mut reqs: MessageReader<ColonizeRequested>,
@@ -214,6 +215,11 @@ pub fn handle_colonize_requested(
                 },
                 completed_at: clock.elapsed,
             });
+            // #468 PR-2 review fold-in: ship query failed (despawn or
+            // missing components). Mirrors the survey handler's "ship
+            // unavailable" branch — Bevy drops the
+            // `PendingAssignment::Colonize` marker with the entity, so
+            // no explicit cleanup is required here.
             continue;
         };
 
@@ -237,6 +243,11 @@ pub fn handle_colonize_requested(
                     },
                     completed_at: clock.elapsed,
                 });
+                // #468 PR-2 review fold-in: terminal Rejected — clear
+                // the `PendingAssignment::Colonize` marker so the next
+                // AI tick can re-evaluate this ship. Mirrors the survey
+                // handler's marker hygiene.
+                commands_buf.entity(req.ship).remove::<PendingAssignment>();
                 continue;
             }
         };
@@ -252,6 +263,8 @@ pub fn handle_colonize_requested(
                 },
                 completed_at: clock.elapsed,
             });
+            // #468 PR-2 review fold-in: terminal Rejected — clear marker.
+            commands_buf.entity(req.ship).remove::<PendingAssignment>();
             continue;
         };
 
@@ -298,6 +311,8 @@ pub fn handle_colonize_requested(
                 completed_at: clock.elapsed,
             });
             queue.sync_prediction(ship_pos.as_array(), docked_system);
+            // #468 PR-2 review fold-in: terminal Rejected — clear marker.
+            commands_buf.entity(req.ship).remove::<PendingAssignment>();
             continue;
         }
 
@@ -324,6 +339,8 @@ pub fn handle_colonize_requested(
                     completed_at: clock.elapsed,
                 });
                 queue.sync_prediction(ship_pos.as_array(), docked_system);
+                // #468 PR-2 review fold-in: terminal Rejected — clear marker.
+                commands_buf.entity(req.ship).remove::<PendingAssignment>();
                 continue;
             }
         }

--- a/macrocosmo/tests/ai_colonize_requires_core.rs
+++ b/macrocosmo/tests/ai_colonize_requires_core.rs
@@ -114,14 +114,25 @@ fn setup_colonizer_scenario(app: &mut App) -> (Entity, Entity, Entity, Entity) {
     (empire, home, target, colony_ship)
 }
 
-/// Returns `true` if the `AiCommandOutbox` contains a `colonize_system`
-/// command targeting the given system. The outbox holds AI commands
-/// after `dispatch_ai_pending_commands` drains them from the bus and
-/// before the light-speed window elapses, so it's the post-tick
-/// observation surface for emitted commands.
-fn outbox_has_colonize_for(app: &App, target_system: Entity) -> bool {
+/// Returns `true` if there's an in-flight `colonize_system` AI command
+/// for the given target system OR the issuing empire has stamped a
+/// `PendingAssignment::Colonize` marker on a ship for this target.
+///
+/// Surfaces checked:
+/// 1. `AiCommandOutbox.entries` — pre-#468-PR2 light-speed shim (still
+///    used by non-migrated kinds).
+/// 2. `PendingAiShipCommand` — #468 PR-2 per-ship pipeline. With
+///    Ruler→ship = 0 light delay the holder is drained the same tick
+///    it's spawned, so this surface only catches the very-narrow
+///    in-flight window.
+/// 3. `PendingAssignment::Colonize` — stamped on the ship at dispatch
+///    time and removed once the issuing empire learns the target is
+///    colonized. This is the durable "the AI committed to this target"
+///    surface that survives the courier window collapsing to zero.
+fn outbox_has_colonize_for(app: &mut App, target_system: Entity) -> bool {
+    use macrocosmo::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
     let outbox = app.world().resource::<AiCommandOutbox>();
-    outbox.entries.iter().any(|entry| {
+    let outbox_hit = outbox.entries.iter().any(|entry| {
         let cmd = &entry.command;
         if cmd.kind != cmd_ids::colonize_system() {
             return false;
@@ -132,6 +143,27 @@ fn outbox_has_colonize_for(app: &App, target_system: Entity) -> bool {
             }
             _ => false,
         }
+    });
+    if outbox_hit {
+        return true;
+    }
+    // #468 PR-2: colonize_system migrated to PendingAiShipCommand.
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    let in_flight = {
+        let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+        q.iter(app.world())
+            .any(|p| p.kind == cmd_ids::colonize_system() && p.target_system == target_system)
+    };
+    if in_flight {
+        return true;
+    }
+    // Marker surface: dispatch stamps `PendingAssignment::Colonize`
+    // BEFORE the holder matures, so even with zero light-delay (Ruler
+    // at the ship) this is a durable signal that the AI committed.
+    let mut q = app.world_mut().query::<&PendingAssignment>();
+    q.iter(app.world()).any(|pa| {
+        matches!(pa.kind, AssignmentKind::Colonize)
+            && matches!(pa.target, AssignmentTarget::System(t) if t == target_system)
     })
 }
 
@@ -190,7 +222,7 @@ fn colonize_system_not_emitted_when_target_lacks_core() {
     }
 
     assert!(
-        !outbox_has_colonize_for(&app, target),
+        !outbox_has_colonize_for(&mut app, target),
         "AI emitted colonize_system for a target with no own Core present \
          — this is the loop bug the Core-presence filter must close."
     );
@@ -210,7 +242,7 @@ fn colonize_system_emitted_when_target_has_core() {
     }
 
     assert!(
-        outbox_has_colonize_for(&app, target),
+        outbox_has_colonize_for(&mut app, target),
         "AI must emit colonize_system when own Core is present at the target"
     );
 }

--- a/macrocosmo/tests/ai_command_lightspeed.rs
+++ b/macrocosmo/tests/ai_command_lightspeed.rs
@@ -31,6 +31,10 @@
 //!    Ruler→target.
 //! 3. `survey_ai_scout_at_home_ruler_remote_delays_by_ruler_to_ship` —
 //!    Symmetric: Ruler at frontier (5 ly), Scout at home. Same delay.
+//!
+//! #468 PR-2 adds analogous zero-delay regressions for `colonize_system`,
+//! `reposition`, and `blockade`, plus a reject-path test for the
+//! colonize marker (the other two kinds don't carry a `PendingAssignment`).
 
 mod common;
 
@@ -399,18 +403,19 @@ fn rejected_survey_at_drain_time_releases_pending_assignment() {
         sent_at: now,
         arrives_at: now + 1,
     });
-    app.world_mut()
-        .entity_mut(scout)
-        .insert(PendingAssignment {
-            faction: empire,
-            kind: AssignmentKind::Survey,
-            target: AssignmentTarget::System(frontier),
-            since: now,
-        });
+    app.world_mut().entity_mut(scout).insert(PendingAssignment {
+        faction: empire,
+        kind: AssignmentKind::Survey,
+        target: AssignmentTarget::System(frontier),
+        since: now,
+    });
 
     // Sanity: the marker is stamped before the drain runs.
     assert!(
-        app.world().entity(scout).get::<PendingAssignment>().is_some(),
+        app.world()
+            .entity(scout)
+            .get::<PendingAssignment>()
+            .is_some(),
         "PendingAssignment must be present pre-drain (test setup invariant)",
     );
 
@@ -432,8 +437,398 @@ fn rejected_survey_at_drain_time_releases_pending_assignment() {
         "Holder must be drained even on reject path",
     );
     assert!(
-        app.world().entity(scout).get::<PendingAssignment>().is_none(),
+        app.world()
+            .entity(scout)
+            .get::<PendingAssignment>()
+            .is_none(),
         "PendingAssignment must be removed when survey is rejected at drain time \
          (otherwise the ship is permanently excluded from AI dispatches)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #468 PR-2: colonize_system / reposition / blockade zero-delay regressions.
+//
+// Shape: stage a ship in-system, manually spawn a matured
+// `PendingAiShipCommand` with `arrives_at = sent_at = now` (= Ruler→ship
+// zero light delay), then advance one tick and assert the corresponding
+// typed `*Requested` event fired. This is the same shape as PR-1's
+// `rejected_survey_at_drain_time_releases_pending_assignment` but on the
+// success path. We bypass the dispatcher (`dispatch_ai_pending_commands`)
+// because the PR-2 contract under test is the drain side
+// (`drain_ai_ship_commands` → `apply_*_to_ship`); dispatcher coverage is
+// pinned by `survey_ai_scout_at_home_ruler_at_home_target_far_zero_delay`
+// and the dedup tests in `ai_npc_outbox_dedup.rs`.
+//
+// Bypassing also lets the test disable AI policy emission entirely
+// (`AiPlayerMode(false)` + no `PlayerEmpire` marker won't help — the NPC
+// path always marks the empire), so the assertion isn't muddled by
+// coincidental NPC-emitted commands.
+// ---------------------------------------------------------------------------
+
+/// Minimal world for the matured-holder tests. Spawns one empire with a
+/// Ruler at `home`, plus a target system + an in-system ship.
+fn setup_matured_holder_world(
+    app: &mut App,
+    ship_design: &str,
+    target_distance_ly: f64,
+) -> (Entity, Entity, Entity, Entity) {
+    let empire = app
+        .world_mut()
+        .spawn((
+            Empire {
+                name: "PR-2 Holder Test".into(),
+            },
+            Faction {
+                id: "pr2_holder_test".into(),
+                name: "PR-2 Holder Test".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+        ))
+        .id();
+
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let target = spawn_test_system(
+        app.world_mut(),
+        "Target",
+        [target_distance_ly, 0.0, 0.0],
+        1.0,
+        true,
+        false,
+    );
+    let ship = spawn_test_ship(
+        app.world_mut(),
+        "Ship-1",
+        ship_design,
+        home,
+        [0.0, 0.0, 0.0],
+    );
+    app.world_mut()
+        .entity_mut(ship)
+        .get_mut::<Ship>()
+        .unwrap()
+        .owner = Owner::Empire(empire);
+
+    spawn_test_ruler(app.world_mut(), empire, home);
+
+    (empire, home, target, ship)
+}
+
+/// Spawn a matured `PendingAiShipCommand` (arrives_at = sent_at = now).
+fn spawn_matured_holder(
+    app: &mut App,
+    kind: macrocosmo_ai::CommandKindId,
+    ship: Entity,
+    target_system: Entity,
+    issuer_empire: Entity,
+) {
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    let now = app.world().resource::<GameClock>().elapsed;
+    app.world_mut().spawn(PendingAiShipCommand {
+        kind,
+        target_system,
+        ship,
+        issuer_empire,
+        sent_at: now,
+        arrives_at: now,
+    });
+}
+
+/// #468 PR-2: matured `colonize_system` PendingAiShipCommand at zero
+/// light delay must drain into a `ColonizeRequested` within the same
+/// tick. Pre-fix the AI paid Ruler→target light delay (~300 hd for
+/// 5 ly) before firing; post-fix the wire-up to
+/// `drain_ai_ship_commands` releases the event the instant the
+/// holder matures.
+#[test]
+fn colonize_ai_ship_at_home_ruler_at_home_target_far_zero_delay() {
+    use macrocosmo::ship::command_events::ColonizeRequested;
+
+    let mut app = test_app();
+    // Disable AI policy emission so we observe only the drain we set up.
+    app.insert_resource(AiPlayerMode(false));
+
+    let (empire, _home, target, ship) =
+        setup_matured_holder_world(&mut app, "colony_ship_mk1", 5.0);
+    spawn_matured_holder(&mut app, cmd_ids::colonize_system(), ship, target, empire);
+
+    app.world_mut()
+        .resource_mut::<Messages<ColonizeRequested>>()
+        .update();
+
+    let mut colonize_event_total = 0usize;
+    for _ in 0..3 {
+        advance_time(&mut app, 1);
+        colonize_event_total += {
+            let messages = app.world().resource::<Messages<ColonizeRequested>>();
+            messages.iter_current_update_messages().count()
+        };
+    }
+    assert!(
+        colonize_event_total > 0,
+        "matured colonize_system PendingAiShipCommand at zero light delay must \
+         drain into ColonizeRequested within 3 ticks — #468 PR-2 regression"
+    );
+}
+
+/// #468 PR-2: matured `reposition` PendingAiShipCommand at zero light
+/// delay must drain into a `MoveRequested` within the same tick.
+#[test]
+fn reposition_ai_ship_at_home_ruler_at_home_target_far_zero_delay() {
+    use macrocosmo::ship::command_events::MoveRequested;
+
+    let mut app = test_app();
+    app.insert_resource(AiPlayerMode(false));
+
+    let (empire, _home, target, ship) = setup_matured_holder_world(&mut app, "scout_mk1", 5.0);
+    spawn_matured_holder(&mut app, cmd_ids::reposition(), ship, target, empire);
+
+    app.world_mut()
+        .resource_mut::<Messages<MoveRequested>>()
+        .update();
+
+    let mut move_event_total = 0usize;
+    for _ in 0..3 {
+        advance_time(&mut app, 1);
+        move_event_total += {
+            let messages = app.world().resource::<Messages<MoveRequested>>();
+            messages.iter_current_update_messages().count()
+        };
+    }
+    assert!(
+        move_event_total > 0,
+        "matured reposition PendingAiShipCommand at zero light delay must drain \
+         into MoveRequested within 3 ticks — #468 PR-2 regression"
+    );
+}
+
+/// #468 PR-2: matured `blockade` PendingAiShipCommand at zero light
+/// delay must drain into a `MoveRequested` within the same tick.
+/// Both reposition and blockade share `apply_move_to_ship`; this test
+/// pins the routing wire-up for blockade.
+#[test]
+fn blockade_ai_ship_at_home_ruler_at_home_target_far_zero_delay() {
+    use macrocosmo::ship::command_events::MoveRequested;
+
+    let mut app = test_app();
+    app.insert_resource(AiPlayerMode(false));
+
+    let (empire, _home, target, ship) = setup_matured_holder_world(&mut app, "scout_mk1", 5.0);
+    spawn_matured_holder(&mut app, cmd_ids::blockade(), ship, target, empire);
+
+    app.world_mut()
+        .resource_mut::<Messages<MoveRequested>>()
+        .update();
+
+    let mut move_event_total = 0usize;
+    for _ in 0..3 {
+        advance_time(&mut app, 1);
+        move_event_total += {
+            let messages = app.world().resource::<Messages<MoveRequested>>();
+            messages.iter_current_update_messages().count()
+        };
+    }
+    assert!(
+        move_event_total > 0,
+        "matured blockade PendingAiShipCommand at zero light delay must drain \
+         into MoveRequested within 3 ticks — #468 PR-2 regression"
+    );
+}
+
+/// #468 PR-2 BLOCKER regression (mirrors PR-1's survey reject test):
+/// when a matured `colonize_system` `PendingAiShipCommand` is rejected
+/// at drain time (ship no longer idle / owner changed / despawned),
+/// the `PendingAssignment::Colonize` marker stamped at outbox-spawn
+/// time MUST be removed too. Otherwise the ship is permanently
+/// excluded from future AI colonize dispatches because the dedup scan
+/// in `npc_decision.rs` filters by `PendingAssignment`.
+#[test]
+fn rejected_colonize_at_drain_time_releases_pending_assignment() {
+    use macrocosmo::ai::AiBusResource;
+    use macrocosmo::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    use macrocosmo::ship::{CommandQueue, QueuedCommand};
+
+    let mut app = test_app();
+    // Disable AI policy emission so the test exclusively exercises the
+    // drain reject path — without this the next NPC tick could
+    // re-stamp the marker after we observe its removal.
+    app.insert_resource(AiPlayerMode(false));
+    app.insert_resource(AiBusResource::default());
+
+    let empire = app
+        .world_mut()
+        .spawn((
+            Empire {
+                name: "Reject Colonize Test".into(),
+            },
+            Faction {
+                id: "reject_colonize_test".into(),
+                name: "Reject Colonize Test".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+        ))
+        .id();
+
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let frontier = spawn_test_system(
+        app.world_mut(),
+        "Frontier",
+        [5.0, 0.0, 0.0],
+        1.0,
+        false,
+        false,
+    );
+    let colony_ship = spawn_test_ship(
+        app.world_mut(),
+        "Colony-1",
+        "colony_ship_mk1",
+        home,
+        [0.0, 0.0, 0.0],
+    );
+    app.world_mut()
+        .entity_mut(colony_ship)
+        .get_mut::<Ship>()
+        .unwrap()
+        .owner = Owner::Empire(empire);
+
+    // Force the ship into a non-idle state so apply_colonize_to_ship
+    // takes the queue-not-empty reject branch on maturity.
+    {
+        let mut em = app.world_mut().entity_mut(colony_ship);
+        if let Some(mut queue) = em.get_mut::<CommandQueue>() {
+            queue.commands.push(QueuedCommand::MoveTo { system: home });
+        }
+    }
+
+    // Manually spawn the in-flight holder + stamp the colonize marker
+    // — same shape `dispatch_ship_command_per_ship` produces.
+    let now = app.world().resource::<GameClock>().elapsed;
+    app.world_mut().spawn(PendingAiShipCommand {
+        kind: cmd_ids::colonize_system(),
+        target_system: frontier,
+        ship: colony_ship,
+        issuer_empire: empire,
+        sent_at: now,
+        arrives_at: now + 1,
+    });
+    app.world_mut()
+        .entity_mut(colony_ship)
+        .insert(PendingAssignment {
+            faction: empire,
+            kind: AssignmentKind::Colonize,
+            target: AssignmentTarget::System(frontier),
+            since: now,
+        });
+
+    assert!(
+        app.world()
+            .entity(colony_ship)
+            .get::<PendingAssignment>()
+            .is_some(),
+        "PendingAssignment::Colonize must be present pre-drain (test setup invariant)",
+    );
+
+    for _ in 0..3 {
+        advance_time(&mut app, 1);
+    }
+
+    let holder_remains = {
+        let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+        q.iter(app.world()).any(|p| p.ship == colony_ship)
+    };
+    assert!(
+        !holder_remains,
+        "Holder must be drained even on colonize reject path",
+    );
+    assert!(
+        app.world()
+            .entity(colony_ship)
+            .get::<PendingAssignment>()
+            .is_none(),
+        "PendingAssignment::Colonize must be removed when colonize_system is \
+         rejected at drain time (otherwise the ship is permanently excluded \
+         from future AI colonize dispatches)",
+    );
+}
+
+/// #468 PR-2: holder cleanup contract for `reposition` — even though
+/// the kind doesn't carry a `PendingAssignment` marker (movement
+/// orders are idempotent — no per-empire dedup needed), the in-flight
+/// holder MUST still be despawned on reject paths so it doesn't leak
+/// across ticks. Mirrors the colonize cleanup test minus the marker
+/// assertion.
+#[test]
+fn rejected_reposition_at_drain_time_despawns_holder() {
+    use macrocosmo::ai::AiBusResource;
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    use macrocosmo::ship::{CommandQueue, QueuedCommand};
+
+    let mut app = test_app();
+    app.insert_resource(AiPlayerMode(false));
+    app.insert_resource(AiBusResource::default());
+
+    let empire = app
+        .world_mut()
+        .spawn((
+            Empire {
+                name: "Reject Reposition".into(),
+            },
+            Faction {
+                id: "reject_reposition".into(),
+                name: "Reject Reposition".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+        ))
+        .id();
+
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    let target = spawn_test_system(app.world_mut(), "Target", [5.0, 0.0, 0.0], 1.0, true, false);
+    let ship = spawn_test_ship(
+        app.world_mut(),
+        "Ship-1",
+        "scout_mk1",
+        home,
+        [0.0, 0.0, 0.0],
+    );
+    app.world_mut()
+        .entity_mut(ship)
+        .get_mut::<Ship>()
+        .unwrap()
+        .owner = Owner::Empire(empire);
+
+    // Non-idle ship → apply_reposition_to_ship rejects.
+    {
+        let mut em = app.world_mut().entity_mut(ship);
+        if let Some(mut queue) = em.get_mut::<CommandQueue>() {
+            queue.commands.push(QueuedCommand::MoveTo { system: home });
+        }
+    }
+
+    let now = app.world().resource::<GameClock>().elapsed;
+    app.world_mut().spawn(PendingAiShipCommand {
+        kind: cmd_ids::reposition(),
+        target_system: target,
+        ship,
+        issuer_empire: empire,
+        sent_at: now,
+        arrives_at: now + 1,
+    });
+
+    for _ in 0..3 {
+        advance_time(&mut app, 1);
+    }
+
+    let holder_remains = {
+        let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+        q.iter(app.world()).any(|p| p.ship == ship)
+    };
+    assert!(
+        !holder_remains,
+        "reposition holder must be drained on reject path so it doesn't \
+         leak across ticks"
     );
 }

--- a/macrocosmo/tests/ai_command_lightspeed.rs
+++ b/macrocosmo/tests/ai_command_lightspeed.rs
@@ -572,6 +572,113 @@ fn colonize_ai_ship_at_home_ruler_at_home_target_far_zero_delay() {
     );
 }
 
+/// #468 PR-2 review fold-in (Bug BLOCKER): the `*Requested` event
+/// handler `handle_colonize_requested` also rejects on no-core, not-
+/// idle, target-despawned, and not-a-colony-ship branches. Pre-fix
+/// none of those branches stripped `PendingAssignment::Colonize` —
+/// only the drain-side `apply_colonize_to_ship` did. So a colonize
+/// command that survived the drain (ship was idle) but failed at the
+/// settlement handler (no sovereignty Core in target system, etc.)
+/// would leave the marker stamped forever.
+///
+/// This test pins the handler-side cleanup by:
+///   1. spawning a colony ship at the target system (= drain succeeds,
+///      the auto-MoveTo branch is skipped),
+///   2. spawning the ColonizeRequested event directly (= bypass drain),
+///   3. pre-stamping the marker,
+///   4. observing that handle_colonize_requested rejects (no Core in
+///      the target system) AND removes the marker.
+#[test]
+fn colonize_handler_reject_at_no_core_releases_pending_assignment() {
+    use macrocosmo::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
+    use macrocosmo::ship::ShipState;
+    use macrocosmo::ship::command_events::ColonizeRequested;
+
+    let mut app = test_app();
+    app.insert_resource(AiPlayerMode(false));
+
+    // One survey system that doubles as the colonize target — the
+    // ship will be placed inside it (= drain succeeds: ship is docked
+    // at target). The system has no sovereignty Core, so the handler
+    // rejects on the no-core branch.
+    let empire = app
+        .world_mut()
+        .spawn((
+            Empire {
+                name: "Handler Reject Test".into(),
+            },
+            Faction {
+                id: "handler_reject_test".into(),
+                name: "Handler Reject Test".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+        ))
+        .id();
+    let target = spawn_test_system(app.world_mut(), "Target", [0.0, 0.0, 0.0], 1.0, true, false);
+    let colony_ship = spawn_test_ship(
+        app.world_mut(),
+        "Colony-1",
+        "colony_ship_mk1",
+        target,
+        [0.0, 0.0, 0.0],
+    );
+    {
+        let mut em = app.world_mut().entity_mut(colony_ship);
+        em.get_mut::<Ship>().unwrap().owner = Owner::Empire(empire);
+        // Ensure FactionOwner so the handler's #299 Core gate is
+        // exercised (not the neutral-bypass path).
+        em.insert(macrocosmo::faction::FactionOwner(empire));
+        if let Some(mut state) = em.get_mut::<ShipState>() {
+            *state = ShipState::InSystem { system: target };
+        }
+    }
+
+    // Stamp the marker as if the dispatcher had emitted the colonize
+    // earlier and the drain had already let it through (= the
+    // realistic state when handle_colonize_requested sees a request).
+    let now = app.world().resource::<GameClock>().elapsed;
+    app.world_mut()
+        .entity_mut(colony_ship)
+        .insert(PendingAssignment {
+            faction: empire,
+            kind: AssignmentKind::Colonize,
+            target: AssignmentTarget::System(target),
+            since: now,
+        });
+
+    // Reset the message queue so we observe only this test's events.
+    app.world_mut()
+        .resource_mut::<Messages<ColonizeRequested>>()
+        .update();
+
+    // Emit ColonizeRequested directly (bypass drain).
+    app.world_mut()
+        .resource_mut::<Messages<ColonizeRequested>>()
+        .write(ColonizeRequested {
+            command_id: macrocosmo::ship::command_events::CommandId(9_999_001),
+            ship: colony_ship,
+            target_system: target,
+            planet: None,
+            issued_at: now,
+        });
+
+    // One tick is enough for handle_colonize_requested to run.
+    for _ in 0..2 {
+        advance_time(&mut app, 1);
+    }
+
+    assert!(
+        app.world()
+            .entity(colony_ship)
+            .get::<PendingAssignment>()
+            .is_none(),
+        "PendingAssignment::Colonize must be removed when handle_colonize_requested \
+         rejects at the no-Core gate — otherwise the ship is permanently excluded \
+         from future AI colonize dispatches even though the drain succeeded",
+    );
+}
+
 /// #468 PR-2: matured `reposition` PendingAiShipCommand at zero light
 /// delay must drain into a `MoveRequested` within the same tick.
 #[test]

--- a/macrocosmo/tests/ai_npc_no_double_survey_assignment.rs
+++ b/macrocosmo/tests/ai_npc_no_double_survey_assignment.rs
@@ -33,7 +33,7 @@
 //!   after the handler `Ok` arm fired — the eager-remove regression
 //!   would clear it. Then directly populate the empire's
 //!   `KnowledgeStore` with `surveyed = true` for the target and one
-//!   more tick must let `sweep_resolved_survey_assignments` clear it.
+//!   more tick must let `sweep_resolved_assignments` clear it.
 //! - `pending_assignment_clears_when_ship_despawns` (Round 10 Bug C
 //!   fix): the time-based `sweep_stale_assignments` was removed
 //!   because its 200-hex lifetime was shorter than realistic sublight
@@ -365,7 +365,7 @@ fn ai_second_tick_does_not_re_emit_when_all_ships_and_targets_are_pending() {
 /// Scenario B (lifetime contract): the handler `Ok` arm must NOT
 /// remove `PendingAssignment` — the marker is the NPC's decision
 /// memory and outlives the dispatch. Removal is driven by
-/// `sweep_resolved_survey_assignments`, which watches the issuing
+/// `sweep_resolved_assignments`, which watches the issuing
 /// empire's `KnowledgeStore` for `surveyed = true` on the target.
 ///
 /// This pins the post-`7ad059a` lifetime semantics: under the old
@@ -464,7 +464,7 @@ fn pending_assignment_outlives_handler_ok_until_knowledge_arrives() {
         });
     }
 
-    // One more tick — `sweep_resolved_survey_assignments` runs in the
+    // One more tick — `sweep_resolved_assignments` runs in the
     // `AiTickSet::CommandDrain` set on every Update and should now
     // notice the issuing empire knows the target is surveyed.
     advance_time(&mut app, 1);
@@ -473,7 +473,7 @@ fn pending_assignment_outlives_handler_ok_until_knowledge_arrives() {
     assert!(
         marker.is_none(),
         "PendingAssignment was not swept after KnowledgeStore reported \
-         surveyed=true on the target — sweep_resolved_survey_assignments \
+         surveyed=true on the target — sweep_resolved_assignments \
          regression",
     );
 }

--- a/macrocosmo/tests/ai_npc_outbox_dedup.rs
+++ b/macrocosmo/tests/ai_npc_outbox_dedup.rs
@@ -307,25 +307,37 @@ fn outbox_dedups_survey_system_during_light_delay_window() {
 /// Bug A regression (colonize path): same shape as the survey case
 /// but for `colonize_system`. Two colony ships, one colonizable
 /// target with an owned Core in place — only one `colonize_system`
-/// command may live in the outbox during the light-speed window.
+/// command may live in flight during the light-speed window.
+///
+/// #468 PR-2: `colonize_system` migrated to the per-ship
+/// `PendingAiShipCommand` pipeline keyed on Ruler→ship distance, not
+/// Ruler→target. The colony ships are staged at a remote loitering
+/// system 5 ly away from the Ruler's home so the courier window
+/// stays open across multiple decision ticks — placing them at home
+/// would give a 0 light-delay and the command would mature instantly,
+/// erasing the in-flight dedup window.
 #[test]
 fn outbox_dedups_colonize_system_during_light_delay_window() {
     let mut app = test_app();
     // `target_surveyed = true` so Rule 3 considers the frontier a
     // valid colonization candidate.
-    let (empire, home, frontier) = setup_far_target(&mut app, "Aurelian", 5.0, true);
+    let (empire, _home, frontier) = setup_far_target(&mut app, "Aurelian", 5.0, true);
 
     // Satisfy the Core-presence gate (#299).
     place_core_at(app.world_mut(), empire, frontier, [5.0, 0.0, 0.0]);
 
-    // Two idle colony ships at home.
+    // Stage the colony ships at a remote loitering system 5 ly from
+    // the Ruler. With #468 PR-2 the colonize_system courier delay is
+    // Ruler→ship, so this keeps the in-flight window open across the
+    // dedup-check ticks.
+    let loiter = spawn_test_system(app.world_mut(), "Loiter", [0.0, 5.0, 0.0], 1.0, true, false);
     for i in 0..2 {
         let s = spawn_test_ship(
             app.world_mut(),
             &format!("Colonizer-{}", i),
             "colony_ship_mk1",
-            home,
-            [0.0, 0.0, 0.0],
+            loiter,
+            [0.0, 5.0, 0.0],
         );
         app.world_mut()
             .entity_mut(s)
@@ -353,7 +365,7 @@ fn outbox_dedups_colonize_system_during_light_delay_window() {
     let after_second = count_outbox_for(&mut app, cmd_ids::colonize_system(), frontier);
     assert_eq!(
         after_second, 1,
-        "expected outbox to still hold exactly 1 colonize command for the \
+        "expected exactly 1 in-flight colonize command for the \
          frontier (the light-speed window has not elapsed); got {} — \
          Bug A regression",
         after_second,

--- a/macrocosmo/tests/ai_per_region_npc_smoke.rs
+++ b/macrocosmo/tests/ai_per_region_npc_smoke.rs
@@ -384,12 +384,63 @@ fn outbox_entries_for(
         .collect()
 }
 
-fn count_outbox_for(app: &App, kind: macrocosmo_ai::CommandKindId, target: Entity) -> usize {
-    outbox_entries_for(app, kind, target).len()
+/// #468 PR-2: counts in-flight commands across both the legacy
+/// `AiCommandOutbox` and the per-ship `PendingAiShipCommand` surfaces.
+/// Migrated kinds (`survey_system`, `colonize_system`, `reposition`,
+/// `blockade`) only land on the latter; non-migrated kinds still land
+/// on the former. Mirrors the helper in
+/// `tests/ai_npc_outbox_dedup.rs::count_outbox_for`.
+///
+/// Takes `&mut App` because Bevy 0.18's `World::query::<T>` requires a
+/// mutable World to build the QueryState. The `&App` outbox lookup
+/// upstream is preserved by destructuring up front.
+fn count_outbox_for(app: &mut App, kind: macrocosmo_ai::CommandKindId, target: Entity) -> usize {
+    let outbox_count = outbox_entries_for(app, kind.clone(), target).len();
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+    let ship_command_count = q
+        .iter(app.world())
+        .filter(|p| p.kind == kind && p.target_system == target)
+        .count();
+    outbox_count + ship_command_count
+}
+
+/// #468 PR-2: durable "AI has committed to this target" surface for
+/// kinds that stamp a `PendingAssignment`. The legacy `count_outbox_for`
+/// helper above ONLY captures the in-flight courier window; when
+/// Ruler→ship = 0 light delay collapses that window to zero (as in
+/// the per-region smoke test), the holder is despawned the same tick
+/// it's spawned and the only durable signal left is the marker on the
+/// ship entity.
+fn count_pending_assignments_for(
+    app: &mut App,
+    kind: macrocosmo_ai::CommandKindId,
+    target: Entity,
+) -> usize {
+    use macrocosmo::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
+    let assignment_kind = if kind == cmd_ids::survey_system() {
+        AssignmentKind::Survey
+    } else if kind == cmd_ids::colonize_system() {
+        AssignmentKind::Colonize
+    } else {
+        return 0;
+    };
+    let mut q = app.world_mut().query::<&PendingAssignment>();
+    q.iter(app.world())
+        .filter(|pa| {
+            pa.kind == assignment_kind
+                && matches!(pa.target, AssignmentTarget::System(t) if t == target)
+        })
+        .count()
 }
 
 /// Extract the `ship_0` Entity from a command's params (used by Rule 3
 /// `colonize_system` to pass the ship the order is for).
+///
+/// #468 PR-2: colonize_system migrated off the outbox; the cross-region
+/// leak guard now reads `PendingAiShipCommand.ship` directly. Helper
+/// retained for PR-3 / future tests that exercise non-migrated kinds.
+#[allow(dead_code)]
 fn cmd_ship_0(cmd: &macrocosmo_ai::Command) -> Option<Entity> {
     match cmd.params.get("ship_0")? {
         macrocosmo_ai::CommandValue::Entity(e) => Some(Entity::from_bits(e.0)),
@@ -415,8 +466,18 @@ fn per_region_npc_emits_independently_and_no_cross_region_leak() {
 
     // ----- Mid: Rule 3 (colonize) must fire in BOTH regions, each
     // pointing at its OWN frontier target.
-    let target_a_count = count_outbox_for(&app, cmd_ids::colonize_system(), layout.target_a);
-    let target_b_count = count_outbox_for(&app, cmd_ids::colonize_system(), layout.target_b);
+    // #468 PR-2: with the colony ships and Ruler at home (Ruler→ship
+    // light delay = 0), the colonize_system `PendingAiShipCommand`
+    // matures the same tick it's spawned. By the time we observe,
+    // the holder + outbox surfaces are likely empty — the durable
+    // signal is the `PendingAssignment::Colonize` marker on the ship,
+    // stamped at dispatch time. Fold both surfaces into the per-target
+    // signal so the assertion stays correct across the dispatch path
+    // migration.
+    let target_a_count = count_outbox_for(&mut app, cmd_ids::colonize_system(), layout.target_a)
+        + count_pending_assignments_for(&mut app, cmd_ids::colonize_system(), layout.target_a);
+    let target_b_count = count_outbox_for(&mut app, cmd_ids::colonize_system(), layout.target_b)
+        + count_pending_assignments_for(&mut app, cmd_ids::colonize_system(), layout.target_b);
     assert!(
         target_a_count >= 1,
         "Mid A must dispatch colonize on target_a (region A); got {}",
@@ -428,25 +489,28 @@ fn per_region_npc_emits_independently_and_no_cross_region_leak() {
         target_b_count,
     );
 
-    // ----- Cross-region leak guard: every colonize_system command must
-    // pair (target ∈ region A) with (ship_0 ∈ region A's idle ships),
-    // and likewise for region B.
+    // ----- Cross-region leak guard: every colonize commitment must
+    // pair (target ∈ region A) with (ship ∈ region A's idle ships), and
+    // likewise for region B.
+    //
+    // #468 PR-2: colonize_system migrated from `AiCommandOutbox` (which
+    // stored the command's full `params` map) to per-ship
+    // `PendingAiShipCommand` + `PendingAssignment` marker. With zero
+    // light delay the holder is despawned same-tick; the marker is the
+    // durable surface. We walk `(Entity, &PendingAssignment)` and
+    // derive `(target, ship)` from `(pa.target, ship_entity)`.
     {
-        let outbox = app.world().resource::<AiCommandOutbox>();
-        let kind = cmd_ids::colonize_system();
-        for entry in outbox.entries.iter() {
-            let cmd = &entry.command;
-            if cmd.kind != kind {
-                continue;
-            }
-            let target_sys = match cmd.params.get("target_system") {
-                Some(macrocosmo_ai::CommandValue::System(s)) => Entity::from_bits(s.0),
-                _ => continue,
-            };
-            let Some(ship) = cmd_ship_0(cmd) else {
-                continue;
-            };
-
+        use macrocosmo::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
+        let pairs: Vec<(Entity, Entity)> = {
+            let mut q = app.world_mut().query::<(Entity, &PendingAssignment)>();
+            q.iter(app.world())
+                .filter(|(_, pa)| matches!(pa.kind, AssignmentKind::Colonize))
+                .filter_map(|(ship, pa)| match pa.target {
+                    AssignmentTarget::System(t) => Some((t, ship)),
+                })
+                .collect()
+        };
+        for (target_sys, ship) in pairs {
             if target_sys == layout.target_a {
                 assert_eq!(
                     ship, layout.colony_ship_a,
@@ -564,27 +628,60 @@ fn per_region_npc_emits_independently_and_no_cross_region_leak() {
         );
     }
 
-    // ----- Sanity: AiCommandOutbox carries entries from BOTH regions
-    // in the same world (= multi-Mid is actually live).
-    let outbox = app.world().resource::<AiCommandOutbox>();
+    // ----- Sanity: in-flight AI command entries from BOTH regions
+    // (= multi-Mid is actually live). #468 PR-2: colonize_system
+    // migrated off `AiCommandOutbox` onto `PendingAiShipCommand`; we
+    // walk both surfaces so the assertion remains target-agnostic of
+    // which kind drove the entries.
     let mut seen_a = false;
     let mut seen_b = false;
-    for entry in outbox.entries.iter() {
-        if let Some(macrocosmo_ai::CommandValue::System(s)) =
-            entry.command.params.get("target_system")
-        {
-            if Entity::from_bits(s.0) == layout.target_a {
+    {
+        let outbox = app.world().resource::<AiCommandOutbox>();
+        for entry in outbox.entries.iter() {
+            if let Some(macrocosmo_ai::CommandValue::System(s)) =
+                entry.command.params.get("target_system")
+            {
+                if Entity::from_bits(s.0) == layout.target_a {
+                    seen_a = true;
+                }
+                if Entity::from_bits(s.0) == layout.target_b {
+                    seen_b = true;
+                }
+            }
+        }
+    }
+    {
+        use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+        let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+        for p in q.iter(app.world()) {
+            if p.target_system == layout.target_a {
                 seen_a = true;
             }
-            if Entity::from_bits(s.0) == layout.target_b {
+            if p.target_system == layout.target_b {
                 seen_b = true;
+            }
+        }
+    }
+    // #468 PR-2: also check PendingAssignment markers — they remain
+    // even after the holder matures and despawns.
+    {
+        use macrocosmo::ai::assignments::{AssignmentTarget, PendingAssignment};
+        let mut q = app.world_mut().query::<&PendingAssignment>();
+        for pa in q.iter(app.world()) {
+            if let AssignmentTarget::System(t) = pa.target {
+                if t == layout.target_a {
+                    seen_a = true;
+                }
+                if t == layout.target_b {
+                    seen_b = true;
+                }
             }
         }
     }
     assert!(
         seen_a && seen_b,
-        "outbox must hold target_system entries for both regions \
-         (saw target_a={}, target_b={})",
+        "in-flight AI commands must cover both regions (saw target_a={}, \
+         target_b={})",
         seen_a,
         seen_b,
     );

--- a/macrocosmo/tests/mid_agent_member_filter.rs
+++ b/macrocosmo/tests/mid_agent_member_filter.rs
@@ -231,22 +231,59 @@ fn setup_two_region_empire(
 }
 
 /// Count outbox entries of `kind` whose `target_system` matches.
-fn count_outbox_for(app: &App, kind: macrocosmo_ai::CommandKindId, target: Entity) -> usize {
-    let outbox = app.world().resource::<AiCommandOutbox>();
-    outbox
-        .entries
-        .iter()
-        .filter(|entry| {
-            let cmd = &entry.command;
-            if cmd.kind != kind {
-                return false;
-            }
-            match cmd.params.get("target_system") {
-                Some(macrocosmo_ai::CommandValue::System(sys_id)) => target.to_bits() == sys_id.0,
-                _ => false,
-            }
-        })
-        .count()
+///
+/// #468 PR-2: also folds in the per-ship `PendingAiShipCommand`
+/// pipeline + the durable `PendingAssignment` marker, since several
+/// kinds (survey_system, colonize_system, reposition, blockade) no
+/// longer flow through `AiCommandOutbox`.
+fn count_outbox_for(app: &mut App, kind: macrocosmo_ai::CommandKindId, target: Entity) -> usize {
+    let outbox_count = {
+        let outbox = app.world().resource::<AiCommandOutbox>();
+        outbox
+            .entries
+            .iter()
+            .filter(|entry| {
+                let cmd = &entry.command;
+                if cmd.kind != kind {
+                    return false;
+                }
+                match cmd.params.get("target_system") {
+                    Some(macrocosmo_ai::CommandValue::System(sys_id)) => {
+                        target.to_bits() == sys_id.0
+                    }
+                    _ => false,
+                }
+            })
+            .count()
+    };
+    use macrocosmo::ai::command_consumer::PendingAiShipCommand;
+    let ship_command_count = {
+        let mut q = app.world_mut().query::<&PendingAiShipCommand>();
+        q.iter(app.world())
+            .filter(|p| p.kind == kind && p.target_system == target)
+            .count()
+    };
+    // PendingAssignment marker is the durable surface — survives a
+    // zero light-delay window where the holder despawns same-tick.
+    use macrocosmo::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
+    let assignment_kind_match = if kind == cmd_ids::survey_system() {
+        Some(AssignmentKind::Survey)
+    } else if kind == cmd_ids::colonize_system() {
+        Some(AssignmentKind::Colonize)
+    } else {
+        None
+    };
+    let assignment_count = if let Some(akind) = assignment_kind_match {
+        let mut q = app.world_mut().query::<&PendingAssignment>();
+        q.iter(app.world())
+            .filter(|pa| {
+                pa.kind == akind && matches!(pa.target, AssignmentTarget::System(t) if t == target)
+            })
+            .count()
+    } else {
+        0
+    };
+    outbox_count + ship_command_count + assignment_count
 }
 
 #[test]
@@ -285,8 +322,8 @@ fn each_mid_agent_only_dispatches_within_its_own_region() {
     // Each Mid must have dispatched a colonize_system command at the
     // target inside ITS region only. Cross-region targets must stay
     // empty (no leakage).
-    let target_a_count = count_outbox_for(&app, cmd_ids::colonize_system(), target_a);
-    let target_b_count = count_outbox_for(&app, cmd_ids::colonize_system(), target_b);
+    let target_a_count = count_outbox_for(&mut app, cmd_ids::colonize_system(), target_a);
+    let target_b_count = count_outbox_for(&mut app, cmd_ids::colonize_system(), target_b);
     assert!(
         target_a_count >= 1,
         "Mid A must dispatch colonize on target_a (region A); got {}",
@@ -298,37 +335,39 @@ fn each_mid_agent_only_dispatches_within_its_own_region() {
         target_b_count
     );
 
-    // Each colonize command's `ship_0` parameter must be the ship from
-    // the same region (no cross-region ship reuse).
-    let outbox = app.world().resource::<AiCommandOutbox>();
-    let cmd_kind = cmd_ids::colonize_system();
-    for entry in outbox.entries.iter() {
-        let cmd = &entry.command;
-        if cmd.kind != cmd_kind {
-            continue;
-        }
-        let target_sys = match cmd.params.get("target_system") {
-            Some(macrocosmo_ai::CommandValue::System(s)) => Entity::from_bits(s.0),
-            _ => continue,
+    // Each colonize commitment's ship must be the ship from the same
+    // region (no cross-region ship reuse).
+    //
+    // #468 PR-2: colonize commitments now live on the ship entity as
+    // `PendingAssignment::Colonize` (target = system). Walk the marker
+    // surface; the legacy outbox-entry walk would be empty here.
+    {
+        use macrocosmo::ai::assignments::{AssignmentKind, AssignmentTarget, PendingAssignment};
+        let pairs: Vec<(Entity, Entity)> = {
+            let mut q = app.world_mut().query::<(Entity, &PendingAssignment)>();
+            q.iter(app.world())
+                .filter(|(_, pa)| matches!(pa.kind, AssignmentKind::Colonize))
+                .filter_map(|(ship, pa)| match pa.target {
+                    AssignmentTarget::System(t) => Some((t, ship)),
+                })
+                .collect()
         };
-        let ship = match cmd.params.get("ship_0") {
-            Some(macrocosmo_ai::CommandValue::Entity(e)) => Entity::from_bits(e.0),
-            _ => continue,
-        };
-        if target_sys == target_a {
-            assert_eq!(
-                ship, colony_a,
-                "colonize on target_a must use the region-A ship (colony_a); \
-                 got ship={:?}, expected {:?} — cross-region leakage",
-                ship, colony_a
-            );
-        } else if target_sys == target_b {
-            assert_eq!(
-                ship, colony_b,
-                "colonize on target_b must use the region-B ship (colony_b); \
-                 got ship={:?}, expected {:?} — cross-region leakage",
-                ship, colony_b
-            );
+        for (target_sys, ship) in pairs {
+            if target_sys == target_a {
+                assert_eq!(
+                    ship, colony_a,
+                    "colonize on target_a must use the region-A ship (colony_a); \
+                     got ship={:?}, expected {:?} — cross-region leakage",
+                    ship, colony_a
+                );
+            } else if target_sys == target_b {
+                assert_eq!(
+                    ship, colony_b,
+                    "colonize on target_b must use the region-B ship (colony_b); \
+                     got ship={:?}, expected {:?} — cross-region leakage",
+                    ship, colony_b
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

PR-2 of #468. Migrates three more AI ship-control kinds — `colonize_system`, `reposition`, `blockade` — off the legacy `AiCommandOutbox` / `drain_ai_commands` path onto the per-ship `PendingAiShipCommand` pipeline PR-1 introduced. Light-delay is now `Ruler→ship` (the order has to reach the *ship*, not the target system) — pre-fix the AI paid ~300 hd before a 5 ly colonize / reposition / blockade could fire.

Also includes the design refactor deferred from PR-1: PR-1's `dispatch_survey_per_ship` is generalised into `dispatch_ship_command_per_ship` so each kind only contributes the kind-specific bits (currently just an `Option<PendingAssignment factory>`).

## Migrated kinds

- **`colonize_system`** — stamps `PendingAssignment::Colonize` for per-faction dedup. `apply_colonize_to_ship` mirrors `apply_survey_to_ship` (marker stripped on every reject branch).
- **`reposition`** — pure movement order; no marker. `apply_reposition_to_ship` → `apply_move_to_ship`.
- **`blockade`** — pure movement order; no marker. `apply_blockade_to_ship` → `apply_move_to_ship`.

## Generic refactor

`dispatch_ship_command_per_ship(cmd, …, assignment_factory: Option<fn(Entity, Entity, i64) -> PendingAssignment>)` — survey and colonize pass `Some(::survey_system)` / `Some(::colonize_system)`; reposition + blockade pass `None`. `intended_state` / `has_return_leg` for the projection write still come from `knowledge::command_kind_to_*`.

## Assignment / save-format

- New `AssignmentKind::Colonize` variant + `PendingAssignment::colonize_system` constructor.
- `sweep_resolved_survey_assignments` extended: also drops Colonize markers once the issuing empire's `KnowledgeStore` shows `target.colonized = true`.
- Save-format additive: `SavedPendingAssignment.kind` u8 encoding adds tag `1 = Colonize` (SAVE_VERSION **unchanged** — older saves with tag `0` still decode to `Survey`).

## Dedup scan

- `npc_decision.rs` `pending_ai_ship_commands` scan now also routes `colonize_system` entries into `outbox_colonize_per_empire`.
- `pending_assignments` scan picks up `AssignmentKind::Colonize` into `pending_colonize_targets`.

## Tests

New zero-delay regressions in `ai_command_lightspeed.rs`:
1. `colonize_ai_ship_at_home_ruler_at_home_target_far_zero_delay`
2. `reposition_ai_ship_at_home_ruler_at_home_target_far_zero_delay`
3. `blockade_ai_ship_at_home_ruler_at_home_target_far_zero_delay`
4. `rejected_colonize_at_drain_time_releases_pending_assignment`
5. `rejected_reposition_at_drain_time_despawns_holder` (reposition has no marker — verifies the holder is still despawned on reject)

Updated helpers in `ai_colonize_requires_core.rs`, `ai_per_region_npc_smoke.rs`, and `mid_agent_member_filter.rs` to look up commitments via both `AiCommandOutbox` AND `PendingAiShipCommand` / `PendingAssignment::Colonize` markers. With Ruler→ship = 0 light delay the holder despawns the same tick it spawns, so the durable signal is the marker.

## Non-goals (PR-3 follow-up)

`attack_target`, `move_ruler`, `load_deliverable`, `unload_deliverable`, `colonize_planet`, and the `fortify_system` mis-categorisation are PR-3. Issue #468 stays open until PR-3 lands.

## Test plan

- [x] `cargo check -p macrocosmo --tests` clean
- [x] `cargo test -p macrocosmo --test ai_command_lightspeed -- --test-threads=1` — 9 passed
- [x] `cargo test -p macrocosmo --test ai_npc_outbox_dedup -- --test-threads=1` — 2 passed
- [x] `cargo test -p macrocosmo --test short_rules_cutover_sentinel -- --test-threads=1` — 2 passed
- [x] `cargo test -p macrocosmo --test fixtures_smoke -- --test-threads=1` — 1 passed + 1 ignored (SAVE_VERSION unchanged)
- [x] `cargo test --workspace --tests -- --test-threads=1` — 3570 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)