### PR TITLE
fix(balance): #445 shipyard parallel slots + speed multiplier (capability→modifier migration)

### DIFF
--- a/macrocosmo/scripts/buildings/system/init.lua
+++ b/macrocosmo/scripts/buildings/system/init.lua
@@ -23,9 +23,19 @@ local shipyard = define_building {
     build_time = 30,
     maintenance = 1.0,
     is_system_building = true,
+    -- #445 follow-up: the `shipyard` capability is retained for backward
+    -- compat (some tests still inspect it). All runtime callers now read
+    -- `system.shipyard_build_parallel_slots` from `SystemModifiers`.
+    -- A separate issue removes the capability entry entirely.
     capabilities = { shipyard = {} },
     modifiers = {
-        { target = "system.shipyard_capacity", base_add = 1 },
+        -- #445: Renamed from `shipyard_capacity`. Each shipyard adds +1
+        -- parallel build slot; `tick_build_queue` processes that many
+        -- orders simultaneously from the queue head.
+        { target = "system.shipyard_build_parallel_slots", base_add = 1 },
+        -- Speed is intentionally NOT modified here — shipyard buildings
+        -- contribute parallelism, not throughput. Future mass-production
+        -- modules / techs target `system.shipyard_build_speed`.
     },
     ship_design_id = "station_shipyard_v1",
 }

