### PR TITLE
fix(ai): resource gate + Rule 6 fleet_composition semantics (resource starvation hotfix)

### DIFF
--- a/macrocosmo/src/ai/command_consumer.rs
+++ b/macrocosmo/src/ai/command_consumer.rs
@@ -797,8 +797,43 @@ fn handle_build_structure(
             }
         }
 
-        // Find an empty slot
-        let empty_slot = buildings.slots.iter().position(|s| s.is_none());
+        // Hotfix-3: same-building dedup at the colony level.
+        // Mirrors the system-building branch above (line 736-746).
+        // The brp QA report observed a single colony with 165
+        // stacked `mine` orders — Rule 5b re-emits every Reason
+        // tick and pre-hotfix the planet-building branch had no
+        // dedup, so each re-emit found a free slot and pushed
+        // another order. The same-building-id-already-queued check
+        // collapses the runaway stack to one outstanding order at
+        // a time per (colony, building_id). A future "build two
+        // mines for parallel slots" workflow can opt out by
+        // emitting with an explicit `target_slot` param (not
+        // wired today).
+        if building_queue
+            .queue
+            .iter()
+            .any(|o| o.building_id.as_str() == building_id_str)
+        {
+            debug!(
+                "build_structure (planet): '{}' already queued at colony {:?} (system {:?}), skipping duplicate emission",
+                building_id_str, colony_entity, sys
+            );
+            continue;
+        }
+
+        // Find an empty slot, excluding slots already targeted by
+        // pending orders in this queue (defense in depth — without
+        // this two distinct building_id orders could race for the
+        // same slot index; the same-id dedup above already covers
+        // the common case but a future expansion may emit multiple
+        // building kinds per tick).
+        let pending_slots: std::collections::HashSet<usize> =
+            building_queue.queue.iter().map(|o| o.target_slot).collect();
+        let empty_slot = buildings
+            .slots
+            .iter()
+            .enumerate()
+            .position(|(i, s)| s.is_none() && !pending_slots.contains(&i));
         let Some(slot_idx) = empty_slot else { continue };
 
         building_queue.push_build_order(BuildingOrder {

--- a/macrocosmo/src/ai/mid_adapter.rs
+++ b/macrocosmo/src/ai/mid_adapter.rs
@@ -20,6 +20,7 @@ use macrocosmo_ai::{Command, FactionId, Proposal};
 
 use super::npc_decision::NpcContext;
 use crate::ai::convert::to_ai_faction;
+use crate::amount::Amt;
 
 /// What the Mid layer can read about the game world. Bevy-agnostic
 /// in spirit — the trait stays decoupled from `Query` / `Resource`
@@ -96,6 +97,18 @@ pub trait MidGameAdapter {
     /// the call site can copy a single value (matches the legacy
     /// `let survey_count = … let colony_count_ships = … let
     /// combat_count = …` block).
+    ///
+    /// **Hotfix-3 semantics**: counts every empire-owned ship that
+    /// currently exists OR is queued in any of the empire's colony
+    /// build queues, regardless of `ShipState` (InSystem, SubLight,
+    /// InFTL, Surveying, Settling, Refitting, Loitering, Scouting). The
+    /// previous semantics (filter on `system.is_some()` inside
+    /// `NpcContext.ships`) drove an infinite-build loop for
+    /// `explorer_mk1`: once an explorer transitioned to `Surveying`,
+    /// `survey_count` dropped to 0 and Rule 6 re-emitted `build_ship`
+    /// every Reason tick until the empire ran out of minerals. Queued
+    /// orders are folded in so the count rises the moment a build is
+    /// pushed, not 30 hexadies later when the ship spawns.
     fn fleet_composition(&self) -> FleetComposition;
 
     /// Whether the empire has any unsurveyed systems known to it.
@@ -169,6 +182,54 @@ pub trait MidGameAdapter {
     fn idle_couriers(&self) -> &[Entity] {
         &[]
     }
+
+    /// Hotfix-3 resource gate: `true` when the empire's combined
+    /// minerals + energy stockpile (summed across the Mid's
+    /// `member_systems`) can afford `design_id`'s build cost RIGHT
+    /// NOW. **Soft gate** — ignores future revenue / maintenance
+    /// accrual, permits deficit spending as long as the stockpile is
+    /// non-zero. Rules 6 (`build_ship`) and 3.5 (`deploy_deliverable
+    /// → build_deliverable`) consult this before emitting a
+    /// proposal; absent the gate a starving empire re-emits every
+    /// Reason tick and the handler-side dedup eventually fills the
+    /// build queue with orders that can never make progress because
+    /// `tick_production`'s investment step has nothing to draw on.
+    ///
+    /// **Default `true`** = preserves StubAdapter behaviour. An
+    /// unknown `design_id` also returns `true` so the adapter does
+    /// not silently suppress a Rule emission on a typo (the handler
+    /// will warn-and-skip).
+    fn can_afford_design(&self, _design_id: &str) -> bool {
+        true
+    }
+
+    /// Hotfix-3 resource gate: same soft-stockpile check as
+    /// [`Self::can_afford_design`] but keyed on a Building id. Used
+    /// by Rule 5a (`build_structure` shipyard) and the Short-side
+    /// Rule 5b (slot fill — mine / farm / power_plant) so a
+    /// minerals-starved empire stops stacking orders the colony
+    /// build queue cannot drain.
+    ///
+    /// **Default `true`** = preserves StubAdapter behaviour.
+    fn can_afford_building(&self, _building_id: &str) -> bool {
+        true
+    }
+
+    /// Current minerals stockpile (sum across `member_systems`).
+    /// Exposed so rule implementations / tests can introspect the
+    /// gate decision; production rules consume the boolean
+    /// [`Self::can_afford_design`] / [`Self::can_afford_building`]
+    /// helpers instead. Default `Amt(u64::MAX)` so StubAdapter
+    /// callers never accidentally trigger the gate.
+    fn current_minerals(&self) -> Amt {
+        Amt(u64::MAX)
+    }
+
+    /// Current energy stockpile (sum across `member_systems`). See
+    /// [`Self::current_minerals`].
+    fn current_energy(&self) -> Amt {
+        Amt(u64::MAX)
+    }
 }
 
 /// Three counts Rule 6 needs to pick the next ship to build.
@@ -217,6 +278,36 @@ pub struct BevyMidGameAdapter<'a> {
     /// idle_colonizers vs. idle_couriers so the two rules never
     /// double-book the same ship.
     pub idle_couriers: &'a [Entity],
+    /// Hotfix-3: pre-computed empire-wide fleet composition.
+    /// Includes ships in every `ShipState` variant (in-transit,
+    /// surveying, settling, etc.) AND any same-design ships
+    /// currently queued in colony `BuildQueue`s, so the count rises
+    /// the moment Rule 6 emits a `build_ship` order rather than 30
+    /// hexadies later when the ship spawns. Closes the infinite
+    /// `explorer_mk1` loop where the surveying-ship's
+    /// `system: None` evicted it from `NpcContext.ships` and Rule 6
+    /// re-emitted every tick.
+    pub fleet_composition: FleetComposition,
+    /// Hotfix-3: sum of `ResourceStockpile.minerals` across this
+    /// Mid's `member_systems`. Consumed by [`MidGameAdapter::can_afford_design`]
+    /// / [`MidGameAdapter::can_afford_building`] gates so a starving
+    /// empire stops emitting build orders the colony queue cannot
+    /// drain. Soft gate: zero stockpile blocks emission, deficit
+    /// spending (`stockpile > 0 && revenue < expense`) is permitted.
+    pub current_minerals: Amt,
+    /// Hotfix-3: sum of `ResourceStockpile.energy`. See
+    /// [`Self::current_minerals`].
+    pub current_energy: Amt,
+    /// Hotfix-3: design registry borrow used by
+    /// [`MidGameAdapter::can_afford_design`] to look up
+    /// `build_cost_minerals` / `build_cost_energy`. `None` only in
+    /// test setups that never load the Lua registry; an unknown
+    /// `design_id` returns `true` from the gate so a typo does not
+    /// silently suppress an emission (the handler will warn).
+    pub design_registry: Option<&'a crate::ship_design::ShipDesignRegistry>,
+    /// Hotfix-3: building registry borrow used by
+    /// [`MidGameAdapter::can_afford_building`].
+    pub building_registry: Option<&'a crate::colony::BuildingRegistry>,
 }
 
 impl<'a> BevyMidGameAdapter<'a> {
@@ -299,16 +390,14 @@ impl<'a> MidGameAdapter for BevyMidGameAdapter<'a> {
     }
 
     fn fleet_composition(&self) -> FleetComposition {
-        // Three independent passes (rather than one fused pass) is
-        // intentional — a future ship that satisfies multiple
-        // predicates (e.g. both `can_survey` and `is_combat`) must be
-        // counted in every matching bucket.
-        let ships = &self.context.ships;
-        FleetComposition {
-            survey_count: ships.iter().filter(|s| s.can_survey).count(),
-            colony_count: ships.iter().filter(|s| s.can_colonize).count(),
-            combat_count: ships.iter().filter(|s| s.is_combat).count(),
-        }
+        // Hotfix-3: return the empire-wide census pre-computed in
+        // `npc_decision_tick` (covers every `ShipState` variant +
+        // BuildQueue-queued ships). Pre-hotfix this iterated
+        // `NpcContext.ships`, which is filtered on
+        // `system.is_some()` — surveying / in-transit ships were
+        // silently evicted, causing Rule 6 to re-emit `build_ship
+        // explorer_mk1` every tick until the empire starved.
+        self.fleet_composition
     }
 
     fn has_unsurveyed_targets(&self) -> bool {
@@ -336,6 +425,40 @@ impl<'a> MidGameAdapter for BevyMidGameAdapter<'a> {
 
     fn idle_couriers(&self) -> &[Entity] {
         self.idle_couriers
+    }
+
+    fn can_afford_design(&self, design_id: &str) -> bool {
+        // Unknown design → permissive: avoid silently suppressing
+        // a Rule emission on a typo; the handler will warn.
+        let Some(registry) = self.design_registry else {
+            return true;
+        };
+        let Some(def) = registry.get(design_id) else {
+            return true;
+        };
+        // Soft gate: each resource must be individually fundable
+        // out of the current stockpile. Cost == 0 trivially passes
+        // (Amt comparison is on raw u64).
+        self.current_minerals >= def.build_cost_minerals
+            && self.current_energy >= def.build_cost_energy
+    }
+
+    fn can_afford_building(&self, building_id: &str) -> bool {
+        let Some(registry) = self.building_registry else {
+            return true;
+        };
+        let Some(def) = registry.get(building_id) else {
+            return true;
+        };
+        self.current_minerals >= def.minerals_cost && self.current_energy >= def.energy_cost
+    }
+
+    fn current_minerals(&self) -> Amt {
+        self.current_minerals
+    }
+
+    fn current_energy(&self) -> Amt {
+        self.current_energy
     }
 }
 

--- a/macrocosmo/src/ai/mid_adapter.rs
+++ b/macrocosmo/src/ai/mid_adapter.rs
@@ -183,13 +183,28 @@ pub trait MidGameAdapter {
         &[]
     }
 
-    /// Hotfix-3 resource gate: `true` when the empire's combined
-    /// minerals + energy stockpile (summed across the Mid's
-    /// `member_systems`) can afford `design_id`'s build cost RIGHT
-    /// NOW. **Soft gate** — ignores future revenue / maintenance
-    /// accrual, permits deficit spending as long as the stockpile is
-    /// non-zero. Rules 6 (`build_ship`) and 3.5 (`deploy_deliverable
-    /// → build_deliverable`) consult this before emitting a
+    /// Hotfix-3 resource gate (#529 A migration: pending-aware
+    /// form): `true` when the empire's combined minerals + energy
+    /// stockpile **MINUS the remaining cost of every in-flight
+    /// build order** can afford `design_id`'s build cost.
+    ///
+    /// The pending-aware adjustment makes the AI take its own
+    /// commitments into account: a stockpile of 100 minerals with
+    /// one corvette already queued (cost 80, invested 0) leaves
+    /// effective availability of 20, so a second corvette emit is
+    /// rejected. Without it, the gate fires only when the
+    /// stockpile has already dropped — too late to prevent the
+    /// double-order that drains both builds.
+    ///
+    /// **Soft gate** — ignores future revenue / maintenance
+    /// accrual. Permits deficit spending (`revenue < expense`) as
+    /// long as the pending-adjusted balance is non-zero; the
+    /// design contract is "stockpile must not dip to zero", not
+    /// "stockpile must cover the entire queue at once" (production
+    /// spreads orders over `build_time_total`).
+    ///
+    /// Rules 6 (`build_ship`) and 3.5 (`deploy_deliverable →
+    /// build_deliverable`) consult this before emitting a
     /// proposal; absent the gate a starving empire re-emits every
     /// Reason tick and the handler-side dedup eventually fills the
     /// build queue with orders that can never make progress because
@@ -203,21 +218,29 @@ pub trait MidGameAdapter {
         true
     }
 
-    /// Hotfix-3 resource gate: same soft-stockpile check as
+    /// Hotfix-3 resource gate (#529 A migration: pending-aware
+    /// form): same pending-adjusted stockpile check as
     /// [`Self::can_afford_design`] but keyed on a Building id. Used
     /// by Rule 5a (`build_structure` shipyard) and the Short-side
     /// Rule 5b (slot fill — mine / farm / power_plant) so a
     /// minerals-starved empire stops stacking orders the colony
-    /// build queue cannot drain.
+    /// build queue cannot drain. Pending orders subtracted include
+    /// every system-building order on a member-of-region
+    /// `SystemBuildingQueue`; per-colony planet `BuildingQueue`
+    /// entries are not yet folded in (the rule's `handle_*` dedup
+    /// is the backstop for now).
     ///
     /// **Default `true`** = preserves StubAdapter behaviour.
     fn can_afford_building(&self, _building_id: &str) -> bool {
         true
     }
 
-    /// Current minerals stockpile (sum across `member_systems`).
-    /// Exposed so rule implementations / tests can introspect the
-    /// gate decision; production rules consume the boolean
+    /// Current minerals stockpile **net of pending build orders**
+    /// (sum across `member_systems` minus
+    /// `Σ (minerals_cost - minerals_invested)` across colony
+    /// `BuildQueue` and system `SystemBuildingQueue`). Exposed so
+    /// rule implementations / tests can introspect the gate
+    /// decision; production rules consume the boolean
     /// [`Self::can_afford_design`] / [`Self::can_afford_building`]
     /// helpers instead. Default `Amt(u64::MAX)` so StubAdapter
     /// callers never accidentally trigger the gate.
@@ -225,7 +248,7 @@ pub trait MidGameAdapter {
         Amt(u64::MAX)
     }
 
-    /// Current energy stockpile (sum across `member_systems`). See
+    /// Current energy stockpile, pending-adjusted. See
     /// [`Self::current_minerals`].
     fn current_energy(&self) -> Amt {
         Amt(u64::MAX)
@@ -288,15 +311,24 @@ pub struct BevyMidGameAdapter<'a> {
     /// `system: None` evicted it from `NpcContext.ships` and Rule 6
     /// re-emitted every tick.
     pub fleet_composition: FleetComposition,
-    /// Hotfix-3: sum of `ResourceStockpile.minerals` across this
-    /// Mid's `member_systems`. Consumed by [`MidGameAdapter::can_afford_design`]
-    /// / [`MidGameAdapter::can_afford_building`] gates so a starving
+    /// Hotfix-3 + #529 A migration: sum of
+    /// `ResourceStockpile.minerals` across this Mid's
+    /// `member_systems`, **minus the remaining cost of every
+    /// in-flight build order** the empire owns (per-colony
+    /// `BuildQueue` ships/deliverables + per-system
+    /// `SystemBuildingQueue` buildings). Consumed by
+    /// [`MidGameAdapter::can_afford_design`] /
+    /// [`MidGameAdapter::can_afford_building`] gates so a starving
     /// empire stops emitting build orders the colony queue cannot
-    /// drain. Soft gate: zero stockpile blocks emission, deficit
-    /// spending (`stockpile > 0 && revenue < expense`) is permitted.
+    /// drain. Soft gate: zero pending-adjusted stockpile blocks
+    /// emission, deficit spending (`stockpile > 0 && revenue <
+    /// expense`) is permitted. Saturating subtract — if pending
+    /// exceeds stockpile the field clamps to zero, which is the
+    /// correct signal for an empire that has already over-committed
+    /// itself.
     pub current_minerals: Amt,
-    /// Hotfix-3: sum of `ResourceStockpile.energy`. See
-    /// [`Self::current_minerals`].
+    /// Hotfix-3 + #529 A migration: pending-adjusted sum of
+    /// `ResourceStockpile.energy`. See [`Self::current_minerals`].
     pub current_energy: Amt,
     /// Hotfix-3: design registry borrow used by
     /// [`MidGameAdapter::can_afford_design`] to look up

--- a/macrocosmo/src/ai/mid_stance.rs
+++ b/macrocosmo/src/ai/mid_stance.rs
@@ -143,7 +143,14 @@ impl MidStanceAgent {
         // ship within one tick.
         let idle_couriers = adapter.idle_couriers();
         let frontier = adapter.expansion_frontier_systems();
-        if !frontier.is_empty() && !idle_couriers.is_empty() {
+        // Hotfix-3 resource gate: `deploy_deliverable` decomposes
+        // into `build_deliverable(infrastructure_core)` at the
+        // colony, so the same stockpile check applies. Pre-hotfix a
+        // starving empire flooded Cores onto the frontier list.
+        if !frontier.is_empty()
+            && !idle_couriers.is_empty()
+            && adapter.can_afford_design("infrastructure_core")
+        {
             for (ship, &target) in idle_couriers.iter().zip(frontier.iter()) {
                 let cmd = Command::new(cmd_ids::deploy_deliverable(), faction_id, now)
                     .with_param(
@@ -168,7 +175,18 @@ impl MidStanceAgent {
         let can_build = adapter.can_build_ships();
         let systems_with_core = adapter.systems_with_core();
         let colony_count = adapter.colony_count();
-        if can_build < 1.0 && systems_with_core > 0.0 && colony_count > 0.0 {
+        if can_build < 1.0
+            && systems_with_core > 0.0
+            && colony_count > 0.0
+            // Hotfix-3 resource gate: don't emit shipyard build
+            // proposals an empty stockpile cannot pay for. Pre-hotfix
+            // the system-building dedup absorbed the per-tick
+            // re-emission, but only after the slot was already
+            // booked — a minerals-starved empire still left the
+            // shipyard order frozen in the queue forever, starving
+            // every later rule that needs the shipyard.
+            && adapter.can_afford_building("shipyard")
+        {
             let cmd = Command::new(cmd_ids::build_structure(), faction_id, now)
                 .with_param("building_id", CommandValue::Str("shipyard".into()));
             // `build_structure` has no `target_system` param — the
@@ -191,17 +209,33 @@ impl MidStanceAgent {
         if can_build >= 1.0 {
             let comp = adapter.fleet_composition();
 
-            if comp.survey_count == 0 && adapter.has_unsurveyed_targets() {
-                let cmd = Command::new(cmd_ids::build_ship(), faction_id, now)
-                    .with_param("design_id", CommandValue::Str("explorer_mk1".into()));
-                proposals.push(Proposal::faction_wide(cmd));
+            // Hotfix-3: priority order is `survey → colony → combat<3`.
+            // The branch picks the highest-priority *unmet need*, then
+            // applies the resource gate. Failing the gate means
+            // "wait, don't spend" — we do NOT fall through to a
+            // cheaper branch because the cheaper need wasn't the one
+            // we identified. Mirrors how a starving human player
+            // would defer the build rather than switch designs.
+            //
+            // Pre-hotfix the gate condition didn't exist, so this
+            // structural shape (separate need-detection then gate)
+            // is new. The legacy fall-through behaviour
+            // (survey_count != 0 → check colony → check combat) is
+            // preserved for the need-detection step itself.
+            let pick = if comp.survey_count == 0 && adapter.has_unsurveyed_targets() {
+                Some("explorer_mk1")
             } else if comp.colony_count == 0 && adapter.has_colonizable_targets() {
-                let cmd = Command::new(cmd_ids::build_ship(), faction_id, now)
-                    .with_param("design_id", CommandValue::Str("colony_ship_mk1".into()));
-                proposals.push(Proposal::faction_wide(cmd));
+                Some("colony_ship_mk1")
             } else if comp.combat_count < 3 {
+                Some("patrol_corvette")
+            } else {
+                None
+            };
+            if let Some(design_id) = pick
+                && adapter.can_afford_design(design_id)
+            {
                 let cmd = Command::new(cmd_ids::build_ship(), faction_id, now)
-                    .with_param("design_id", CommandValue::Str("patrol_corvette".into()));
+                    .with_param("design_id", CommandValue::Str(design_id.into()));
                 proposals.push(Proposal::faction_wide(cmd));
             }
         }
@@ -254,6 +288,11 @@ mod tests {
         fleet_composition: FleetComposition,
         has_unsurveyed_targets: bool,
         has_colonizable_targets: bool,
+        /// Hotfix-3 resource gate. `None` = trait default (always
+        /// affordable). `Some(set)` = explicit allow-list of
+        /// `design_id` strings the stub considers fundable.
+        affordable_designs: Option<std::collections::HashSet<String>>,
+        affordable_buildings: Option<std::collections::HashSet<String>>,
     }
 
     impl StubAdapter {
@@ -273,6 +312,8 @@ mod tests {
                 fleet_composition: FleetComposition::default(),
                 has_unsurveyed_targets: false,
                 has_colonizable_targets: false,
+                affordable_designs: None,
+                affordable_buildings: None,
             }
         }
     }
@@ -319,6 +360,18 @@ mod tests {
         }
         fn has_colonizable_targets(&self) -> bool {
             self.has_colonizable_targets
+        }
+        fn can_afford_design(&self, design_id: &str) -> bool {
+            match &self.affordable_designs {
+                Some(set) => set.contains(design_id),
+                None => true,
+            }
+        }
+        fn can_afford_building(&self, building_id: &str) -> bool {
+            match &self.affordable_buildings {
+                Some(set) => set.contains(building_id),
+                None => true,
+            }
         }
     }
 
@@ -770,5 +823,220 @@ mod tests {
                 .all(|p| p.command.kind.as_str() != "fortify_system"),
             "can_build < 1 → no fortify",
         );
+    }
+
+    // ---- Hotfix-3: resource gate + Rule 6 fleet_composition semantics ----
+    //
+    // Pre-hotfix Rule 6 saw `survey_count == 0` for an empire whose
+    // only explorer was currently surveying (because the surveying
+    // ship's `ShipState::Surveying` left `info.system == None` and
+    // `NpcContext.ships` filtered those out). The infinite-build loop
+    // that followed (`build_ship explorer_mk1` every Reason tick)
+    // bankrupted starter empires by stacking maintenance against a
+    // depleted stockpile.
+
+    /// Pin: Rule 6's explorer branch stays silent when the empire's
+    /// fleet census already contains a surveyor — alive OR currently
+    /// `Surveying` OR `InFTL` OR `SubLight`. The hotfix routes the
+    /// census via `BevyMidGameAdapter.fleet_composition` (pre-computed
+    /// in `npc_decision_tick` over the unfiltered `all_ships` query +
+    /// build queue), so even a ship in `ShipState::Surveying` is
+    /// counted.
+    #[test]
+    fn rule_6_explorer_not_re_built_while_alive_survey_ship_exists() {
+        let mut affordable = std::collections::HashSet::new();
+        affordable.insert("explorer_mk1".into());
+        affordable.insert("colony_ship_mk1".into());
+        affordable.insert("patrol_corvette".into());
+        let stub = StubAdapter {
+            can_build: 1.0,
+            colony_count: 1.0,
+            total_ships: 10.0,
+            // survey_count == 1 → explorer branch must be silent
+            // even though `has_unsurveyed_targets` is true and the
+            // resource gate permits the build. This is the
+            // surveying-explorer case: the ship is alive but in
+            // `ShipState::Surveying`, and pre-hotfix the
+            // `info.system.is_some()` filter on `NpcContext.ships`
+            // dropped it, collapsing the count to 0.
+            fleet_composition: FleetComposition {
+                survey_count: 1,
+                colony_count: 1,
+                combat_count: 3,
+            },
+            has_unsurveyed_targets: true,
+            has_colonizable_targets: false,
+            affordable_designs: Some(affordable),
+            ..StubAdapter::empty()
+        };
+        let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
+        for p in &proposals {
+            if p.command.kind.as_str() == "build_ship" {
+                match p.command.params.get("design_id") {
+                    Some(CommandValue::Str(s)) => assert_ne!(
+                        s.as_ref(),
+                        "explorer_mk1",
+                        "Rule 6 must not re-emit explorer while one is alive",
+                    ),
+                    _ => panic!("build_ship missing design_id"),
+                }
+            }
+        }
+    }
+
+    /// Pin: when every surveyor has been destroyed (census shows
+    /// `survey_count == 0`), Rule 6 still fires — confirms the
+    /// hotfix did not over-correct into "never re-build".
+    #[test]
+    fn rule_6_explorer_re_built_when_all_destroyed() {
+        let mut affordable = std::collections::HashSet::new();
+        affordable.insert("explorer_mk1".into());
+        let stub = StubAdapter {
+            can_build: 1.0,
+            colony_count: 1.0,
+            total_ships: 10.0,
+            fleet_composition: FleetComposition {
+                survey_count: 0,
+                colony_count: 0,
+                combat_count: 5,
+            },
+            has_unsurveyed_targets: true,
+            affordable_designs: Some(affordable),
+            ..StubAdapter::empty()
+        };
+        let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
+        let build = proposals
+            .iter()
+            .find(|p| p.command.kind.as_str() == "build_ship")
+            .expect("Rule 6 must rebuild explorer after every surveyor destroyed");
+        match build.command.params.get("design_id") {
+            Some(CommandValue::Str(s)) => assert_eq!(s.as_ref(), "explorer_mk1"),
+            _ => panic!("expected design_id"),
+        }
+    }
+
+    /// Pin: Rule 6's explorer branch stays silent when the empire's
+    /// stockpile cannot pay for the build, even if every other
+    /// condition (no survey ship, has unsurveyed targets) matches.
+    /// This stops the runaway "build, fail, retry" loop the brp QA
+    /// report observed.
+    #[test]
+    fn rule_6_silent_when_stockpile_cannot_afford_explorer() {
+        let stub = StubAdapter {
+            can_build: 1.0,
+            colony_count: 1.0,
+            total_ships: 10.0,
+            fleet_composition: FleetComposition {
+                survey_count: 0,
+                colony_count: 0,
+                combat_count: 5,
+            },
+            has_unsurveyed_targets: true,
+            // affordable_designs = Some(empty) → can_afford_design
+            // returns false for every id, including explorer_mk1.
+            affordable_designs: Some(std::collections::HashSet::new()),
+            ..StubAdapter::empty()
+        };
+        let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
+        assert!(
+            proposals
+                .iter()
+                .all(|p| p.command.kind.as_str() != "build_ship"),
+            "stockpile zero → Rule 6 must not emit any build_ship",
+        );
+    }
+
+    /// Pin: Rule 5a's shipyard branch honours the building-cost
+    /// resource gate. Pre-hotfix the dedup absorbed re-emissions but
+    /// the order was still booked the moment a slot opened — even if
+    /// the minerals weren't there to invest.
+    #[test]
+    fn rule_5a_silent_when_stockpile_cannot_afford_shipyard() {
+        let stub = StubAdapter {
+            can_build: 0.0,
+            systems_with_core: 1.0,
+            colony_count: 2.0,
+            affordable_buildings: Some(std::collections::HashSet::new()),
+            ..StubAdapter::empty()
+        };
+        let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
+        assert!(
+            proposals
+                .iter()
+                .all(|p| p.command.kind.as_str() != "build_structure"),
+            "stockpile zero → Rule 5a must not emit shipyard",
+        );
+    }
+
+    /// Pin: priority semantics — Rule 6 picks the
+    /// highest-priority unmet need, then applies the gate. A
+    /// failing gate on the picked design must NOT fall through to
+    /// the next branch. Pre-fold-in the gate was inlined per-branch
+    /// with `else if`, which would have let an explorer-needing
+    /// empire substitute a cheaper colony / corvette purchase the
+    /// player did not authorise.
+    #[test]
+    fn rule_6_does_not_fall_through_to_cheaper_branch_when_top_priority_gate_fails() {
+        // Survey is the top priority (survey_count == 0 &&
+        // has_unsurveyed_targets), but the empire can only afford
+        // colony_ship_mk1, not explorer_mk1.
+        let mut affordable = std::collections::HashSet::new();
+        affordable.insert("colony_ship_mk1".into());
+        affordable.insert("patrol_corvette".into());
+        let stub = StubAdapter {
+            can_build: 1.0,
+            colony_count: 1.0,
+            total_ships: 10.0,
+            fleet_composition: FleetComposition {
+                survey_count: 0,
+                colony_count: 0,
+                combat_count: 1,
+            },
+            has_unsurveyed_targets: true,
+            has_colonizable_targets: true,
+            affordable_designs: Some(affordable),
+            ..StubAdapter::empty()
+        };
+        let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
+        assert!(
+            proposals
+                .iter()
+                .all(|p| p.command.kind.as_str() != "build_ship"),
+            "Rule 6 must NOT substitute a cheaper design when its top-priority pick fails the gate",
+        );
+    }
+
+    /// Soft gate sanity: deficit spending (revenue < expense, but
+    /// stockpile non-zero) is PERMITTED. The hotfix is a stockpile
+    /// gate, not a black-budget gate.
+    #[test]
+    fn rule_6_permits_deficit_spending_when_stockpile_positive() {
+        // The stub's `affordable_designs = None` is the trait
+        // default (always affordable), modelling a real adapter
+        // whose stockpile passes the soft check even though the
+        // empire's metrics would predict a future deficit. With
+        // every other Rule 6 gate met, the build must emit.
+        let stub = StubAdapter {
+            can_build: 1.0,
+            colony_count: 1.0,
+            total_ships: 10.0,
+            fleet_composition: FleetComposition {
+                survey_count: 0,
+                colony_count: 0,
+                combat_count: 5,
+            },
+            has_unsurveyed_targets: true,
+            affordable_designs: None,
+            ..StubAdapter::empty()
+        };
+        let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
+        let build = proposals
+            .iter()
+            .find(|p| p.command.kind.as_str() == "build_ship")
+            .expect("deficit-but-non-zero stockpile must still permit Rule 6");
+        match build.command.params.get("design_id") {
+            Some(CommandValue::Str(s)) => assert_eq!(s.as_ref(), "explorer_mk1"),
+            _ => panic!("expected design_id"),
+        }
     }
 }

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -69,6 +69,12 @@ pub struct ResourceGateParams<'w, 's> {
     /// already-queued ship orders into the Rule 6 fleet census so
     /// the count rises the moment Rule 6 emits, not 30 hexadies
     /// later when the ship spawns.
+    ///
+    /// #529 A migration: also walked to subtract pending ship/
+    /// deliverable orders' remaining cost from the empire's
+    /// stockpile sum before the resource gate sees it, so the AI
+    /// accounts for its own in-flight commitments when deciding
+    /// whether to emit a new build.
     pub build_queues: Query<
         'w,
         's,
@@ -76,6 +82,22 @@ pub struct ResourceGateParams<'w, 's> {
             &'static crate::colony::building_queue::BuildQueue,
             &'static crate::faction::FactionOwner,
         ),
+    >,
+    /// Per-StarSystem `SystemBuildingQueue` (#529 A migration). Lists
+    /// in-flight system-building orders (shipyard / port / research
+    /// lab) whose `minerals_remaining` / `energy_remaining` is
+    /// subtracted from the stockpile sum for the same reason as
+    /// `build_queues`. Sovereignty / membership is enforced by
+    /// intersecting against the Mid's `member_systems_set` at the
+    /// call site (the queue itself doesn't carry an empire id).
+    pub system_building_queues: Query<
+        'w,
+        's,
+        (
+            Entity,
+            &'static crate::colony::system_buildings::SystemBuildingQueue,
+        ),
+        With<crate::galaxy::StarSystem>,
     >,
     /// Building registry borrow for [`super::mid_adapter::MidGameAdapter::can_afford_building`].
     pub building_registry: Option<Res<'w, crate::colony::BuildingRegistry>>,
@@ -398,11 +420,17 @@ pub struct EmpireShortInputs {
     pub net_production_energy: f64,
     /// Empire-wide net food production (`net_production_food`).
     pub net_production_food: f64,
-    /// Hotfix-3: sum of `ResourceStockpile.minerals` across the
-    /// region's `member_systems`. Consumed by Rule 5b's resource
-    /// gate (`ShortGameAdapter::can_afford_building`).
+    /// Hotfix-3 + #529 A migration: sum of
+    /// `ResourceStockpile.minerals` across the region's
+    /// `member_systems`, **minus the remaining cost of every
+    /// in-flight build order** the empire owns (per-colony
+    /// `BuildQueue` ships/deliverables + per-system
+    /// `SystemBuildingQueue` buildings). Consumed by Rule 5b's
+    /// resource gate (`ShortGameAdapter::can_afford_building`).
+    /// Saturating subtract: clamps to zero when pending > stockpile.
     pub current_minerals: crate::amount::Amt,
-    /// Hotfix-3: sum of `ResourceStockpile.energy`.
+    /// Hotfix-3 + #529 A migration: pending-adjusted sum of
+    /// `ResourceStockpile.energy`. See [`Self::current_minerals`].
     pub current_energy: crate::amount::Amt,
 }
 
@@ -1343,6 +1371,72 @@ pub fn npc_decision_tick(
                 current_energy = current_energy.add(stockpile.energy);
             }
         }
+
+        // #529 A migration: subtract the **remaining** cost of all
+        // pending build orders the empire has already committed to.
+        // The pre-migration gate compared `current_stockpile_sum >=
+        // cost`, which ignored in-flight orders — an empire with
+        // stockpile 100 and one corvette (cost 80, invested 0)
+        // already in queue would happily emit a second corvette
+        // (gate sees `100 >= 50`), then starve both when the
+        // production tick drained the stockpile.
+        //
+        // The pending-aware form subtracts `cost - invested` for
+        // every queued ship/deliverable order (colony `BuildQueue`)
+        // and every queued building order (system-level
+        // `SystemBuildingQueue` — shipyard / port / research_lab).
+        // Per-colony `BuildingQueue` (mine / farm / power_plant
+        // construction) is intentionally **not** walked here: those
+        // queues live on Colony entities outside this
+        // `ResourceGateParams` for now (adding the query would push
+        // the bundle past Bevy's 16-param limit). The same-tick
+        // dedup at `handle_build_structure` is the backstop for
+        // planet-building re-emits in the meantime; once the
+        // adapter rules need it the planet `BuildingQueue` will be
+        // folded in too.
+        //
+        // `Amt::sub` is saturating: if pending > stockpile the
+        // available value clamps to zero rather than wrapping, so
+        // the gate becomes "any new emit is rejected" — the correct
+        // signal for an empire that has already over-committed
+        // itself. The contract is "stockpile cannot dip to zero"
+        // not "stockpile must cover everything in the queue
+        // simultaneously" because production tick spreads orders
+        // over their build_time; the gate's job is "AI should stop
+        // adding work to a queue whose tail will starve".
+        let mut pending_minerals = crate::amount::Amt::ZERO;
+        let mut pending_energy = crate::amount::Amt::ZERO;
+        for (queue, owner) in &resource_gate.build_queues {
+            if owner.0 != entity {
+                continue;
+            }
+            for order in &queue.queue {
+                let m_rem = order.minerals_cost.sub(order.minerals_invested);
+                let e_rem = order.energy_cost.sub(order.energy_invested);
+                pending_minerals = pending_minerals.add(m_rem);
+                pending_energy = pending_energy.add(e_rem);
+            }
+        }
+        for (sys_entity, sys_queue) in &resource_gate.system_building_queues {
+            // SystemBuildingQueue has no owner component — gate by
+            // membership in the Mid's `member_systems` set. This is
+            // the same scope used for the stockpile sum above, so
+            // pending and stockpile are consistently region-scoped.
+            if !member_systems_set.contains(&sys_entity) {
+                continue;
+            }
+            for order in &sys_queue.queue {
+                pending_minerals = pending_minerals.add(order.minerals_remaining);
+                pending_energy = pending_energy.add(order.energy_remaining);
+            }
+            // Demolition/upgrade orders intentionally not folded in:
+            // demolition refunds resources rather than spending them,
+            // and the small minority of upgrade orders today are not
+            // emitted by the AI (player-only path). Adding them later
+            // is a 3-line change once a Rule actually issues them.
+        }
+        let current_minerals = current_minerals.sub(pending_minerals);
+        let current_energy = current_energy.sub(pending_energy);
 
         let adapter = crate::ai::mid_adapter::BevyMidGameAdapter {
             faction: entity,

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -53,6 +53,38 @@ pub struct DedupParams<'w, 's> {
     pub planet_systems: Query<'w, 's, &'static crate::galaxy::Planet>,
 }
 
+/// Hotfix-3: bundle of queries / resources used to drive the
+/// resource gate + Rule 6 fleet census. Centralised in one
+/// `SystemParam` so the outer `npc_decision_tick` fn stays under
+/// Bevy's 16-param limit even after the gate plumbing lands.
+#[derive(SystemParam)]
+pub struct ResourceGateParams<'w, 's> {
+    /// Per-StarSystem stockpile. Resources are local to the system
+    /// (see `CLAUDE.md` — "ResourceStockpile on StarSystem"). We sum
+    /// across the Mid's `member_systems` for the empire-wide
+    /// affordability check.
+    pub stockpiles:
+        Query<'w, 's, &'static crate::colony::ResourceStockpile, With<crate::galaxy::StarSystem>>,
+    /// Per-colony `BuildQueue`. Walked once per empire to fold
+    /// already-queued ship orders into the Rule 6 fleet census so
+    /// the count rises the moment Rule 6 emits, not 30 hexadies
+    /// later when the ship spawns.
+    pub build_queues: Query<
+        'w,
+        's,
+        (
+            &'static crate::colony::building_queue::BuildQueue,
+            &'static crate::faction::FactionOwner,
+        ),
+    >,
+    /// Building registry borrow for [`super::mid_adapter::MidGameAdapter::can_afford_building`].
+    pub building_registry: Option<Res<'w, crate::colony::BuildingRegistry>>,
+    /// Ship design registry borrow. Folded into this bundle (was a
+    /// standalone param) to free a slot so [`ResourceGateParams`]
+    /// itself fits under Bevy's 16-param ceiling.
+    pub design_registry: Option<Res<'w, crate::ship_design::ShipDesignRegistry>>,
+}
+
 /// Marker component: this empire's decisions are made by the AI policy.
 /// Applied to NPC empires automatically, and optionally to the player
 /// empire when `--ai-player` is passed or `AiPlayerMode(true)` is set.
@@ -366,6 +398,12 @@ pub struct EmpireShortInputs {
     pub net_production_energy: f64,
     /// Empire-wide net food production (`net_production_food`).
     pub net_production_food: f64,
+    /// Hotfix-3: sum of `ResourceStockpile.minerals` across the
+    /// region's `member_systems`. Consumed by Rule 5b's resource
+    /// gate (`ShortGameAdapter::can_afford_building`).
+    pub current_minerals: crate::amount::Amt,
+    /// Hotfix-3: sum of `ResourceStockpile.energy`.
+    pub current_energy: crate::amount::Amt,
 }
 
 /// Rank candidate unsurveyed systems by "accessibility" — a raw-distance
@@ -588,7 +626,6 @@ pub fn npc_decision_tick(
         &crate::ship::CommandQueue,
     )>,
     research_queues: Query<&ResearchQueue, With<Empire>>,
-    design_registry: Option<Res<crate::ship_design::ShipDesignRegistry>>,
     empire_rulers: Query<&EmpireRuler, With<Empire>>,
     ruler_q: Query<(&StationedAt, Option<&AboardShip>), With<Ruler>>,
     // Round 9 PR #2 Step 4 + Round 11 Bug A + #468 PR-1: dedup against
@@ -620,6 +657,10 @@ pub fn npc_decision_tick(
     // automatically activate cross-region isolation.
     mid_agents: Query<(Entity, &super::mid_agent::MidAgent)>,
     regions: Query<&crate::region::Region>,
+    // Hotfix-3: bundled because individual stockpile + build queue +
+    // building registry params would push the function over Bevy's
+    // 16-param limit.
+    resource_gate: ResourceGateParams,
     #[cfg(feature = "ai-log")] mut log: Option<ResMut<super::debug_log::AiLogConfig>>,
 ) {
     use crate::knowledge::SystemVisibilityTier;
@@ -1111,10 +1152,12 @@ pub fn npc_decision_tick(
                     .unwrap_or([0.0, 0.0, 0.0]);
                 let has_pending = pending_assigned_ships.contains(&ship_entity);
                 let is_idle = system.is_some() && queue.commands.is_empty() && !has_pending;
-                let can_survey = design_registry
+                let can_survey = resource_gate
+                    .design_registry
                     .as_ref()
                     .is_some_and(|r| r.can_survey(&ship.design_id));
-                let can_colonize = design_registry
+                let can_colonize = resource_gate
+                    .design_registry
                     .as_ref()
                     .is_some_and(|r| r.can_colonize(&ship.design_id));
                 let is_combat = !can_survey && !can_colonize && !ship.is_immobile();
@@ -1212,6 +1255,95 @@ pub fn npc_decision_tick(
             let split = colonizable_demand.min(all_idle_colonizers.len());
             (&all_idle_colonizers[..split], &all_idle_colonizers[split..])
         };
+
+        // Hotfix-3 (A): empire-wide fleet census. The Rule 6 logic
+        // needs to see the explorer that's currently surveying
+        // (which is in `ShipState::Surveying`, NOT
+        // `ShipState::InSystem`, so it was evicted by the
+        // `info.system.is_some()` filter that builds
+        // `NpcContext.ships`). We re-walk `all_ships` here with
+        // only the empire-ownership filter so every alive ship is
+        // counted regardless of state.
+        //
+        // Same-design ships already queued in any colony build
+        // queue owned by this empire are also folded in so the
+        // count rises the moment Rule 6 emits a `build_ship`
+        // proposal, not 30 hexadies later when the ship spawns.
+        // Without this, the gate fires once, the dedup absorbs
+        // re-emissions for that one build, but the moment build
+        // completes the new ship starts surveying and Rule 6 sees
+        // `survey_count == 0` again — infinite loop returns.
+        let mut census = crate::ai::mid_adapter::FleetComposition::default();
+        if let Some(ref registry) = resource_gate.design_registry {
+            for (_, ship, _, _) in &all_ships {
+                if ship.owner != crate::ship::Owner::Empire(entity) {
+                    continue;
+                }
+                let can_survey = registry.can_survey(&ship.design_id);
+                let can_colonize = registry.can_colonize(&ship.design_id);
+                let is_combat = !can_survey && !can_colonize && !ship.is_immobile();
+                if can_survey {
+                    census.survey_count += 1;
+                }
+                if can_colonize {
+                    census.colony_count += 1;
+                }
+                if is_combat {
+                    census.combat_count += 1;
+                }
+            }
+            // Fold queued (not-yet-spawned) ship orders from every
+            // empire-owned colony into the census. `BuildKind::Ship`
+            // entries name a `design_id`; `Deliverable` entries do
+            // not contribute (they expand into Core / payload items,
+            // not ships).
+            for (queue, owner) in &resource_gate.build_queues {
+                if owner.0 != entity {
+                    continue;
+                }
+                for order in &queue.queue {
+                    if !matches!(order.kind, crate::colony::building_queue::BuildKind::Ship) {
+                        continue;
+                    }
+                    let can_survey = registry.can_survey(&order.design_id);
+                    let can_colonize = registry.can_colonize(&order.design_id);
+                    // Mirror the per-ship `is_combat` derivation. We
+                    // can't reach `is_immobile()` from a design id
+                    // without instantiating; queued ships are always
+                    // mobile by construction (Lua-defined hulls have
+                    // sublight_speed > 0 for the player-facing
+                    // designs Rule 6 emits), so we treat them as
+                    // mobile here.
+                    let is_combat = !can_survey && !can_colonize;
+                    if can_survey {
+                        census.survey_count += 1;
+                    }
+                    if can_colonize {
+                        census.colony_count += 1;
+                    }
+                    if is_combat {
+                        census.combat_count += 1;
+                    }
+                }
+            }
+        }
+
+        // Hotfix-3 (B): empire-wide stockpile. Sum across the Mid's
+        // `member_systems`. Today every empire has one region whose
+        // `member_systems` is the empire's owned-system set, so this
+        // equals the empire total. Multi-region splits (PR2c+) keep
+        // the per-region sum intact — each Mid sees only its own
+        // region's stockpile, which is the correct soft gate for
+        // per-region build decisions.
+        let mut current_minerals = crate::amount::Amt::ZERO;
+        let mut current_energy = crate::amount::Amt::ZERO;
+        for &sys in member_systems_slice {
+            if let Ok(stockpile) = resource_gate.stockpiles.get(sys) {
+                current_minerals = current_minerals.add(stockpile.minerals);
+                current_energy = current_energy.add(stockpile.energy);
+            }
+        }
+
         let adapter = crate::ai::mid_adapter::BevyMidGameAdapter {
             faction: entity,
             context: &context,
@@ -1221,6 +1353,11 @@ pub fn npc_decision_tick(
             member_systems: member_systems_slice,
             expansion_frontier: &context.expansion_frontier_systems,
             idle_couriers: idle_couriers_slice,
+            fleet_composition: census,
+            current_minerals,
+            current_energy,
+            design_registry: resource_gate.design_registry.as_deref(),
+            building_registry: resource_gate.building_registry.as_deref(),
         };
         // Stance is read from the per-MidAgent state. Today every
         // rule ignores stance (`MidStanceAgent::decide` accepts but
@@ -1344,6 +1481,12 @@ pub fn npc_decision_tick(
                 free_building_slots,
                 net_production_energy,
                 net_production_food,
+                // Hotfix-3: reuse the stockpile sum already
+                // computed for the Mid adapter — same `member_systems`
+                // scope, same numbers. The Short adapter consumes
+                // these via `can_afford_building` (Rule 5b).
+                current_minerals,
+                current_energy,
             },
         );
 

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -75,14 +75,29 @@ pub struct ResourceGateParams<'w, 's> {
     /// stockpile sum before the resource gate sees it, so the AI
     /// accounts for its own in-flight commitments when deciding
     /// whether to emit a new build.
+    ///
+    /// PR #531 Codex review fold-in (finding 1): the tuple now
+    /// carries `&Colony` so the pending-subtraction walk can resolve
+    /// each colony's host system via [`crate::colony::Colony::system`]
+    /// and gate by `member_systems_set` — without this filter a
+    /// pending order in region B would erroneously reduce region
+    /// A's available stockpile (the stockpile sum and the pending
+    /// subtraction must share the same region scope).
     pub build_queues: Query<
         'w,
         's,
         (
             &'static crate::colony::building_queue::BuildQueue,
+            &'static crate::colony::Colony,
             &'static crate::faction::FactionOwner,
         ),
     >,
+    /// Planet → host-system resolver used by `Colony::system()` inside
+    /// the per-colony `BuildQueue` walk. Folded into this bundle
+    /// alongside `build_queues` so the call site can look up a
+    /// colony's region membership without adding a top-level
+    /// `Query<&Planet>` (16-param limit).
+    pub planets: Query<'w, 's, &'static crate::galaxy::Planet>,
     /// Per-StarSystem `SystemBuildingQueue` (#529 A migration). Lists
     /// in-flight system-building orders (shipyard / port / research
     /// lab) whose `minerals_remaining` / `energy_remaining` is
@@ -363,26 +378,39 @@ pub struct LastAiDecisionTick(pub i64);
 
 /// Per-tick precompute that `npc_decision_tick` publishes for the
 /// downstream `run_short_agents` system (#449 PR2d). Lets the
-/// per-`ShortAgent` Rule ports read empire-level data without
+/// per-`ShortAgent` Rule ports read region-level data without
 /// re-running the ECS scans `npc_decision_tick` already performed.
 ///
-/// The map is keyed by **empire entity** (the `MidAgent → Region →
-/// empire` chain a Short uses). Cleared at the start of every
-/// `npc_decision_tick` so stale entries from a despawned empire never
-/// leak into the next tick.
+/// PR #531 Codex review fold-in (finding 2): the map is keyed by
+/// **region entity** (= `MidAgent.region`). Pre-fix it was keyed by
+/// empire entity, which silently overwrote earlier MidAgent outputs
+/// when an empire had multiple MidAgents / Regions — every downstream
+/// `run_short_agents` call then read whichever region was inserted
+/// last, making colony ShortAgents gate Rule 5b against another
+/// region's stockpile. Per-region keying preserves the per-MidAgent
+/// stockpile sums + survey assignment slices that PR2c+ multi-region
+/// splits depend on.
+///
+/// Cleared at the start of every `npc_decision_tick` so stale entries
+/// from a despawned region never leak into the next tick.
 ///
 /// Not registered with `Reflect` — purely transient per-tick scratch.
 #[derive(Resource, Default, Debug)]
 pub struct ShortAgentTickInputs {
-    pub per_empire: std::collections::HashMap<Entity, EmpireShortInputs>,
+    pub per_region: std::collections::HashMap<Entity, RegionShortInputs>,
 }
 
-/// Inputs needed by `ShortStanceAgent::decide` for one empire on one
+/// Inputs needed by `ShortStanceAgent::decide` for one region on one
 /// tick. Built by `npc_decision_tick` from the same data it produces
 /// for the Mid layer; consumed by `run_short_agents` to build per-agent
 /// `BevyShortAgentAdapter`s.
+///
+/// PR #531 Codex review fold-in (finding 2): renamed from
+/// `EmpireShortInputs` to reflect that the contents (stockpile sums,
+/// fleet partitions, survey assignments) are region-scoped — each
+/// MidAgent / Region produces one row.
 #[derive(Default, Debug)]
-pub struct EmpireShortInputs {
+pub struct RegionShortInputs {
     /// Per-fleet idle surveyor list: `Ship.fleet == Some(fleet)` AND
     /// `is_idle && can_survey`. Built once per empire; per-fleet
     /// ShortAgents look up by their `ShortScope::Fleet(fleet)` key.
@@ -700,10 +728,14 @@ pub fn npc_decision_tick(
     last_tick.0 = now;
 
     // PR2d: clear stale per-tick scratch from the previous tick before
-    // the empire loop below repopulates it. `run_short_agents` runs
+    // the MidAgent loop below repopulates it. `run_short_agents` runs
     // `.after(npc_decision_tick)` so the data we populate here is the
     // input it consumes the same frame.
-    short_inputs.per_empire.clear();
+    //
+    // PR #531 Codex review fold-in: keyed per-region (was per-empire)
+    // so a multi-MidAgent empire keeps a row per region instead of
+    // overwriting earlier inserts.
+    short_inputs.per_region.clear();
 
     // #299 / #446: precompute per-empire "systems with our own Core"
     // before the empire loop. Used to filter `colonizable_systems` —
@@ -1325,7 +1357,14 @@ pub fn npc_decision_tick(
             // entries name a `design_id`; `Deliverable` entries do
             // not contribute (they expand into Core / payload items,
             // not ships).
-            for (queue, owner) in &resource_gate.build_queues {
+            //
+            // PR #531 Codex review fold-in: the Rule 6 fleet census is
+            // intentionally empire-wide — a ship being built in region
+            // B still belongs to the empire and counts toward
+            // "do we have enough surveyors yet?". The region-scope
+            // filter applies only to the pending stockpile subtraction
+            // walk below, not here.
+            for (queue, _colony, owner) in &resource_gate.build_queues {
                 if owner.0 != entity {
                     continue;
                 }
@@ -1406,8 +1445,24 @@ pub fn npc_decision_tick(
         // adding work to a queue whose tail will starve".
         let mut pending_minerals = crate::amount::Amt::ZERO;
         let mut pending_energy = crate::amount::Amt::ZERO;
-        for (queue, owner) in &resource_gate.build_queues {
+        for (queue, colony, owner) in &resource_gate.build_queues {
             if owner.0 != entity {
+                continue;
+            }
+            // PR #531 Codex review fold-in (finding 1): region-scope
+            // the pending subtraction so it matches the stockpile-sum
+            // scope above. Without this gate, a pending ship /
+            // deliverable in region B would erroneously reduce
+            // region A's available stockpile and could incorrectly
+            // block Rule 6 / Rule 3.5 / shipyard decisions for an
+            // empire whose MidAgents see independent region budgets.
+            // Mirrors the `member_systems_set.contains(&sys_entity)`
+            // gate on `system_building_queues` below — both walks
+            // now share the same region scope.
+            let Some(sys) = colony.system(&resource_gate.planets) else {
+                continue;
+            };
+            if !member_systems_set.contains(&sys) {
                 continue;
             }
             for order in &queue.queue {
@@ -1566,9 +1621,16 @@ pub fn npc_decision_tick(
             .0
             .current(&metric_id("net_production_food"))
             .unwrap_or(0.0);
-        short_inputs.per_empire.insert(
-            entity,
-            EmpireShortInputs {
+        // PR #531 Codex review fold-in (finding 2): key by **region
+        // entity** (= the MidAgent's region), not empire entity. With
+        // one MidAgent per Region, this preserves per-region stockpile
+        // sums + survey assignments for multi-region empires —
+        // previously the second MidAgent's `entity`-keyed insert
+        // overwrote the first's data and `run_short_agents` saw only
+        // "whichever region was inserted last".
+        short_inputs.per_region.insert(
+            mid_agent.region,
+            RegionShortInputs {
                 idle_surveyors_by_fleet,
                 unsurveyed_targets: context.unsurveyed_systems.clone(),
                 survey_assignments_by_fleet,

--- a/macrocosmo/src/ai/short_adapter.rs
+++ b/macrocosmo/src/ai/short_adapter.rs
@@ -79,6 +79,18 @@ pub trait ShortGameAdapter {
     /// Net food production for this colony. Same proxy story as
     /// [`Self::free_building_slots`].
     fn net_production_food(&self) -> f64;
+
+    /// Hotfix-3 resource gate: `true` when the empire's combined
+    /// stockpile can fund `building_id`'s minerals + energy cost
+    /// RIGHT NOW. Soft gate — permits deficit spending as long as
+    /// the stockpile is non-zero. Used by Rule 5b (slot fill —
+    /// `power_plant` / `farm` / `mine`) so a minerals-starved
+    /// colony stops stacking orders the build queue cannot drain.
+    ///
+    /// **Default `true`** = preserves StubAdapter behaviour.
+    fn can_afford_building(&self, _building_id: &str) -> bool {
+        true
+    }
 }
 
 /// Bevy implementation of [`ShortGameAdapter`]. Constructed
@@ -109,6 +121,19 @@ pub struct BevyShortAgentAdapter<'a> {
     pub free_building_slots: f64,
     pub net_production_energy: f64,
     pub net_production_food: f64,
+    /// Hotfix-3: sum of `ResourceStockpile.minerals` across the
+    /// empire's owned systems. Consumed by
+    /// [`ShortGameAdapter::can_afford_building`] in Rule 5b. Zero
+    /// when the empire has no owned systems (defensive).
+    pub current_minerals: crate::amount::Amt,
+    /// Hotfix-3: sum of `ResourceStockpile.energy`. See
+    /// [`Self::current_minerals`].
+    pub current_energy: crate::amount::Amt,
+    /// Hotfix-3: building registry borrow. `None` only in test
+    /// setups that never load the Lua registry; an unknown
+    /// `building_id` returns `true` from the gate so a typo does
+    /// not silently suppress an emission (the handler will warn).
+    pub building_registry: Option<&'a crate::colony::BuildingRegistry>,
 }
 
 impl<'a> ShortGameAdapter for BevyShortAgentAdapter<'a> {
@@ -142,5 +167,15 @@ impl<'a> ShortGameAdapter for BevyShortAgentAdapter<'a> {
 
     fn net_production_food(&self) -> f64 {
         self.net_production_food
+    }
+
+    fn can_afford_building(&self, building_id: &str) -> bool {
+        let Some(registry) = self.building_registry else {
+            return true;
+        };
+        let Some(def) = registry.get(building_id) else {
+            return true;
+        };
+        self.current_minerals >= def.minerals_cost && self.current_energy >= def.energy_cost
     }
 }

--- a/macrocosmo/src/ai/short_agent_runtime.rs
+++ b/macrocosmo/src/ai/short_agent_runtime.rs
@@ -520,15 +520,22 @@ pub fn run_short_agents(
         let faction = to_ai_faction(empire);
 
         // PR2d: route this agent through `ShortStanceAgent` (Rules 2
-        // and 5b). Inputs are sourced from the per-empire scratch
+        // and 5b). Inputs are sourced from the per-region scratch
         // populated by `npc_decision_tick` upstream — Bug A dedup
-        // (`pending_survey_targets`) and the empire's `member_systems`
-        // intersection are already applied there. The Mid-side empire
-        // scratch may be missing if the empire's MidAgent was skipped
-        // this frame (player-empire with `auto_managed = false`); in
-        // that case `idle_surveyors` / `unsurveyed_targets` collapse
-        // to empty slices and `ShortStanceAgent` stays silent.
-        let inputs = short_inputs.per_empire.get(&empire);
+        // (`pending_survey_targets`) and the region's `member_systems`
+        // intersection are already applied there. The Mid-side region
+        // scratch may be missing if the MidAgent was skipped this
+        // frame (`auto_managed = false`, e.g. player empire); in that
+        // case `idle_surveyors` / `unsurveyed_targets` collapse to
+        // empty slices and `ShortStanceAgent` stays silent.
+        //
+        // PR #531 Codex review fold-in (finding 2): look up by
+        // **region entity** (= `mid.region`) so multi-MidAgent
+        // empires read their own region's stockpile sum + fleet
+        // assignments, not "whichever region was inserted last by
+        // the upstream MidAgent loop". Single-MidAgent empires
+        // observe the same behaviour as the pre-fix per-empire key.
+        let inputs = short_inputs.per_region.get(&mid.region);
         // Per-fleet view of `unsurveyed_targets`: filter out anything
         // a sibling Fleet in this empire already claimed earlier in
         // the loop. Allocated owned (not borrowed from `inputs`) so

--- a/macrocosmo/src/ai/short_agent_runtime.rs
+++ b/macrocosmo/src/ai/short_agent_runtime.rs
@@ -464,6 +464,10 @@ pub fn run_short_agents(
     regions: Query<&Region>,
     mid_agents: Query<&super::mid_agent::MidAgent>,
     short_inputs: Res<ShortAgentTickInputs>,
+    // Hotfix-3: building registry needed by Rule 5b's
+    // `can_afford_building` gate. `Option<Res<_>>` so test setups
+    // that never load the Lua registry continue to work.
+    building_registry: Option<Res<crate::colony::BuildingRegistry>>,
     clock: Res<GameClock>,
     mut last_tick: Local<i64>,
 ) {
@@ -595,6 +599,15 @@ pub fn run_short_agents(
                 .unwrap_or((0.0, 0.0, 0.0)),
             ShortScope::Fleet(_) => (0.0, 0.0, 0.0),
         };
+        // Hotfix-3: empire stockpile sums for the resource gate.
+        // Mid populates `current_minerals` / `current_energy` per
+        // empire in the same `npc_decision_tick` pass; we read them
+        // out here. `Amt::ZERO` for empires the Mid skipped this
+        // frame — gate then trivially fails (correct fallback for
+        // "we don't know what they have").
+        let (current_minerals, current_energy) = inputs
+            .map(|i| (i.current_minerals, i.current_energy))
+            .unwrap_or((crate::amount::Amt::ZERO, crate::amount::Amt::ZERO));
         let adapter = BevyShortAgentAdapter {
             empire,
             scope: agent.scope,
@@ -604,6 +617,9 @@ pub fn run_short_agents(
             free_building_slots,
             net_production_energy,
             net_production_food,
+            current_minerals,
+            current_energy,
+            building_registry: building_registry.as_deref(),
         };
         let proposals = ShortStanceAgent::decide(&adapter, faction, now);
         // Record this fleet's survey claims so sibling Fleet

--- a/macrocosmo/src/ai/short_stance.rs
+++ b/macrocosmo/src/ai/short_stance.rs
@@ -86,9 +86,17 @@ impl ShortStanceAgent {
                     } else {
                         "mine"
                     };
-                    let cmd = Command::new(cmd_ids::build_structure(), faction_id, now)
-                        .with_param("building_id", CommandValue::Str(building_id.into()));
-                    proposals.push(Proposal::faction_wide(cmd));
+                    // Hotfix-3 resource gate: don't stack orders an
+                    // empty stockpile cannot fund. Without this a
+                    // single colony absorbed every Reason tick's
+                    // `mine` emit until the queue had 100+ identical
+                    // orders (cf. the brp QA report: "AI re-queues
+                    // identical 'mine' building order every tick").
+                    if adapter.can_afford_building(building_id) {
+                        let cmd = Command::new(cmd_ids::build_structure(), faction_id, now)
+                            .with_param("building_id", CommandValue::Str(building_id.into()));
+                        proposals.push(Proposal::faction_wide(cmd));
+                    }
                 }
             }
         }
@@ -117,6 +125,9 @@ mod tests {
         free_building_slots: f64,
         net_production_energy: f64,
         net_production_food: f64,
+        /// Hotfix-3 resource gate. `None` = permissive default;
+        /// `Some(set)` = explicit allow-list of building ids.
+        affordable_buildings: Option<std::collections::HashSet<String>>,
     }
 
     impl StubAdapter {
@@ -130,6 +141,7 @@ mod tests {
                 free_building_slots: 0.0,
                 net_production_energy: 0.0,
                 net_production_food: 0.0,
+                affordable_buildings: None,
             }
         }
 
@@ -143,6 +155,7 @@ mod tests {
                 free_building_slots: 0.0,
                 net_production_energy: 0.0,
                 net_production_food: 0.0,
+                affordable_buildings: None,
             }
         }
     }
@@ -171,6 +184,12 @@ mod tests {
         }
         fn net_production_food(&self) -> f64 {
             self.net_production_food
+        }
+        fn can_afford_building(&self, building_id: &str) -> bool {
+            match &self.affordable_buildings {
+                Some(set) => set.contains(building_id),
+                None => true,
+            }
         }
     }
 

--- a/macrocosmo/tests/ai_resource_gate_hotfix.rs
+++ b/macrocosmo/tests/ai_resource_gate_hotfix.rs
@@ -328,15 +328,35 @@ fn push_pending_ship_order(
     });
 }
 
-/// Capture `EmpireShortInputs.current_minerals / current_energy` after a
-/// single Mid tick. Asserts the empire's inputs row is populated.
+/// Capture `RegionShortInputs.current_minerals / current_energy` after a
+/// single Mid tick. Asserts the inputs row for the empire's primary
+/// region is populated.
+///
+/// PR #531 Codex review fold-in (finding 2): `ShortAgentTickInputs` is
+/// keyed by **region entity** rather than empire entity, so single-region
+/// test setups resolve the empire's primary region via the
+/// `find_empire_region` helper before indexing.
 fn snapshot_current_amounts(app: &App, empire: Entity) -> (Amt, Amt) {
+    let region = find_empire_region(app, empire);
     let inputs = app.world().resource::<ShortAgentTickInputs>();
-    let empire_inputs = inputs
-        .per_empire
+    let region_inputs = inputs
+        .per_region
+        .get(&region)
+        .expect("RegionShortInputs should be populated for the empire's primary region");
+    (region_inputs.current_minerals, region_inputs.current_energy)
+}
+
+/// Resolve the empire's primary `Region` entity. Used by tests that need
+/// to look up `ShortAgentTickInputs.per_region` keys. Panics if no region
+/// has been backfilled yet (always the case after the first Update
+/// because `backfill_mid_agents_for_ai_controlled` runs every frame).
+fn find_empire_region(app: &App, empire: Entity) -> Entity {
+    let registry = app.world().resource::<macrocosmo::region::RegionRegistry>();
+    *registry
+        .by_empire
         .get(&empire)
-        .expect("EmpireShortInputs should be populated for the empire");
-    (empire_inputs.current_minerals, empire_inputs.current_energy)
+        .and_then(|regions| regions.first())
+        .expect("RegionRegistry should contain at least one region for the empire")
 }
 
 /// #529 A migration: the AI's pending-aware resource gate subtracts every
@@ -361,7 +381,7 @@ fn resource_gate_subtracts_pending_orders_from_stockpile() {
     let (empire, _home) = spawn_empire_with_colony(&mut app);
 
     // Prime: schema::declare_all runs in Startup, the Mid pipeline
-    // populates `EmpireShortInputs` from the first Update onwards.
+    // populates `RegionShortInputs` from the first Update onwards.
     advance_time(&mut app, 1);
     let (m_before, e_before) = snapshot_current_amounts(&app, empire);
 

--- a/macrocosmo/tests/ai_resource_gate_hotfix.rs
+++ b/macrocosmo/tests/ai_resource_gate_hotfix.rs
@@ -1,0 +1,282 @@
+//! Hotfix-3 regression tests — AI resource starvation + Rule 6
+//! fleet-composition semantics.
+//!
+//! Two bugs were observed on a long-run brp QA session:
+//!
+//! 1. **Infinite `explorer_mk1` build loop** — Rule 6's first branch
+//!    fires when `comp.survey_count == 0 && has_unsurveyed_targets`.
+//!    Pre-hotfix `survey_count` was derived from
+//!    `NpcContext.ships`, whose builder filters on
+//!    `info.system.is_some()`. The moment an explorer transitioned
+//!    to `ShipState::Surveying` its `system` collapsed to `None`,
+//!    the count went back to 0, and Rule 6 re-emitted `build_ship
+//!    explorer_mk1` every Reason tick. Each cycle paid the full
+//!    explorer maintenance + build cost, eventually bankrupting the
+//!    starter empire.
+//!
+//! 2. **AI re-queues identical building order every tick** — the brp
+//!    QA report observed a single colony with **165 stacked `mine`
+//!    orders**. Rule 5b emits the same `build_structure` proposal
+//!    every Reason tick once production is short; the per-tick
+//!    dedup that absorbs system-building re-emissions
+//!    (`handle_build_structure` system branch, line ~736) did not
+//!    have a planet-building counterpart, so every emit found a
+//!    free slot and pushed another order.
+//!
+//! Both bugs share a deeper root cause — **no resource gate** on
+//! the build rules. Even with the dedup fixed, an empire with
+//! stockpile == 0 would still emit, queue, and starve. The hotfix
+//! adds a soft `current_stockpile >= cost` gate to every build
+//! emission (Rules 5a / 5b / 6 / 3.5), permitting deficit spending
+//! (revenue < expense) but refusing to stack orders an empty
+//! stockpile cannot fund.
+//!
+//! This integration test pins the consumer-side planet-building
+//! dedup behaviour via the production `drain_ai_commands`
+//! pipeline. Pure-logic gate tests (no Bevy app required) live as
+//! `#[test]`s alongside `MidStanceAgent::decide` in
+//! `src/ai/mid_stance.rs::tests` — they cover Rule 6 fleet-census
+//! semantics, Rule 5a stockpile gate, and the deficit-spending
+//! escape hatch.
+
+mod common;
+
+use bevy::prelude::*;
+
+use macrocosmo::ai::AiPlayerMode;
+use macrocosmo::ai::plugin::AiBusResource;
+use macrocosmo::ai::schema::ids::command as cmd_ids;
+use macrocosmo::amount::Amt;
+use macrocosmo::colony::building_queue::BuildingQueue;
+use macrocosmo::faction::FactionOwner;
+use macrocosmo::knowledge::{KnowledgeStore, SystemVisibilityMap};
+use macrocosmo::player::{Empire, Faction, PlayerEmpire};
+use macrocosmo_ai::{Command, CommandValue};
+
+use common::{
+    advance_time, spawn_mock_core_ship, spawn_test_colony, spawn_test_ruler, spawn_test_system,
+    test_app,
+};
+
+/// Mirror of `to_ai_faction(empire)` (private to the ai module). We
+/// rebuild the conversion here so the test can craft a `Command`
+/// whose `issuer.0 == empire.index()` without pulling in private
+/// internals.
+fn faction_id_for(empire: Entity) -> macrocosmo_ai::FactionId {
+    macrocosmo_ai::FactionId(empire.index().index())
+}
+
+/// Spawn a minimal NPC empire with one colonised, sovereign system
+/// and a non-zero stockpile. Returns `(empire, system)`.
+///
+/// **Why `AiPlayerMode(true)`**: lets the empire be `PlayerEmpire`
+/// while still routing through the AI command pipeline. The test
+/// directly emits commands onto the bus rather than relying on the
+/// Mid rule logic, so the player flag is purely an authorisation
+/// switch.
+fn spawn_empire_with_colony(app: &mut App) -> (Entity, Entity) {
+    app.insert_resource(AiPlayerMode(true));
+
+    let empire = app
+        .world_mut()
+        .spawn((
+            Empire {
+                name: "Stockpile Test".into(),
+            },
+            PlayerEmpire,
+            Faction {
+                id: "stockpile_test".into(),
+                name: "Stockpile Test".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+            KnowledgeStore::default(),
+            SystemVisibilityMap::default(),
+        ))
+        .id();
+
+    let home = spawn_test_system(app.world_mut(), "Home", [0.0, 0.0, 0.0], 1.0, true, true);
+    app.world_mut()
+        .entity_mut(empire)
+        .insert(macrocosmo::galaxy::HomeSystem(home));
+    spawn_test_ruler(app.world_mut(), empire, home);
+
+    // Colony with 4 free slots and a fat stockpile (so the test can
+    // observe the dedup independent of the stockpile gate).
+    let colony = spawn_test_colony(
+        app.world_mut(),
+        home,
+        Amt::units(10_000),
+        Amt::units(10_000),
+        vec![None, None, None, None],
+    );
+    // Re-stamp colony owner (helper picks the first empire it finds,
+    // which can be a different auto-spawned test empire).
+    app.world_mut()
+        .entity_mut(colony)
+        .insert(FactionOwner(empire));
+
+    // Sovereignty is set by `update_sovereignty` from CoreShip → AtSystem
+    // → FactionOwner. Spawning a mock Core ship at home routes the
+    // ownership through the production path; without it the per-tick
+    // `update_sovereignty` resets the manual stamp back to None and
+    // `handle_build_structure`'s owned-systems gate drops the order.
+    spawn_mock_core_ship(app.world_mut(), home, empire);
+
+    (empire, home)
+}
+
+/// Emit a `build_structure(building_id = "mine")` directly onto the
+/// bus, addressed to `empire`. Returns the issued command for log /
+/// assertion.
+fn emit_build_mine(world: &mut World, empire: Entity, now: i64) -> Command {
+    let cmd = Command::new(cmd_ids::build_structure(), faction_id_for(empire), now)
+        .with_param("building_id", CommandValue::Str("mine".into()));
+    world
+        .resource_mut::<AiBusResource>()
+        .0
+        .emit_command(cmd.clone());
+    cmd
+}
+
+/// Hotfix-3: planet-building dedup at the colony level. Emitting the
+/// same `build_structure(mine)` twice within one tick must result in
+/// **one** outstanding `BuildingQueue` order, not two. Pre-hotfix the
+/// dedup branch only fired for system buildings (shipyard / port /
+/// lab); planet buildings (mine / farm / power_plant) stacked
+/// unbounded, leading the brp QA report's 165× mine stack.
+#[test]
+fn planet_building_dedup_at_colony_collapses_duplicate_emits() {
+    let mut app = test_app();
+    let (empire, _home) = spawn_empire_with_colony(&mut app);
+
+    // First tick triggers Startup (registers AI schema kinds, builds
+    // resources). Without this the direct `emit_command` call below
+    // would be dropped with an "undeclared command kind" warning
+    // because `schema::declare_all` runs in Startup.
+    advance_time(&mut app, 1);
+
+    // Two identical `mine` commands in the same tick.
+    emit_build_mine(app.world_mut(), empire, 1);
+    emit_build_mine(app.world_mut(), empire, 1);
+
+    // Drive the AI bus dispatch + handler chain. Origin == destination
+    // (Ruler at home, build_structure resolves to capital == home) so
+    // light-speed delay is zero — five Update cycles is enough to
+    // clear `emit → outbox → drain → handler`.
+    for _ in 0..5 {
+        advance_time(&mut app, 1);
+    }
+
+    let mut found_queues = Vec::new();
+    {
+        let mut q = app.world_mut().query::<(&BuildingQueue, &FactionOwner)>();
+        for (queue, owner) in q.iter(app.world()) {
+            if owner.0 != empire {
+                continue;
+            }
+            let mines = queue
+                .queue
+                .iter()
+                .filter(|o| o.building_id.as_str() == "mine")
+                .count();
+            found_queues.push(mines);
+        }
+    }
+    let total_mines: usize = found_queues.iter().sum();
+    assert_eq!(
+        total_mines, 1,
+        "Hotfix-3 planet dedup: two identical `mine` emits must collapse to one queue order, got per-colony counts {:?}",
+        found_queues,
+    );
+}
+
+/// Hotfix-3: dedup still kicks in across multiple ticks. The
+/// per-tick stockpile gate suppresses fresh emits when the order is
+/// in-flight, but if the AI logic side fails to gate (e.g. legacy
+/// code path, future regression), the consumer-side dedup is the
+/// last line of defense. Pin three back-to-back emits in three
+/// separate ticks → still one queue order.
+#[test]
+fn planet_building_dedup_survives_multi_tick_re_emission() {
+    let mut app = test_app();
+    let (empire, _home) = spawn_empire_with_colony(&mut app);
+
+    // Startup tick first so AI schema is declared (see comment in
+    // `planet_building_dedup_at_colony_collapses_duplicate_emits`).
+    advance_time(&mut app, 1);
+
+    // Tick 1 emit → drive dispatch → tick 2 emit → … → tick 3 emit.
+    emit_build_mine(app.world_mut(), empire, 1);
+    advance_time(&mut app, 1);
+    emit_build_mine(app.world_mut(), empire, 2);
+    advance_time(&mut app, 1);
+    emit_build_mine(app.world_mut(), empire, 3);
+    for _ in 0..3 {
+        advance_time(&mut app, 1);
+    }
+
+    let mut total_mines = 0usize;
+    {
+        let mut q = app.world_mut().query::<(&BuildingQueue, &FactionOwner)>();
+        for (queue, owner) in q.iter(app.world()) {
+            if owner.0 != empire {
+                continue;
+            }
+            total_mines += queue
+                .queue
+                .iter()
+                .filter(|o| o.building_id.as_str() == "mine")
+                .count();
+        }
+    }
+    assert_eq!(
+        total_mines, 1,
+        "Hotfix-3: three sequential `mine` emits across separate ticks must still result in 1 queue order",
+    );
+}
+
+/// Hotfix-3 sanity: dedup is keyed on `building_id`, NOT on order
+/// arrival ordering. A different building (farm) emitted after a
+/// mine must be allowed through — the per-tick stockpile gate is
+/// the only thing that throttles cross-building emits, and we
+/// model an empire with enough stockpile to fund both.
+#[test]
+fn planet_building_dedup_does_not_block_different_building_id() {
+    let mut app = test_app();
+    let (empire, _home) = spawn_empire_with_colony(&mut app);
+
+    // Startup tick first so AI schema is declared.
+    advance_time(&mut app, 1);
+
+    emit_build_mine(app.world_mut(), empire, 1);
+    let farm_cmd = Command::new(cmd_ids::build_structure(), faction_id_for(empire), 1)
+        .with_param("building_id", CommandValue::Str("farm".into()));
+    app.world_mut()
+        .resource_mut::<AiBusResource>()
+        .0
+        .emit_command(farm_cmd);
+
+    for _ in 0..5 {
+        advance_time(&mut app, 1);
+    }
+
+    let (mut mines, mut farms) = (0usize, 0usize);
+    {
+        let mut q = app.world_mut().query::<(&BuildingQueue, &FactionOwner)>();
+        for (queue, owner) in q.iter(app.world()) {
+            if owner.0 != empire {
+                continue;
+            }
+            for o in &queue.queue {
+                match o.building_id.as_str() {
+                    "mine" => mines += 1,
+                    "farm" => farms += 1,
+                    _ => {}
+                }
+            }
+        }
+    }
+    assert_eq!(mines, 1, "one mine queued");
+    assert_eq!(farms, 1, "farm not blocked by mine's dedup entry");
+}

--- a/macrocosmo/tests/ai_resource_gate_hotfix.rs
+++ b/macrocosmo/tests/ai_resource_gate_hotfix.rs
@@ -44,13 +44,18 @@ mod common;
 use bevy::prelude::*;
 
 use macrocosmo::ai::AiPlayerMode;
+use macrocosmo::ai::npc_decision::ShortAgentTickInputs;
 use macrocosmo::ai::plugin::AiBusResource;
 use macrocosmo::ai::schema::ids::command as cmd_ids;
 use macrocosmo::amount::Amt;
-use macrocosmo::colony::building_queue::BuildingQueue;
+use macrocosmo::colony::building_queue::{
+    BuildKind, BuildOrder, BuildQueue, BuildingOrder, BuildingQueue,
+};
+use macrocosmo::colony::system_buildings::SystemBuildingQueue;
 use macrocosmo::faction::FactionOwner;
 use macrocosmo::knowledge::{KnowledgeStore, SystemVisibilityMap};
 use macrocosmo::player::{Empire, Faction, PlayerEmpire};
+use macrocosmo::scripting::building_api::BuildingId;
 use macrocosmo_ai::{Command, CommandValue};
 
 use common::{
@@ -279,4 +284,224 @@ fn planet_building_dedup_does_not_block_different_building_id() {
     }
     assert_eq!(mines, 1, "one mine queued");
     assert_eq!(farms, 1, "farm not blocked by mine's dedup entry");
+}
+
+// ---------------------------------------------------------------------------
+// #529 A migration: pending-aware resource gate (PR #531 fold-in)
+// ---------------------------------------------------------------------------
+
+/// Find the first colony entity owned by `empire` that carries a
+/// `BuildQueue` (ship/deliverable orders). Panics if none exists —
+/// `spawn_empire_with_colony` always attaches one.
+fn find_empire_owned_colony(app: &mut App, empire: Entity) -> Entity {
+    let world = app.world_mut();
+    let mut q = world.query_filtered::<(Entity, &FactionOwner), With<BuildQueue>>();
+    q.iter(world)
+        .find(|(_, o)| o.0 == empire)
+        .map(|(e, _)| e)
+        .expect("empire-owned colony with BuildQueue should exist")
+}
+
+/// Push a synthetic pending ship build order onto `colony`'s `BuildQueue`
+/// with the specified cost / invested split. Used to simulate an
+/// "in-flight" commitment that the pending-aware gate must subtract.
+fn push_pending_ship_order(
+    world: &mut World,
+    colony: Entity,
+    minerals_cost: Amt,
+    minerals_invested: Amt,
+    energy_cost: Amt,
+    energy_invested: Amt,
+) {
+    let mut queue = world.get_mut::<BuildQueue>(colony).unwrap();
+    queue.queue.push(BuildOrder {
+        order_id: 99_999,
+        kind: BuildKind::Ship,
+        design_id: "fake_pending".into(),
+        display_name: "Fake Pending".into(),
+        minerals_cost,
+        minerals_invested,
+        energy_cost,
+        energy_invested,
+        build_time_total: 30,
+        build_time_remaining: 30,
+    });
+}
+
+/// Capture `EmpireShortInputs.current_minerals / current_energy` after a
+/// single Mid tick. Asserts the empire's inputs row is populated.
+fn snapshot_current_amounts(app: &App, empire: Entity) -> (Amt, Amt) {
+    let inputs = app.world().resource::<ShortAgentTickInputs>();
+    let empire_inputs = inputs
+        .per_empire
+        .get(&empire)
+        .expect("EmpireShortInputs should be populated for the empire");
+    (empire_inputs.current_minerals, empire_inputs.current_energy)
+}
+
+/// #529 A migration: the AI's pending-aware resource gate subtracts every
+/// in-flight `BuildOrder`'s **remaining** cost (= `cost - invested`) from
+/// the empire's combined stockpile sum before it reaches the rule layer.
+///
+/// Pre-fix: `current_stockpile_sum >= cost` ignored in-flight orders, so
+/// an empire with 100 minerals and a corvette already queued (cost 80,
+/// invested 0) would happily emit a second corvette (gate sees `100 >=
+/// 50`), and then starve both when the production tick drained the
+/// stockpile. The pending-aware form (= this fold-in) makes the gate see
+/// `100 - 80 = 20` instead, so the second emit is rejected.
+///
+/// We assert by **delta**: snapshot `current_minerals/energy` before and
+/// after injecting the pending order. This sidesteps production /
+/// maintenance drift and per-test-app starter stockpile variations — the
+/// invariant we want to pin is "pending order remaining cost flows into
+/// the published `current_*` values", not the absolute stockpile number.
+#[test]
+fn resource_gate_subtracts_pending_orders_from_stockpile() {
+    let mut app = test_app();
+    let (empire, _home) = spawn_empire_with_colony(&mut app);
+
+    // Prime: schema::declare_all runs in Startup, the Mid pipeline
+    // populates `EmpireShortInputs` from the first Update onwards.
+    advance_time(&mut app, 1);
+    let (m_before, e_before) = snapshot_current_amounts(&app, empire);
+
+    let colony = find_empire_owned_colony(&mut app, empire);
+    // Pending: 80 minerals + 50 energy, invested 0 → remaining = full cost.
+    push_pending_ship_order(
+        app.world_mut(),
+        colony,
+        Amt::units(80),
+        Amt::ZERO,
+        Amt::units(50),
+        Amt::ZERO,
+    );
+
+    // Run another tick so `npc_decision_tick` recomputes the
+    // pending-adjusted stockpile sum.
+    advance_time(&mut app, 1);
+    let (m_after, e_after) = snapshot_current_amounts(&app, empire);
+
+    // delta = before − after (= "the pending order subtracted this much from
+    // the published value"). +1 hex of production raises stockpile but does
+    // NOT change the pending subtraction; for the delta we approximate by
+    // allowing ≥ pending (production may have added to the headroom).
+    let m_subtracted = m_before.sub(m_after);
+    let e_subtracted = e_before.sub(e_after);
+    assert!(
+        m_subtracted >= Amt::units(80),
+        "pending order remaining minerals_cost (80) must lower current_minerals by ≥ 80; \
+         got delta = {:?}, before = {:?}, after = {:?}",
+        m_subtracted,
+        m_before,
+        m_after,
+    );
+    assert!(
+        e_subtracted >= Amt::units(50),
+        "pending order remaining energy_cost (50) must lower current_energy by ≥ 50; \
+         got delta = {:?}, before = {:?}, after = {:?}",
+        e_subtracted,
+        e_before,
+        e_after,
+    );
+}
+
+/// Pending order with partial investment: subtract only the REMAINING
+/// cost (= `cost - invested`), not the full cost. As the order's
+/// production tick consumes resources, the pending-aware gate
+/// progressively unblocks new emits — the AI's "headroom" grows as work
+/// is completed. Same delta-based assertion as the full-cost case above,
+/// just with smaller numbers.
+#[test]
+fn resource_gate_subtracts_only_remaining_cost_when_pending_invested() {
+    let mut app = test_app();
+    let (empire, _home) = spawn_empire_with_colony(&mut app);
+    advance_time(&mut app, 1);
+    let (m_before, e_before) = snapshot_current_amounts(&app, empire);
+
+    let colony = find_empire_owned_colony(&mut app, empire);
+    // 80 cost, 30 already invested → remaining 50.
+    // 50 cost, 20 already invested → remaining 30.
+    push_pending_ship_order(
+        app.world_mut(),
+        colony,
+        Amt::units(80),
+        Amt::units(30),
+        Amt::units(50),
+        Amt::units(20),
+    );
+
+    advance_time(&mut app, 1);
+    let (m_after, e_after) = snapshot_current_amounts(&app, empire);
+
+    let m_subtracted = m_before.sub(m_after);
+    let e_subtracted = e_before.sub(e_after);
+    // The remaining cost is 50 minerals / 30 energy. The lower bound pins
+    // that the subtraction reflects pending — without the pending-aware
+    // logic the delta would be only the production / maintenance drift
+    // between two ticks (≪ 50).
+    //
+    // TODO (#529 follow-up): once the test harness controls production /
+    // maintenance per-tick we can add an upper-bound (= "must NOT subtract
+    // the full cost"). The current delta-based form doesn't reliably
+    // distinguish remaining (50) from full (80) under arbitrary
+    // production drift, but it does pin the contract that *something*
+    // pending-related is subtracted.
+    assert!(
+        m_subtracted >= Amt::units(50),
+        "must subtract at least the remaining cost (80 - 30 = 50); got delta = {:?}",
+        m_subtracted,
+    );
+    assert!(
+        e_subtracted >= Amt::units(30),
+        "must subtract at least the remaining cost (50 - 20 = 30); got delta = {:?}",
+        e_subtracted,
+    );
+}
+
+/// `SystemBuildingQueue` entries (= shipyard / port / research_lab build
+/// orders on the StarSystem) also subtract from the pending-aware
+/// stockpile, mirroring the per-colony `BuildQueue` walk. Sub-agent
+/// implementation note: the walk gates on `member_systems_set` because
+/// `SystemBuildingQueue` has no owner component.
+#[test]
+fn system_building_queue_pending_also_subtracts_from_stockpile() {
+    let mut app = test_app();
+    let (empire, home) = spawn_empire_with_colony(&mut app);
+    advance_time(&mut app, 1);
+    let (m_before, e_before) = snapshot_current_amounts(&app, empire);
+
+    // Push a pending shipyard build order on the home system's
+    // SystemBuildingQueue (= system-level builds: shipyard / port / lab).
+    {
+        let mut q = app
+            .world_mut()
+            .get_mut::<SystemBuildingQueue>(home)
+            .expect("home system should have SystemBuildingQueue (spawned by spawn_test_colony)");
+        q.queue.push(BuildingOrder {
+            order_id: 99_999,
+            building_id: BuildingId::new("shipyard"),
+            target_slot: 0,
+            minerals_remaining: Amt::units(150),
+            energy_remaining: Amt::units(100),
+            build_time_remaining: 30,
+        });
+    }
+
+    advance_time(&mut app, 1);
+    let (m_after, e_after) = snapshot_current_amounts(&app, empire);
+
+    let m_subtracted = m_before.sub(m_after);
+    let e_subtracted = e_before.sub(e_after);
+    assert!(
+        m_subtracted >= Amt::units(150),
+        "system-building queue minerals_remaining (150) must lower current_minerals by ≥ 150; \
+         got delta = {:?}",
+        m_subtracted,
+    );
+    assert!(
+        e_subtracted >= Amt::units(100),
+        "system-building queue energy_remaining (100) must lower current_energy by ≥ 100; \
+         got delta = {:?}",
+        e_subtracted,
+    );
 }

--- a/macrocosmo/tests/ai_resource_gate_region_scope.rs
+++ b/macrocosmo/tests/ai_resource_gate_region_scope.rs
@@ -1,0 +1,406 @@
+//! PR #531 Codex review fold-in regression tests — multi-region
+//! scoping of the AI resource gate.
+//!
+//! Two scoping bugs were flagged by reviewer (frodo821) on the
+//! `fix/hotfix-3-resource-gate` branch:
+//!
+//! 1. **Pending subtraction not region-scoped.** `npc_decision_tick`
+//!    sums `current_minerals/energy` from the MidAgent's
+//!    `member_systems`, but pre-fold it then walked **every** colony
+//!    `BuildQueue` owned by the empire and subtracted those pending
+//!    orders from the per-region stockpile sum. With multiple regions,
+//!    a pending ship in region B would erroneously reduce region A's
+//!    headroom and could incorrectly block Rule 6 / Rule 3.5 / shipyard
+//!    decisions.
+//!
+//! 2. **`ShortAgentTickInputs` keyed by empire, not region.** The
+//!    scratch map populated each tick was keyed by empire entity, so a
+//!    multi-MidAgent empire saw later MidAgent inserts overwrite
+//!    earlier ones; `run_short_agents` then read whichever region was
+//!    inserted last, gating colony ShortAgents against another
+//!    region's stockpile.
+//!
+//! These tests pin the per-region invariants after the fix:
+//! * `colony_pending_outside_region_not_subtracted_from_other_region`
+//! * `multi_midagent_inputs_keyed_by_region_not_overwritten`
+//!
+//! The 2-region setup mirrors `ai_short_agent_per_region_routing.rs`
+//! (manual `Region` + `MidAgent` splice — the production spawn pipeline
+//! only emits one Region per empire today).
+
+mod common;
+
+use bevy::prelude::*;
+
+use macrocosmo::ai::AiPlayerMode;
+use macrocosmo::ai::npc_decision::ShortAgentTickInputs;
+use macrocosmo::ai::{MidAgent, core::MidTermState};
+use macrocosmo::amount::Amt;
+use macrocosmo::colony::ResourceStockpile;
+use macrocosmo::colony::building_queue::{BuildKind, BuildOrder, BuildQueue};
+use macrocosmo::faction::FactionOwner;
+use macrocosmo::galaxy::HomeSystem;
+use macrocosmo::knowledge::{
+    KnowledgeStore, ObservationSource, SystemKnowledge, SystemSnapshot, SystemVisibilityMap,
+    SystemVisibilityTier,
+};
+use macrocosmo::player::{Empire, Faction, PlayerEmpire};
+use macrocosmo::region::{Region, RegionMembership, RegionRegistry, spawn_initial_region};
+
+use common::{advance_time, spawn_test_colony, spawn_test_ruler, spawn_test_system, test_app};
+
+/// Layout of the synthetic 2-region empire used by both tests.
+#[derive(Debug, Clone, Copy)]
+struct TwoRegionLayout {
+    empire: Entity,
+    region_a: Entity,
+    region_b: Entity,
+    home_a: Entity,
+    home_b: Entity,
+    colony_a: Entity,
+    colony_b: Entity,
+}
+
+/// Build a single empire with **two** distinct regions, each containing
+/// one colonised system. Resource stockpiles + KnowledgeStore are
+/// preseeded so `npc_decision_tick` produces a `RegionShortInputs` row
+/// for each MidAgent.
+///
+/// Cost-control note: we set `AiPlayerMode(true)` and tag the empire
+/// `PlayerEmpire` so `mark_player_ai_controlled` flips `AiControlled`
+/// for us — without that the MidAgent loop in `npc_decision_tick`
+/// skips the empire (`auto_managed = false` for un-AI player empires).
+fn build_two_region_layout(app: &mut App) -> TwoRegionLayout {
+    app.insert_resource(AiPlayerMode(true));
+    let world = app.world_mut();
+    if world.get_resource::<RegionRegistry>().is_none() {
+        world.insert_resource(RegionRegistry::default());
+    }
+
+    let empire = world
+        .spawn((
+            Empire {
+                name: "MultiRegion".into(),
+            },
+            PlayerEmpire,
+            Faction {
+                id: "multi_region".into(),
+                name: "MultiRegion".into(),
+                can_diplomacy: false,
+                allowed_diplomatic_options: Default::default(),
+            },
+            KnowledgeStore::default(),
+            SystemVisibilityMap::default(),
+        ))
+        .id();
+
+    let home_a = spawn_test_system(world, "HomeA", [0.0, 0.0, 0.0], 1.0, true, true);
+    let home_b = spawn_test_system(world, "HomeB", [100.0, 0.0, 0.0], 1.0, true, true);
+    world.entity_mut(empire).insert(HomeSystem(home_a));
+
+    spawn_test_ruler(world, empire, home_a);
+
+    // Mark both systems Surveyed in the empire's vis map + record their
+    // snapshot in KnowledgeStore so the MidAgent rule pipeline sees
+    // them as catalogued (otherwise `colonizable_systems` collapses).
+    {
+        let mut em = world.entity_mut(empire);
+        let mut vis = em.get_mut::<SystemVisibilityMap>().unwrap();
+        for sys in [home_a, home_b] {
+            vis.set(sys, SystemVisibilityTier::Surveyed);
+        }
+    }
+    {
+        let mut em = world.entity_mut(empire);
+        let mut store = em.get_mut::<KnowledgeStore>().unwrap();
+        let mut record = |sys: Entity, name: &str, pos: [f64; 3]| {
+            store.update(SystemKnowledge {
+                system: sys,
+                observed_at: 0,
+                received_at: 0,
+                data: SystemSnapshot {
+                    name: name.into(),
+                    position: pos,
+                    surveyed: true,
+                    colonized: true,
+                    ..Default::default()
+                },
+                source: ObservationSource::Direct,
+            });
+        };
+        record(home_a, "HomeA", [0.0, 0.0, 0.0]);
+        record(home_b, "HomeB", [100.0, 0.0, 0.0]);
+    }
+
+    // Region A: spawned via the production helper (member = home_a only).
+    let region_a = spawn_initial_region(world, empire, home_a);
+
+    // Region B: hand-spawned (multi-region splits are not yet emitted
+    // by the production spawn pipeline; matches the pattern used in
+    // `ai_short_agent_per_region_routing.rs`).
+    let region_b = world
+        .spawn(Region {
+            empire,
+            member_systems: vec![home_b],
+            capital_system: home_b,
+            mid_agent: None,
+        })
+        .id();
+    world
+        .entity_mut(home_b)
+        .insert(RegionMembership { region: region_b });
+    world
+        .resource_mut::<RegionRegistry>()
+        .by_empire
+        .entry(empire)
+        .or_default()
+        .push(region_b);
+
+    // One MidAgent per Region.
+    let mid_a = world
+        .spawn(MidAgent {
+            region: region_a,
+            state: MidTermState::default(),
+            auto_managed: true,
+        })
+        .id();
+    let mid_b = world
+        .spawn(MidAgent {
+            region: region_b,
+            state: MidTermState::default(),
+            auto_managed: true,
+        })
+        .id();
+    world.get_mut::<Region>(region_a).unwrap().mid_agent = Some(mid_a);
+    world.get_mut::<Region>(region_b).unwrap().mid_agent = Some(mid_b);
+
+    // Colonies — distinct stockpiles per system so the two
+    // `RegionShortInputs` rows are observably different. Helper
+    // attaches `ResourceStockpile` to the StarSystem on first call.
+    //
+    // Stockpile A: minerals=10_000, energy=5_000
+    // Stockpile B: minerals=  500, energy=  250
+    //
+    // Region A is intentionally much richer than Region B so the
+    // overwrite-style bug (= last-write wins on the empire key) would
+    // collapse both rows to the same value and the test would catch it.
+    let colony_a = spawn_test_colony(
+        world,
+        home_a,
+        Amt::units(10_000),
+        Amt::units(5_000),
+        vec![None, None, None, None],
+    );
+    world.entity_mut(colony_a).insert(FactionOwner(empire));
+    let colony_b = spawn_test_colony(
+        world,
+        home_b,
+        Amt::units(500),
+        Amt::units(250),
+        vec![None, None, None, None],
+    );
+    world.entity_mut(colony_b).insert(FactionOwner(empire));
+
+    TwoRegionLayout {
+        empire,
+        region_a,
+        region_b,
+        home_a,
+        home_b,
+        colony_a,
+        colony_b,
+    }
+}
+
+/// Snapshot the per-region `current_minerals / current_energy` after
+/// the Mid pipeline has run. Panics if either region's row is missing
+/// — the test exists precisely to ensure both rows are populated.
+fn snapshot_per_region(app: &App, region: Entity) -> (Amt, Amt) {
+    let inputs = app.world().resource::<ShortAgentTickInputs>();
+    let row = inputs
+        .per_region
+        .get(&region)
+        .unwrap_or_else(|| panic!("RegionShortInputs missing for region {:?}", region));
+    (row.current_minerals, row.current_energy)
+}
+
+/// Finding 1 regression: a pending build order in **region B** must not
+/// reduce **region A's** published `current_minerals`. Pre-fold-in, the
+/// pending-subtraction walk in `npc_decision_tick` iterated every
+/// colony `BuildQueue` owned by the empire regardless of which region
+/// the colony's host system belonged to — so a pending order in B
+/// silently subtracted from A's headroom.
+#[test]
+fn colony_pending_outside_region_not_subtracted_from_other_region() {
+    let mut app = test_app();
+    let layout = build_two_region_layout(&mut app);
+
+    // Prime: Startup tick declares AI schema + populates the first
+    // `ShortAgentTickInputs` rows.
+    advance_time(&mut app, 1);
+    let (m_a_before, e_a_before) = snapshot_per_region(&app, layout.region_a);
+    let _ = layout.home_a;
+    let _ = layout.home_b;
+
+    // Push a pending ship order onto the colony living in **region B**.
+    {
+        let mut queue = app
+            .world_mut()
+            .get_mut::<BuildQueue>(layout.colony_b)
+            .expect("colony_b should carry BuildQueue (spawn_test_colony seeds it)");
+        queue.queue.push(BuildOrder {
+            order_id: 42,
+            kind: BuildKind::Ship,
+            design_id: "fake_pending_region_b".into(),
+            display_name: "Fake Pending (Region B)".into(),
+            minerals_cost: Amt::units(80),
+            minerals_invested: Amt::ZERO,
+            energy_cost: Amt::units(50),
+            energy_invested: Amt::ZERO,
+            build_time_total: 30,
+            build_time_remaining: 30,
+        });
+    }
+
+    // Re-tick so `npc_decision_tick` recomputes the per-region sums.
+    advance_time(&mut app, 1);
+    let (m_a_after, e_a_after) = snapshot_per_region(&app, layout.region_a);
+    let (m_b_after, e_b_after) = snapshot_per_region(&app, layout.region_b);
+
+    // Region A must be untouched by the pending order in B. We allow
+    // a tiny tolerance for production/maintenance drift between the
+    // two ticks (the `+ 5` minerals/energy seeded by `spawn_test_colony`
+    // production); the pending-order delta (80 / 50) is an order of
+    // magnitude larger than typical drift, so the assertion would
+    // trivially fail under the pre-fold-in code.
+    let region_a_minerals_drift = if m_a_before > m_a_after {
+        m_a_before.sub(m_a_after)
+    } else {
+        m_a_after.sub(m_a_before)
+    };
+    let region_a_energy_drift = if e_a_before > e_a_after {
+        e_a_before.sub(e_a_after)
+    } else {
+        e_a_after.sub(e_a_before)
+    };
+    assert!(
+        region_a_minerals_drift < Amt::units(50),
+        "region A minerals drift = {:?} (before {:?}, after {:?}); a region-B pending order \
+         must NOT subtract from region A's per_region.current_minerals",
+        region_a_minerals_drift,
+        m_a_before,
+        m_a_after,
+    );
+    assert!(
+        region_a_energy_drift < Amt::units(30),
+        "region A energy drift = {:?} (before {:?}, after {:?}); a region-B pending order \
+         must NOT subtract from region A's per_region.current_energy",
+        region_a_energy_drift,
+        e_a_before,
+        e_a_after,
+    );
+
+    // Region B must show the subtraction (= invariant in the inverse
+    // direction — the pending order belongs to B so B's row should
+    // reflect it). This is the same assertion shape as
+    // `resource_gate_subtracts_pending_orders_from_stockpile` in
+    // `ai_resource_gate_hotfix.rs`, restated against the per-region
+    // row.
+    assert!(
+        m_b_after <= Amt::units(500).sub(Amt::units(80)).add(Amt::units(20)),
+        "region B per_region.current_minerals = {:?}; should be <= 500 - 80 + production drift \
+         (the pending order's 80 minerals must be subtracted from region B's row)",
+        m_b_after,
+    );
+    assert!(
+        e_b_after <= Amt::units(250).sub(Amt::units(50)).add(Amt::units(20)),
+        "region B per_region.current_energy = {:?}; should be <= 250 - 50 + production drift",
+        e_b_after,
+    );
+}
+
+/// Finding 2 regression: an empire with **two** MidAgents must produce
+/// two **distinct** `RegionShortInputs` rows — one per region, with
+/// the region-specific stockpile sum. Pre-fold-in, both MidAgents'
+/// inserts collided on the same empire key and the second overwrote
+/// the first.
+///
+/// The setup gives region A 10_000 minerals and region B 500 — the
+/// gap is large enough that the legacy empire-keyed map would have
+/// returned the same value for both lookups, immediately failing the
+/// `!=` assertion. With per-region keying both rows are preserved.
+#[test]
+fn multi_midagent_inputs_keyed_by_region_not_overwritten() {
+    let mut app = test_app();
+    let layout = build_two_region_layout(&mut app);
+
+    advance_time(&mut app, 1);
+
+    let inputs = app.world().resource::<ShortAgentTickInputs>();
+    assert!(
+        inputs.per_region.contains_key(&layout.region_a),
+        "ShortAgentTickInputs.per_region must contain region_a after one Mid tick",
+    );
+    assert!(
+        inputs.per_region.contains_key(&layout.region_b),
+        "ShortAgentTickInputs.per_region must contain region_b after one Mid tick",
+    );
+    assert!(
+        inputs.per_region.len() >= 2,
+        "ShortAgentTickInputs.per_region must hold at least 2 rows for a 2-MidAgent empire; got {}",
+        inputs.per_region.len(),
+    );
+
+    let (m_a, e_a) = snapshot_per_region(&app, layout.region_a);
+    let (m_b, e_b) = snapshot_per_region(&app, layout.region_b);
+
+    // Region A stockpile is order-of-magnitude larger than region B's
+    // (10_000 vs 500). With per-empire keying the second MidAgent
+    // would overwrite the first (or vice versa) and both lookups
+    // would return the same value — fail.
+    assert_ne!(
+        m_a, m_b,
+        "per_region[region_a].current_minerals ({:?}) must differ from \
+         per_region[region_b].current_minerals ({:?}); equal values indicate the legacy \
+         empire-keyed scratch map (per-MidAgent overwrites)",
+        m_a, m_b,
+    );
+    assert_ne!(
+        e_a, e_b,
+        "per_region[region_a].current_energy ({:?}) must differ from \
+         per_region[region_b].current_energy ({:?})",
+        e_a, e_b,
+    );
+
+    // Sanity: region A row reflects the richer stockpile.
+    assert!(
+        m_a > m_b,
+        "region A is seeded with 10_000 minerals and region B with 500; per_region[A] ({:?}) \
+         should exceed per_region[B] ({:?})",
+        m_a,
+        m_b,
+    );
+
+    // Sanity (`ResourceStockpile` on the StarSystem entity stays the
+    // source of truth — the `current_*` fields are derived from it).
+    let stockpile_a = app
+        .world()
+        .get::<ResourceStockpile>(layout.home_a)
+        .expect("home_a should carry ResourceStockpile");
+    let stockpile_b = app
+        .world()
+        .get::<ResourceStockpile>(layout.home_b)
+        .expect("home_b should carry ResourceStockpile");
+    assert!(
+        stockpile_a.minerals > stockpile_b.minerals,
+        "underlying stockpile A should still exceed stockpile B (regression guard against \
+         spawn_test_colony reshuffling resources between systems)",
+    );
+
+    // Make sure the empire entity is still distinct from both region
+    // entities — defends against accidental aliasing in case Bevy
+    // recycles ids in some future refactor (`region_a == empire`
+    // would mask the keying-by-region check).
+    assert_ne!(layout.empire, layout.region_a);
+    assert_ne!(layout.empire, layout.region_b);
+}


### PR DESCRIPTION
## Summary

Closes a brp-QA-captured starvation cascade where Rule 6 stacks infinite `explorer_mk1` builds and Rule 5b stacks identical `mine` orders unbounded — both of which bankrupt the starter empire within a few hundred hexadies. Three coupled fixes plus regression coverage:

- **Rule 6 fleet-composition semantics**: pre-compute an empire census from the unfiltered `all_ships` query + colony `BuildQueue` entries. A surveying explorer (`ShipState::Surveying`, `system == None`) is counted; a queued explorer is counted; the infinite loop closes.
- **Soft resource gate** (`current_stockpile >= cost`) on Rules 3.5 (`deploy_deliverable`), 5a (`build_structure(shipyard)`), 5b (mine/farm/power_plant), and every Rule 6 branch. Soft by design — deficit spending (revenue < expense, but stockpile > 0) is permitted; only an empty stockpile blocks. Rule 6 picks the top-priority unmet need *then* applies the gate, with no fall-through to a cheaper design the player did not authorise.
- **Planet-building dedup at the colony level** in `handle_build_structure` — mirrors the existing system-building dedup so the brp QA report's `165× mine` stack is collapsed to a single outstanding order per `(colony, building_id)`.

Plumbing detail: new `ResourceGateParams` SystemParam bundles `ResourceStockpile` + `BuildQueue` + `BuildingRegistry` + `ShipDesignRegistry` (last one folded in from a standalone `npc_decision_tick` param to free a slot under Bevy's 16-param ceiling). The per-empire stockpile sum is published to `EmpireShortInputs` so `run_short_agents` reuses the same numbers for Rule 5b's gate.

## Root cause

1. **Infinite explorer build loop** — `NpcContext.ships` filters on `info.system.is_some()`. Surveying ships have `system == None` → evicted from list → `survey_count == 0` → Rule 6 re-emits every Reason tick → 1 explorer / 30 hexadies + maintenance accrual → bankruptcy.
2. **165× `mine` stack** — `handle_build_structure`'s planet branch had no per-emit dedup (only the system branch did). Rule 5b emits every tick; each emit found a free slot and pushed another order.
3. **No stockpile gate** — even after both dedup fixes, an empire with stockpile == 0 still emitted orders the colony queue could not drain, freezing the empire's economy at zero throughput.

## Test plan

- [x] `cargo test --workspace --tests -- --test-threads=1` → 3647 passed / 0 failed (baseline 3632 + new tests).
- [x] +7 unit tests in `src/ai/mid_stance.rs::tests` — Rule 6 census semantics, gate behaviour, no-fall-through, deficit-spending escape hatch, Rule 5a gate.
- [x] +3 integration tests in `tests/ai_resource_gate_hotfix.rs` — planet-building dedup via production `drain_ai_commands` pipeline (single-tick, multi-tick, cross-building-id).
- [x] `cargo build --workspace` clean, no new warnings on hotfix files.
- [x] `rustfmt --edition 2024 --check` clean on all touched files.
- [x] SAVE_VERSION 20 unchanged; `tests/fixtures_smoke.rs::load_minimal_game_fixture_smoke` green.
- [x] `tests/smoke.rs::all_systems_no_query_conflict` green (no B0001 from new queries).

## Files

- `macrocosmo/src/ai/mid_adapter.rs` — `MidGameAdapter::can_afford_design` / `can_afford_building`, pre-computed `fleet_composition` field on `BevyMidGameAdapter`.
- `macrocosmo/src/ai/mid_stance.rs` — Rules 3.5 / 5a / 6 gated; Rule 6 priority pick → gate (no fall-through).
- `macrocosmo/src/ai/short_adapter.rs` — `ShortGameAdapter::can_afford_building`, stockpile fields on `BevyShortAgentAdapter`.
- `macrocosmo/src/ai/short_stance.rs` — Rule 5b gated.
- `macrocosmo/src/ai/short_agent_runtime.rs` — wires `BuildingRegistry` + per-empire stockpile from `EmpireShortInputs`.
- `macrocosmo/src/ai/npc_decision.rs` — `ResourceGateParams` SystemParam, fleet census computation, stockpile sum, published to `EmpireShortInputs`.
- `macrocosmo/src/ai/command_consumer.rs` — `handle_build_structure` planet branch: same-building dedup + pending-slot tracking.
- `macrocosmo/tests/ai_resource_gate_hotfix.rs` — new integration test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)