### PR TITLE
fix(ai): #469 rank survey targets by ship-relative ETA + greedy per-ship

### DIFF
--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -235,6 +235,12 @@ pub struct ShipInfo {
     pub design_id: String,
     /// The system the ship is currently docked at, or `None` if in transit.
     pub system: Option<Entity>,
+    /// The ship's current world position. For idle docked ships this
+    /// equals the docked system's position; threaded into `NpcContext`
+    /// so `rank_survey_targets_for_ship` (#469) can compute ETAs from
+    /// the ship's actual location rather than a single empire-wide
+    /// reference point.
+    pub position: [f64; 3],
     /// `true` when the ship is `InSystem` with an empty command queue.
     pub is_idle: bool,
     pub can_survey: bool,
@@ -243,6 +249,10 @@ pub struct ShipInfo {
     /// it can participate in combat.
     pub is_combat: bool,
     pub ftl_range: f64,
+    /// Ship-level sublight speed in c (after design lookup). Needed by
+    /// `rank_survey_targets_for_ship` to convert the sublight remainder
+    /// of an FTL+sublight route into hexadies.
+    pub sublight_speed: f64,
     /// `Ship.fleet` back-pointer (#287 γ-1). `None` only for the brief
     /// window between ship spawn and `prune_empty_fleets`. Used by
     /// PR2d's per-fleet `ShortAgent` to partition idle surveyors by
@@ -316,7 +326,26 @@ pub struct EmpireShortInputs {
     /// will key by region. Bug A dedup
     /// (`PendingAssignment` ∪ outbox-resident commands) is already
     /// applied here.
+    ///
+    /// #469: kept for `NpcContext.unsurveyed_systems` /
+    /// `has_unsurveyed_targets` bookkeeping, but Rule 2 emission now
+    /// consumes `survey_assignments_by_fleet` (pre-paired ship→target
+    /// tuples produced by ship-relative ETA ranking). The two views are
+    /// derived from the same candidate pool.
     pub unsurveyed_targets: Vec<Entity>,
+    /// #469: Greedy `(ship, target)` assignments produced inside
+    /// `npc_decision_tick` by `rank_survey_targets_for_ship`. Each entry
+    /// pairs an idle surveyor in `fleet` with its best ETA-ranked
+    /// target. The greedy 1-pass guarantees no two ships in the same
+    /// empire share a target on the same tick; `ShortStanceAgent` emits
+    /// one `survey_system` command per pair.
+    ///
+    /// Pre-pairing happens here (rather than in `ShortStanceAgent`)
+    /// because the ETA score depends on ship position, FTL range, and
+    /// sublight speed — data the engine-agnostic Short layer doesn't
+    /// see. `ShortStanceAgent::decide` consumes the slice for emission
+    /// only.
+    pub survey_assignments_by_fleet: std::collections::HashMap<Entity, Vec<(Entity, Entity)>>,
     /// Empire-wide free building slots (proxied through the
     /// `free_building_slots` faction metric on the bus).
     pub free_building_slots: f64,
@@ -326,8 +355,10 @@ pub struct EmpireShortInputs {
     pub net_production_food: f64,
 }
 
-/// Rank candidate unsurveyed systems by "accessibility" — an approximation
-/// of travel time that's more useful than raw distance.
+/// Rank candidate unsurveyed systems by "accessibility" — a raw-distance
+/// approximation kept for legacy callers and for the empire-level
+/// `NpcContext.unsurveyed_systems` ordering consumed by
+/// `MidStanceAgent`'s `has_unsurveyed_targets` flag.
 ///
 /// FTL routing ([`crate::ship::movement::plan_ftl_route`]) rejects
 /// unsurveyed destinations, so reaching an unsurveyed star always ends in
@@ -343,6 +374,12 @@ pub struct EmpireShortInputs {
 /// When the empire has no surveyed systems at all (fresh start, pre-capital),
 /// gap collapses to raw distance from the reference position — good enough
 /// for the first dispatch.
+///
+/// #469: per-ship survey dispatch no longer goes through this helper —
+/// `rank_survey_targets_for_ship` is the ETA-based ranker that drives
+/// `survey_system` emission. This function is retained for the
+/// "empire has any unsurveyed targets at all?" presence check the Mid
+/// layer reads via `has_unsurveyed_targets`, where order doesn't matter.
 ///
 /// Returns entity ids in rank order (best first).
 pub fn rank_survey_targets(
@@ -371,6 +408,142 @@ pub fn rank_survey_targets(
             .then(a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
     });
     scored.into_iter().map(|(e, _, _)| e).collect()
+}
+
+/// #469: Estimated travel time (in hexadies) for `ship` to reach a
+/// single unsurveyed `target_pos`, accounting for the FTL/sublight
+/// movement model.
+///
+/// Mirrors the dispatch path used by `start_ftl_travel_full` +
+/// `start_sublight_travel_with_bonus` without actually executing any
+/// movement:
+///
+/// 1. **Direct sublight** — straight-line `ship_pos → target_pos` at
+///    `ship_sublight_speed`. Always considered; used as the baseline /
+///    fallback when no FTL hop helps.
+/// 2. **FTL-assisted** — for each surveyed waypoint reachable from
+///    `ship_pos` in one FTL jump (within `ship_ftl_range`), compute
+///    FTL leg time + sublight remainder from waypoint to target.
+///    Picks the minimum across all waypoints.
+///
+/// Multi-hop FTL chains are intentionally not modelled here. The
+/// dispatcher's `plan_full_route` does walk multi-hop FTL when the
+/// destination is surveyed, but unsurveyed targets always end in a
+/// sublight leg from *some* surveyed point — and the closest such
+/// waypoint to the target is what matters for ETA ranking. The
+/// 1-hop greedy approximation is accurate enough for rank ordering
+/// while staying cheap: O(surveyed_count) per (ship, target) call.
+///
+/// Returns `None` when the target is unreachable — either the ship has
+/// neither sublight nor FTL propulsion, or no candidate route yields a
+/// finite ETA.
+///
+/// Speeds use the same unit conventions as
+/// [`crate::physics::sublight_travel_hexadies`] (sublight as a fraction
+/// of c) and `start_ftl_travel_full` (FTL as multiples of c, with
+/// `base_ftl_speed_c == INITIAL_FTL_SPEED_C` matching the unbonused
+/// dispatcher default).
+pub fn score_survey_target_eta(
+    target_pos: [f64; 3],
+    ship_pos: [f64; 3],
+    ship_ftl_range: f64,
+    ship_sublight_speed: f64,
+    surveyed_positions: &[[f64; 3]],
+) -> Option<i64> {
+    use crate::physics::{distance_ly_arr, sublight_travel_hexadies};
+    use crate::ship::INITIAL_FTL_SPEED_C;
+    use crate::time_system::HEXADIES_PER_YEAR;
+
+    let mut best: Option<i64> = None;
+
+    // Pure sublight baseline — only meaningful if the ship can move
+    // sublight at all.
+    if ship_sublight_speed > 0.0 {
+        let dist = distance_ly_arr(ship_pos, target_pos);
+        let t = sublight_travel_hexadies(dist, ship_sublight_speed);
+        best = Some(t);
+    }
+
+    // FTL-assisted: hop to the surveyed waypoint that minimises
+    // (ftl_leg + sublight_remainder). Skip if the ship has no FTL
+    // (matches the dispatcher: `ship.ftl_range <= 0.0` rejects FTL).
+    if ship_ftl_range > 0.0 {
+        for waypoint in surveyed_positions {
+            let to_waypoint = distance_ly_arr(ship_pos, *waypoint);
+            if to_waypoint > ship_ftl_range {
+                continue;
+            }
+            // FTL leg time using INITIAL_FTL_SPEED_C and ceil semantics
+            // to mirror `start_ftl_travel_full`.
+            let ftl_hexadies =
+                (to_waypoint * HEXADIES_PER_YEAR as f64 / INITIAL_FTL_SPEED_C).ceil() as i64;
+            // Sublight remainder from waypoint to target. If the ship
+            // can't move sublight, an FTL hop that doesn't land us on
+            // the target is useless — skip.
+            if ship_sublight_speed <= 0.0 {
+                // Only count if the waypoint *is* the target. Targets
+                // are unsurveyed and waypoints are surveyed, so they
+                // never coincide — but guard anyway for symmetry.
+                let dist = distance_ly_arr(*waypoint, target_pos);
+                if dist < 1e-9 {
+                    let candidate = ftl_hexadies;
+                    best = Some(best.map_or(candidate, |b| b.min(candidate)));
+                }
+                continue;
+            }
+            let sublight_remainder = distance_ly_arr(*waypoint, target_pos);
+            let sublight_hexadies =
+                sublight_travel_hexadies(sublight_remainder, ship_sublight_speed);
+            let candidate = ftl_hexadies + sublight_hexadies;
+            best = Some(best.map_or(candidate, |b| b.min(candidate)));
+        }
+    }
+
+    best
+}
+
+/// #469: Rank unsurveyed `candidates` for a specific surveyor by
+/// ship-relative ETA. Tie-break is `(score, Entity::index())` lex order
+/// — deterministic across runs given Bevy's deterministic Entity
+/// allocation.
+///
+/// Targets for which `score_survey_target_eta` returns `None`
+/// (unreachable) are dropped. A `ruler_to_ship_delay` term is included
+/// in the score to model the courier window the AI dispatch path
+/// (`PendingAiShipCommand`, #468) waits before the ship can execute —
+/// for co-located ruler/ship it's 0, but for ships out at the frontier
+/// it lets a closer ship's ranking dominate over a far-from-ship target
+/// the ruler happens to be sitting next to.
+pub fn rank_survey_targets_for_ship(
+    candidates: &[(Entity, [f64; 3])],
+    surveyed_positions: &[[f64; 3]],
+    ship_pos: [f64; 3],
+    ship_ftl_range: f64,
+    ship_sublight_speed: f64,
+    ruler_pos: [f64; 3],
+) -> Vec<(Entity, i64)> {
+    use crate::physics::{distance_ly_arr, light_delay_hexadies};
+
+    let courier_delay = light_delay_hexadies(distance_ly_arr(ruler_pos, ship_pos));
+
+    let mut scored: Vec<(Entity, i64)> = candidates
+        .iter()
+        .filter_map(|(e, pos)| {
+            score_survey_target_eta(
+                *pos,
+                ship_pos,
+                ship_ftl_range,
+                ship_sublight_speed,
+                surveyed_positions,
+            )
+            .map(|eta| (*e, courier_delay.saturating_add(eta)))
+        })
+        .collect();
+    // Deterministic tie-break: same ETA → lower Entity index wins.
+    // `Entity::index()` is stable per allocation, so the sort order
+    // is reproducible across runs for a deterministic spawn order.
+    scored.sort_by_key(|(e, score)| (*score, e.index()));
+    scored
 }
 
 pub fn npc_decision_tick(
@@ -770,6 +943,21 @@ pub fn npc_decision_tick(
                     crate::ship::ShipState::InSystem { system } => Some(*system),
                     _ => None,
                 };
+                // #469: resolve the ship's world position. Idle ships
+                // (the only ones Rule 2 emits for) are always
+                // `InSystem`, so the docked system's position is
+                // authoritative. In-transit / surveying ships fall
+                // back to [0,0,0]; they're filtered out of the idle
+                // surveyor set anyway, so the value is never consumed
+                // for ranking.
+                let position = system
+                    .and_then(|sys| {
+                        star_positions
+                            .iter()
+                            .find(|(e, _)| *e == sys)
+                            .map(|(_, p)| p.as_array())
+                    })
+                    .unwrap_or([0.0, 0.0, 0.0]);
                 let has_pending = pending_assigned_ships.contains(&ship_entity);
                 let is_idle = system.is_some() && queue.commands.is_empty() && !has_pending;
                 let can_survey = design_registry
@@ -783,11 +971,13 @@ pub fn npc_decision_tick(
                     entity: ship_entity,
                     design_id: ship.design_id.clone(),
                     system,
+                    position,
                     is_idle,
                     can_survey,
                     can_colonize,
                     is_combat,
                     ftl_range: ship.ftl_range,
+                    sublight_speed: ship.sublight_speed,
                     fleet: ship.fleet,
                 }
             })
@@ -896,6 +1086,70 @@ pub fn npc_decision_tick(
                     .push(ship.entity);
             }
         }
+
+        // #469: build per-ship greedy survey assignments using
+        // ship-relative ETA scoring. Each idle surveyor is paired with
+        // its lowest-ETA target; once a target is claimed it is
+        // removed from the candidate pool so two ships in the same
+        // empire never share a target on the same tick. The Mid-side
+        // `pending_survey_targets` dedup (`PendingAssignment` ∪
+        // outbox-resident commands) is already applied to `candidates`
+        // upstream, so this greedy pass only competes within the
+        // current tick's fresh dispatches.
+        //
+        // Per-ship rebuilds of the candidate slice (one per surveyor)
+        // are O(idle_surveyors × candidates × surveyed) — bounded
+        // small for realistic empire sizes. A bipartite assignment
+        // (Hungarian) is overkill; greedy is correct enough per the
+        // issue brief.
+        let mut survey_assignments_by_fleet: std::collections::HashMap<
+            Entity,
+            Vec<(Entity, Entity)>,
+        > = std::collections::HashMap::new();
+        let mut claimed_targets: std::collections::HashSet<Entity> =
+            std::collections::HashSet::new();
+        let candidate_pool: Vec<(Entity, [f64; 3])> = candidates.clone();
+        // Iterate idle surveyors in a deterministic order so that when
+        // two ships could compete for the same target, the
+        // lower-Entity-index ship gets first pick. Without this the
+        // greedy result depends on ECS iteration order.
+        let mut surveyors_in_order: Vec<&ShipInfo> = context
+            .ships
+            .iter()
+            .filter(|s| s.is_idle && s.can_survey && s.fleet.is_some())
+            .collect();
+        surveyors_in_order.sort_by_key(|s| s.entity.index());
+        for ship in surveyors_in_order {
+            let fleet = match ship.fleet {
+                Some(f) => f,
+                None => continue,
+            };
+            // Filter out targets already claimed by a sibling ship
+            // earlier in this loop.
+            let remaining: Vec<(Entity, [f64; 3])> = candidate_pool
+                .iter()
+                .filter(|(t, _)| !claimed_targets.contains(t))
+                .copied()
+                .collect();
+            if remaining.is_empty() {
+                continue;
+            }
+            let ranked = rank_survey_targets_for_ship(
+                &remaining,
+                &surveyed_positions,
+                ship.position,
+                ship.ftl_range,
+                ship.sublight_speed,
+                reference_pos,
+            );
+            if let Some((best, _)) = ranked.first().copied() {
+                survey_assignments_by_fleet
+                    .entry(fleet)
+                    .or_default()
+                    .push((ship.entity, best));
+                claimed_targets.insert(best);
+            }
+        }
         let fid = to_ai_faction(entity);
         let metric_id = |base: &str| crate::ai::schema::ids::metric::for_faction(base, fid);
         let free_building_slots = bus
@@ -915,6 +1169,7 @@ pub fn npc_decision_tick(
             EmpireShortInputs {
                 idle_surveyors_by_fleet,
                 unsurveyed_targets: context.unsurveyed_systems.clone(),
+                survey_assignments_by_fleet,
                 free_building_slots,
                 net_production_energy,
                 net_production_food,

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -505,27 +505,26 @@ pub fn score_survey_target_eta(
 /// #469: Rank unsurveyed `candidates` for a specific surveyor by
 /// ship-relative ETA. Tie-break is `(score, Entity::index())` lex order
 /// — deterministic across runs given Bevy's deterministic Entity
-/// allocation.
+/// allocation within a single process. (Save/reload reassigns indices
+/// so the tie-break is not stable across persistence boundaries; this
+/// is acceptable for AI dispatch which has no save-format guarantee.)
 ///
 /// Targets for which `score_survey_target_eta` returns `None`
-/// (unreachable) are dropped. A `ruler_to_ship_delay` term is included
-/// in the score to model the courier window the AI dispatch path
-/// (`PendingAiShipCommand`, #468) waits before the ship can execute —
-/// for co-located ruler/ship it's 0, but for ships out at the frontier
-/// it lets a closer ship's ranking dominate over a far-from-ship target
-/// the ruler happens to be sitting next to.
+/// (unreachable) are dropped.
+///
+/// #469 review fold-in: the previous `courier_delay` term added
+/// `light_delay_hexadies(ruler→ship)` to every candidate's score for a
+/// single ship call. A constant offset within a per-ship ranking has
+/// no effect on rank order — the term was dead weight that wasted two
+/// `distance_ly_arr` calls per surveyor without changing any output.
+/// Removed; `ruler_pos` parameter dropped from the signature.
 pub fn rank_survey_targets_for_ship(
     candidates: &[(Entity, [f64; 3])],
     surveyed_positions: &[[f64; 3]],
     ship_pos: [f64; 3],
     ship_ftl_range: f64,
     ship_sublight_speed: f64,
-    ruler_pos: [f64; 3],
 ) -> Vec<(Entity, i64)> {
-    use crate::physics::{distance_ly_arr, light_delay_hexadies};
-
-    let courier_delay = light_delay_hexadies(distance_ly_arr(ruler_pos, ship_pos));
-
     let mut scored: Vec<(Entity, i64)> = candidates
         .iter()
         .filter_map(|(e, pos)| {
@@ -536,12 +535,10 @@ pub fn rank_survey_targets_for_ship(
                 ship_sublight_speed,
                 surveyed_positions,
             )
-            .map(|eta| (*e, courier_delay.saturating_add(eta)))
+            .map(|eta| (*e, eta))
         })
         .collect();
     // Deterministic tie-break: same ETA → lower Entity index wins.
-    // `Entity::index()` is stable per allocation, so the sort order
-    // is reproducible across runs for a deterministic spawn order.
     scored.sort_by_key(|(e, score)| (*score, e.index()));
     scored
 }
@@ -1140,8 +1137,8 @@ pub fn npc_decision_tick(
                 ship.position,
                 ship.ftl_range,
                 ship.sublight_speed,
-                reference_pos,
             );
+            let _ = reference_pos; // #469 fold-in: ruler_pos no longer needed (courier_delay dropped).
             if let Some((best, _)) = ranked.first().copied() {
                 survey_assignments_by_fleet
                     .entry(fleet)

--- a/macrocosmo/src/ai/short_adapter.rs
+++ b/macrocosmo/src/ai/short_adapter.rs
@@ -48,7 +48,22 @@ pub trait ShortGameAdapter {
     /// upstream still owns this filter chain (`pending_survey_targets`
     /// in `npc_decision.rs`), so the per-fleet ShortAgent simply
     /// slices into the same set.
+    ///
+    /// #469: kept for diagnostics / fallback only — Rule 2 emission
+    /// now consumes [`Self::survey_assignments`] (pre-paired
+    /// `(ship, target)` tuples computed with ship-relative ETA).
     fn unsurveyed_targets(&self) -> &[Entity];
+
+    /// #469: Greedy `(ship, target)` assignments produced by
+    /// `npc_decision_tick` for this fleet using ship-relative ETA
+    /// ranking. `ShortStanceAgent`'s Fleet branch emits one
+    /// `survey_system` command per pair, replacing the legacy
+    /// `surveyors.zip(targets)` pattern that pre-#469 ignored ship
+    /// position and FTL geometry.
+    ///
+    /// Empty slice for non-Fleet scopes and for Fleet scopes with no
+    /// reachable targets after dedup.
+    fn survey_assignments(&self) -> &[(Entity, Entity)];
 
     // ---- ColonizedSystem scope ----
 
@@ -85,6 +100,10 @@ pub struct BevyShortAgentAdapter<'a> {
     /// scopes). Same upstream dedup as the Mid-side `unsurveyed_systems`
     /// (`pending_survey_targets` filter applied in `npc_decision_tick`).
     pub unsurveyed_targets: &'a [Entity],
+    /// #469: Pre-paired `(ship, target)` greedy assignments produced
+    /// by `npc_decision_tick` for this fleet. Empty slice for non-Fleet
+    /// scopes and for Fleet scopes with no reachable targets.
+    pub survey_assignments: &'a [(Entity, Entity)],
     /// Pre-resolved metrics for ColonizedSystem scope (zero for
     /// non-ColonizedSystem scopes).
     pub free_building_slots: f64,
@@ -107,6 +126,10 @@ impl<'a> ShortGameAdapter for BevyShortAgentAdapter<'a> {
 
     fn unsurveyed_targets(&self) -> &[Entity] {
         self.unsurveyed_targets
+    }
+
+    fn survey_assignments(&self) -> &[(Entity, Entity)] {
+        self.survey_assignments
     }
 
     fn free_building_slots(&self) -> f64 {

--- a/macrocosmo/src/ai/short_agent_runtime.rs
+++ b/macrocosmo/src/ai/short_agent_runtime.rs
@@ -531,28 +531,58 @@ pub fn run_short_agents(
         // the trait method `unsurveyed_targets()` can hand out a
         // slice that lives for the call.
         let unsurveyed_filtered: Vec<Entity>;
-        let (idle_surveyors_for_scope, unsurveyed_targets): (&[Entity], &[Entity]) =
-            match agent.scope {
-                ShortScope::Fleet(fleet) => {
-                    let surveyors = inputs
-                        .and_then(|i| i.idle_surveyors_by_fleet.get(&fleet))
-                        .map(|v| v.as_slice())
-                        .unwrap_or(empty.as_slice());
-                    let raw_targets = inputs
-                        .map(|i| i.unsurveyed_targets.as_slice())
-                        .unwrap_or(empty.as_slice());
-                    unsurveyed_filtered = raw_targets
-                        .iter()
-                        .copied()
-                        .filter(|t| !claimed_survey_targets.contains(&(empire, *t)))
-                        .collect();
-                    (surveyors, unsurveyed_filtered.as_slice())
-                }
-                ShortScope::ColonizedSystem(_) => {
-                    unsurveyed_filtered = Vec::new();
-                    (empty.as_slice(), empty.as_slice())
-                }
-            };
+        // #469: per-fleet pre-paired survey assignments (computed
+        // upstream by `rank_survey_targets_for_ship` greedy). Filtered
+        // here against `claimed_survey_targets` so a target claimed by
+        // a sibling Fleet earlier in this loop is dropped — preserves
+        // the per-tick exactly-once-per-target invariant the legacy
+        // `claimed_survey_targets` set originally enforced when the
+        // emission consumed `unsurveyed_targets` directly.
+        let assignments_filtered: Vec<(Entity, Entity)>;
+        let empty_assignments: Vec<(Entity, Entity)> = Vec::new();
+        let (idle_surveyors_for_scope, unsurveyed_targets, survey_assignments): (
+            &[Entity],
+            &[Entity],
+            &[(Entity, Entity)],
+        ) = match agent.scope {
+            ShortScope::Fleet(fleet) => {
+                let surveyors = inputs
+                    .and_then(|i| i.idle_surveyors_by_fleet.get(&fleet))
+                    .map(|v| v.as_slice())
+                    .unwrap_or(empty.as_slice());
+                let raw_targets = inputs
+                    .map(|i| i.unsurveyed_targets.as_slice())
+                    .unwrap_or(empty.as_slice());
+                unsurveyed_filtered = raw_targets
+                    .iter()
+                    .copied()
+                    .filter(|t| !claimed_survey_targets.contains(&(empire, *t)))
+                    .collect();
+                let raw_assignments = inputs
+                    .and_then(|i| i.survey_assignments_by_fleet.get(&fleet))
+                    .map(|v| v.as_slice())
+                    .unwrap_or(empty_assignments.as_slice());
+                assignments_filtered = raw_assignments
+                    .iter()
+                    .copied()
+                    .filter(|(_, t)| !claimed_survey_targets.contains(&(empire, *t)))
+                    .collect();
+                (
+                    surveyors,
+                    unsurveyed_filtered.as_slice(),
+                    assignments_filtered.as_slice(),
+                )
+            }
+            ShortScope::ColonizedSystem(_) => {
+                unsurveyed_filtered = Vec::new();
+                assignments_filtered = Vec::new();
+                (
+                    empty.as_slice(),
+                    empty.as_slice(),
+                    empty_assignments.as_slice(),
+                )
+            }
+        };
         let (free_building_slots, net_production_energy, net_production_food) = match agent.scope {
             ShortScope::ColonizedSystem(_) => inputs
                 .map(|i| {
@@ -570,6 +600,7 @@ pub fn run_short_agents(
             scope: agent.scope,
             idle_surveyors: idle_surveyors_for_scope,
             unsurveyed_targets,
+            survey_assignments,
             free_building_slots,
             net_production_energy,
             net_production_food,

--- a/macrocosmo/src/ai/short_stance.rs
+++ b/macrocosmo/src/ai/short_stance.rs
@@ -41,25 +41,40 @@ impl ShortStanceAgent {
         match adapter.scope() {
             ShortScope::Fleet(_fleet_entity) => {
                 // ----- Rule 2: Survey unsurveyed systems.
-                // Mirror of the legacy Mid-side Rule 2: zip
-                // `idle_surveyors × unsurveyed_targets` (one ship per
-                // target, up to whichever runs out first), emit
-                // `survey_system` with `target_system` + `ship_count = 1`
-                // + `ship_0`. The adapter's `unsurveyed_targets` is the
-                // final Rule 2 input — `npc_decision_tick` already
-                // applied the Bug A dedup (`PendingAssignment` ∪
-                // outbox-resident `survey_system` commands) before
-                // building `pending_survey_targets`, so the agent does
-                // **not** re-dedup.
-                let surveyors = adapter.idle_surveyors();
-                let targets = adapter.unsurveyed_targets();
-                if !surveyors.is_empty() && !targets.is_empty() {
-                    for (ship, &target) in surveyors.iter().zip(targets.iter()) {
+                // #469: emission consumes pre-paired
+                // `survey_assignments` (computed by `npc_decision_tick`
+                // via `rank_survey_targets_for_ship` — ship-relative
+                // ETA + greedy 1-pass). One `survey_system` command
+                // per pair. Falls back to the legacy
+                // `idle_surveyors × unsurveyed_targets` zip when no
+                // assignments are provided (test stubs that haven't
+                // migrated, headless callers without star positions).
+                let assignments = adapter.survey_assignments();
+                if !assignments.is_empty() {
+                    for (ship, target) in assignments {
                         let cmd = Command::new(cmd_ids::survey_system(), faction_id, now)
-                            .with_param("target_system", CommandValue::System(to_ai_system(target)))
+                            .with_param(
+                                "target_system",
+                                CommandValue::System(to_ai_system(*target)),
+                            )
                             .with_param("ship_count", CommandValue::I64(1))
                             .with_param("ship_0", CommandValue::Entity(to_ai_entity(*ship)));
-                        proposals.push(Proposal::at_system(cmd, to_ai_system(target)));
+                        proposals.push(Proposal::at_system(cmd, to_ai_system(*target)));
+                    }
+                } else {
+                    let surveyors = adapter.idle_surveyors();
+                    let targets = adapter.unsurveyed_targets();
+                    if !surveyors.is_empty() && !targets.is_empty() {
+                        for (ship, &target) in surveyors.iter().zip(targets.iter()) {
+                            let cmd = Command::new(cmd_ids::survey_system(), faction_id, now)
+                                .with_param(
+                                    "target_system",
+                                    CommandValue::System(to_ai_system(target)),
+                                )
+                                .with_param("ship_count", CommandValue::I64(1))
+                                .with_param("ship_0", CommandValue::Entity(to_ai_entity(*ship)));
+                            proposals.push(Proposal::at_system(cmd, to_ai_system(target)));
+                        }
                     }
                 }
             }
@@ -108,6 +123,7 @@ mod tests {
         scope: ShortScope,
         idle_surveyors: Vec<Entity>,
         unsurveyed_targets: Vec<Entity>,
+        survey_assignments: Vec<(Entity, Entity)>,
         free_building_slots: f64,
         net_production_energy: f64,
         net_production_food: f64,
@@ -120,6 +136,7 @@ mod tests {
                 scope: ShortScope::Fleet(fleet),
                 idle_surveyors: vec![],
                 unsurveyed_targets: vec![],
+                survey_assignments: vec![],
                 free_building_slots: 0.0,
                 net_production_energy: 0.0,
                 net_production_food: 0.0,
@@ -132,6 +149,7 @@ mod tests {
                 scope: ShortScope::ColonizedSystem(system),
                 idle_surveyors: vec![],
                 unsurveyed_targets: vec![],
+                survey_assignments: vec![],
                 free_building_slots: 0.0,
                 net_production_energy: 0.0,
                 net_production_food: 0.0,
@@ -151,6 +169,9 @@ mod tests {
         }
         fn unsurveyed_targets(&self) -> &[Entity] {
             &self.unsurveyed_targets
+        }
+        fn survey_assignments(&self) -> &[(Entity, Entity)] {
+            &self.survey_assignments
         }
         fn free_building_slots(&self) -> f64 {
             self.free_building_slots

--- a/macrocosmo/src/ai/short_stance.rs
+++ b/macrocosmo/src/ai/short_stance.rs
@@ -45,37 +45,27 @@ impl ShortStanceAgent {
                 // `survey_assignments` (computed by `npc_decision_tick`
                 // via `rank_survey_targets_for_ship` — ship-relative
                 // ETA + greedy 1-pass). One `survey_system` command
-                // per pair. Falls back to the legacy
-                // `idle_surveyors × unsurveyed_targets` zip when no
-                // assignments are provided (test stubs that haven't
-                // migrated, headless callers without star positions).
-                let assignments = adapter.survey_assignments();
-                if !assignments.is_empty() {
-                    for (ship, target) in assignments {
-                        let cmd = Command::new(cmd_ids::survey_system(), faction_id, now)
-                            .with_param(
-                                "target_system",
-                                CommandValue::System(to_ai_system(*target)),
-                            )
-                            .with_param("ship_count", CommandValue::I64(1))
-                            .with_param("ship_0", CommandValue::Entity(to_ai_entity(*ship)));
-                        proposals.push(Proposal::at_system(cmd, to_ai_system(*target)));
-                    }
-                } else {
-                    let surveyors = adapter.idle_surveyors();
-                    let targets = adapter.unsurveyed_targets();
-                    if !surveyors.is_empty() && !targets.is_empty() {
-                        for (ship, &target) in surveyors.iter().zip(targets.iter()) {
-                            let cmd = Command::new(cmd_ids::survey_system(), faction_id, now)
-                                .with_param(
-                                    "target_system",
-                                    CommandValue::System(to_ai_system(target)),
-                                )
-                                .with_param("ship_count", CommandValue::I64(1))
-                                .with_param("ship_0", CommandValue::Entity(to_ai_entity(*ship)));
-                            proposals.push(Proposal::at_system(cmd, to_ai_system(target)));
-                        }
-                    }
+                // per pair.
+                //
+                // #469 review fold-in: the legacy
+                // `idle_surveyors × unsurveyed_targets` zip fallback
+                // was removed. It enabled a cross-fleet race where
+                // fleet2's fallback emit could overrun a target that
+                // `npc_decision_tick`'s greedy had already assigned
+                // to a higher-ETA ship in fleet1 (the per-tick
+                // `claimed_survey_targets` set is populated only AFTER
+                // each Fleet ShortAgent emits, so a fleet visited
+                // first in the empire loop could not see siblings'
+                // future claims). With the fallback gone the only
+                // emission path is the pre-paired greedy assignment;
+                // a fleet without an entry in
+                // `survey_assignments_by_fleet` stays silent that tick.
+                for (ship, target) in adapter.survey_assignments() {
+                    let cmd = Command::new(cmd_ids::survey_system(), faction_id, now)
+                        .with_param("target_system", CommandValue::System(to_ai_system(*target)))
+                        .with_param("ship_count", CommandValue::I64(1))
+                        .with_param("ship_0", CommandValue::Entity(to_ai_entity(*ship)));
+                    proposals.push(Proposal::at_system(cmd, to_ai_system(*target)));
                 }
             }
             ShortScope::ColonizedSystem(_system_entity) => {
@@ -187,15 +177,18 @@ mod tests {
     // ---- Rule 2 (Fleet scope) ----
 
     #[test]
-    fn fleet_scope_emits_survey_per_zip_pair() {
+    fn fleet_scope_emits_survey_per_assignment_pair() {
+        // #469 review fold-in: the legacy zip path was deleted (it
+        // enabled a cross-fleet race in production); ShortStanceAgent
+        // now consumes only the pre-paired survey assignments produced
+        // upstream by `rank_survey_targets_for_ship`.
         let fleet = Entity::from_raw_u32(10).unwrap();
         let target_a = Entity::from_raw_u32(50).unwrap();
         let target_b = Entity::from_raw_u32(51).unwrap();
         let surveyor_a = Entity::from_raw_u32(200).unwrap();
         let surveyor_b = Entity::from_raw_u32(201).unwrap();
         let stub = StubAdapter {
-            idle_surveyors: vec![surveyor_a, surveyor_b],
-            unsurveyed_targets: vec![target_a, target_b],
+            survey_assignments: vec![(surveyor_a, target_a), (surveyor_b, target_b)],
             ..StubAdapter::fleet(fleet)
         };
         let proposals = ShortStanceAgent::decide(&stub, FactionId(7), 10);
@@ -217,28 +210,28 @@ mod tests {
         }
     }
 
+    /// #469 review fold-in: `idle_surveyors` + `unsurveyed_targets`
+    /// without `survey_assignments` no longer emits. The greedy
+    /// upstream is the only legal source for survey commands; anything
+    /// else would re-open the cross-fleet race.
     #[test]
-    fn fleet_scope_silent_without_surveyors() {
+    fn fleet_scope_silent_without_assignments() {
         let fleet = Entity::from_raw_u32(10).unwrap();
         let target = Entity::from_raw_u32(50).unwrap();
+        let surveyor = Entity::from_raw_u32(200).unwrap();
+        // Even with both surveyors and targets in the adapter, no
+        // assignments means no emit. Pre-fix this hit the legacy zip
+        // fallback and emitted (surveyor, target).
         let stub = StubAdapter {
+            idle_surveyors: vec![surveyor],
             unsurveyed_targets: vec![target],
             ..StubAdapter::fleet(fleet)
         };
         let proposals = ShortStanceAgent::decide(&stub, FactionId(7), 10);
-        assert!(proposals.is_empty());
-    }
-
-    #[test]
-    fn fleet_scope_silent_without_targets() {
-        let fleet = Entity::from_raw_u32(10).unwrap();
-        let surveyor = Entity::from_raw_u32(200).unwrap();
-        let stub = StubAdapter {
-            idle_surveyors: vec![surveyor],
-            ..StubAdapter::fleet(fleet)
-        };
-        let proposals = ShortStanceAgent::decide(&stub, FactionId(7), 10);
-        assert!(proposals.is_empty());
+        assert!(
+            proposals.is_empty(),
+            "without survey_assignments the Fleet ShortAgent must stay silent",
+        );
     }
 
     // ---- Rule 5b (ColonizedSystem scope) ----

--- a/macrocosmo/tests/ai_rank_survey_targets_eta.rs
+++ b/macrocosmo/tests/ai_rank_survey_targets_eta.rs
@@ -56,13 +56,13 @@ fn rank_prefers_target_reachable_via_ftl_hub_over_pure_sublight() {
     let ship_ftl_range = 25.0; // can reach the waypoint
     let ship_sublight = 0.5;
 
+    let _ = ruler_pos; // #469 fold-in: ruler_pos no longer affects ranking.
     let ranked = rank_survey_targets_for_ship(
         &candidates,
         &surveyed,
         ship_pos,
         ship_ftl_range,
         ship_sublight,
-        ruler_pos,
     );
 
     assert_eq!(ranked.len(), 2);
@@ -104,6 +104,7 @@ fn rank_prefers_ship_nearest_target_when_ship_far_from_ruler() {
 
     let ship_ftl_range = 0.0; // no FTL → only sublight matters
     let ship_sublight = 0.5;
+    let _ = ruler_pos; // #469 fold-in: ruler_pos no longer affects ranking.
 
     let ranked = rank_survey_targets_for_ship(
         &candidates,
@@ -111,7 +112,6 @@ fn rank_prefers_ship_nearest_target_when_ship_far_from_ruler() {
         ship_pos,
         ship_ftl_range,
         ship_sublight,
-        ruler_pos,
     );
 
     assert_eq!(ranked.len(), 2);
@@ -164,7 +164,7 @@ fn greedy_per_ship_assigns_each_ship_to_its_nearest_target() {
             .filter(|(t, _)| !claimed.contains(t))
             .collect();
         let ranked = rank_survey_targets_for_ship(
-            &remaining, &surveyed, pos, ftl_range, sublight, ruler_pos,
+            &remaining, &surveyed, pos, ftl_range, sublight,
         );
         let (best, _) = ranked.first().copied().expect("at least one target");
         assignments.push((ship, best));
@@ -215,8 +215,8 @@ fn tiebreak_resolves_same_score_by_entity_index_and_is_stable() {
     );
     let candidates = vec![(hi_index, [5.0, 0.0, 0.0]), (lo_index, [-5.0, 0.0, 0.0])];
 
-    let run1 = rank_survey_targets_for_ship(&candidates, &surveyed, ship_pos, 0.0, 0.5, ruler_pos);
-    let run2 = rank_survey_targets_for_ship(&candidates, &surveyed, ship_pos, 0.0, 0.5, ruler_pos);
+    let run1 = rank_survey_targets_for_ship(&candidates, &surveyed, ship_pos, 0.0, 0.5);
+    let run2 = rank_survey_targets_for_ship(&candidates, &surveyed, ship_pos, 0.0, 0.5);
 
     assert_eq!(run1.len(), 2);
     assert_eq!(run1[0].1, run1[1].1, "test setup: ETAs must match");
@@ -281,6 +281,86 @@ fn score_ftl_beats_sublight_when_hub_available() {
     );
 }
 
+/// #469 review fold-in (BLOCKER): the legacy
+/// `idle_surveyors × unsurveyed_targets` zip fallback in
+/// `ShortStanceAgent` enabled a cross-fleet race — fleet2 visited
+/// first in the empire loop would fall back to the zip path and emit
+/// a survey for any target in `unsurveyed_targets`, including targets
+/// that `npc_decision_tick`'s greedy had pre-assigned to a higher-ETA
+/// ship in fleet1. `claimed_survey_targets` was populated only AFTER
+/// each Fleet ShortAgent emitted, so a fleet visited first could not
+/// see siblings' future claims.
+///
+/// Fix: delete the fallback entirely. Post-fix the only emission path
+/// is `survey_assignments` (pre-paired by greedy); a fleet without an
+/// entry stays silent. This test pins the contract by exercising the
+/// stub directly: presence of `idle_surveyors` + `unsurveyed_targets`
+/// without `survey_assignments` must NOT emit.
+///
+/// (The drop is observed via the absent fallback path in
+/// `short_stance.rs::ShortStanceAgent::decide`; this regression test
+/// lives here so the cross-PR contract — npc_decision pre-pairs +
+/// short_stance consumes pairs only — has a single failure-surface.)
+#[test]
+fn cross_fleet_race_blocked_when_no_assignments() {
+    use macrocosmo::ai::ShortScope;
+    use macrocosmo::ai::short_adapter::ShortGameAdapter;
+    use macrocosmo::ai::short_stance::ShortStanceAgent;
+    use macrocosmo_ai::FactionId;
+
+    struct StubNoAssignments {
+        empire: Entity,
+        scope: ShortScope,
+        idle: Vec<Entity>,
+        targets: Vec<Entity>,
+    }
+
+    impl ShortGameAdapter for StubNoAssignments {
+        fn empire(&self) -> Entity {
+            self.empire
+        }
+        fn scope(&self) -> &ShortScope {
+            &self.scope
+        }
+        fn idle_surveyors(&self) -> &[Entity] {
+            &self.idle
+        }
+        fn unsurveyed_targets(&self) -> &[Entity] {
+            &self.targets
+        }
+        fn survey_assignments(&self) -> &[(Entity, Entity)] {
+            &[]
+        }
+        fn free_building_slots(&self) -> f64 {
+            0.0
+        }
+        fn net_production_energy(&self) -> f64 {
+            0.0
+        }
+        fn net_production_food(&self) -> f64 {
+            0.0
+        }
+    }
+
+    let mut world = World::new();
+    let fleet = world.spawn_empty().id();
+    let ship = world.spawn_empty().id();
+    let target = world.spawn_empty().id();
+    let empire = world.spawn_empty().id();
+    let stub = StubNoAssignments {
+        empire,
+        scope: ShortScope::Fleet(fleet),
+        idle: vec![ship],
+        targets: vec![target],
+    };
+    let proposals = ShortStanceAgent::decide(&stub, FactionId(99), 0);
+    assert!(
+        proposals.is_empty(),
+        "without survey_assignments, ShortStanceAgent must stay silent — \
+         otherwise a cross-fleet race re-opens (PR #508 BLOCKER fold-in)"
+    );
+}
+
 #[test]
 fn rank_drops_unreachable_targets() {
     let mut world = World::new();
@@ -293,14 +373,14 @@ fn rank_drops_unreachable_targets() {
     ];
     // Ship has no propulsion → every target unreachable → both dropped.
     let ranked =
-        rank_survey_targets_for_ship(&candidates, &[], [0.0, 0.0, 0.0], 0.0, 0.0, [0.0, 0.0, 0.0]);
+        rank_survey_targets_for_ship(&candidates, &[], [0.0, 0.0, 0.0], 0.0, 0.0);
     assert!(ranked.is_empty(), "no propulsion → no rankable targets");
 
     // Restore propulsion — both targets are reachable now (they're at
     // the same distance, so deterministic tie-break orders them by
     // Entity::index()).
     let ranked =
-        rank_survey_targets_for_ship(&candidates, &[], [0.0, 0.0, 0.0], 0.0, 0.5, [0.0, 0.0, 0.0]);
+        rank_survey_targets_for_ship(&candidates, &[], [0.0, 0.0, 0.0], 0.0, 0.5);
     assert_eq!(ranked.len(), 2);
     let _ = (reachable, unreachable);
 }

--- a/macrocosmo/tests/ai_rank_survey_targets_eta.rs
+++ b/macrocosmo/tests/ai_rank_survey_targets_eta.rs
@@ -1,0 +1,306 @@
+//! Regression tests for #469 — `rank_survey_targets_for_ship` must
+//! score candidate unsurveyed systems by ship-relative ETA
+//! (FTL-to-waypoint + sublight remainder), not raw 3D distance.
+//!
+//! Coverage matches the issue's four acceptance criteria:
+//!
+//! 1. **FTL hub preference** — two equidistant targets, one with a
+//!    surveyed waypoint inside the ship's FTL range, the other pure
+//!    sublight. The FTL-reachable target wins.
+//! 2. **Ship-relative ranking** — a ship at the frontier picks the
+//!    target nearest itself, not the target nearest its ruler.
+//! 3. **Per-ship greedy** — two ships, two targets each ship-nearest
+//!    to one. Each ship gets its own nearest; no double-assignment.
+//! 4. **Deterministic tie-break** — two same-ETA targets resolve by
+//!    `Entity::index()`, stable across repeated calls.
+
+use bevy::prelude::*;
+use macrocosmo::ai::npc_decision::{rank_survey_targets_for_ship, score_survey_target_eta};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Make a target with a real `Entity` id and a position.
+fn make_target(world: &mut World, pos: [f64; 3]) -> (Entity, [f64; 3]) {
+    (world.spawn_empty().id(), pos)
+}
+
+// ---------------------------------------------------------------------------
+// #1 FTL hub preference
+// ---------------------------------------------------------------------------
+
+/// Two unsurveyed targets equidistant from the ship in raw 3D, but
+/// target_a sits 1ly from a surveyed waypoint inside the ship's FTL
+/// range, while target_b is in deep space far from any waypoint. ETA
+/// ranking must put target_a first because the FTL jump collapses
+/// most of its travel time.
+#[test]
+fn rank_prefers_target_reachable_via_ftl_hub_over_pure_sublight() {
+    let mut world = World::new();
+
+    // Ship at origin. Two targets equidistant (~30ly), but a surveyed
+    // waypoint sits 20ly out close to target_a:
+    //   ship: [0, 0, 0]
+    //   waypoint (surveyed): [20, 0, 0]
+    //   target_a (unsurveyed): [21, 0, 0]   -> 21ly raw; 20ly FTL + 1ly sublight
+    //   target_b (unsurveyed): [0, 21, 0]   -> 21ly raw, no waypoint near it
+    let ship_pos = [0.0, 0.0, 0.0];
+    let ruler_pos = [0.0, 0.0, 0.0]; // co-located → courier_delay = 0
+    let surveyed = vec![[20.0, 0.0, 0.0]];
+
+    let (target_a, pos_a) = make_target(&mut world, [21.0, 0.0, 0.0]);
+    let (target_b, pos_b) = make_target(&mut world, [0.0, 21.0, 0.0]);
+    let candidates = vec![(target_a, pos_a), (target_b, pos_b)];
+
+    let ship_ftl_range = 25.0; // can reach the waypoint
+    let ship_sublight = 0.5;
+
+    let ranked = rank_survey_targets_for_ship(
+        &candidates,
+        &surveyed,
+        ship_pos,
+        ship_ftl_range,
+        ship_sublight,
+        ruler_pos,
+    );
+
+    assert_eq!(ranked.len(), 2);
+    assert_eq!(
+        ranked[0].0, target_a,
+        "FTL-via-hub target must rank ahead of pure-sublight equidistant target"
+    );
+    assert_eq!(ranked[1].0, target_b);
+    assert!(
+        ranked[0].1 < ranked[1].1,
+        "target_a ETA ({}) must be < target_b ETA ({})",
+        ranked[0].1,
+        ranked[1].1
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #2 Ship-relative ranking
+// ---------------------------------------------------------------------------
+
+/// Ship is far from the ruler (out at the frontier). One target is
+/// nearer to the ruler, another is nearer to the ship. The ETA-based
+/// ranker must prefer the ship-nearest target — the old raw-distance +
+/// home-tiebreak ranker would have picked the ruler-nearest one.
+#[test]
+fn rank_prefers_ship_nearest_target_when_ship_far_from_ruler() {
+    let mut world = World::new();
+
+    let ship_pos = [100.0, 0.0, 0.0]; // ship at the frontier
+    let ruler_pos = [0.0, 0.0, 0.0]; // home base
+
+    // c1 near ruler / far from ship; c2 near ship / far from ruler.
+    let (c1, pos_c1) = make_target(&mut world, [3.0, 0.0, 0.0]);
+    let (c2, pos_c2) = make_target(&mut world, [103.0, 0.0, 0.0]);
+    let candidates = vec![(c1, pos_c1), (c2, pos_c2)];
+    // No surveyed waypoints — every score collapses to pure sublight
+    // from ship_pos, which is what we want to assert.
+    let surveyed: Vec<[f64; 3]> = vec![];
+
+    let ship_ftl_range = 0.0; // no FTL → only sublight matters
+    let ship_sublight = 0.5;
+
+    let ranked = rank_survey_targets_for_ship(
+        &candidates,
+        &surveyed,
+        ship_pos,
+        ship_ftl_range,
+        ship_sublight,
+        ruler_pos,
+    );
+
+    assert_eq!(ranked.len(), 2);
+    assert_eq!(
+        ranked[0].0, c2,
+        "ship-nearest target must rank first (was selecting ruler-nearest pre-#469)"
+    );
+    assert_eq!(ranked[1].0, c1);
+}
+
+// ---------------------------------------------------------------------------
+// #3 Per-ship greedy (no double-assignment)
+// ---------------------------------------------------------------------------
+
+/// Two ships at different positions, two targets each ship-nearest to
+/// one. The greedy 1-pass assignment must give each ship its own
+/// nearest target — never both ships to the same target.
+///
+/// This exercises the greedy logic the way `npc_decision_tick` runs
+/// it: rank per ship, claim the head, drop it from the pool, rank the
+/// next ship.
+#[test]
+fn greedy_per_ship_assigns_each_ship_to_its_nearest_target() {
+    let mut world = World::new();
+
+    let ruler_pos = [0.0, 0.0, 0.0];
+    let ship_alpha_pos = [-50.0, 0.0, 0.0];
+    let ship_bravo_pos = [50.0, 0.0, 0.0];
+
+    let (target_left, pos_left) = make_target(&mut world, [-55.0, 0.0, 0.0]);
+    let (target_right, pos_right) = make_target(&mut world, [55.0, 0.0, 0.0]);
+    let candidates = vec![(target_left, pos_left), (target_right, pos_right)];
+    let surveyed: Vec<[f64; 3]> = vec![];
+
+    let ftl_range = 0.0;
+    let sublight = 0.5;
+
+    // Greedy 1-pass mirroring `npc_decision_tick`'s inner loop.
+    let mut claimed: std::collections::HashSet<Entity> = std::collections::HashSet::new();
+    let mut assignments: Vec<(Entity, Entity)> = Vec::new();
+    // Use real entities so the greedy step has stable identity.
+    let ship_alpha = world.spawn_empty().id();
+    let ship_bravo = world.spawn_empty().id();
+    let ships = [(ship_alpha, ship_alpha_pos), (ship_bravo, ship_bravo_pos)];
+
+    for (ship, pos) in ships {
+        let remaining: Vec<(Entity, [f64; 3])> = candidates
+            .iter()
+            .copied()
+            .filter(|(t, _)| !claimed.contains(t))
+            .collect();
+        let ranked = rank_survey_targets_for_ship(
+            &remaining, &surveyed, pos, ftl_range, sublight, ruler_pos,
+        );
+        let (best, _) = ranked.first().copied().expect("at least one target");
+        assignments.push((ship, best));
+        claimed.insert(best);
+    }
+
+    assert_eq!(assignments.len(), 2);
+    // Alpha → target_left (its nearest); Bravo → target_right.
+    assert!(
+        assignments.contains(&(ship_alpha, target_left)),
+        "alpha must claim target_left (its ship-nearest)",
+    );
+    assert!(
+        assignments.contains(&(ship_bravo, target_right)),
+        "bravo must claim target_right (its ship-nearest)",
+    );
+    // And neither target is double-claimed.
+    let targets: Vec<Entity> = assignments.iter().map(|(_, t)| *t).collect();
+    let unique: std::collections::HashSet<_> = targets.iter().copied().collect();
+    assert_eq!(
+        unique.len(),
+        targets.len(),
+        "no target may be double-claimed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #4 Deterministic tie-break
+// ---------------------------------------------------------------------------
+
+/// Two candidates with identical ETA: the rank order must be
+/// determined by `Entity::index()` ascending, and must be stable
+/// across repeated invocations of the same `World`.
+#[test]
+fn tiebreak_resolves_same_score_by_entity_index_and_is_stable() {
+    let mut world = World::new();
+
+    let ship_pos = [0.0, 0.0, 0.0];
+    let ruler_pos = [0.0, 0.0, 0.0];
+    let surveyed: Vec<[f64; 3]> = vec![];
+
+    // Two targets at the same distance → identical ETA.
+    let lo_index = world.spawn_empty().id();
+    let hi_index = world.spawn_empty().id();
+    assert!(
+        lo_index.index() < hi_index.index(),
+        "deterministic Entity allocation: spawn order = index order"
+    );
+    let candidates = vec![(hi_index, [5.0, 0.0, 0.0]), (lo_index, [-5.0, 0.0, 0.0])];
+
+    let run1 = rank_survey_targets_for_ship(&candidates, &surveyed, ship_pos, 0.0, 0.5, ruler_pos);
+    let run2 = rank_survey_targets_for_ship(&candidates, &surveyed, ship_pos, 0.0, 0.5, ruler_pos);
+
+    assert_eq!(run1.len(), 2);
+    assert_eq!(run1[0].1, run1[1].1, "test setup: ETAs must match");
+    assert_eq!(
+        run1[0].0, lo_index,
+        "same-ETA tie must resolve to lower Entity::index() first"
+    );
+    assert_eq!(run1[1].0, hi_index);
+    assert_eq!(run1, run2, "ranking must be stable across repeated calls");
+}
+
+// ---------------------------------------------------------------------------
+// Sanity coverage for `score_survey_target_eta` directly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn score_pure_sublight_when_no_ftl() {
+    // No FTL, 10ly at 0.5c → 1200 hexadies (10 / (1/60 * 0.5) = 1200).
+    let eta = score_survey_target_eta([10.0, 0.0, 0.0], [0.0, 0.0, 0.0], 0.0, 0.5, &[]);
+    assert_eq!(eta, Some(1200));
+}
+
+#[test]
+fn score_returns_none_when_ship_immobile() {
+    // No FTL, no sublight, no waypoint coincident with target → None.
+    let eta = score_survey_target_eta([10.0, 0.0, 0.0], [0.0, 0.0, 0.0], 0.0, 0.0, &[]);
+    assert_eq!(eta, None);
+}
+
+#[test]
+fn score_ftl_beats_sublight_when_hub_available() {
+    // 100ly target, ship has FTL 60ly + sublight 0.5c. Waypoint at
+    // 60ly along the way.
+    //
+    // Pure sublight: 100 / (1/60 * 0.5) = 12000 hexadies.
+    // FTL leg: 60ly at 10c → 60 / (60 * 10) yr = 0.1yr = 6 hex (ceil).
+    // Sublight remainder: 40 / (1/60 * 0.5) = 4800 hex.
+    // FTL-assisted total ≈ 4806.
+    let eta_ftl = score_survey_target_eta(
+        [100.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+        60.0,
+        0.5,
+        &[[60.0, 0.0, 0.0]],
+    )
+    .expect("reachable");
+
+    let eta_pure_sublight = score_survey_target_eta(
+        [100.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+        0.0,
+        0.5,
+        &[[60.0, 0.0, 0.0]],
+    )
+    .expect("reachable");
+
+    assert!(
+        eta_ftl < eta_pure_sublight,
+        "FTL-assisted ETA ({}) must beat pure-sublight ETA ({})",
+        eta_ftl,
+        eta_pure_sublight,
+    );
+}
+
+#[test]
+fn rank_drops_unreachable_targets() {
+    let mut world = World::new();
+    let reachable = world.spawn_empty().id();
+    let unreachable = world.spawn_empty().id();
+
+    let candidates = vec![
+        (reachable, [10.0, 0.0, 0.0]),
+        (unreachable, [10.0, 0.0, 0.0]),
+    ];
+    // Ship has no propulsion → every target unreachable → both dropped.
+    let ranked =
+        rank_survey_targets_for_ship(&candidates, &[], [0.0, 0.0, 0.0], 0.0, 0.0, [0.0, 0.0, 0.0]);
+    assert!(ranked.is_empty(), "no propulsion → no rankable targets");
+
+    // Restore propulsion — both targets are reachable now (they're at
+    // the same distance, so deterministic tie-break orders them by
+    // Entity::index()).
+    let ranked =
+        rank_survey_targets_for_ship(&candidates, &[], [0.0, 0.0, 0.0], 0.0, 0.5, [0.0, 0.0, 0.0]);
+    assert_eq!(ranked.len(), 2);
+    let _ = (reachable, unreachable);
+}

--- a/macrocosmo/tests/short_rules_cutover_sentinel.rs
+++ b/macrocosmo/tests/short_rules_cutover_sentinel.rs
@@ -136,6 +136,31 @@ fn short_emits_survey_system_after_cutover() {
     // would dispatch + despawn the holder in the same tick the
     // Short layer emitted the command.
     let loiter = spawn_test_system(app.world_mut(), "Loiter", [0.0, 5.0, 0.0], 1.0, true, false);
+    // #469: the ETA-based ranker (`rank_survey_targets_for_ship`)
+    // computes ship-relative travel time, so a scout parked at
+    // `loiter` would score loiter as ETA=0 and survey it instead of
+    // the frontier — unless loiter is already in the empire's
+    // KnowledgeStore as surveyed (then `npc_decision_tick` filters it
+    // out of the candidate pool). Mark loiter surveyed here so the
+    // candidate set collapses to just `frontier`, matching the test's
+    // intent.
+    {
+        let mut em = app.world_mut().entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        store.update(SystemKnowledge {
+            system: loiter,
+            observed_at: 0,
+            received_at: 0,
+            data: SystemSnapshot {
+                name: "Loiter".into(),
+                position: [0.0, 5.0, 0.0],
+                surveyed: true,
+                colonized: false,
+                ..Default::default()
+            },
+            source: ObservationSource::Direct,
+        });
+    }
     let scout = spawn_test_ship(
         app.world_mut(),
         "Scout-1",


### PR DESCRIPTION
## Summary

`rank_survey_targets` ranked candidate unsurveyed systems by raw 3D distance (gap to nearest surveyed waypoint + Ruler-home tiebreak). That approximation tracked command arrival order pre-#468, but post-#468 the dispatcher fires immediately for co-located ruler/ship and the ranking quality becomes load-bearing — and raw distance ignores:

- the FTL/sublight movement model (equidistant targets diverge wildly once one has a surveyed FTL hub inside the ship's range)
- ship position (a scout at the frontier still ranked using the Ruler's home as reference)
- tie-break determinism (`sort_by` stable preserves ECS iteration order, which depends on `Entity` allocation timing)

This PR replaces raw distance with ship-relative ETA + greedy per-ship assignment.

## Changes

- `score_survey_target_eta(target, ship_pos, ftl_range, sublight, surveyed)` — hexadies ETA mirroring the `start_ftl_travel_full` + `start_sublight_travel_with_bonus` dispatch path. Picks the best surveyed waypoint within FTL range and adds the sublight remainder; falls back to pure sublight; returns `None` for immobile / unreachable.
- `rank_survey_targets_for_ship(...)` — per-ship ranker with `(score, Entity::index())` deterministic tie-break and a Ruler→ship light-delay term so the score reflects total dispatch-to-arrival time.
- `ShipInfo` now carries `position` + `sublight_speed`. `NpcContext` plumbs them through.
- `npc_decision_tick` runs a greedy 1-pass assignment per empire (idle surveyors sorted by `Entity::index()` for determinism), publishing `survey_assignments_by_fleet: HashMap<Entity, Vec<(Entity, Entity)>>` in `EmpireShortInputs`. The Fleet-scope `ShortStanceAgent` consumes the pre-paired tuples for emission; the legacy `idle_surveyors × unsurveyed_targets` zip is kept as a fallback for test stubs.
- `short_rules_cutover_sentinel::short_emits_survey_system_after_cutover`: one-line setup fix — a scout parked at a loiter system now correctly scores ETA=0 for surveying its current location unless the empire's `KnowledgeStore` marks it surveyed. The test now does so, matching its original intent.

The legacy `rank_survey_targets` helper is retained for the empire-level `unsurveyed_systems` presence check the Mid layer reads via `has_unsurveyed_targets`.

## Test plan

- [x] `cargo check -p macrocosmo --tests` clean
- [x] `cargo test --workspace --tests -- --test-threads=1` — 3579 passed, 0 failed (baseline ≥ 3571 + 8 new)
- [x] New `tests/ai_rank_survey_targets_eta.rs` covers all four acceptance criteria:
  - FTL hub preference vs pure-sublight equidistant target
  - ship-relative ranking when ship is far from ruler
  - greedy per-ship with no double-assignment
  - deterministic same-ETA tie-break by `Entity::index()`, stable across calls
- [x] Plus scoring-function sanity: pure sublight, immobile ship returns `None`, FTL beats sublight when waypoint is in range, unreachable targets are dropped.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)