--- a/macrocosmo/src/ai/command_consumer.rs
+++ b/macrocosmo/src/ai/command_consumer.rs
@@ -437,7 +437,7 @@ fn queue_ship_at_shipyard(
     if let Some((colony_entity, mut build_queue)) = host_colony {
         // #470 fold-in (HIGH B): dedup same-design `Ship` orders at this
         // colony. Rule 6 in `mid_stance.rs` (`combat_count < 3 &&
-        // shipyard_capacity > 0`) re-emits `build_ship` every Reason
+        // shipyard_build_parallel_slots > 0`) re-emits `build_ship` every Reason
         // tick; without dedup the same design stacks up while the first
         // ship is still in the 30-hexadie build window, turning the
         // #470 fix from "AI doesn't build" into "AI floods one design".
@@ -475,7 +475,7 @@ fn queue_ship_at_shipyard(
 fn has_shipyard_check(system: Entity, sys_mods_q: &Query<&crate::galaxy::SystemModifiers>) -> bool {
     sys_mods_q
         .get(system)
-        .map(|m| m.shipyard_capacity.value().final_value() > crate::amount::Amt::ZERO)
+        .map(|m| m.shipyard_build_parallel_slots.value().final_value() > crate::amount::Amt::ZERO)
         .unwrap_or(false)
 }
 
@@ -2258,7 +2258,7 @@ mod tests {
             production_bonus_research: Amt::ZERO,
             production_bonus_food: Amt::ZERO,
             modifiers: vec![crate::modifier::ParsedModifier {
-                target: "system.shipyard_capacity".into(),
+                target: "system.shipyard_build_parallel_slots".into(),
                 base_add: 1.0,
                 multiplier: 0.0,
                 add: 0.0,
@@ -2289,10 +2289,10 @@ mod tests {
 
         let faction_id = to_ai_faction(empire_entity);
 
-        // SystemModifiers with shipyard_capacity seeded so has_shipyard check passes.
+        // SystemModifiers with shipyard_build_parallel_slots seeded so has_shipyard check passes.
         let mut sys_mods = crate::galaxy::SystemModifiers::default();
         sys_mods
-            .shipyard_capacity
+            .shipyard_build_parallel_slots
             .push_modifier(crate::modifier::Modifier {
                 id: "test_shipyard".into(),
                 label: "Test Shipyard".into(),
@@ -2730,7 +2730,7 @@ mod tests {
             production_bonus_research: Amt::ZERO,
             production_bonus_food: Amt::ZERO,
             modifiers: vec![crate::modifier::ParsedModifier {
-                target: "system.shipyard_capacity".into(),
+                target: "system.shipyard_build_parallel_slots".into(),
                 base_add: 1.0,
                 multiplier: 0.0,
                 add: 0.0,
@@ -2763,7 +2763,7 @@ mod tests {
 
         let mut sys_mods = crate::galaxy::SystemModifiers::default();
         sys_mods
-            .shipyard_capacity
+            .shipyard_build_parallel_slots
             .push_modifier(crate::modifier::Modifier {
                 id: "test_shipyard".into(),
                 label: "Test Shipyard".into(),

--- a/macrocosmo/src/ai/emitters.rs
+++ b/macrocosmo/src/ai/emitters.rs
@@ -182,6 +182,14 @@ pub fn emit_economic_metrics(
     tech_tree: Option<Res<TechTree>>,
     ai_building_registry: Option<Res<crate::colony::BuildingRegistry>>,
     core_ships: Query<(&crate::galaxy::AtSystem, &FactionOwner), With<crate::ship::CoreShip>>,
+    // #445: Per-system shipyard parallel-slot count, sourced from the
+    // canonical `SystemModifiers` rather than capability presence.
+    // Drives two distinct metrics: `systems_with_shipyard` (set count
+    // — number of systems with at least one slot) and
+    // `total_shipyard_slots` (sum across the empire — total build
+    // throughput). `can_build_ships` re-uses the set count so existing
+    // policy gates compare against a 0 / ≥1 binary.
+    sys_mods_q: Query<(Entity, &crate::galaxy::SystemModifiers, &Sovereignty), With<StarSystem>>,
 ) {
     // Per-empire: set of systems with at least one Core-equipped ship.
     // Used to gate system-building construction (Infrastructure Core is
@@ -195,8 +203,40 @@ pub fn emit_economic_metrics(
     }
 
     // Pre-compute system-level building info per owner empire, keyed by empire entity.
-    let mut shipyard_counts: HashMap<Entity, f64> = HashMap::new();
+    // #445 (HIGH fold-in): two distinct metrics with explicit semantics.
+    //
+    // - `systems_with_shipyard` = **set-count** of owned systems that
+    //   have at least one shipyard slot. Restored from the pre-#445
+    //   "binary 'has shipyard' per system" reading after consumers got
+    //   silently broken when the value was changed to a sum of slots.
+    // - `total_shipyard_slots` = **sum** of `shipyard_build_parallel_slots`
+    //   across the empire's owned systems (= total parallel build
+    //   throughput). New metric — future policies that want
+    //   throughput-aware decisions should read this.
+    //
+    // `can_build_ships` continues to carry the *set count* (numerically
+    // equal to `systems_with_shipyard`) so existing `mid_stance` Rule
+    // 5a / 6 gates (`< 1.0` / `>= 1.0`) stay binary-compatible. Port
+    // still uses the capability path until #445 follow-up gives port a
+    // similar canonical numeric modifier.
+    let mut shipyard_set_counts: HashMap<Entity, f64> = HashMap::new();
+    let mut shipyard_slot_totals: HashMap<Entity, f64> = HashMap::new();
     let mut port_counts: HashMap<Entity, f64> = HashMap::new();
+    for (_sys_entity, sm, sov) in &sys_mods_q {
+        let Some(Owner::Empire(owner)) = sov.owner else {
+            continue;
+        };
+        let slots = sm.shipyard_build_parallel_slots.value().final_value();
+        if slots > crate::amount::Amt::ZERO {
+            // Set-count: this system has shipyard capacity, regardless
+            // of how many slots.
+            *shipyard_set_counts.entry(owner).or_default() += 1.0;
+            // Slot total: `whole()` keeps the count as integer
+            // shipyards. Fractional future modifiers (unlikely) round
+            // down.
+            *shipyard_slot_totals.entry(owner).or_default() += slots.whole() as f64;
+        }
+    }
     if let Some(ref registry) = ai_building_registry {
         let reverse = crate::colony::system_buildings::build_reverse_design_map(registry);
         for (_entity, ship, state, _slot) in &ai_station_ships {
@@ -208,9 +248,6 @@ pub fn emit_economic_metrics(
             if let Owner::Empire(owner) = ship.owner {
                 if let Some(bid) = reverse.get(&ship.design_id) {
                     if let Some(def) = registry.get(bid.as_str()) {
-                        if def.capabilities.contains_key("shipyard") {
-                            *shipyard_counts.entry(owner).or_default() += 1.0;
-                        }
                         if def.capabilities.contains_key("port") {
                             *port_counts.entry(owner).or_default() += 1.0;
                         }
@@ -420,11 +457,26 @@ pub fn emit_economic_metrics(
         );
 
         // Infrastructure metrics
-        let sys_shipyard = shipyard_counts.get(&empire_entity).copied().unwrap_or(0.0);
+        // #445 (HIGH fold-in): emit set-count and total-slots as two
+        // distinct metrics. `can_build_ships` re-uses the set-count
+        // value so existing `mid_stance` Rule 5a / 6 gates keep their
+        // binary semantics (`< 1.0` / `>= 1.0`).
+        let sys_shipyard_set = shipyard_set_counts
+            .get(&empire_entity)
+            .copied()
+            .unwrap_or(0.0);
+        let sys_shipyard_slots = shipyard_slot_totals
+            .get(&empire_entity)
+            .copied()
+            .unwrap_or(0.0);
         let sys_port = port_counts.get(&empire_entity).copied().unwrap_or(0.0);
         writer.emit(
             &metric::for_faction("systems_with_shipyard", fid),
-            sys_shipyard,
+            sys_shipyard_set,
+        );
+        writer.emit(
+            &metric::for_faction("total_shipyard_slots", fid),
+            sys_shipyard_slots,
         );
         writer.emit(&metric::for_faction("systems_with_port", fid), sys_port);
         let sys_core = core_systems_per_empire
@@ -438,9 +490,13 @@ pub fn emit_economic_metrics(
             &metric::for_faction("free_building_slots", fid),
             max_slots - used_slots,
         );
+        // `can_build_ships` carries the set-count (0 = no shipyard
+        // anywhere, ≥ 1 = at least one). Numerically identical to
+        // `systems_with_shipyard`. Consumers comparing `< 1.0` /
+        // `>= 1.0` work unchanged.
         writer.emit(
             &metric::for_faction("can_build_ships", fid),
-            if sys_shipyard > 0.0 { 1.0 } else { 0.0 },
+            sys_shipyard_set,
         );
 
         // Technology metrics — currently global TechTree, emitted for each empire.

--- a/macrocosmo/src/ai/mid_adapter.rs
+++ b/macrocosmo/src/ai/mid_adapter.rs
@@ -47,9 +47,12 @@ pub trait MidGameAdapter {
     /// `NpcContext.ruler_aboard == false && ruler_entity.is_some()`.
     fn ruler_movable(&self) -> bool;
 
-    /// Per-faction `can_build_ships` metric (0.0 / 1.0 today). Rule
-    /// 5a fires only when this is below 1.0 — i.e. the empire still
-    /// lacks a usable shipyard.
+    /// Per-faction `can_build_ships` metric. Numerically equal to
+    /// `systems_with_shipyard` (a set count): `0.0` = no shipyard
+    /// anywhere, `>= 1.0` = at least one owned shipyard. Rule 5a
+    /// fires only when this is below 1.0 — i.e. the empire still
+    /// lacks a usable shipyard. For total parallel build throughput
+    /// use `total_shipyard_slots` instead (#445 fold-in).
     fn can_build_ships(&self) -> f64;
 
     /// Per-faction `systems_with_core` metric. Rule 5a's #370 gate:

--- a/macrocosmo/src/ai/schema.rs
+++ b/macrocosmo/src/ai/schema.rs
@@ -425,7 +425,15 @@ fn declare_metrics(bus: &mut AiBus) {
         spec(
             MetricType::Gauge,
             Retention::Long,
-            "count of owned systems with a functioning shipyard",
+            "set-count of owned systems with at least one shipyard slot (#445: was a sum of parallel-slot counts; renamed-back to set-count semantics)",
+        ),
+    );
+    bus.declare_metric(
+        m::total_shipyard_slots(),
+        spec(
+            MetricType::Gauge,
+            Retention::Long,
+            "#445: sum of `shipyard_build_parallel_slots` across the empire's owned systems (= effective build throughput)",
         ),
     );
     bus.declare_metric(

--- a/macrocosmo/src/ai/schema/ids.rs
+++ b/macrocosmo/src/ai/schema/ids.rs
@@ -82,6 +82,7 @@ pub mod metric {
         "research_output_ratio",
         // 1.7 Infrastructure
         "systems_with_shipyard",
+        "total_shipyard_slots",
         "systems_with_port",
         "systems_with_core",
         "max_building_slots",
@@ -225,6 +226,14 @@ pub mod metric {
     // 1.7 Infrastructure ------------------------------------------------
     pub fn systems_with_shipyard() -> MetricId {
         MetricId::from("systems_with_shipyard")
+    }
+    /// #445 (HIGH fold-in): sum of `shipyard_build_parallel_slots`
+    /// across the empire's owned systems. Distinct from
+    /// `systems_with_shipyard` (which is a *set count* — number of
+    /// systems with ≥1 slot). Both are emitted so that future policy
+    /// rules can pick the semantic they need.
+    pub fn total_shipyard_slots() -> MetricId {
+        MetricId::from("total_shipyard_slots")
     }
     pub fn systems_with_port() -> MetricId {
         MetricId::from("systems_with_port")

--- a/macrocosmo/src/colony/building_queue.rs
+++ b/macrocosmo/src/colony/building_queue.rs
@@ -372,13 +372,19 @@ pub fn tick_build_queue(
     last_tick: Res<LastProductionTick>,
     design_registry: Res<crate::ship_design::ShipDesignRegistry>,
     building_registry: Res<crate::scripting::building_api::BuildingRegistry>,
-    mut colonies: Query<(&Colony, &mut BuildQueue, &crate::faction::FactionOwner)>,
+    mut colonies: Query<(
+        Entity,
+        &Colony,
+        &mut BuildQueue,
+        &crate::faction::FactionOwner,
+    )>,
     mut stockpiles: Query<&mut ResourceStockpile, With<StarSystem>>,
     mut deliverable_stockpiles: Query<&mut DeliverableStockpile, With<StarSystem>>,
     positions: Query<&Position>,
     stars: Query<&StarSystem>,
     planets: Query<&Planet>,
     sys_mods_q: Query<&crate::galaxy::SystemModifiers, With<StarSystem>>,
+    mut speed_acc: ResMut<super::ShipyardSpeedAccumulators>,
     mut events: MessageWriter<GameEvent>,
     mut fact_sys: FactSysParam,
     // Round 9 PR #1 Step 3: per-faction routing.
@@ -415,19 +421,69 @@ pub fn tick_build_queue(
 
     let mut results: Vec<BuildResult> = Vec::new();
 
-    for (colony, mut build_queue, faction_owner) in &mut colonies {
+    for (colony_entity, colony, mut build_queue, faction_owner) in &mut colonies {
         let Some(sys) = colony.system(&planets) else {
             continue;
         };
 
-        // #35: Skip ship construction if system has no shipyard capability.
-        // Deliverables also require a shipyard.
-        let has_shipyard = sys_mods_q
-            .get(sys)
-            .map(|m| m.shipyard_capacity.value().final_value() > crate::amount::Amt::ZERO)
-            .unwrap_or(false);
-        if !build_queue.queue.is_empty() && !has_shipyard {
+        // #35 / #445: Skip construction if the system has zero parallel
+        // shipyard slots. The "has shipyard" gate is now identical to
+        // "parallel_slots > 0" — a system with N shipyards builds up to N
+        // orders in parallel from the head of the queue (was binary
+        // before: any extra shipyards beyond the first were inert).
+        let sm = sys_mods_q.get(sys).ok();
+        let parallel_slots_amt = sm
+            .map(|m| m.shipyard_build_parallel_slots.value().final_value())
+            .unwrap_or(crate::amount::Amt::ZERO);
+        // `whole()` truncates fractional slots — a half-built shipyard
+        // shouldn't grant partial parallelism. With integer `base_add` from
+        // the Lua modifier this matches shipyard count exactly.
+        let parallel_slots: usize = parallel_slots_amt.whole() as usize;
+        if !build_queue.queue.is_empty() && parallel_slots == 0 {
             warn!("System lacks a Shipyard; skipping construction");
+            // Clear the accumulator while paused — a queue that resumes
+            // later should not get a free "save up" boost from progress
+            // accrued while it had no shipyard at all.
+            speed_acc.0.remove(&colony_entity);
+            continue;
+        }
+
+        // #445: Speed multiplier on the per-hexadie countdown. Default
+        // base = 1.0 so untouched systems behave exactly as before.
+        // Future modules/techs (e.g. mass-production line) can push
+        // positive `base_add` to speed throughput. `ScopedModifiers`
+        // math already clamps to >=0 (a -1.0 base_add yields 0× = full
+        // stop).
+        let speed_mult_amt: Amt = sm
+            .map(|m| m.shipyard_build_speed.value().final_value())
+            .unwrap_or(Amt::units(1));
+
+        // #445 (BLOCKER fold-in): fractional accumulator. Replaces the
+        // legacy `effective_delta = max(1, round(delta * speed))` floor
+        // that nullified sub-1.0 speed modifiers at GameSpeed=1. Each
+        // tick we add `delta * speed` (as fixed-point Amt) to the
+        // accumulator, extract the integer whole-part as the tick's
+        // effective progress, and keep the sub-unit remainder for the
+        // next tick. Two ticks at 0.5× ⇒ 1 hexadie of progress total.
+        //
+        // `mul_u64(delta as u64)` is safe: `delta` is `clock.elapsed -
+        // last_tick.0`, both i64, and we already returned early on
+        // `delta <= 0`. The fixed-point product stays within u64 range
+        // for any realistic delta (`u64::MAX / SCALE` ≈ 1.8e16).
+        let raw_progress: Amt = speed_mult_amt.mul_u64(delta.max(0) as u64);
+        let acc_entry = speed_acc.0.entry(colony_entity).or_insert(Amt::ZERO);
+        *acc_entry = acc_entry.add(raw_progress);
+        let effective_delta: i64 = acc_entry.whole() as i64;
+        // Keep the sub-unit remainder. `frac()` returns the milli part
+        // (0..1000) as u64; wrapping it back into Amt preserves it
+        // across ticks.
+        *acc_entry = Amt(acc_entry.frac());
+
+        if effective_delta == 0 {
+            // No whole hexadie of progress accrued yet — skip this tick
+            // entirely. Floor 1 fallback is gone: a 0.3× debuff now
+            // takes ~3 GameSpeed=1 ticks to clear one hexadie, matching
+            // the displayed multiplier exactly.
             continue;
         }
 
@@ -441,40 +497,94 @@ pub fn tick_build_queue(
         let mut total_energy_consumed = Amt::ZERO;
         let mut completed: Vec<Completion> = Vec::new();
 
-        for _ in 0..delta {
+        for _ in 0..effective_delta {
             if build_queue.queue.is_empty() {
                 break;
             }
-            let order = &mut build_queue.queue[0];
+            // #445: Each effective hexadie, advance up to `parallel_slots`
+            // orders from the head. Completed orders pop off, shifting the
+            // queue forward so subsequent iterations naturally pick the
+            // next pending head.
+            let active_this_tick = parallel_slots.min(build_queue.queue.len());
+            for idx in 0..active_this_tick {
+                let order = &mut build_queue.queue[idx];
 
-            let minerals_needed = order.minerals_cost.sub(order.minerals_invested);
-            let minerals_transfer = minerals_needed.min(available_minerals);
-            order.minerals_invested = order.minerals_invested.add(minerals_transfer);
-            available_minerals = available_minerals.sub(minerals_transfer);
-            total_minerals_consumed = total_minerals_consumed.add(minerals_transfer);
+                // #445 (HIGH fold-in): per-tick prorated cost. Previous
+                // greedy "transfer up to (cost - invested) every tick"
+                // meant slot 0 swallowed the whole stockpile, leaving
+                // slots 1+ with funding=0 but their `build_time` still
+                // decremented — when resources arrived later, those
+                // back-slots would instant-complete.
+                //
+                // Now each slot needs `(cost / build_time_total)` per
+                // hexadie. If the system can't afford that share for a
+                // given slot, that slot stalls (no resource transfer,
+                // no build_time decrement). The `is_complete()` gate
+                // still requires both `invested == cost` and
+                // `build_time <= 0`, so a partially funded order can't
+                // complete until both ledgers agree.
+                let build_time_total = order.build_time_total.max(1) as u64;
+                let mineral_share = order.minerals_cost.div_amt(Amt::units(build_time_total));
+                let energy_share = order.energy_cost.div_amt(Amt::units(build_time_total));
 
-            let energy_needed = order.energy_cost.sub(order.energy_invested);
-            let energy_transfer = energy_needed.min(available_energy);
-            order.energy_invested = order.energy_invested.add(energy_transfer);
-            available_energy = available_energy.sub(energy_transfer);
-            total_energy_consumed = total_energy_consumed.add(energy_transfer);
+                let minerals_remaining = order.minerals_cost.sub(order.minerals_invested);
+                let energy_remaining = order.energy_cost.sub(order.energy_invested);
+                let mineral_demand = mineral_share.min(minerals_remaining);
+                let energy_demand = energy_share.min(energy_remaining);
 
-            // #32: Decrement build time
-            order.build_time_remaining -= 1;
+                let mineral_affordable = available_minerals >= mineral_demand;
+                let energy_affordable = available_energy >= energy_demand;
+                if !mineral_affordable || !energy_affordable {
+                    // Slot stalls — neither resource transfer nor
+                    // build_time decrement. Avoids the "instant complete
+                    // on resource refill" regression.
+                    continue;
+                }
 
-            if build_queue.queue[0].is_complete() {
-                let completed_order = build_queue.queue.remove(0);
-                match completed_order.kind {
-                    BuildKind::Ship => completed.push(Completion::Ship {
-                        design_id: completed_order.design_id,
-                        display_name: completed_order.display_name,
-                    }),
-                    BuildKind::Deliverable { .. } => {
-                        completed.push(Completion::Deliverable {
-                            definition_id: completed_order.design_id,
+                order.minerals_invested = order.minerals_invested.add(mineral_demand);
+                available_minerals = available_minerals.sub(mineral_demand);
+                total_minerals_consumed = total_minerals_consumed.add(mineral_demand);
+
+                order.energy_invested = order.energy_invested.add(energy_demand);
+                available_energy = available_energy.sub(energy_demand);
+                total_energy_consumed = total_energy_consumed.add(energy_demand);
+
+                // #32 / #445: Decrement build time only when this
+                // slot's per-tick cost share was actually funded.
+                // Clamp at zero — an under-time order is "ready to
+                // finish" as soon as cost catches up.
+                order.build_time_remaining = (order.build_time_remaining - 1).max(0);
+            }
+
+            // Sweep all completed orders in the active window. In normal
+            // play queue[0] finishes first (it's been getting resource
+            // and time priority), but a parallel slot may finish an
+            // order out-of-order if a near-complete order is queued
+            // behind a much larger one (e.g. tests / save-restored
+            // mid-flight orders). Walk the active window in head-first
+            // order and pop each completion; popping shifts indices so
+            // we re-check the current index.
+            let mut i = 0;
+            while i < build_queue.queue.len() && i < active_this_tick {
+                if build_queue.queue[i].is_complete() {
+                    let completed_order = build_queue.queue.remove(i);
+                    match completed_order.kind {
+                        BuildKind::Ship => completed.push(Completion::Ship {
+                            design_id: completed_order.design_id,
                             display_name: completed_order.display_name,
-                        });
+                        }),
+                        BuildKind::Deliverable { .. } => {
+                            completed.push(Completion::Deliverable {
+                                definition_id: completed_order.design_id,
+                                display_name: completed_order.display_name,
+                            });
+                        }
                     }
+                    // Don't advance i — next order shifted into this slot.
+                    // `active_this_tick` shrinks effectively because we now
+                    // have one fewer order to consider in the window.
+                } else {
+                    i += 1;
                 }
             }
         }

--- a/macrocosmo/src/colony/mod.rs
+++ b/macrocosmo/src/colony/mod.rs
@@ -32,12 +32,36 @@ pub struct ColonyPlugin;
 #[reflect(Resource)]
 pub struct LastProductionTick(pub i64);
 
+/// #445 (BLOCKER fold-in): fractional accumulator for
+/// `shipyard_build_speed` multipliers under 1.0×. Keyed by colony Entity
+/// (= 1:1 with `BuildQueue`).
+///
+/// When `speed_mult < 1.0`, a single tick's raw progress (e.g.
+/// `delta=1 * 0.5 = 0.5`) would round down to `effective_delta = 0` and
+/// the queue would never advance (previously the code force-floored to
+/// 1, which **nullified** sub-1.0 modifiers — a punitive debuff with
+/// `speed=0.3` behaved identically to no debuff at `GameSpeed=1`).
+///
+/// The accumulator carries the fractional remainder across ticks: each
+/// tick we add `delta * speed_mult` (as `Amt`) to the accumulator,
+/// extract the integer whole-part into `effective_delta`, and keep the
+/// sub-unit remainder for next tick. Two ticks at 0.5× yield 1 hexadie
+/// of progress total, which matches the displayed multiplier.
+///
+/// Held as a `Resource` (runtime-only `HashMap`) rather than a field
+/// on `BuildQueue` to avoid bumping `SAVE_VERSION`. Save/reload zeroes
+/// the accumulator — acceptable in pre-alpha because a single hexadie
+/// of fractional drift is invisible at gameplay scale.
+#[derive(Resource, Default)]
+pub struct ShipyardSpeedAccumulators(pub std::collections::HashMap<Entity, Amt>);
+
 impl Plugin for ColonyPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LastProductionTick>()
             .init_resource::<BuildingRegistry>()
             .init_resource::<AlertCooldowns>()
             .init_resource::<PendingSovereigntyChanges>()
+            .init_resource::<ShipyardSpeedAccumulators>()
             .add_systems(
                 Startup,
                 load_building_registry.after(crate::scripting::load_all_scripts),

--- a/macrocosmo/src/colony/system_buildings.rs
+++ b/macrocosmo/src/colony/system_buildings.rs
@@ -520,7 +520,8 @@ pub fn sync_system_capability_modifiers(
 
     for (sys_entity, mut sys_mods) in &mut systems {
         // Clear previous building-sourced modifiers (prefix "syscap:")
-        clear_prefixed(&mut sys_mods.shipyard_capacity, "syscap:");
+        clear_prefixed(&mut sys_mods.shipyard_build_parallel_slots, "syscap:");
+        clear_prefixed(&mut sys_mods.shipyard_build_speed, "syscap:");
         clear_prefixed(&mut sys_mods.port_ftl_range_bonus, "syscap:");
         clear_prefixed(&mut sys_mods.port_travel_time_factor, "syscap:");
         clear_prefixed(&mut sys_mods.port_repair, "syscap:");
@@ -544,8 +545,18 @@ pub fn sync_system_capability_modifiers(
                 let id = format!("syscap:{}[{:?}]:{}", def.id, ship_entity, pm.target);
                 let modifier = pm.to_modifier(id, &def.name);
                 match pm.target.as_str() {
-                    "system.shipyard_capacity" => {
-                        sys_mods.shipyard_capacity.push_modifier(modifier);
+                    // #445: New canonical target. `shipyard_capacity` (the old
+                    // name) is intentionally NOT accepted — Lua scripts must
+                    // migrate. If any save / mod still emits the old string we
+                    // silently drop it; the test fixtures and bundled scripts
+                    // have all been updated.
+                    "system.shipyard_build_parallel_slots" => {
+                        sys_mods
+                            .shipyard_build_parallel_slots
+                            .push_modifier(modifier);
+                    }
+                    "system.shipyard_build_speed" => {
+                        sys_mods.shipyard_build_speed.push_modifier(modifier);
                     }
                     "system.port_ftl_range_bonus" => {
                         sys_mods.port_ftl_range_bonus.push_modifier(modifier);
@@ -556,7 +567,36 @@ pub fn sync_system_capability_modifiers(
                     "system.port_repair" => {
                         sys_mods.port_repair.push_modifier(modifier);
                     }
-                    _ => {} // Not a system capability target — handled by colony sync
+                    other => {
+                        // #445 (MEDIUM fold-in): warn on unknown
+                        // `system.*` targets so Lua modders catch the
+                        // rename instead of silently shipping broken
+                        // modifiers. `colony.*` / `job:*` / other
+                        // namespaces are handled by sibling sync
+                        // functions, so we stay silent for those.
+                        if let Some(stripped) = other.strip_prefix("system.") {
+                            // Hint: old `shipyard_capacity` was renamed
+                            // by #445 to `shipyard_build_parallel_slots`.
+                            // Any other unknown target indicates a
+                            // typo, a removed field, or a new modifier
+                            // pending a Rust-side handler.
+                            let hint = if stripped == "shipyard_capacity" {
+                                " (renamed by #445 to 'system.shipyard_build_parallel_slots' — \
+                                 please update your Lua building definition)"
+                            } else {
+                                " (#445 fold-in: did the target get renamed? \
+                                 unknown `system.*` modifiers are dropped on the floor)"
+                            };
+                            bevy::log::warn!(
+                                "sync_system_capability_modifiers: unknown system modifier \
+                                 target '{}' on building '{}' — silently dropped{}",
+                                other,
+                                def.id,
+                                hint,
+                            );
+                        }
+                        // Not a system capability target — handled by colony sync
+                    }
                 }
             }
         }

--- a/macrocosmo/src/deep_space/mod.rs
+++ b/macrocosmo/src/deep_space/mod.rs
@@ -951,11 +951,15 @@ pub fn relay_knowledge_propagate_system(
     // #216: Star system data for FTL-relayed SystemKnowledge updates. Mirrors
     // the queries used by `propagate_knowledge` so the snapshot payload is
     // identical to the direct-light path.
+    // #445: Co-queried `SystemModifiers` lets the relay path read
+    // `shipyard_build_parallel_slots` without consuming a separate
+    // system-param slot (the function is already at the 16-param limit).
     system_q: Query<(
         Entity,
         &crate::galaxy::StarSystem,
         &crate::components::Position,
         Option<&crate::colony::ResourceStockpile>,
+        Option<&crate::galaxy::SystemModifiers>,
     )>,
     colonies: crate::knowledge::ColonySnapshotQuery,
     planets: Query<&crate::galaxy::Planet>,
@@ -1120,22 +1124,32 @@ pub fn relay_knowledge_propagate_system(
         }
 
         // #216: FTL-relayed SystemKnowledge.
-        for (sys_entity, star, sys_pos, stockpile) in &system_q {
+        for (sys_entity, star, sys_pos, stockpile, sys_mods) in &system_q {
             let dist = crate::physics::distance_ly(source_pos, sys_pos);
             if source_range > 0.0 && dist > source_range {
                 continue;
             }
 
+            // Port stays on the capability path for now — port carries three
+            // distinct modifiers (ftl_range_bonus / travel_time_factor /
+            // repair) whose binary "has port" gate doesn't map cleanly to a
+            // single threshold. Separate refactor tracked.
             let relay_has_port = ships.iter().any(|(_e, ship, state, _pos, _hp, slot)| {
                 slot.is_some()
                     && matches!(state, crate::ship::ShipState::InSystem { system: s } if *s == sys_entity)
                     && reverse.get(&ship.design_id).and_then(|bid| building_registry.get(bid.as_str())).is_some_and(|def| def.capabilities.contains_key("port"))
             });
-            let relay_has_shipyard = ships.iter().any(|(_e, ship, state, _pos, _hp, slot)| {
-                slot.is_some()
-                    && matches!(state, crate::ship::ShipState::InSystem { system: s } if *s == sys_entity)
-                    && reverse.get(&ship.design_id).and_then(|bid| building_registry.get(bid.as_str())).is_some_and(|def| def.capabilities.contains_key("shipyard"))
-            });
+            // #445: Shipyard presence now derives from
+            // `shipyard_build_parallel_slots` so the relayed snapshot
+            // matches the production-side gate (one source of truth for
+            // "does this system have a shipyard"). Treats 0 slots as
+            // "no shipyard" whether the system never had one or the
+            // building was destroyed.
+            let relay_has_shipyard = sys_mods
+                .map(|m| {
+                    m.shipyard_build_parallel_slots.value().final_value() > crate::amount::Amt::ZERO
+                })
+                .unwrap_or(false);
 
             // #457: Build a snapshot per receiving empire because hostile_map
             // is receiver-specific (directional faction relations).

--- a/macrocosmo/src/galaxy/mod.rs
+++ b/macrocosmo/src/galaxy/mod.rs
@@ -293,8 +293,18 @@ pub struct SystemModifiers {
     pub ship_speed: ScopedModifiers,
     pub ship_attack: ScopedModifiers,
     pub ship_defense: ScopedModifiers,
-    /// Shipyard capacity: >0 means "has shipyard". Each shipyard adds +1.
-    pub shipyard_capacity: ScopedModifiers,
+    /// #445: Parallel build slots at this system's shipyards. Each shipyard
+    /// building contributes +1 slot. `tick_build_queue` processes up to
+    /// `final_value()` orders in parallel from the head of the queue, so
+    /// adding more shipyards actually lets the system build more ships at
+    /// once (was previously a binary "has shipyard" gate).
+    pub shipyard_build_parallel_slots: ScopedModifiers,
+    /// #445: Multiplier on `build_time_remaining` decrement per tick.
+    /// Default base = 1.0 (multiplier identity). Reserved for future
+    /// "mass production line" modules or speed-boost techs; shipyard
+    /// buildings themselves do NOT contribute to speed (use parallel
+    /// slots for that).
+    pub shipyard_build_speed: ScopedModifiers,
     /// Port FTL range bonus (light-years). Base=0, port adds +10.
     pub port_ftl_range_bonus: ScopedModifiers,
     /// Port travel time factor. Base=1.0 (no port), port adds -0.2 → 0.8.
@@ -309,7 +319,10 @@ impl Default for SystemModifiers {
             ship_speed: ScopedModifiers::default(),
             ship_attack: ScopedModifiers::default(),
             ship_defense: ScopedModifiers::default(),
-            shipyard_capacity: ScopedModifiers::default(),
+            shipyard_build_parallel_slots: ScopedModifiers::default(),
+            // Identity multiplier so `effective_delta = delta * 1.0 = delta`
+            // when no modifiers are attached. Matches `port_travel_time_factor`.
+            shipyard_build_speed: ScopedModifiers::new(Amt::units(1)),
             port_ftl_range_bonus: ScopedModifiers::default(),
             port_travel_time_factor: ScopedModifiers::new(Amt::units(1)),
             port_repair: ScopedModifiers::default(),

--- a/macrocosmo/src/knowledge/mod.rs
+++ b/macrocosmo/src/knowledge/mod.rs
@@ -1920,7 +1920,7 @@ pub fn propagate_knowledge(
                 .map(|m| m.port_repair.value().final_value() > Amt::ZERO)
                 .unwrap_or(false);
             let sys_has_shipyard = sys_mods
-                .map(|m| m.shipyard_capacity.value().final_value() > Amt::ZERO)
+                .map(|m| m.shipyard_build_parallel_slots.value().final_value() > Amt::ZERO)
                 .unwrap_or(false);
             let snapshot = build_system_snapshot(
                 entity,

--- a/macrocosmo/src/ui/ai_debug/governor.rs
+++ b/macrocosmo/src/ui/ai_debug/governor.rs
@@ -76,6 +76,7 @@ fn metric_groups() -> Vec<(&'static str, Vec<MetricId>)> {
             "Infrastructure",
             vec![
                 m::systems_with_shipyard(),
+                m::total_shipyard_slots(),
                 m::systems_with_port(),
                 m::max_building_slots(),
                 m::used_building_slots(),

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -354,9 +354,7 @@ mod empire_view_tests {
 
     fn spawn_empire(world: &mut World, name: &str, is_player: bool) -> Entity {
         let mut e = world.spawn((
-            Empire {
-                name: name.into(),
-            },
+            Empire { name: name.into() },
             Faction {
                 id: name.to_lowercase(),
                 name: name.into(),
@@ -2745,7 +2743,7 @@ pub fn apply_design_refit(
     // any colony — inconsistent with construction rules.
     let has_shipyard = sys_mods_q
         .get(system_entity)
-        .map(|m| m.shipyard_capacity.value().final_value() > crate::amount::Amt::ZERO)
+        .map(|m| m.shipyard_build_parallel_slots.value().final_value() > crate::amount::Amt::ZERO)
         .unwrap_or(false);
     if !has_shipyard {
         return;

--- a/macrocosmo/src/ui/system_panel/mod.rs
+++ b/macrocosmo/src/ui/system_panel/mod.rs
@@ -1378,7 +1378,9 @@ fn draw_right_panel(
         // Determine shipyard availability via capability check on station ships.
         let has_shipyard = sys_mods_q
             .get(sel_entity)
-            .map(|m| m.shipyard_capacity.value().final_value() > crate::amount::Amt::ZERO)
+            .map(|m| {
+                m.shipyard_build_parallel_slots.value().final_value() > crate::amount::Amt::ZERO
+            })
             .unwrap_or(false);
 
         // Collect colonies in this system along with a snapshot of their build queues.
@@ -2128,7 +2130,7 @@ pub fn ship_build_host_colony(
 ) -> Option<Entity> {
     let has_shipyard = sys_mods_q
         .get(system_entity)
-        .map(|m| m.shipyard_capacity.value().final_value() > crate::amount::Amt::ZERO)
+        .map(|m| m.shipyard_build_parallel_slots.value().final_value() > crate::amount::Amt::ZERO)
         .unwrap_or(false);
     if !has_shipyard {
         return None;

--- a/macrocosmo/tests/ai_ship_build_queue.rs
+++ b/macrocosmo/tests/ai_ship_build_queue.rs
@@ -51,7 +51,7 @@ use common::{advance_time, spawn_mock_core_ship, spawn_test_ruler, test_app};
 // ---------------------------------------------------------------------------
 
 /// Build a single-system NPC empire with:
-///   - one shipyard-capable system (via a `SystemModifiers.shipyard_capacity`
+///   - one shipyard-capable system (via a `SystemModifiers.shipyard_build_parallel_slots`
 ///     entry — equivalent to having an active shipyard station for
 ///     `has_shipyard_check` purposes)
 ///   - one planet under that system
@@ -100,7 +100,7 @@ fn build_npc_with_shipyard_colony(app: &mut App) -> (Entity, Entity, Entity, Ent
     // without needing to spawn an actual station Ship + station design.
     let mut sys_mods = SystemModifiers::default();
     sys_mods
-        .shipyard_capacity
+        .shipyard_build_parallel_slots
         .push_modifier(macrocosmo::modifier::Modifier {
             id: "fixture_shipyard".into(),
             label: "Fixture Shipyard".into(),
@@ -485,7 +485,7 @@ fn build_ship_warns_when_shipyard_system_has_no_owned_colony() {
     // `empire_b` so it does not match the issuer.
     let mut sys_mods = SystemModifiers::default();
     sys_mods
-        .shipyard_capacity
+        .shipyard_build_parallel_slots
         .push_modifier(macrocosmo::modifier::Modifier {
             id: "conquered_shipyard".into(),
             label: "Conquered Shipyard".into(),

--- a/macrocosmo/tests/common/mod.rs
+++ b/macrocosmo/tests/common/mod.rs
@@ -129,10 +129,11 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         ship_design_id: Some("station_research_lab_v1".into()),
         colony_slots: None,
     });
-    // Helper for capability-tagged buildings: the AI emitters rely
-    // on `def.capabilities.contains_key("shipyard")` /
-    // `contains_key("port")` to count operational system buildings;
-    // production Lua sets these via `capability "shipyard" {}`.
+    // Helper for capability-tagged buildings: port still uses
+    // `def.capabilities.contains_key("port")` in the AI emitter
+    // (#445 only migrated the shipyard emitter to the modifier path).
+    // Shipyard keeps its capability entry for back-compat with tests
+    // that haven't yet switched to the modifier-driven query.
     let cap_shipyard: HashMap<String, CapabilityParams> = {
         let mut m = HashMap::new();
         m.insert("shipyard".into(), CapabilityParams::default());
@@ -155,7 +156,7 @@ pub fn create_test_building_registry() -> macrocosmo::colony::BuildingRegistry {
         production_bonus_energy: Amt::ZERO,
         production_bonus_research: Amt::ZERO,
         production_bonus_food: Amt::ZERO,
-        modifiers: vec![pm("system.shipyard_capacity", 1.0)],
+        modifiers: vec![pm("system.shipyard_build_parallel_slots", 1.0)],
         is_system_building: true,
         capabilities: cap_shipyard,
         upgrade_to: Vec::new(),
@@ -423,6 +424,11 @@ pub fn test_app() -> App {
     // on it at runtime) always observes the test clock.
     app.add_plugins(macrocosmo::ai::AiPlugin);
     app.insert_resource(LastProductionTick(0));
+    // #445 (BLOCKER fold-in): fractional accumulator resource for
+    // sub-1.0 shipyard speed multipliers. `tick_build_queue` takes
+    // this as `ResMut`, so tests must seed it (or the system panics
+    // with "Resource does not exist").
+    app.init_resource::<macrocosmo::colony::ShipyardSpeedAccumulators>();
     app.insert_resource(EventLog::default());
     app.insert_resource(EventSystem::default());
     app.insert_resource(EventBus::default());
@@ -801,6 +807,10 @@ pub fn full_test_app() -> App {
     // introduced by AI systems at CI time.
     app.add_plugins(macrocosmo::ai::AiPlugin);
     app.insert_resource(LastProductionTick(0));
+    // #445 (BLOCKER fold-in): fractional accumulator resource for
+    // sub-1.0 shipyard speed multipliers. Mirror of the seeding in
+    // `test_app` so `full_test_app`-based tests don't panic.
+    app.init_resource::<macrocosmo::colony::ShipyardSpeedAccumulators>();
     app.insert_resource(EventLog::default());
     app.insert_resource(EventSystem::default());
     app.init_resource::<species::SpeciesRegistry>();

--- a/macrocosmo/tests/refit_shipyard_gate.rs
+++ b/macrocosmo/tests/refit_shipyard_gate.rs
@@ -143,14 +143,15 @@ fn spawn_test_ship(world: &mut World, system: Entity, design_revision: u64) -> E
 }
 
 /// Attach a `SystemModifiers` component to `sys` with the given shipyard
-/// capacity (>0 means "has shipyard").
-fn install_system_modifiers(world: &mut World, sys: Entity, shipyard_capacity_units: u64) {
+/// parallel build slots (>0 means "has shipyard"). Renamed from
+/// `shipyard_capacity_units` after #445.
+fn install_system_modifiers(world: &mut World, sys: Entity, shipyard_parallel_slots: u64) {
     let mut mods = SystemModifiers::default();
-    if shipyard_capacity_units > 0 {
-        mods.shipyard_capacity.push_modifier(Modifier {
+    if shipyard_parallel_slots > 0 {
+        mods.shipyard_build_parallel_slots.push_modifier(Modifier {
             id: "test_shipyard".into(),
             label: "test shipyard".into(),
-            base_add: macrocosmo::amount::SignedAmt::from_amt(Amt::units(shipyard_capacity_units)),
+            base_add: macrocosmo::amount::SignedAmt::from_amt(Amt::units(shipyard_parallel_slots)),
             multiplier: macrocosmo::amount::SignedAmt::ZERO,
             add: macrocosmo::amount::SignedAmt::ZERO,
             expires_at: None,

--- a/macrocosmo/tests/ship.rs
+++ b/macrocosmo/tests/ship.rs
@@ -352,10 +352,15 @@ fn test_build_queue_spawns_ship() {
                 kind: macrocosmo::colony::BuildKind::default(),
                 design_id: "explorer_mk1".to_string(),
                 display_name: "Explorer".to_string(),
+                // #445 (HIGH fold-in): cost is prorated per tick, so a
+                // single-tick completion requires the order to be
+                // **already fully invested** in both ledgers. Mimics
+                // "an almost-done build" — the build_queue tick should
+                // recognise both conditions met and pop it off.
                 minerals_cost: Amt::units(50),
-                minerals_invested: Amt::ZERO,
+                minerals_invested: Amt::units(50),
                 energy_cost: Amt::units(30),
-                energy_invested: Amt::ZERO,
+                energy_invested: Amt::units(30),
                 build_time_total: 60,
                 build_time_remaining: 0, // set to 0 so it completes with resources
             }],

--- a/macrocosmo/tests/shipyard_parallel_slots.rs
+++ b/macrocosmo/tests/shipyard_parallel_slots.rs
@@ -1,0 +1,643 @@
+//! #445 regression: shipyard count actually multiplies build throughput.
+//!
+//! Pre-#445 every callsite reading `SystemModifiers.shipyard_capacity`
+//! only checked `> 0` — so a system with two shipyards had the **same**
+//! ship throughput as a system with one. `tick_build_queue` processed
+//! only `queue[0]` per hexadie and the AI emitter capped the
+//! `systems_with_shipyard` metric at the binary "has shipyard" tier.
+//!
+//! Post-fix the canonical modifier is renamed
+//! `shipyard_build_parallel_slots`; `tick_build_queue` advances up to
+//! `final_value()` head orders per hexadie and a separate
+//! `shipyard_build_speed` modifier (default 1.0 multiplier) lets future
+//! techs/modules speed throughput without piggybacking on the shipyard
+//! building.
+//!
+//! These eight tests pin the new behaviour (5 baseline + 3 adversarial
+//! fold-in from #445 review):
+//!
+//! 1. `shipyard_two_parallel_orders_progress_simultaneously` —
+//!    two shipyards (= parallel_slots=2), three queued orders, one tick
+//!    advances the first two by 1 hexadie each while the third is
+//!    untouched.
+//! 2. `shipyard_one_parallel_order_only_head_progresses` —
+//!    single shipyard (= parallel_slots=1), three queued orders, only
+//!    `queue[0]` decrements (regression: previous behaviour preserved
+//!    for the single-shipyard case).
+//! 3. `shipyard_zero_no_progress` — parallel_slots=0, queue is
+//!    untouched and the "system lacks a Shipyard" warn fires.
+//! 4. `shipyard_build_speed_default_1_0` — speed modifier untouched,
+//!    `effective_delta == delta`, ten ticks decrement build_time by ten.
+//! 5. `shipyard_build_speed_multiplier_2x_speeds_progress` — push a
+//!    `+1.0` (= total 2.0×) speed modifier and confirm a single tick
+//!    decrements build_time by two.
+//! 6. `shipyard_parallel_cost_consumption_matches_slot_count` — fold-in
+//!    HIGH: per-tick cost is prorated across parallel slots (regression:
+//!    pre-fold-in slot 0 was greedy and slots 1+ got zero invested).
+//! 7. `shipyard_build_speed_half_progress_accumulates_over_2_ticks` —
+//!    fold-in BLOCKER: sub-1.0 speed multipliers accumulate over
+//!    multiple ticks instead of being nullified by the floor-1 fallback.
+//! 8. `shipyard_parallel_starvation_does_not_advance_build_time` —
+//!    fold-in HIGH: a starved parallel slot's `build_time` does NOT
+//!    decrement (regression: pre-fold-in it did, leading to
+//!    instant-complete on resource refill).
+
+mod common;
+
+use bevy::prelude::*;
+use macrocosmo::amount::{Amt, SignedAmt};
+use macrocosmo::colony::building_queue::{BuildKind, BuildOrder, BuildQueue};
+use macrocosmo::colony::{
+    Buildings, Colony, FoodConsumption, MaintenanceCost, Production, ProductionFocus,
+    ResourceCapacity, ResourceStockpile,
+};
+use macrocosmo::components::Position;
+use macrocosmo::faction::FactionOwner;
+use macrocosmo::galaxy::SystemModifiers;
+use macrocosmo::modifier::{ModifiedValue, Modifier};
+
+use common::{advance_time, find_planet, spawn_test_empire, spawn_test_system, test_app};
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/// Build a `Modifier` that adds `units` parallel build slots. Used to seed
+/// shipyard count without spawning station ships.
+fn shipyard_slot_modifier(id: &str, units: i64) -> Modifier {
+    Modifier {
+        id: id.into(),
+        label: id.into(),
+        base_add: SignedAmt::units(units),
+        multiplier: SignedAmt::ZERO,
+        add: SignedAmt::ZERO,
+        expires_at: None,
+        on_expire_event: None,
+    }
+}
+
+/// Build a `Modifier` adding `units` to `shipyard_build_speed`. Base value
+/// is 1.0, so `+1.0` becomes a 2× speed multiplier.
+fn shipyard_speed_modifier(id: &str, units: i64) -> Modifier {
+    Modifier {
+        id: id.into(),
+        label: id.into(),
+        // We add to base, not multiplier. `final_value` = (base + base_add)
+        // × (1.0 + Σ multiplier) — keeping the addition on base avoids
+        // double-multiplying when future modifiers also touch base.
+        base_add: SignedAmt::units(units),
+        multiplier: SignedAmt::ZERO,
+        add: SignedAmt::ZERO,
+        expires_at: None,
+        on_expire_event: None,
+    }
+}
+
+/// Like `shipyard_speed_modifier` but takes a milli-units offset so
+/// sub-1.0 debuffs can be exercised (e.g. `-500` = -0.5, which combines
+/// with the 1.0 base to a final 0.5× speed).
+fn shipyard_speed_modifier_milli(id: &str, millis: i64) -> Modifier {
+    Modifier {
+        id: id.into(),
+        label: id.into(),
+        base_add: SignedAmt::milli(millis),
+        multiplier: SignedAmt::ZERO,
+        add: SignedAmt::ZERO,
+        expires_at: None,
+        on_expire_event: None,
+    }
+}
+
+/// Replace the `SystemModifiers` on `sys` with one tuned to the given
+/// shipyard count + optional extra speed-modifier units. `speed_extra_units`
+/// = 0 keeps the default `1.0` base.
+fn install_shipyard_mods(world: &mut World, sys: Entity, shipyards: i64, speed_extra_units: i64) {
+    let mut mods = SystemModifiers::default();
+    if shipyards > 0 {
+        mods.shipyard_build_parallel_slots
+            .push_modifier(shipyard_slot_modifier("test_shipyards", shipyards));
+    }
+    if speed_extra_units != 0 {
+        mods.shipyard_build_speed
+            .push_modifier(shipyard_speed_modifier(
+                "test_speed_boost",
+                speed_extra_units,
+            ));
+    }
+    world.entity_mut(sys).insert(mods);
+}
+
+/// Like `install_shipyard_mods` but takes the speed offset in milli-units
+/// so sub-1.0 speeds can be exercised (e.g. `speed_extra_millis = -500`
+/// for 0.5×).
+fn install_shipyard_mods_milli(
+    world: &mut World,
+    sys: Entity,
+    shipyards: i64,
+    speed_extra_millis: i64,
+) {
+    let mut mods = SystemModifiers::default();
+    if shipyards > 0 {
+        mods.shipyard_build_parallel_slots
+            .push_modifier(shipyard_slot_modifier("test_shipyards", shipyards));
+    }
+    if speed_extra_millis != 0 {
+        mods.shipyard_build_speed
+            .push_modifier(shipyard_speed_modifier_milli(
+                "test_speed_milli",
+                speed_extra_millis,
+            ));
+    }
+    world.entity_mut(sys).insert(mods);
+}
+
+/// Helper: replace the stockpile on `sys` with a fully-stocked one so
+/// build orders never starve.
+fn set_full_stockpile(world: &mut World, sys: Entity) {
+    world.entity_mut(sys).insert((
+        ResourceStockpile {
+            minerals: Amt::units(1_000_000),
+            energy: Amt::units(1_000_000),
+            research: Amt::ZERO,
+            food: Amt::units(10_000),
+            authority: Amt::ZERO,
+        },
+        ResourceCapacity::default(),
+    ));
+}
+
+/// Construct a BuildOrder with the given resource cost and build_time.
+/// `minerals_invested` / `energy_invested` start at zero — the tick loop
+/// transfers stockpile resources into them before checking completion.
+fn make_order(name: &str, minerals: u64, energy: u64, build_time: i64) -> BuildOrder {
+    BuildOrder {
+        order_id: 0,
+        kind: BuildKind::default(),
+        design_id: "explorer_mk1".to_string(),
+        display_name: name.to_string(),
+        minerals_cost: Amt::units(minerals),
+        minerals_invested: Amt::ZERO,
+        energy_cost: Amt::units(energy),
+        energy_invested: Amt::ZERO,
+        build_time_total: build_time,
+        build_time_remaining: build_time,
+    }
+}
+
+/// Spawn a colony with the given `BuildQueue` already populated and return
+/// the colony entity. The colony has no Buildings (only Shipyard gating via
+/// SystemModifiers matters for `tick_build_queue`).
+fn spawn_colony_with_queue(
+    world: &mut World,
+    sys: Entity,
+    empire: Entity,
+    queue: Vec<BuildOrder>,
+) -> Entity {
+    let planet = find_planet(world, sys);
+    let mut bq = BuildQueue::default();
+    // `push_order` assigns monotonic `order_id`s so the in-place
+    // `is_complete()` check downstream behaves identically to a real
+    // queue. Using raw `queue =` here would leave order_id=0 which is
+    // fine but inconsistent with the production push path.
+    for order in queue {
+        bq.push_order(order);
+    }
+    world
+        .spawn((
+            Colony {
+                planet,
+                growth_rate: 0.0,
+            },
+            Production {
+                minerals_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                energy_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                research_per_hexadies: ModifiedValue::new(Amt::ZERO),
+                food_per_hexadies: ModifiedValue::new(Amt::ZERO),
+            },
+            bq,
+            Buildings { slots: vec![None] },
+            macrocosmo::colony::BuildingQueue::default(),
+            ProductionFocus::default(),
+            MaintenanceCost::default(),
+            FoodConsumption::default(),
+            FactionOwner(empire),
+            Position::from([0.0, 0.0, 0.0]),
+        ))
+        .id()
+}
+
+/// Read the current `(build_time_remaining)` for each queued order at
+/// `colony`. Order matches the queue order.
+fn collect_build_times(world: &mut World, colony: Entity) -> Vec<i64> {
+    world
+        .get::<BuildQueue>(colony)
+        .map(|bq| bq.queue.iter().map(|o| o.build_time_remaining).collect())
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// #1 — two shipyards advance two head orders simultaneously
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipyard_two_parallel_orders_progress_simultaneously() {
+    let mut app = test_app();
+    let empire = spawn_test_empire(app.world_mut());
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Sys-2-Yards",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+    set_full_stockpile(app.world_mut(), sys);
+    install_shipyard_mods(app.world_mut(), sys, 2, 0);
+
+    // Three orders, each with build_time=60. After 1 tick the first
+    // two should decrement to 59 while the third stays at 60.
+    let queue = vec![
+        make_order("a", 100, 50, 60),
+        make_order("b", 100, 50, 60),
+        make_order("c", 100, 50, 60),
+    ];
+    let colony = spawn_colony_with_queue(app.world_mut(), sys, empire, queue);
+
+    advance_time(&mut app, 1);
+
+    let times = collect_build_times(app.world_mut(), colony);
+    assert_eq!(
+        times,
+        vec![59, 59, 60],
+        "first two head orders should each decrement by 1; the third (no parallel slot left) must stay at 60"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #2 — single shipyard preserves single-order behaviour
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipyard_one_parallel_order_only_head_progresses() {
+    let mut app = test_app();
+    let empire = spawn_test_empire(app.world_mut());
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Sys-1-Yard",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+    set_full_stockpile(app.world_mut(), sys);
+    install_shipyard_mods(app.world_mut(), sys, 1, 0);
+
+    let queue = vec![
+        make_order("head", 100, 50, 60),
+        make_order("mid", 100, 50, 60),
+        make_order("tail", 100, 50, 60),
+    ];
+    let colony = spawn_colony_with_queue(app.world_mut(), sys, empire, queue);
+
+    advance_time(&mut app, 1);
+
+    let times = collect_build_times(app.world_mut(), colony);
+    assert_eq!(
+        times,
+        vec![59, 60, 60],
+        "single shipyard should only progress the head order — regression: pre-#445 behavior"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #3 — zero shipyards: queue is left untouched
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipyard_zero_no_progress() {
+    let mut app = test_app();
+    let empire = spawn_test_empire(app.world_mut());
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Sys-0-Yards",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+    set_full_stockpile(app.world_mut(), sys);
+    // shipyards=0 — install default SystemModifiers without seeding the
+    // parallel-slots modifier. The default `0` value should hit the
+    // early-return in `tick_build_queue`.
+    install_shipyard_mods(app.world_mut(), sys, 0, 0);
+
+    let queue = vec![make_order("orphan", 100, 50, 60)];
+    let colony = spawn_colony_with_queue(app.world_mut(), sys, empire, queue);
+
+    advance_time(&mut app, 10);
+
+    let times = collect_build_times(app.world_mut(), colony);
+    assert_eq!(
+        times,
+        vec![60],
+        "no shipyard ⇒ no progress; queue retained at full build_time"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #4 — speed modifier default 1.0 is identity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipyard_build_speed_default_1_0() {
+    let mut app = test_app();
+    let empire = spawn_test_empire(app.world_mut());
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Sys-Speed-1x",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+    set_full_stockpile(app.world_mut(), sys);
+    // Single shipyard, speed untouched (= 1.0 base default).
+    install_shipyard_mods(app.world_mut(), sys, 1, 0);
+
+    let queue = vec![make_order("a", 100, 50, 60)];
+    let colony = spawn_colony_with_queue(app.world_mut(), sys, empire, queue);
+
+    advance_time(&mut app, 10);
+
+    let times = collect_build_times(app.world_mut(), colony);
+    assert_eq!(
+        times,
+        vec![50],
+        "default speed=1.0 ⇒ 10 ticks decrement build_time by 10"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #5 — speed multiplier 2x doubles per-tick decrement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipyard_build_speed_multiplier_2x_speeds_progress() {
+    let mut app = test_app();
+    let empire = spawn_test_empire(app.world_mut());
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Sys-Speed-2x",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+    set_full_stockpile(app.world_mut(), sys);
+    // Single shipyard, +1.0 speed (base 1.0 + 1.0 = 2.0× total).
+    install_shipyard_mods(app.world_mut(), sys, 1, 1);
+
+    let queue = vec![make_order("a", 100, 50, 60)];
+    let colony = spawn_colony_with_queue(app.world_mut(), sys, empire, queue);
+
+    advance_time(&mut app, 1);
+
+    let times = collect_build_times(app.world_mut(), colony);
+    // effective_delta = 1 * 2 = 2 → build_time decrements by 2 in a
+    // single tick.
+    assert_eq!(
+        times,
+        vec![58],
+        "speed=2.0 ⇒ 1 tick decrements build_time by 2"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #6 (HIGH fold-in) — parallel cost is prorated per slot per tick
+// ---------------------------------------------------------------------------
+//
+// Pre fold-in: `tick_build_queue` transferred up to `(cost - invested)`
+// per slot per tick, greedily draining the stockpile into slot 0 and
+// leaving slots 1+ with zero invested resources while still decrementing
+// their build_time. Once resources arrived later, slots 1+ would
+// instant-complete.
+//
+// Post fold-in: each slot needs `cost / build_time_total` per tick.
+// With `parallel_slots=2` and `build_time_total=60` per order, a single
+// tick should withdraw `2 * (100 / 60) ≈ 3.33` minerals and
+// `2 * (50 / 60) ≈ 1.67` energy total from the stockpile, leaving each
+// of the first two orders with their respective per-tick share invested.
+
+#[test]
+fn shipyard_parallel_cost_consumption_matches_slot_count() {
+    use macrocosmo::colony::building_queue::BuildQueue;
+
+    let mut app = test_app();
+    let empire = spawn_test_empire(app.world_mut());
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Sys-Parallel-Cost",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+    // Stock just enough to fund a few ticks comfortably but far less
+    // than the full per-order cost.
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
+            minerals: Amt::units(1_000),
+            energy: Amt::units(1_000),
+            research: Amt::ZERO,
+            food: Amt::units(1_000),
+            authority: Amt::ZERO,
+        },
+        ResourceCapacity::default(),
+    ));
+    install_shipyard_mods(app.world_mut(), sys, 2, 0);
+
+    let queue = vec![
+        make_order("a", 100, 100, 60),
+        make_order("b", 100, 100, 60),
+        make_order("c", 100, 100, 60),
+    ];
+    let colony = spawn_colony_with_queue(app.world_mut(), sys, empire, queue);
+
+    advance_time(&mut app, 1);
+
+    // 100 / 60 = 1.667 (Amt::div_amt truncates to milli precision).
+    let per_tick_share = Amt::units(100).div_amt(Amt::units(60));
+    let two_slot_consumption = per_tick_share.mul_u64(2);
+
+    // Stockpile delta — slot 0 and slot 1 each pulled one share.
+    let stockpile = app
+        .world()
+        .get::<ResourceStockpile>(sys)
+        .expect("stockpile");
+    assert_eq!(
+        stockpile.minerals,
+        Amt::units(1_000).sub(two_slot_consumption),
+        "two parallel slots withdraw 2x per-tick share of minerals"
+    );
+    assert_eq!(
+        stockpile.energy,
+        Amt::units(1_000).sub(two_slot_consumption),
+        "two parallel slots withdraw 2x per-tick share of energy"
+    );
+
+    // Per-order ledgers — first two orders each accumulated a single share.
+    let bq = app.world().get::<BuildQueue>(colony).expect("bq");
+    assert_eq!(
+        bq.queue[0].minerals_invested, per_tick_share,
+        "slot 0 invested its prorated minerals share"
+    );
+    assert_eq!(
+        bq.queue[1].minerals_invested, per_tick_share,
+        "slot 1 invested its prorated minerals share (no longer greedy-starved)"
+    );
+    assert_eq!(
+        bq.queue[2].minerals_invested,
+        Amt::ZERO,
+        "slot 2 outside the parallel window stays untouched"
+    );
+    assert_eq!(
+        bq.queue[0].energy_invested, per_tick_share,
+        "slot 0 invested its prorated energy share"
+    );
+    assert_eq!(
+        bq.queue[1].energy_invested, per_tick_share,
+        "slot 1 invested its prorated energy share"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #7 (BLOCKER fold-in) — sub-1.0 speed accumulates across ticks
+// ---------------------------------------------------------------------------
+//
+// Pre fold-in: `delta=1 * speed=0.5 = 0.5` rounded to 0, then the floor-1
+// fallback bumped `effective_delta` back to 1 — nullifying the 0.5×
+// debuff at GameSpeed=1. Post fold-in: the fractional accumulator
+// carries the 0.5 forward to tick 2, where it adds to another 0.5 and
+// crosses the integer threshold.
+
+#[test]
+fn shipyard_build_speed_half_progress_accumulates_over_2_ticks() {
+    let mut app = test_app();
+    let empire = spawn_test_empire(app.world_mut());
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Sys-Speed-Half",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+    set_full_stockpile(app.world_mut(), sys);
+    // Single shipyard, base_add = -500 millis → final speed = 0.5×.
+    install_shipyard_mods_milli(app.world_mut(), sys, 1, -500);
+
+    let queue = vec![make_order("half", 100, 50, 10)];
+    let colony = spawn_colony_with_queue(app.world_mut(), sys, empire, queue);
+
+    // Tick 1: accumulator = 0.5, effective_delta = 0, queue untouched.
+    advance_time(&mut app, 1);
+    let times_after_t1 = collect_build_times(app.world_mut(), colony);
+    assert_eq!(
+        times_after_t1,
+        vec![10],
+        "0.5× speed: tick 1 accrues 0.5 hexadie (sub-unit) — no whole hexadie of progress yet"
+    );
+
+    // Tick 2: accumulator = 0.5 + 0.5 = 1.0, effective_delta = 1, queue progresses by 1.
+    advance_time(&mut app, 1);
+    let times_after_t2 = collect_build_times(app.world_mut(), colony);
+    assert_eq!(
+        times_after_t2,
+        vec![9],
+        "0.5× speed: tick 2 crosses the integer threshold and decrements build_time by 1 \
+         (= 1 hexadie of progress accumulated across 2 ticks, matching the displayed multiplier)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #8 (HIGH fold-in) — starved parallel slot does NOT advance build_time
+// ---------------------------------------------------------------------------
+//
+// Pre fold-in: with `parallel_slots=2` and a stockpile that could only
+// fund slot 0, slot 1 still had its `build_time_remaining` decremented
+// while its `minerals_invested` stayed at zero. Once resources caught
+// up later, slot 1 would instant-complete. Post fold-in: slot 1 stalls
+// entirely (no resource transfer, no build_time decrement).
+
+#[test]
+fn shipyard_parallel_starvation_does_not_advance_build_time() {
+    use macrocosmo::colony::building_queue::BuildQueue;
+
+    let mut app = test_app();
+    let empire = spawn_test_empire(app.world_mut());
+
+    let sys = spawn_test_system(
+        app.world_mut(),
+        "Sys-Starve-Slot",
+        [0.0, 0.0, 0.0],
+        1.0,
+        true,
+        true,
+    );
+    // Two-slot setup. Each order's per-tick share of minerals is
+    // 100/60 = 1.667. Stockpile is funded for exactly one slot's share
+    // (= 2 minerals, well under 2 × 1.667 = 3.333) — slot 0 funds,
+    // slot 1 stalls.
+    app.world_mut().entity_mut(sys).insert((
+        ResourceStockpile {
+            minerals: Amt::units(2),
+            energy: Amt::units(1_000),
+            research: Amt::ZERO,
+            food: Amt::units(1_000),
+            authority: Amt::ZERO,
+        },
+        ResourceCapacity::default(),
+    ));
+    install_shipyard_mods(app.world_mut(), sys, 2, 0);
+
+    let queue = vec![
+        make_order("funded", 100, 100, 60),
+        make_order("starved", 100, 100, 60),
+    ];
+    let colony = spawn_colony_with_queue(app.world_mut(), sys, empire, queue);
+
+    advance_time(&mut app, 1);
+
+    let bq = app.world().get::<BuildQueue>(colony).expect("bq");
+    let per_tick_share = Amt::units(100).div_amt(Amt::units(60));
+
+    // Slot 0: funded, build_time decremented, share invested.
+    assert_eq!(
+        bq.queue[0].build_time_remaining, 59,
+        "funded slot 0 decrements build_time as normal"
+    );
+    assert_eq!(
+        bq.queue[0].minerals_invested, per_tick_share,
+        "funded slot 0 accumulates one share of minerals"
+    );
+    // Slot 1: starved (stockpile drained to ~0.33 after slot 0's pull),
+    // build_time stays at 60, no resources invested.
+    assert_eq!(
+        bq.queue[1].build_time_remaining, 60,
+        "starved slot 1 must NOT decrement build_time (regression: \
+         pre-fold-in this would have been 59, leading to instant-complete \
+         on resource refill)"
+    );
+    assert_eq!(
+        bq.queue[1].minerals_invested,
+        Amt::ZERO,
+        "starved slot 1 invested zero — stockpile lacked its per-tick share"
+    );
+}

--- a/macrocosmo/tests/system_building_capabilities.rs
+++ b/macrocosmo/tests/system_building_capabilities.rs
@@ -2,14 +2,20 @@
 //!
 //! Bug: production Lua building definitions for `shipyard`, `port`, and
 //! `orbital_research_lab` lacked the `capabilities = { ... }` field. The AI
-//! emitter (`ai/emitters.rs:198-220`) reads `def.capabilities.contains_key("shipyard")`
-//! / `"port"` to compute `systems_with_shipyard` / `can_build_ships`. With the
-//! capability missing, `can_build_ships` was permanently 0.0, causing
-//! NPC empires to be unable to build ships and Rule 5a to spam-construct
-//! shipyards forever.
+//! emitter (`ai/emitters.rs:198-220`) used to read
+//! `def.capabilities.contains_key("shipyard")` / `"port"` to compute
+//! `systems_with_shipyard` / `can_build_ships`. With the capability
+//! missing, `can_build_ships` was permanently 0.0, causing NPC empires to
+//! be unable to build ships and Rule 5a to spam-construct shipyards forever.
 //!
-//! Fix: production Lua now declares the canonical capability name on each
-//! system building (matches the test fixture in `tests/fixtures/buildings_test.lua`).
+//! Fix: production Lua declares the canonical capability name on each
+//! system building (matches the test fixture in
+//! `tests/fixtures/buildings_test.lua`). #445 then migrated the *shipyard*
+//! emitter path to read `SystemModifiers.shipyard_build_parallel_slots`
+//! directly — port / research_lab still use capability presence pending a
+//! follow-up refactor, so this test still guards both. The `capabilities`
+//! entry on `shipyard` is now also load-bearing for backward-compat tests
+//! that haven't yet migrated; see follow-up issue.
 
 use macrocosmo::scripting::ScriptEngine;
 use macrocosmo::scripting::building_api::parse_building_definitions;


### PR DESCRIPTION
## Summary
- Root fix for #445 — `shipyard_capacity` was binary-evaluated in 7 callsites, making any 2nd+ shipyard in the same system completely inert.
- Renamed `shipyard_capacity` → **`shipyard_build_parallel_slots`** (semantic-explicit, base=0, each shipyard +1) and made the value load-bearing: `tick_build_queue` now processes N head orders in parallel where N = parallel_slots.
- New **`shipyard_build_speed`** modifier (base=1.0 multiplier identity), reserved for future tech/module bonuses. Fractional accumulator (new runtime-only `ShipyardSpeedAccumulators` Resource) preserves sub-1.0 speed semantics across ticks instead of being silently nullified at low GameSpeed.
- Consolidated **capability path → modifier path** for the "has shipyard" check across 7 callsites (UI 3 + knowledge + AI emitter + AI command consumer + colony tick + deep_space relay). The Lua `capabilities = { shipyard = {} }` definition is retained for backward compat; removal is filed as a follow-up.
- Per-slot cost share gating prevents the "slots 2+3 tick down to negative build_time then instant-complete on resource refill" greedy-starvation bug.
- Migration warning emitted on unknown `system.*` modifier targets (tagged `#445` for grep) so modders updating from `shipyard_capacity` get explicit feedback.

## Adversarial review fold-ins (BLOCKER + 2 HIGH + 2 MEDIUM all in-PR)
1. **BLOCKER (bug lens)** — fractional accumulator replaces floor-1 fallback (was: 0.3× debuff silently became 1.0× at delta=1)
2. **HIGH** — `systems_with_shipyard` metric reverted to set-count semantics; new `total_shipyard_slots` carries the slot sum
3. **HIGH** — parallel cost greedy starvation gated per slot
4. **MEDIUM** — `sync_system_capability_modifiers` warns on unknown `system.*` targets with migration hint
5. **MEDIUM** — +3 regression tests covering cost consumption / sub-1.0 accumulator / starvation stall

## Follow-up issues (deferred, out of scope)
1. Drop dual-contract `capabilities = { shipyard = {} }` from Lua
2. Sovereignty owner attribution symmetry between `tick_build_queue` (host colony FactionOwner) and AI emitter (system Sovereignty)
3. Split `BuildKind::Deliverable` vs `BuildKind::Ship` into separate slot pools
4. `tick_build_queue` SystemParam bundle (14 params after fold-in, approaching 16-param ceiling)
5. Field rename to a less verbose form after the deprecation window for old `shipyard_capacity` name
6. AI Rule 5a frontier shipyard strategy using `total_shipyard_slots`
7. `shipyard_build_speed` Lua-driven additive (mass-production line module / assembly automation tech)

## Test plan
- [x] `cargo test --workspace --tests -- --test-threads=1` → **3599 passed / 0 failed** (baseline 3596 after #470 merge + 3 fold-in tests; the 5 spec tests were already in the pre-fold-in baseline)
- [x] `cargo build --workspace` → no new warnings
- [x] `rustfmt --edition 2024 --check` → clean
- [x] `tests/fixtures_smoke.rs::load_minimal_game_fixture_smoke` → green (`SAVE_VERSION = 20` unchanged — accumulator is runtime-only)
- [x] `tests/smoke.rs::all_systems_no_query_conflict` → green
- [x] 8 new regression tests in `tests/shipyard_parallel_slots.rs` all pass

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)