### PR TITLE
fix(ai): Round 17 hotfix bundle — resource gate code-review follow-ups (F1/F2/F3)

### DIFF
--- a/macrocosmo/src/ai/command_consumer.rs
+++ b/macrocosmo/src/ai/command_consumer.rs
@@ -58,6 +58,18 @@ pub struct PendingRulerBoarding {
 pub struct BuildResearchParams<'w, 's> {
     design_registry: Option<Res<'w, ShipDesignRegistry>>,
     building_registry: Option<Res<'w, BuildingRegistry>>,
+    /// #532 F1: deliverable / structure registry borrow used by
+    /// [`handle_build_deliverable`] to resolve cost / build_time /
+    /// cargo_size / display_name for deliverable ids such as
+    /// `"infrastructure_core"`. The deliverable id space is distinct
+    /// from `ShipDesignRegistry` — `define_deliverable { id =
+    /// "infrastructure_core" }` lives here, while
+    /// `define_ship_design { id = "infrastructure_core_v1" }` lives in
+    /// `design_registry`. Before the F1 fold-in the handler resolved
+    /// deliverables through `design_registry`; tests masked the bug by
+    /// injecting a fake `ShipDesignDefinition` with the deliverable id,
+    /// so production Rule 3.5 frontier core deployment silently stalled.
+    deliverable_registry: Option<Res<'w, crate::deep_space::DeliverableRegistry>>,
     /// #470: Ship build orders live on the **Colony** entity (mirror of the
     /// player UI in `system_panel::mod.rs` — the player-facing flow always
     /// picks the first colony in the system as the host). Pre-#470 the AI
@@ -943,34 +955,53 @@ fn handle_build_deliverable(
         return;
     };
 
-    // Resolve cost / build_time from the design registry. Deliverables
-    // share the design registry with ships (both flow through the
-    // shipyard `BuildQueue`); a missing entry means the Lua definition
-    // hasn't been loaded — we surface a warn and skip.
-    let Some(ref registry) = br.design_registry else {
-        warn!("build_deliverable: ShipDesignRegistry not available");
+    // #532 F1: resolve cost / build_time / cargo_size / display_name
+    // from the **DeliverableRegistry**, not the `ShipDesignRegistry`.
+    // Production `scripts/structures/cores.lua` declares
+    // `define_deliverable { id = "infrastructure_core", ... }`, and its
+    // companion `scripts/ships/core_hulls.lua` declares a separate
+    // `define_ship_design { id = "infrastructure_core_v1", ... }` for
+    // the immobile core ship that gets spawned on deploy. Pre-fold-in
+    // this handler used `design_registry.get(definition_id)`, which
+    // resolved against the wrong registry; tests masked the bug by
+    // injecting a fake `ShipDesignDefinition` keyed on the deliverable
+    // id. The queued `BuildOrder.design_id` stays as the deliverable id
+    // (e.g. `"infrastructure_core"`) — downstream
+    // `process_deliverable_commands` uses that to look up
+    // `spawns_as_ship` via the same `DeliverableRegistry`.
+    let Some(ref registry) = br.deliverable_registry else {
+        warn!("build_deliverable: DeliverableRegistry not available");
         return;
     };
-    let Some(design) = registry.get(&definition_id) else {
+    let Some(def) = registry.get(&definition_id) else {
         warn!(
             "build_deliverable: unknown deliverable definition '{}'",
             definition_id
         );
         return;
     };
+    let Some(meta) = def.deliverable.as_ref() else {
+        warn!(
+            "build_deliverable: definition '{}' is not shipyard-buildable \
+             (no DeliverableMetadata — declared via `define_structure`?)",
+            definition_id
+        );
+        return;
+    };
 
-    let build_time = registry.build_time(&definition_id);
     let order = BuildOrder {
         order_id: 0,
-        kind: BuildKind::Deliverable { cargo_size: 1 },
+        kind: BuildKind::Deliverable {
+            cargo_size: meta.cargo_size,
+        },
         design_id: definition_id.clone(),
-        display_name: design.name.clone(),
-        minerals_cost: design.build_cost_minerals,
+        display_name: def.name.clone(),
+        minerals_cost: meta.cost.minerals,
         minerals_invested: Amt::ZERO,
-        energy_cost: design.build_cost_energy,
+        energy_cost: meta.cost.energy,
         energy_invested: Amt::ZERO,
-        build_time_total: build_time,
-        build_time_remaining: build_time,
+        build_time_total: meta.build_time,
+        build_time_remaining: meta.build_time,
     };
 
     // #470: Walk colonies and pick the first one hosted in the chosen
@@ -3173,30 +3204,45 @@ mod tests {
         }
     }
 
-    /// Helper: a minimal deliverable definition in the design registry.
-    /// Mirrors the shape used by `infrastructure_core` in the production
-    /// Lua scripts (cost / build_time small enough that tests don't
-    /// have to advance the queue).
-    fn test_deliverable_design_registry() -> ShipDesignRegistry {
-        use crate::ship_design::ShipDesignDefinition;
-        let mut registry = ShipDesignRegistry::default();
-        registry.insert(ShipDesignDefinition {
+    /// Helper: a minimal deliverable definition in the deliverable
+    /// registry. Mirrors the shape used by `infrastructure_core` in the
+    /// production Lua scripts (cost / build_time small enough that
+    /// tests don't have to advance the queue).
+    ///
+    /// #532 F1: this previously returned a `ShipDesignRegistry` with a
+    /// fake `ShipDesignDefinition` keyed on the deliverable id —
+    /// masking the bug that the handler looked up the wrong registry.
+    /// After F1 the handler resolves via `DeliverableRegistry`, so the
+    /// helper inserts a real `DeliverableDefinition` instead.
+    fn test_deliverable_registry() -> crate::deep_space::DeliverableRegistry {
+        use crate::deep_space::{
+            DeliverableMetadata, DeliverableRegistry, ResourceCost, StructureDefinition,
+        };
+        let mut registry = DeliverableRegistry::default();
+        registry.insert(StructureDefinition {
             id: "infra_core".into(),
             name: "Infrastructure Core".into(),
             description: String::new(),
-            hull_id: "deliverable_hull".into(),
-            modules: vec![],
-            can_survey: false,
-            can_colonize: false,
-            maintenance: Amt::ZERO,
-            build_cost_minerals: Amt::units(20),
-            build_cost_energy: Amt::units(10),
-            build_time: 5,
-            hp: 1.0,
-            sublight_speed: 0.0,
-            ftl_range: 0.0,
-            revision: 0,
-            is_direct_buildable: true,
+            max_hp: 1.0,
+            energy_drain: Amt::ZERO,
+            capabilities: std::collections::HashMap::new(),
+            prerequisites: None,
+            deliverable: Some(DeliverableMetadata {
+                cost: ResourceCost {
+                    minerals: Amt::units(20),
+                    energy: Amt::units(10),
+                },
+                build_time: 5,
+                cargo_size: 1,
+                scrap_refund: 0.25,
+                // These per-handler tests do not exercise the deploy /
+                // spawn pipeline that consumes `spawns_as_ship`.
+                spawns_as_ship: None,
+            }),
+            upgrade_to: Vec::new(),
+            upgrade_from: None,
+            on_built: None,
+            on_upgraded: None,
         });
         registry
     }
@@ -3204,7 +3250,7 @@ mod tests {
     #[test]
     fn build_deliverable_queues_order_at_owned_system() {
         let mut app = test_app();
-        app.insert_resource(test_deliverable_design_registry());
+        app.insert_resource(test_deliverable_registry());
 
         let world = app.world_mut();
         let empire_entity = world
@@ -3272,7 +3318,7 @@ mod tests {
     #[test]
     fn build_deliverable_dedups_same_definition_per_system() {
         let mut app = test_app();
-        app.insert_resource(test_deliverable_design_registry());
+        app.insert_resource(test_deliverable_registry());
 
         let world = app.world_mut();
         let empire_entity = world

--- a/macrocosmo/src/ai/mid_adapter.rs
+++ b/macrocosmo/src/ai/mid_adapter.rs
@@ -235,6 +235,30 @@ pub trait MidGameAdapter {
         true
     }
 
+    /// #532 F2 resource gate: returns the id of the cheapest
+    /// direct-buildable combat design the empire can currently afford
+    /// (pending-aware via [`Self::can_afford_design`]), or `None` if
+    /// no affordable combat design exists.
+    ///
+    /// Rule 8 (fortify) uses this to emit `build_ship{design_id}`
+    /// directly, bypassing the legacy `fortify_system` auto-pick which
+    /// has no affordability check. Mirrors Rules 5a / 6's
+    /// "adapter-decides-then-Mid-emits" pattern: the adapter owns the
+    /// registry walk + gate, the Mid only constructs the [`Command`].
+    ///
+    /// "Combat" matches the legacy `handle_fortify_system` heuristic:
+    /// `is_direct_buildable && !can_survey && !can_colonize`. Cheapest
+    /// tiebreaker = sum of `build_cost_minerals + build_cost_energy`
+    /// (`Amt::saturating_add`).
+    ///
+    /// **Default `None`** = preserves StubAdapter behaviour. The
+    /// `fortify_system` command-kind / handler intentionally remain
+    /// reachable for non-Rule-8 emitters (e.g. future Lua policy
+    /// scripts); only Rule 8's choice of command kind changes.
+    fn affordable_fortify_design(&self) -> Option<String> {
+        None
+    }
+
     /// Current minerals stockpile **net of pending build orders**
     /// (sum across `member_systems` minus
     /// `Σ (minerals_cost - minerals_invested)` across colony
@@ -508,6 +532,26 @@ impl<'a> MidGameAdapter for BevyMidGameAdapter<'a> {
         self.current_minerals >= def.minerals_cost && self.current_energy >= def.energy_cost
     }
 
+    fn affordable_fortify_design(&self) -> Option<String> {
+        // Mirrors the legacy `handle_fortify_system` auto-pick:
+        // `is_direct_buildable && !can_survey && !can_colonize`. Layer
+        // the pending-aware affordability gate on top, then pick the
+        // cheapest by `build_cost_minerals + build_cost_energy`. The
+        // cheapest tiebreaker is the conservative "spend least" choice
+        // — Rule 8 fortifies a low-priority empire-wide combat gap, so
+        // burning the smaller stockpile makes sense; once #467
+        // introduces stance-weighted priorities Rule 8 may want to
+        // pick by combat-effectiveness instead, but that's a follow-up.
+        let registry = self.design_registry?;
+        registry
+            .designs
+            .values()
+            .filter(|d| d.is_direct_buildable && !d.can_survey && !d.can_colonize)
+            .filter(|d| self.can_afford_design(&d.id))
+            .min_by_key(|d| d.build_cost_minerals.add(d.build_cost_energy).0)
+            .map(|d| d.id.clone())
+    }
+
     fn current_minerals(&self) -> Amt {
         self.current_minerals
     }
@@ -530,7 +574,291 @@ pub fn arbitrate(proposals: Vec<Proposal>) -> Vec<Command> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use macrocosmo_ai::{CommandKindId, FactionId, Locality, SystemRef};
+    use crate::ship_design::{ShipDesignDefinition, ShipDesignRegistry};
+    use macrocosmo_ai::{AiBus, CommandKindId, FactionId, Locality, SystemRef};
+
+    /// Build a neutral [`NpcContext`] for adapter-method unit tests.
+    /// `NpcContext` has no `Default` impl (its fields are populated by
+    /// the per-empire ECS scan in `npc_decision_tick`), so the tests
+    /// hand-build an empty one here.
+    fn neutral_npc_context() -> NpcContext {
+        NpcContext {
+            hostile_systems: vec![],
+            unsurveyed_systems: vec![],
+            colonizable_systems: vec![],
+            expansion_frontier_systems: vec![],
+            ships: vec![],
+            is_researching: false,
+            ruler_entity: None,
+            ruler_system: None,
+            ruler_aboard: false,
+        }
+    }
+
+    /// Build a minimal `BevyMidGameAdapter` for adapter-method unit
+    /// tests. `NpcContext` / bus / per-tick scratch slices are all set
+    /// to neutral defaults — tests override only the registry +
+    /// stockpile fields they care about.
+    fn make_adapter<'a>(
+        faction: Entity,
+        context: &'a NpcContext,
+        bus: &'a AiBus,
+        member_systems: &'a [Entity],
+        design_registry: Option<&'a ShipDesignRegistry>,
+        current_minerals: Amt,
+        current_energy: Amt,
+    ) -> BevyMidGameAdapter<'a> {
+        BevyMidGameAdapter {
+            faction,
+            context,
+            bus,
+            idle_combat: &[],
+            idle_colonizers: &[],
+            member_systems,
+            expansion_frontier: &[],
+            idle_couriers: &[],
+            fleet_composition: FleetComposition::default(),
+            current_minerals,
+            current_energy,
+            design_registry,
+            building_registry: None,
+            deliverable_registry: None,
+        }
+    }
+
+    /// Helper: build a ship design with explicit cost/role fields. All
+    /// other fields collapse to neutral defaults the gate doesn't
+    /// inspect.
+    fn design(
+        id: &str,
+        can_survey: bool,
+        can_colonize: bool,
+        minerals: Amt,
+        energy: Amt,
+    ) -> ShipDesignDefinition {
+        ShipDesignDefinition {
+            id: id.into(),
+            name: id.into(),
+            description: String::new(),
+            hull_id: "hull".into(),
+            modules: vec![],
+            can_survey,
+            can_colonize,
+            maintenance: Amt::ZERO,
+            build_cost_minerals: minerals,
+            build_cost_energy: energy,
+            build_time: 30,
+            hp: 100.0,
+            sublight_speed: 0.1,
+            ftl_range: 5.0,
+            revision: 0,
+            is_direct_buildable: true,
+        }
+    }
+
+    /// #532 F2: `affordable_fortify_design` returns the cheapest
+    /// **combat** (`is_direct_buildable && !can_survey && !can_colonize`)
+    /// design the empire can afford. Survey + colony designs must be
+    /// filtered out even when they're cheaper, and unaffordable
+    /// combat designs must be skipped in favour of cheaper affordable
+    /// ones.
+    #[test]
+    fn affordable_fortify_design_picks_cheapest_affordable_combat() {
+        let mut registry = ShipDesignRegistry::default();
+        // Cheaper survey design — must be filtered out by the
+        // !can_survey predicate.
+        registry.insert(design(
+            "explorer",
+            true,
+            false,
+            Amt::units(50),
+            Amt::units(20),
+        ));
+        // Cheap combat design (corvette) — should win the pick.
+        registry.insert(design(
+            "patrol_corvette",
+            false,
+            false,
+            Amt::units(100),
+            Amt::units(50),
+        ));
+        // Expensive combat design (cruiser) — affordable but not
+        // cheapest.
+        registry.insert(design(
+            "heavy_cruiser",
+            false,
+            false,
+            Amt::units(500),
+            Amt::units(300),
+        ));
+
+        let faction = Entity::from_raw_u32(1).unwrap();
+        let context = neutral_npc_context();
+        let bus = AiBus::default();
+        let adapter = make_adapter(
+            faction,
+            &context,
+            &bus,
+            &[],
+            Some(&registry),
+            Amt::units(10_000),
+            Amt::units(10_000),
+        );
+
+        assert_eq!(
+            adapter.affordable_fortify_design(),
+            Some("patrol_corvette".into()),
+            "must pick the cheapest combat design when multiple are affordable",
+        );
+    }
+
+    /// #532 F2: when no combat design is affordable, the adapter
+    /// returns `None` and Rule 8 stays silent.
+    #[test]
+    fn affordable_fortify_design_returns_none_when_bankrupt() {
+        let mut registry = ShipDesignRegistry::default();
+        registry.insert(design(
+            "patrol_corvette",
+            false,
+            false,
+            Amt::units(100),
+            Amt::units(50),
+        ));
+
+        let faction = Entity::from_raw_u32(1).unwrap();
+        let context = neutral_npc_context();
+        let bus = AiBus::default();
+        // Bankrupt stockpile — pending-adjusted balance is zero so
+        // the gate rejects every design.
+        let adapter = make_adapter(
+            faction,
+            &context,
+            &bus,
+            &[],
+            Some(&registry),
+            Amt::ZERO,
+            Amt::ZERO,
+        );
+
+        assert_eq!(
+            adapter.affordable_fortify_design(),
+            None,
+            "bankrupt empire must surface no combat design (Rule 8 silent)",
+        );
+    }
+
+    /// #532 F2: registry that contains only survey + colony designs
+    /// (no combat) returns `None` even with a fat stockpile. Pre-fix
+    /// the legacy `fortify_system` auto-pick would fall through to
+    /// "any direct-buildable design" and queue a survey ship; the
+    /// gate avoids this misuse by filtering on role first.
+    #[test]
+    fn affordable_fortify_design_returns_none_when_no_combat_designs() {
+        let mut registry = ShipDesignRegistry::default();
+        registry.insert(design(
+            "explorer",
+            true,
+            false,
+            Amt::units(50),
+            Amt::units(20),
+        ));
+        registry.insert(design(
+            "colony_ship",
+            false,
+            true,
+            Amt::units(80),
+            Amt::units(40),
+        ));
+
+        let faction = Entity::from_raw_u32(1).unwrap();
+        let context = neutral_npc_context();
+        let bus = AiBus::default();
+        let adapter = make_adapter(
+            faction,
+            &context,
+            &bus,
+            &[],
+            Some(&registry),
+            Amt::units(10_000),
+            Amt::units(10_000),
+        );
+
+        assert_eq!(
+            adapter.affordable_fortify_design(),
+            None,
+            "no combat design in registry → None (even with fat stockpile)",
+        );
+    }
+
+    /// #532 F2: partial affordability — only the cheaper combat design
+    /// is affordable, so it wins even when an expensive option exists.
+    /// Demonstrates the gate-then-pick ordering: affordability filter
+    /// runs **before** the min-cost tiebreaker.
+    #[test]
+    fn affordable_fortify_design_skips_unaffordable_combat_designs() {
+        let mut registry = ShipDesignRegistry::default();
+        registry.insert(design(
+            "patrol_corvette",
+            false,
+            false,
+            Amt::units(100),
+            Amt::units(50),
+        ));
+        registry.insert(design(
+            "heavy_cruiser",
+            false,
+            false,
+            Amt::units(500),
+            Amt::units(300),
+        ));
+
+        let faction = Entity::from_raw_u32(1).unwrap();
+        let context = neutral_npc_context();
+        let bus = AiBus::default();
+        // Enough for corvette (100m / 50e), nowhere near cruiser
+        // (500m / 300e).
+        let adapter = make_adapter(
+            faction,
+            &context,
+            &bus,
+            &[],
+            Some(&registry),
+            Amt::units(150),
+            Amt::units(80),
+        );
+
+        assert_eq!(
+            adapter.affordable_fortify_design(),
+            Some("patrol_corvette".into()),
+            "must skip the unaffordable cruiser and pick the affordable corvette",
+        );
+    }
+
+    /// #532 F2 sanity: with no design registry attached, the adapter
+    /// returns `None` (no registry = no way to surface a design id).
+    /// Production always attaches one; this case covers test setups
+    /// that wire `design_registry: None`.
+    #[test]
+    fn affordable_fortify_design_returns_none_without_registry() {
+        let faction = Entity::from_raw_u32(1).unwrap();
+        let context = neutral_npc_context();
+        let bus = AiBus::default();
+        let adapter = make_adapter(
+            faction,
+            &context,
+            &bus,
+            &[],
+            None,
+            Amt::units(10_000),
+            Amt::units(10_000),
+        );
+
+        assert_eq!(
+            adapter.affordable_fortify_design(),
+            None,
+            "no design registry → no design id surfaced",
+        );
+    }
 
     #[test]
     fn arbitrate_strips_locality_and_preserves_order() {

--- a/macrocosmo/src/ai/mid_adapter.rs
+++ b/macrocosmo/src/ai/mid_adapter.rs
@@ -340,6 +340,15 @@ pub struct BevyMidGameAdapter<'a> {
     /// Hotfix-3: building registry borrow used by
     /// [`MidGameAdapter::can_afford_building`].
     pub building_registry: Option<&'a crate::colony::BuildingRegistry>,
+    /// #532 F1: deliverable registry borrow used by
+    /// [`MidGameAdapter::can_afford_design`] to gate deliverable-id
+    /// affordability (e.g. `"infrastructure_core"` from Rule 3.5). The
+    /// design and deliverable id spaces are disjoint in production Lua
+    /// (`define_deliverable { id = "infrastructure_core" }` vs.
+    /// `define_ship_design { id = "infrastructure_core_v1" }`); the gate
+    /// tries `design_registry` first and falls back to this registry on
+    /// miss so a single `can_afford_design` call covers both kinds.
+    pub deliverable_registry: Option<&'a crate::deep_space::DeliverableRegistry>,
 }
 
 impl<'a> BevyMidGameAdapter<'a> {
@@ -460,19 +469,33 @@ impl<'a> MidGameAdapter for BevyMidGameAdapter<'a> {
     }
 
     fn can_afford_design(&self, design_id: &str) -> bool {
-        // Unknown design → permissive: avoid silently suppressing
-        // a Rule emission on a typo; the handler will warn.
-        let Some(registry) = self.design_registry else {
-            return true;
-        };
-        let Some(def) = registry.get(design_id) else {
-            return true;
-        };
-        // Soft gate: each resource must be individually fundable
-        // out of the current stockpile. Cost == 0 trivially passes
-        // (Amt comparison is on raw u64).
-        self.current_minerals >= def.build_cost_minerals
-            && self.current_energy >= def.build_cost_energy
+        // #532 F1: the `design_id` parameter is overloaded — Rule 6
+        // (`build_ship`) passes a `ShipDesignRegistry` id, while
+        // Rule 3.5 (`build_deliverable` after macro decomposition)
+        // passes a `DeliverableRegistry` id (e.g.
+        // `"infrastructure_core"`). Try ship-design first; on miss,
+        // fall through to the deliverable registry so the gate covers
+        // both kinds with one call. Unknown in **both** registries →
+        // permissive (avoids silently suppressing a Rule emission on a
+        // typo; the handler will warn).
+        if let Some(registry) = self.design_registry {
+            if let Some(def) = registry.get(design_id) {
+                // Soft gate: each resource must be individually
+                // fundable out of the current stockpile. Cost == 0
+                // trivially passes (Amt comparison is on raw u64).
+                return self.current_minerals >= def.build_cost_minerals
+                    && self.current_energy >= def.build_cost_energy;
+            }
+        }
+        if let Some(registry) = self.deliverable_registry {
+            if let Some(def) = registry.get(design_id) {
+                if let Some(meta) = def.deliverable.as_ref() {
+                    return self.current_minerals >= meta.cost.minerals
+                        && self.current_energy >= meta.cost.energy;
+                }
+            }
+        }
+        true
     }
 
     fn can_afford_building(&self, building_id: &str) -> bool {

--- a/macrocosmo/src/ai/mid_stance.rs
+++ b/macrocosmo/src/ai/mid_stance.rs
@@ -254,9 +254,32 @@ impl MidStanceAgent {
         // ----- Rule 8: Fortify when shipyard exists but few ships.
         // Gated on `can_build_ships >= 1.0 && total_ships <
         // colony_count * 2`.
+        //
+        // #532 F2 resource gate: PR #531 added affordability gates to
+        // Rules 3.5 / 5a / 5b / 6 but **missed Rule 8**. Pre-fix this
+        // emitted `fortify_system` (no `design_id`), and the handler's
+        // auto-pick had no affordability check — a bankrupt empire
+        // with a shipyard and `total_ships < colony_count * 2` would
+        // still queue one unaffordable combat ship per Reason tick.
+        //
+        // Fix: the adapter picks the cheapest affordable
+        // direct-buildable combat design (`affordable_fortify_design`,
+        // pending-aware via `can_afford_design`), then we emit
+        // `build_ship{design_id}` directly. When no affordable combat
+        // design exists the rule is silent — a bankrupt empire
+        // shouldn't queue ships at all. Mirrors Rule 5a / Rule 6's
+        // "adapter-decides-then-Mid-emits" pattern.
+        //
+        // The `fortify_system` command kind + handler remain reachable
+        // for non-Rule-8 callers (e.g. future Lua policy scripts);
+        // only Rule 8's choice of command kind changes.
         let total_ships = adapter.total_ships();
-        if can_build >= 1.0 && total_ships < colony_count * 2.0 {
-            let cmd = Command::new(cmd_ids::fortify_system(), faction_id, now);
+        if can_build >= 1.0
+            && total_ships < colony_count * 2.0
+            && let Some(design_id) = adapter.affordable_fortify_design()
+        {
+            let cmd = Command::new(cmd_ids::build_ship(), faction_id, now)
+                .with_param("design_id", CommandValue::Str(design_id.into()));
             proposals.push(Proposal::faction_wide(cmd));
         }
 
@@ -293,6 +316,12 @@ mod tests {
         /// `design_id` strings the stub considers fundable.
         affordable_designs: Option<std::collections::HashSet<String>>,
         affordable_buildings: Option<std::collections::HashSet<String>>,
+        /// #532 F2: Rule 8's adapter-side pick. `Some(id)` = the stub
+        /// surfaces a concrete combat design id for the rule to emit;
+        /// `None` = rule must stay silent (no affordable combat design).
+        /// Defaults to `Some("patrol_corvette")` so legacy Rule 8 tests
+        /// that don't care about F2 semantics keep firing.
+        fortify_design: Option<String>,
     }
 
     impl StubAdapter {
@@ -314,6 +343,7 @@ mod tests {
                 has_colonizable_targets: false,
                 affordable_designs: None,
                 affordable_buildings: None,
+                fortify_design: Some("patrol_corvette".into()),
             }
         }
     }
@@ -372,6 +402,9 @@ mod tests {
                 Some(set) => set.contains(building_id),
                 None => true,
             }
+        }
+        fn affordable_fortify_design(&self) -> Option<String> {
+            self.fortify_design.clone()
         }
     }
 
@@ -710,19 +743,35 @@ mod tests {
         // Conditions for both fire: weak fleet + can_build >= 1 +
         // total_ships < colony_count * 2. Rule 7 returns immediately
         // after retreat — Rule 8 must not emit.
+        //
+        // Force combat_count >= 3 so Rule 6's third branch (build a
+        // corvette when combat < 3) is silent and the only path to a
+        // `build_ship` proposal would be Rule 8. Then assert no
+        // build_ship + retreat present.
         let stub = StubAdapter {
             fleet_ready: 0.2,
             can_build: 1.0,
             total_ships: 1.0,
             colony_count: 3.0,
+            fleet_composition: FleetComposition {
+                survey_count: 1,
+                colony_count: 1,
+                combat_count: 3,
+            },
             ..StubAdapter::empty()
         };
         let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
         assert!(
             proposals
                 .iter()
+                .all(|p| p.command.kind.as_str() != "build_ship"),
+            "Rule 7 must early-return before Rule 8 runs (no build_ship)",
+        );
+        assert!(
+            proposals
+                .iter()
                 .all(|p| p.command.kind.as_str() != "fortify_system"),
-            "Rule 7 must early-return before Rule 8 runs",
+            "#532 F2: Rule 8 no longer emits fortify_system either",
         );
         assert!(
             proposals
@@ -759,10 +808,14 @@ mod tests {
         );
     }
 
-    // ---- Rule 8 (fortify_system) ----
+    // ---- Rule 8 (fortify — #532 F2: now emits build_ship) ----
 
     #[test]
     fn rule_8_fires_when_shipyard_present_and_few_ships() {
+        // #532 F2: Rule 8 now emits `build_ship{design_id}` directly,
+        // sourced from `adapter.affordable_fortify_design()`. The stub
+        // defaults `fortify_design` to `Some("patrol_corvette")` so
+        // pre-F2 tests stay green.
         let stub = StubAdapter {
             can_build: 1.0,
             colony_count: 3.0,
@@ -778,11 +831,26 @@ mod tests {
             ..StubAdapter::empty()
         };
         let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
+        let build = proposals
+            .iter()
+            .find(|p| p.command.kind.as_str() == "build_ship")
+            .expect("Rule 8 must emit build_ship (post-F2)");
+        match build.command.params.get("design_id") {
+            Some(CommandValue::Str(s)) => assert_eq!(
+                s.as_ref(),
+                "patrol_corvette",
+                "Rule 8 must emit the adapter-picked design id",
+            ),
+            _ => panic!("Rule 8 build_ship missing design_id param"),
+        }
+        // Sanity: #532 F2 — fortify_system is no longer emitted by
+        // Rule 8 itself (the command kind / handler remain for other
+        // call paths).
         assert!(
             proposals
                 .iter()
-                .any(|p| p.command.kind.as_str() == "fortify_system"),
-            "Rule 8 must emit fortify_system",
+                .all(|p| p.command.kind.as_str() != "fortify_system"),
+            "#532 F2: Rule 8 no longer emits fortify_system",
         );
     }
 
@@ -803,8 +871,14 @@ mod tests {
         assert!(
             proposals
                 .iter()
+                .all(|p| p.command.kind.as_str() != "build_ship"),
+            "total_ships >= colony_count*2 → no Rule 8 build_ship",
+        );
+        assert!(
+            proposals
+                .iter()
                 .all(|p| p.command.kind.as_str() != "fortify_system"),
-            "total_ships >= colony_count*2 → no fortify",
+            "#532 F2: also no legacy fortify_system",
         );
     }
 
@@ -820,8 +894,46 @@ mod tests {
         assert!(
             proposals
                 .iter()
+                .all(|p| p.command.kind.as_str() != "build_ship"),
+            "can_build < 1 → no Rule 8 build_ship",
+        );
+        assert!(
+            proposals
+                .iter()
                 .all(|p| p.command.kind.as_str() != "fortify_system"),
-            "can_build < 1 → no fortify",
+            "#532 F2: also no legacy fortify_system",
+        );
+    }
+
+    /// #532 F2: Rule 8 must stay silent when no affordable combat
+    /// design exists (`adapter.affordable_fortify_design()` → `None`).
+    /// Pre-F2 this rule emitted `fortify_system` with no
+    /// affordability check, and the handler's auto-pick queued an
+    /// unaffordable combat ship anyway. Post-fix the rule defers
+    /// rather than booking an order the stockpile can't pay for.
+    #[test]
+    fn rule_8_silent_when_no_affordable_combat_design() {
+        let stub = StubAdapter {
+            can_build: 1.0,
+            colony_count: 3.0,
+            total_ships: 1.0,
+            fleet_composition: FleetComposition {
+                survey_count: 1,
+                colony_count: 1,
+                combat_count: 3,
+            },
+            // Adapter says "no affordable combat design" — bankrupt
+            // empire case.
+            fortify_design: None,
+            ..StubAdapter::empty()
+        };
+        let proposals = MidStanceAgent::decide(&stub, &Stance::default(), "vesk", 10);
+        assert!(
+            proposals.iter().all(|p| {
+                let k = p.command.kind.as_str();
+                k != "build_ship" && k != "fortify_system"
+            }),
+            "Rule 8 must stay silent when affordable_fortify_design returns None",
         );
     }
 

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -83,11 +83,17 @@ pub struct ResourceGateParams<'w, 's> {
     /// pending order in region B would erroneously reduce region
     /// A's available stockpile (the stockpile sum and the pending
     /// subtraction must share the same region scope).
+    ///
+    /// #532 F3: tuple also carries `&BuildingQueue` (planet-level
+    /// mine/farm/power_plant queue). Folded onto the same colony
+    /// query rather than spawning a parallel query — same param
+    /// slot, no 16-param ceiling pressure.
     pub build_queues: Query<
         'w,
         's,
         (
             &'static crate::colony::building_queue::BuildQueue,
+            &'static crate::colony::building_queue::BuildingQueue,
             &'static crate::colony::Colony,
             &'static crate::faction::FactionOwner,
         ),
@@ -1371,7 +1377,7 @@ pub fn npc_decision_tick(
             // "do we have enough surveyors yet?". The region-scope
             // filter applies only to the pending stockpile subtraction
             // walk below, not here.
-            for (queue, _colony, owner) in &resource_gate.build_queues {
+            for (queue, _bldg_queue, _colony, owner) in &resource_gate.build_queues {
                 if owner.0 != entity {
                     continue;
                 }
@@ -1428,18 +1434,13 @@ pub fn npc_decision_tick(
         // production tick drained the stockpile.
         //
         // The pending-aware form subtracts `cost - invested` for
-        // every queued ship/deliverable order (colony `BuildQueue`)
-        // and every queued building order (system-level
-        // `SystemBuildingQueue` — shipyard / port / research_lab).
-        // Per-colony `BuildingQueue` (mine / farm / power_plant
-        // construction) is intentionally **not** walked here: those
-        // queues live on Colony entities outside this
-        // `ResourceGateParams` for now (adding the query would push
-        // the bundle past Bevy's 16-param limit). The same-tick
-        // dedup at `handle_build_structure` is the backstop for
-        // planet-building re-emits in the meantime; once the
-        // adapter rules need it the planet `BuildingQueue` will be
-        // folded in too.
+        // every queued ship/deliverable order (colony `BuildQueue`),
+        // every queued building order (system-level
+        // `SystemBuildingQueue` — shipyard / port / research_lab),
+        // and every queued planet-building order (per-colony
+        // `BuildingQueue` — mine / farm / power_plant). Demolition
+        // orders intentionally excluded (refund semantics);
+        // `upgrade_queue` is AI-unreachable today.
         //
         // `Amt::sub` is saturating: if pending > stockpile the
         // available value clamps to zero rather than wrapping, so
@@ -1452,7 +1453,7 @@ pub fn npc_decision_tick(
         // adding work to a queue whose tail will starve".
         let mut pending_minerals = crate::amount::Amt::ZERO;
         let mut pending_energy = crate::amount::Amt::ZERO;
-        for (queue, colony, owner) in &resource_gate.build_queues {
+        for (queue, bldg_queue, colony, owner) in &resource_gate.build_queues {
             if owner.0 != entity {
                 continue;
             }
@@ -1477,6 +1478,15 @@ pub fn npc_decision_tick(
                 let e_rem = order.energy_cost.sub(order.energy_invested);
                 pending_minerals = pending_minerals.add(m_rem);
                 pending_energy = pending_energy.add(e_rem);
+            }
+            // #532 F3: per-colony BuildingQueue (mine/farm/power_plant)
+            // pending — without this, Rule 5b could cross-id stack
+            // (mine + farm + power_plant each pass the gate after one
+            // consumes most resources; handler dedup only catches
+            // same-id repeats).
+            for order in &bldg_queue.queue {
+                pending_minerals = pending_minerals.add(order.minerals_remaining);
+                pending_energy = pending_energy.add(order.energy_remaining);
             }
         }
         for (sys_entity, sys_queue) in &resource_gate.system_building_queues {

--- a/macrocosmo/src/ai/npc_decision.rs
+++ b/macrocosmo/src/ai/npc_decision.rs
@@ -120,6 +120,13 @@ pub struct ResourceGateParams<'w, 's> {
     /// standalone param) to free a slot so [`ResourceGateParams`]
     /// itself fits under Bevy's 16-param ceiling.
     pub design_registry: Option<Res<'w, crate::ship_design::ShipDesignRegistry>>,
+    /// #532 F1: deliverable registry borrow handed to the
+    /// [`BevyMidGameAdapter::can_afford_design`] gate so the same call
+    /// covers Rule 3.5 deliverable ids (e.g. `"infrastructure_core"`)
+    /// as well as Rule 6 ship-design ids. The two id spaces are
+    /// disjoint in production Lua and the gate falls through
+    /// design → deliverable on miss.
+    pub deliverable_registry: Option<Res<'w, crate::deep_space::DeliverableRegistry>>,
 }
 
 /// Marker component: this empire's decisions are made by the AI policy.
@@ -1507,6 +1514,7 @@ pub fn npc_decision_tick(
             current_energy,
             design_registry: resource_gate.design_registry.as_deref(),
             building_registry: resource_gate.building_registry.as_deref(),
+            deliverable_registry: resource_gate.deliverable_registry.as_deref(),
         };
         // Stance is read from the per-MidAgent state. Today every
         // rule ignores stance (`MidStanceAgent::decide` accepts but

--- a/macrocosmo/src/notifications.rs
+++ b/macrocosmo/src/notifications.rs
@@ -73,9 +73,10 @@ pub struct Notification {
     pub id: u64,
     pub title: String,
     pub description: String,
-    /// Free-form icon identifier. Stored verbatim from Lua; not rendered yet
-    /// because the icon registry (#143) is not implemented.
-    #[allow(dead_code)]
+    /// Free-form icon identifier. Stored verbatim from Lua; the pill UI
+    /// uses it as a single-glyph hint when it happens to be one codepoint,
+    /// otherwise falls back to a priority-based placeholder until the icon
+    /// registry (#143) lands.
     pub icon: Option<String>,
     pub priority: NotificationPriority,
     /// Optional star system the banner can jump to when clicked.
@@ -178,6 +179,25 @@ impl Default for Notification {
             priority: NotificationPriority::Medium,
             target_system: None,
             remaining_seconds: None,
+        }
+    }
+}
+
+impl Notification {
+    /// Single-character glyph used inside the small pill UI. Placeholder
+    /// until the icon registry (#143) lands — until then we accept a
+    /// single-codepoint `icon` string verbatim, else fall back to a
+    /// priority-based default. Always returns a renderable str.
+    pub fn pill_glyph(&self) -> &str {
+        if let Some(ref icon) = self.icon {
+            if icon.chars().count() == 1 {
+                return icon.as_str();
+            }
+        }
+        match self.priority {
+            NotificationPriority::High => "!",
+            NotificationPriority::Medium => "i",
+            NotificationPriority::Low => "·",
         }
     }
 }
@@ -684,6 +704,38 @@ mod tests {
     fn legacy_whitelist_covers_player_respawn_and_resource_alert() {
         assert!(is_legacy_whitelisted(&GameEventKind::PlayerRespawn));
         assert!(is_legacy_whitelisted(&GameEventKind::ResourceAlert));
+    }
+
+    #[test]
+    fn pill_glyph_uses_single_codepoint_icon_when_set() {
+        let n = Notification {
+            icon: Some("⚠".to_string()),
+            priority: NotificationPriority::High,
+            ..Default::default()
+        };
+        assert_eq!(n.pill_glyph(), "⚠");
+    }
+
+    #[test]
+    fn pill_glyph_falls_back_for_multi_char_icon() {
+        let n = Notification {
+            icon: Some("warning".to_string()),
+            priority: NotificationPriority::Medium,
+            ..Default::default()
+        };
+        // multi-char icon string is treated as a tag, not a glyph
+        assert_eq!(n.pill_glyph(), "i");
+    }
+
+    #[test]
+    fn pill_glyph_priority_defaults() {
+        let mut n = Notification::default();
+        n.priority = NotificationPriority::High;
+        assert_eq!(n.pill_glyph(), "!");
+        n.priority = NotificationPriority::Medium;
+        assert_eq!(n.pill_glyph(), "i");
+        n.priority = NotificationPriority::Low;
+        assert_eq!(n.pill_glyph(), "·");
     }
 
     #[test]

--- a/macrocosmo/src/ui/mod.rs
+++ b/macrocosmo/src/ui/mod.rs
@@ -997,8 +997,21 @@ fn draw_top_bar_system(
 }
 
 // ---------------------------------------------------------------------------
-// System 2.5: draw_notifications_system — banner stack at the top (#151)
+// System 2.5: draw_notifications_system — horizontal pill row (#151)
 // ---------------------------------------------------------------------------
+//
+// Notifications are rendered as a row of small priority-colored circles
+// anchored to the right edge just below the top bar (Clausewitz-engine
+// style). Newest entries are placed rightmost so the eye lands on them
+// first. Each pill shows a single-character placeholder glyph (replaced
+// by the icon registry once #143 lands); hovering a pill reveals a
+// popup with the full title, description, TTL, Jump, and Dismiss
+// controls.
+
+const PILL_DIAMETER: f32 = 18.0;
+const PILL_SPACING: f32 = 4.0;
+const PILL_POPUP_MAX_WIDTH: f32 = 360.0;
+const PILL_POPUP_MIN_WIDTH: f32 = 260.0;
 
 fn draw_notifications_system(
     mut contexts: EguiContexts,
@@ -1009,8 +1022,6 @@ fn draw_notifications_system(
         return;
     };
 
-    // Snapshot the items so we can iterate without holding a borrow on the
-    // resource while we also mutate it (dismiss, jump).
     let items: Vec<crate::notifications::Notification> = queue.items.clone();
     if items.is_empty() {
         return;
@@ -1019,83 +1030,14 @@ fn draw_notifications_system(
     let mut to_dismiss: Vec<u64> = Vec::new();
     let mut jump_target: Option<Entity> = None;
 
-    egui::Area::new(egui::Id::new("notification_banners"))
-        .anchor(egui::Align2::CENTER_TOP, egui::vec2(0.0, 48.0))
+    egui::Area::new(egui::Id::new("notification_pills"))
+        .anchor(egui::Align2::RIGHT_TOP, egui::vec2(-8.0, 48.0))
         .order(egui::Order::Foreground)
         .show(ctx, |ui| {
-            ui.vertical_centered(|ui| {
-                ui.set_max_width(420.0);
+            ui.spacing_mut().item_spacing.x = PILL_SPACING;
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 for n in &items {
-                    let (border, fill) = match n.priority {
-                        NotificationPriority::High => (
-                            egui::Color32::from_rgb(220, 80, 80),
-                            egui::Color32::from_rgba_premultiplied(60, 14, 14, 230),
-                        ),
-                        NotificationPriority::Medium => (
-                            egui::Color32::from_rgb(230, 200, 90),
-                            egui::Color32::from_rgba_premultiplied(40, 36, 14, 220),
-                        ),
-                        NotificationPriority::Low => (
-                            egui::Color32::DARK_GRAY,
-                            egui::Color32::from_rgba_premultiplied(20, 20, 20, 200),
-                        ),
-                    };
-
-                    egui::Frame::group(ui.style())
-                        .stroke(egui::Stroke::new(1.5, border))
-                        .fill(fill)
-                        .inner_margin(egui::Margin::same(8))
-                        .show(ui, |ui| {
-                            ui.set_min_width(380.0);
-                            ui.horizontal(|ui| {
-                                ui.vertical(|ui| {
-                                    ui.label(
-                                        egui::RichText::new(&n.title)
-                                            .strong()
-                                            .color(egui::Color32::WHITE),
-                                    );
-                                    if !n.description.is_empty() {
-                                        ui.label(
-                                            egui::RichText::new(&n.description)
-                                                .color(egui::Color32::LIGHT_GRAY),
-                                        );
-                                    }
-                                    if let Some(remaining) = n.remaining_seconds {
-                                        ui.label(
-                                            egui::RichText::new(format!(
-                                                "auto-dismiss in {:.0}s",
-                                                remaining.max(0.0),
-                                            ))
-                                            .small()
-                                            .weak(),
-                                        );
-                                    }
-                                });
-                                ui.with_layout(
-                                    egui::Layout::right_to_left(egui::Align::TOP),
-                                    |ui| {
-                                        if ui
-                                            .button(egui::RichText::new("✕").strong())
-                                            .on_hover_text("Dismiss")
-                                            .clicked()
-                                        {
-                                            to_dismiss.push(n.id);
-                                        }
-                                        if let Some(target) = n.target_system {
-                                            if ui
-                                                .button("Jump")
-                                                .on_hover_text("Select target system")
-                                                .clicked()
-                                            {
-                                                jump_target = Some(target);
-                                                to_dismiss.push(n.id);
-                                            }
-                                        }
-                                    },
-                                );
-                            });
-                        });
-                    ui.add_space(4.0);
+                    draw_notification_pill(ui, n, &mut to_dismiss, &mut jump_target);
                 }
             });
         });
@@ -1106,6 +1048,119 @@ fn draw_notifications_system(
     if let Some(target) = jump_target {
         selected_system.0 = Some(target);
     }
+}
+
+fn notification_pill_colors(priority: NotificationPriority) -> (egui::Color32, egui::Color32) {
+    match priority {
+        NotificationPriority::High => (
+            egui::Color32::from_rgb(255, 120, 120),
+            egui::Color32::from_rgb(170, 30, 30),
+        ),
+        NotificationPriority::Medium => (
+            egui::Color32::from_rgb(240, 210, 110),
+            egui::Color32::from_rgb(140, 110, 30),
+        ),
+        NotificationPriority::Low => (
+            egui::Color32::LIGHT_GRAY,
+            egui::Color32::from_rgb(60, 60, 60),
+        ),
+    }
+}
+
+fn draw_notification_pill(
+    ui: &mut egui::Ui,
+    n: &crate::notifications::Notification,
+    to_dismiss: &mut Vec<u64>,
+    jump_target: &mut Option<Entity>,
+) {
+    let (border, fill) = notification_pill_colors(n.priority);
+
+    let size = egui::vec2(PILL_DIAMETER, PILL_DIAMETER);
+    let (rect, pill_response) = ui.allocate_exact_size(size, egui::Sense::click());
+
+    let radius = PILL_DIAMETER * 0.5;
+    let hovered = pill_response.hovered();
+    let painter = ui.painter();
+    painter.circle_filled(rect.center(), radius, fill);
+    painter.circle_stroke(
+        rect.center(),
+        radius,
+        egui::Stroke::new(if hovered { 1.8 } else { 1.2 }, border),
+    );
+    painter.text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        n.pill_glyph(),
+        egui::FontId::proportional(11.0),
+        egui::Color32::WHITE,
+    );
+
+    // Persist hover state across one frame so the cursor can travel from
+    // the pill into the popup without flicker.
+    let memory_id = ui.make_persistent_id(("notif_pill_hover", n.id));
+    let last_frame_active: bool = ui
+        .memory(|m| m.data.get_temp::<bool>(memory_id))
+        .unwrap_or(false);
+
+    let mut popup_hovered = false;
+    if hovered || last_frame_active {
+        let popup_id = ui.make_persistent_id(("notif_pill_popup", n.id));
+        let popup_pos = rect.right_bottom() + egui::vec2(0.0, PILL_SPACING);
+        let popup_response = egui::Area::new(popup_id)
+            .fixed_pos(popup_pos)
+            .order(egui::Order::Tooltip)
+            .pivot(egui::Align2::RIGHT_TOP)
+            .interactable(true)
+            .show(ui.ctx(), |ui| {
+                egui::Frame::popup(ui.style())
+                    .stroke(egui::Stroke::new(1.0, border))
+                    .show(ui, |ui| {
+                        ui.set_max_width(PILL_POPUP_MAX_WIDTH);
+                        ui.set_min_width(PILL_POPUP_MIN_WIDTH);
+                        ui.label(
+                            egui::RichText::new(&n.title)
+                                .strong()
+                                .color(egui::Color32::WHITE),
+                        );
+                        if !n.description.is_empty() {
+                            ui.label(
+                                egui::RichText::new(&n.description)
+                                    .color(egui::Color32::LIGHT_GRAY),
+                            );
+                        }
+                        if let Some(remaining) = n.remaining_seconds {
+                            ui.label(
+                                egui::RichText::new(format!(
+                                    "auto-dismiss in {:.0}s",
+                                    remaining.max(0.0),
+                                ))
+                                .small()
+                                .weak(),
+                            );
+                        }
+                        ui.add_space(2.0);
+                        ui.horizontal(|ui| {
+                            if let Some(target) = n.target_system {
+                                if ui
+                                    .button("Jump")
+                                    .on_hover_text("Select target system")
+                                    .clicked()
+                                {
+                                    *jump_target = Some(target);
+                                    to_dismiss.push(n.id);
+                                }
+                            }
+                            if ui.button("✕ Dismiss").on_hover_text("Dismiss").clicked() {
+                                to_dismiss.push(n.id);
+                            }
+                        });
+                    });
+            });
+        popup_hovered = popup_response.response.hovered();
+    }
+
+    let active_now = hovered || popup_hovered;
+    ui.memory_mut(|m| m.data.insert_temp(memory_id, active_now));
 }
 
 // ---------------------------------------------------------------------------

--- a/macrocosmo/src/ui/ship_panel.rs
+++ b/macrocosmo/src/ui/ship_panel.rs
@@ -698,68 +698,67 @@ pub fn draw_ship_panel(
         // if surviving members are docked. If the player wants to refit
         // the surviving members, they can open one of those members'
         // panels directly.
-        let fleet_refit_summary: Option<FleetRefitSummary> = (is_actionable
-            .then_some(()))
-        .and_then(|()| ship.fleet)
-        .and_then(|fleet_entity| {
-            let fleet = fleets.get(fleet_entity).ok()?;
-            let members = fleet_members.get(fleet_entity).ok()?;
-            let mut eligible = 0usize;
-            let mut total_m = Amt::ZERO;
-            let mut total_e = Amt::ZERO;
-            let mut max_time: i64 = 0;
-            for member in members.iter() {
-                let Ok((_, m_ship, m_state, _, _, _)) = ships_query.get(*member) else {
-                    continue;
-                };
-                let Some(m_design) = design_registry.get(&m_ship.design_id) else {
-                    continue;
-                };
-                if m_design.revision <= m_ship.design_revision {
-                    continue;
+        let fleet_refit_summary: Option<FleetRefitSummary> = (is_actionable.then_some(()))
+            .and_then(|()| ship.fleet)
+            .and_then(|fleet_entity| {
+                let fleet = fleets.get(fleet_entity).ok()?;
+                let members = fleet_members.get(fleet_entity).ok()?;
+                let mut eligible = 0usize;
+                let mut total_m = Amt::ZERO;
+                let mut total_e = Amt::ZERO;
+                let mut max_time: i64 = 0;
+                for member in members.iter() {
+                    let Ok((_, m_ship, m_state, _, _, _)) = ships_query.get(*member) else {
+                        continue;
+                    };
+                    let Some(m_design) = design_registry.get(&m_ship.design_id) else {
+                        continue;
+                    };
+                    if m_design.revision <= m_ship.design_revision {
+                        continue;
+                    }
+                    // #491 PR-2: Per-member docked filter routed through the
+                    // projection view — own-ship eligibility is decided on
+                    // the player's belief, not realtime ECS. A member with no
+                    // projection / snapshot is skipped (mirrors the outline
+                    // tree's no-store / pre-seed handling).
+                    let Some(m_view) = ship_view(
+                        *member,
+                        &m_ship,
+                        &m_state,
+                        viewing_knowledge,
+                        viewing_empire,
+                    ) else {
+                        continue;
+                    };
+                    if !matches!(m_view.state, ShipSnapshotState::InSystem) {
+                        continue;
+                    }
+                    let Some(m_hull) = hull_registry.get(&m_ship.hull_id) else {
+                        continue;
+                    };
+                    let (cm, ce, t) = crate::ship_design::refit_cost_to_design(
+                        &m_ship.modules,
+                        m_design,
+                        m_hull,
+                        module_registry,
+                    );
+                    eligible += 1;
+                    total_m = total_m.add(cm);
+                    total_e = total_e.add(ce);
+                    if t > max_time {
+                        max_time = t;
+                    }
                 }
-                // #491 PR-2: Per-member docked filter routed through the
-                // projection view — own-ship eligibility is decided on
-                // the player's belief, not realtime ECS. A member with no
-                // projection / snapshot is skipped (mirrors the outline
-                // tree's no-store / pre-seed handling).
-                let Some(m_view) = ship_view(
-                    *member,
-                    &m_ship,
-                    &m_state,
-                    viewing_knowledge,
-                    viewing_empire,
-                ) else {
-                    continue;
-                };
-                if !matches!(m_view.state, ShipSnapshotState::InSystem) {
-                    continue;
-                }
-                let Some(m_hull) = hull_registry.get(&m_ship.hull_id) else {
-                    continue;
-                };
-                let (cm, ce, t) = crate::ship_design::refit_cost_to_design(
-                    &m_ship.modules,
-                    m_design,
-                    m_hull,
-                    module_registry,
-                );
-                eligible += 1;
-                total_m = total_m.add(cm);
-                total_e = total_e.add(ce);
-                if t > max_time {
-                    max_time = t;
-                }
-            }
-            Some(FleetRefitSummary {
-                fleet_entity,
-                fleet_name: fleet.name.clone(),
-                eligible_count: eligible,
-                total_cost_minerals: total_m,
-                total_cost_energy: total_e,
-                max_refit_time: max_time,
-            })
-        });
+                Some(FleetRefitSummary {
+                    fleet_entity,
+                    fleet_name: fleet.name.clone(),
+                    eligible_count: eligible,
+                    total_cost_minerals: total_m,
+                    total_cost_energy: total_e,
+                    max_refit_time: max_time,
+                })
+            });
         // #57: Current ROE
         let current_roe = roe_query.get(ship_entity).copied().unwrap_or_default();
         // #57: Command delay for ROE changes.

--- a/macrocosmo/tests/ai_decomposition_e2e.rs
+++ b/macrocosmo/tests/ai_decomposition_e2e.rs
@@ -72,36 +72,56 @@ use macrocosmo::ship::command_events::{
     ColonizeRequested, DeployDeliverableRequested, LoadDeliverableRequested, MoveRequested,
 };
 use macrocosmo::ship::{Cargo, CargoItem, Owner, Ship};
-use macrocosmo::ship_design::{ShipDesignDefinition, ShipDesignRegistry};
 
 use common::{
     advance_time, spawn_mock_core_ship, spawn_test_ruler, spawn_test_ship,
     spawn_test_system_with_planet, test_app,
 };
 
-/// Build a minimal `infra_core` deliverable design and graft it onto
-/// the existing test design registry. Mirrors the `infrastructure_core`
-/// shape used by the production Lua scripts but with cost / build_time
-/// trimmed so handlers don't gate on production progress.
+/// Build a minimal `infra_core` deliverable definition and graft it
+/// onto the test deliverable registry. Mirrors the production
+/// `infrastructure_core` shape from `scripts/structures/cores.lua` but
+/// with cost / build_time trimmed so handlers don't gate on production
+/// progress.
+///
+/// #532 F1: this used to inject a fake `ShipDesignDefinition` keyed on
+/// the deliverable id because `handle_build_deliverable` previously
+/// resolved through `ShipDesignRegistry`. After F1 the handler resolves
+/// through `DeliverableRegistry`, so this fixture inserts the real
+/// shape — anything else and the bug-free production handler would
+/// reject `definition_id = "infra_core"` as unknown.
 fn install_infra_core_design(app: &mut App) {
-    let mut registry = app.world_mut().resource_mut::<ShipDesignRegistry>();
-    registry.insert(ShipDesignDefinition {
+    use macrocosmo::deep_space::{
+        DeliverableMetadata, DeliverableRegistry, ResourceCost, StructureDefinition,
+    };
+    let mut registry = app.world_mut().resource_mut::<DeliverableRegistry>();
+    registry.insert(StructureDefinition {
         id: "infra_core".into(),
         name: "Infrastructure Core".into(),
         description: String::new(),
-        hull_id: "deliverable_hull".into(),
-        modules: vec![],
-        can_survey: false,
-        can_colonize: false,
-        maintenance: Amt::ZERO,
-        build_cost_minerals: Amt::units(20),
-        build_cost_energy: Amt::units(10),
-        build_time: 5,
-        hp: 1.0,
-        sublight_speed: 0.0,
-        ftl_range: 0.0,
-        revision: 0,
-        is_direct_buildable: true,
+        max_hp: 1.0,
+        energy_drain: Amt::ZERO,
+        capabilities: std::collections::HashMap::new(),
+        prerequisites: None,
+        deliverable: Some(DeliverableMetadata {
+            cost: ResourceCost {
+                minerals: Amt::units(20),
+                energy: Amt::units(10),
+            },
+            build_time: 5,
+            cargo_size: 1,
+            scrap_refund: 0.25,
+            // The deploy / spawn pipeline is not exercised by this
+            // decomposition E2E test (cargo is pre-seeded; unload only
+            // checks the cargo entry by id, not the registry's
+            // `spawns_as_ship` ref). Leaving `None` keeps the fixture
+            // minimal.
+            spawns_as_ship: None,
+        }),
+        upgrade_to: Vec::new(),
+        upgrade_from: None,
+        on_built: None,
+        on_upgraded: None,
     });
 }
 

--- a/macrocosmo/tests/ai_deliverable_registry_resolution.rs
+++ b/macrocosmo/tests/ai_deliverable_registry_resolution.rs
@@ -1,0 +1,390 @@
+//! #532 F1 regression: `handle_build_deliverable` resolves cost / build_time /
+//! cargo_size / display_name via the **DeliverableRegistry**, not the
+//! `ShipDesignRegistry`.
+//!
+//! Pre-F1 the handler queried `ShipDesignRegistry` for the `definition_id`
+//! payload. In production, `scripts/structures/cores.lua` declares
+//! `define_deliverable { id = "infrastructure_core", cost = {minerals=600,
+//! energy=400}, build_time = 120, cargo_size = 5, spawns_as_ship =
+//! core_hulls.infrastructure_core_v1 }` — that id lives in the deliverable /
+//! structure registry, while the companion `infrastructure_core_v1` ship
+//! design lives in the design registry. The pre-fix handler looked up the
+//! wrong registry; Rule 3.5 frontier core deployment silently stalled at the
+//! build queue step.
+//!
+//! Old tests (`ai_region_deadlock_hotfix`, `ai_decomposition_e2e`) masked the
+//! bug by injecting a fake `ShipDesignDefinition` whose id matched the
+//! deliverable id. This file is the **production-shape** regression: it
+//! loads the real `scripts/init.lua` so the deliverable comes from the
+//! authoritative Lua definitions, then drives the AI bus end-to-end to
+//! assert the queued `BuildOrder` carries the real production values.
+//!
+//! Two tests:
+//!
+//! 1. `production_lua_infrastructure_core_lands_on_build_queue` — load the
+//!    real Lua, dispatch `build_deliverable(infrastructure_core)`, assert
+//!    the queued `BuildOrder` has `design_id == "infrastructure_core"`,
+//!    `kind == Deliverable { cargo_size: 5 }`, `minerals_cost == 600`,
+//!    `energy_cost == 400`, `build_time_total == 120`.
+//! 2. `bankrupt_stockpile_rejects_infrastructure_core_emission` — same shape
+//!    but with the system's stockpile at zero. Drive the policy through
+//!    `npc_decision_tick` so the resource gate runs, and assert no
+//!    `BuildOrder` lands on the colony's `BuildQueue`.
+
+mod common;
+
+use bevy::prelude::*;
+
+use macrocosmo::ai::plugin::AiBusResource;
+use macrocosmo::ai::schema::ids::command as cmd_ids;
+use macrocosmo::amount::Amt;
+use macrocosmo::colony::building_queue::{BuildKind, BuildQueue};
+use macrocosmo::colony::{Colony, ResourceStockpile};
+use macrocosmo::components::Position;
+use macrocosmo::deep_space::DeliverableRegistry;
+use macrocosmo::faction::FactionOwner;
+use macrocosmo::galaxy::{HomeSystem, Planet, Sovereignty, StarSystem, SystemModifiers};
+use macrocosmo::player::{Empire, Faction};
+use macrocosmo::ship::Owner;
+use macrocosmo_ai::{Command, CommandValue};
+
+use common::{spawn_mock_core_ship, spawn_test_ruler, test_app};
+
+/// Repo-anchored path to the production `scripts/` directory. Mirrors
+/// `sample_scripts_dir` in `tests/knowledge_kinds.rs` — uses
+/// `CARGO_MANIFEST_DIR` as a stable anchor so the test does not depend on
+/// the runner's working directory.
+fn production_scripts_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts")
+}
+
+/// Load the real `scripts/init.lua` + run the structure-definition parser so
+/// the test `DeliverableRegistry` carries the authoritative
+/// `infrastructure_core` definition (cost 600 minerals / 400 energy,
+/// build_time 120, cargo_size 5). `test_app()` initialises an empty
+/// registry; we drain the parsed defs in on top.
+///
+/// Keeping the Lua load contained in this helper means the test asserts
+/// against the production values without each test needing to know about
+/// the `ScriptEngine` / `structure_api` plumbing.
+fn install_production_infrastructure_core(app: &mut App) {
+    use macrocosmo::scripting::ScriptEngine;
+    use macrocosmo::scripting::structure_api::parse_structure_definitions;
+
+    let engine = ScriptEngine::new_with_scripts_dir(production_scripts_dir())
+        .expect("ScriptEngine must construct against the repo's scripts/ dir");
+    let init = engine.scripts_dir().join("init.lua");
+    engine
+        .load_file(&init)
+        .expect("scripts/init.lua must load cleanly");
+
+    let defs = parse_structure_definitions(engine.lua()).expect("parse structures from Lua");
+    let mut registry = app
+        .world_mut()
+        .remove_resource::<DeliverableRegistry>()
+        .unwrap_or_default();
+    for def in defs {
+        registry.insert(def);
+    }
+    app.insert_resource(registry);
+}
+
+/// Single-system NPC empire ready to receive a `build_deliverable` command:
+///   - One owned `StarSystem` (Sovereignty.owner set + Core ship stamped so
+///     `update_sovereignty` doesn't overwrite the owner each tick).
+///   - One `Planet` under that system.
+///   - One `Colony` on that planet, owner = empire, with an empty
+///     `BuildQueue` ready to receive deliverable orders.
+///   - `ResourceStockpile` seeded per the `stockpile` argument so the
+///     resource gate can be exercised either way.
+///   - `HomeSystem` link + `Ruler` so the AI outbox computes `light_delay
+///     == 0` and the command flows through in a single `app.update()`.
+///
+/// Returns `(empire, system, _planet, colony)`. Mirrors the helper in
+/// `tests/ai_ship_build_queue.rs::build_npc_with_shipyard_colony` but
+/// without the shipyard `SystemModifiers` — `build_deliverable` doesn't
+/// gate on a shipyard the same way (`handle_build_deliverable` only
+/// requires an owned system, not a shipyard).
+fn build_npc_with_owned_colony(
+    app: &mut App,
+    stockpile: ResourceStockpile,
+) -> (Entity, Entity, Entity, Entity) {
+    let world = app.world_mut();
+
+    let empire = world
+        .spawn((
+            Empire {
+                name: "Test NPC".into(),
+            },
+            // `PlayerEmpire` suppresses policy-driven `mark_npc_empires_ai_controlled`
+            // so `npc_decision_tick` won't emit stray commands of its own;
+            // the test drives every command manually for deterministic
+            // assertions. The bankrupt test re-installs `AiControlled` by
+            // hand to exercise the resource-gate path.
+            macrocosmo::player::PlayerEmpire,
+            Faction::new("test_npc", "Test NPC"),
+            macrocosmo::knowledge::KnowledgeStore::default(),
+            macrocosmo::knowledge::SystemVisibilityMap::default(),
+            macrocosmo::empire::CommsParams::default(),
+            macrocosmo::condition::ScopedFlags::default(),
+            macrocosmo::technology::TechTree::default(),
+            macrocosmo::technology::ResearchQueue::default(),
+        ))
+        .id();
+
+    let system = world
+        .spawn((
+            StarSystem {
+                name: "Home".into(),
+                is_capital: false,
+                surveyed: true,
+                star_type: "yellow_dwarf".into(),
+            },
+            Position::from([0.0, 0.0, 0.0]),
+            Sovereignty {
+                owner: Some(Owner::Empire(empire)),
+                control_score: 1.0,
+            },
+            SystemModifiers::default(),
+            stockpile,
+        ))
+        .id();
+
+    let planet = world
+        .spawn((Planet {
+            name: "Home I".into(),
+            system,
+            planet_type: "terrestrial".into(),
+        },))
+        .id();
+
+    let colony = world
+        .spawn((
+            Colony {
+                planet,
+                growth_rate: 0.0,
+            },
+            BuildQueue::default(),
+            FactionOwner(empire),
+        ))
+        .id();
+
+    // Without a Core ship, `update_sovereignty` resets
+    // `Sovereignty.owner` to `None` on the first tick — which would
+    // make the empire "own no systems" and silently drop the
+    // `build_deliverable` command before it reaches the routing logic.
+    spawn_mock_core_ship(app.world_mut(), system, empire);
+    spawn_test_ruler(app.world_mut(), empire, system);
+    app.world_mut()
+        .entity_mut(empire)
+        .insert(HomeSystem(system));
+
+    (empire, system, planet, colony)
+}
+
+fn faction_id_for(empire: Entity) -> macrocosmo_ai::FactionId {
+    macrocosmo_ai::FactionId(empire.index().index())
+}
+
+#[test]
+fn production_lua_infrastructure_core_lands_on_build_queue() {
+    let mut app = test_app();
+
+    // Load the authoritative `infrastructure_core` deliverable from the
+    // shipped Lua scripts. This is the load-bearing difference from the
+    // pre-F1 fixture cascade — the test refuses to invent its own cost /
+    // build_time / cargo_size, so a regression in the handler's registry
+    // lookup or in the production Lua values both surface here.
+    install_production_infrastructure_core(&mut app);
+
+    let stockpile = ResourceStockpile {
+        minerals: Amt::units(10_000),
+        energy: Amt::units(10_000),
+        research: Amt::ZERO,
+        food: Amt::units(1_000),
+        authority: Amt::ZERO,
+    };
+    let (empire, _system, _planet, colony) = build_npc_with_owned_colony(&mut app, stockpile);
+
+    // Prime: run Startup so `schema::declare_all` registers
+    // `build_deliverable` in the bus' `specs` table. Without this prime
+    // tick, `emit_command` silently drops the command (the dispatcher's
+    // unknown-kind warn doesn't surface in test stdout by default).
+    app.update();
+
+    // Dispatch the command directly onto the AI bus, bypassing Mid policy
+    // so the test pins only the consumer-side handler. `definition_id`
+    // matches the production Lua `define_deliverable { id =
+    // "infrastructure_core", ... }`.
+    let cmd = Command::new(cmd_ids::build_deliverable(), faction_id_for(empire), 10).with_param(
+        "definition_id",
+        CommandValue::Str("infrastructure_core".into()),
+    );
+    app.world_mut()
+        .resource_mut::<AiBusResource>()
+        .0
+        .emit_command(cmd);
+
+    // Tick the schedule a few times so the command flows
+    // dispatch → outbox → process → drain → handler. `AiPlugin` orders
+    // the whole chain inside one Update; three ticks is slack against
+    // any future ordering shuffle.
+    for _ in 0..3 {
+        app.update();
+    }
+
+    let queue = app
+        .world()
+        .get::<BuildQueue>(colony)
+        .expect("Colony should still carry its BuildQueue after drain");
+    assert_eq!(
+        queue.queue.len(),
+        1,
+        "expected exactly one BuildOrder; got {} entries",
+        queue.queue.len(),
+    );
+
+    let order = &queue.queue[0];
+    assert_eq!(
+        order.design_id, "infrastructure_core",
+        "BuildOrder.design_id must stay as the deliverable id so \
+         `process_deliverable_commands` can resolve `spawns_as_ship` \
+         via the DeliverableRegistry",
+    );
+    // `BuildKind::Deliverable { cargo_size }` must mirror the production
+    // Lua value (5), NOT the pre-F1 hardcoded `1`. This is the assertion
+    // that pins the cargo_size pass-through.
+    match order.kind {
+        BuildKind::Deliverable { cargo_size } => assert_eq!(
+            cargo_size, 5,
+            "cargo_size must come from DeliverableMetadata (5 in production Lua), \
+             not the hardcoded 1 the pre-F1 handler used",
+        ),
+        BuildKind::Ship => panic!(
+            "BuildKind should be Deliverable, got Ship — the handler must not \
+             fall through the ship path for a deliverable id"
+        ),
+    }
+    assert_eq!(
+        order.minerals_cost,
+        Amt::units(600),
+        "minerals_cost must come from DeliverableMetadata.cost \
+         (600 in production Lua)",
+    );
+    assert_eq!(
+        order.energy_cost,
+        Amt::units(400),
+        "energy_cost must come from DeliverableMetadata.cost \
+         (400 in production Lua)",
+    );
+    assert_eq!(
+        order.build_time_total, 120,
+        "build_time_total must come from DeliverableMetadata.build_time \
+         (120 in production Lua)",
+    );
+    assert_eq!(
+        order.build_time_remaining, 120,
+        "build_time_remaining should be initialised to build_time_total",
+    );
+    assert_eq!(
+        order.display_name, "Infrastructure Core",
+        "display_name must mirror the DeliverableDefinition.name field",
+    );
+}
+
+#[test]
+fn bankrupt_stockpile_rejects_infrastructure_core_emission() {
+    // Mirror image of the happy-path test: identical setup, but the
+    // system stockpile is empty. `npc_decision_tick`'s resource gate must
+    // reject the Rule-3.5 emission via `can_afford_design`. With F1's
+    // adapter unification this gate now consults the deliverable
+    // registry (not just the design registry) so an empty stockpile
+    // suppresses the build_deliverable proposal upstream of the
+    // consumer.
+    //
+    // We exercise the gate by directly testing the adapter helper —
+    // the same code path `MidStanceAgent::decide` runs against Rule 3.5
+    // before emitting. Asserting on the adapter keeps the test
+    // independent of policy state machine churn (`MidStanceAgent::decide`
+    // and Rule 3.5's other gates may change; the affordability boolean
+    // is the invariant we're pinning).
+    let mut app = test_app();
+    install_production_infrastructure_core(&mut app);
+
+    let zero_stockpile = ResourceStockpile {
+        minerals: Amt::ZERO,
+        energy: Amt::ZERO,
+        research: Amt::ZERO,
+        food: Amt::ZERO,
+        authority: Amt::ZERO,
+    };
+    let (empire, _system, _planet, colony) = build_npc_with_owned_colony(&mut app, zero_stockpile);
+    app.update();
+
+    // Path 1: assert the adapter helper rejects the emission. This is
+    // the upstream gate the production Rule 3.5 consults. We build the
+    // minimal adapter shape sufficient for the gate (registry borrows
+    // + `current_*` snapshots) — `MidGameAdapter::can_afford_design`
+    // doesn't touch any of the other fields.
+    use macrocosmo::ai::mid_adapter::{BevyMidGameAdapter, FleetComposition, MidGameAdapter};
+    use macrocosmo::ai::npc_decision::NpcContext;
+    use macrocosmo::ship_design::ShipDesignRegistry;
+
+    // `NpcContext` doesn't derive `Default` — the adapter doesn't touch
+    // any of these fields from inside `can_afford_design`, so empty /
+    // None values are sufficient.
+    let context = NpcContext {
+        hostile_systems: Vec::new(),
+        unsurveyed_systems: Vec::new(),
+        colonizable_systems: Vec::new(),
+        expansion_frontier_systems: Vec::new(),
+        ships: Vec::new(),
+        is_researching: false,
+        ruler_entity: None,
+        ruler_system: None,
+        ruler_aboard: false,
+    };
+    let bus = macrocosmo_ai::AiBus::default();
+    let empty: &[Entity] = &[];
+    let design_reg = app.world().resource::<ShipDesignRegistry>();
+    let deliv_reg = app.world().resource::<DeliverableRegistry>();
+    let adapter = BevyMidGameAdapter {
+        faction: empire,
+        context: &context,
+        bus: &bus,
+        idle_combat: empty,
+        idle_colonizers: empty,
+        member_systems: empty,
+        expansion_frontier: empty,
+        idle_couriers: empty,
+        fleet_composition: FleetComposition::default(),
+        current_minerals: Amt::ZERO,
+        current_energy: Amt::ZERO,
+        design_registry: Some(design_reg),
+        building_registry: None,
+        deliverable_registry: Some(deliv_reg),
+    };
+    assert!(
+        !adapter.can_afford_design("infrastructure_core"),
+        "can_afford_design must reject `infrastructure_core` against a zero \
+         stockpile — the deliverable registry costs 600 minerals + 400 energy, \
+         well above the seeded zero",
+    );
+
+    // Path 2 (belt + braces): even if a stale command somehow reaches
+    // the consumer, the BuildQueue stays clean because we never emit.
+    // Run the schedule a few ticks to confirm no side-effects appear.
+    for _ in 0..3 {
+        app.update();
+    }
+    let queue = app
+        .world()
+        .get::<BuildQueue>(colony)
+        .expect("colony BuildQueue must remain attached");
+    assert!(
+        queue.queue.is_empty(),
+        "no BuildOrder should be queued: zero stockpile must suppress the \
+         emission. Got {} entries.",
+        queue.queue.len(),
+    );
+}

--- a/macrocosmo/tests/ai_region_deadlock_hotfix.rs
+++ b/macrocosmo/tests/ai_region_deadlock_hotfix.rs
@@ -253,35 +253,53 @@ fn install_capital_only_region(app: &mut App, empire: Entity, capital: Entity) {
 }
 
 /// Register a minimal `infrastructure_core` deliverable definition in
-/// the test design registry. Mirrors the production
+/// the test deliverable registry. Mirrors the production
 /// `scripts/structures/cores.lua` shape (id matches; cost / build_time
 /// scaled down so tests don't need to advance the BuildQueue out).
 /// Called from each test's setup before any `advance_time` so the
 /// dispatched `build_deliverable` lookup succeeds.
+///
+/// #532 F1: this used to inject a fake `ShipDesignDefinition` with the
+/// deliverable id because `handle_build_deliverable` previously looked
+/// up `ShipDesignRegistry`. After F1 the handler resolves via
+/// `DeliverableRegistry`, so the test fixture has to inject a real
+/// `DeliverableDefinition` instead — otherwise these tests would now
+/// pass the bug-free production handler an unknown deliverable.
 fn register_test_infrastructure_core(app: &mut App) {
     use macrocosmo::amount::Amt;
-    use macrocosmo::ship_design::{ShipDesignDefinition, ShipDesignRegistry};
+    use macrocosmo::deep_space::{
+        DeliverableMetadata, DeliverableRegistry, ResourceCost, StructureDefinition,
+    };
     let mut registry = app
         .world_mut()
-        .remove_resource::<ShipDesignRegistry>()
+        .remove_resource::<DeliverableRegistry>()
         .unwrap_or_default();
-    registry.insert(ShipDesignDefinition {
+    registry.insert(StructureDefinition {
         id: "infrastructure_core".into(),
         name: "Infrastructure Core".into(),
         description: String::new(),
-        hull_id: "infrastructure_core_hull".into(),
-        modules: vec![],
-        can_survey: false,
-        can_colonize: false,
-        maintenance: Amt::ZERO,
-        build_cost_minerals: Amt::units(1),
-        build_cost_energy: Amt::units(1),
-        build_time: 1,
-        hp: 400.0,
-        sublight_speed: 0.0,
-        ftl_range: 0.0,
-        revision: 0,
-        is_direct_buildable: true,
+        max_hp: 400.0,
+        energy_drain: Amt::ZERO,
+        capabilities: std::collections::HashMap::new(),
+        prerequisites: None,
+        deliverable: Some(DeliverableMetadata {
+            cost: ResourceCost {
+                minerals: Amt::units(1),
+                energy: Amt::units(1),
+            },
+            build_time: 1,
+            cargo_size: 1,
+            scrap_refund: 0.25,
+            // Test fixture: in production this points at
+            // `infrastructure_core_v1` (the immobile core ship design).
+            // The deploy / spawn pipeline is not exercised by these
+            // AI-bus tests, so we leave it `None`.
+            spawns_as_ship: None,
+        }),
+        upgrade_to: Vec::new(),
+        upgrade_from: None,
+        on_built: None,
+        on_upgraded: None,
     });
     app.insert_resource(registry);
 }

--- a/macrocosmo/tests/ai_resource_gate_hotfix.rs
+++ b/macrocosmo/tests/ai_resource_gate_hotfix.rs
@@ -526,6 +526,69 @@ fn system_building_queue_pending_also_subtracts_from_stockpile() {
     );
 }
 
+/// #532 F3: per-colony `BuildingQueue` (mine / farm / power_plant) pending
+/// orders must also subtract from the pending-aware stockpile. Without this,
+/// Rule 5b can stack cross-id planet buildings — `handle_build_structure`'s
+/// same-tick dedup only collapses same-id duplicates, so an empire with
+/// stockpile just enough for one mine could still push a mine + a farm +
+/// a power_plant in successive ticks (each id passes the gate on its own,
+/// each id is unique against the handler's dedup, all three orders land,
+/// all three starve).
+///
+/// We pre-queue a single mine `BuildingOrder` on the colony's
+/// `BuildingQueue`, then snapshot the post-tick
+/// `RegionShortInputs.current_minerals/energy` — which is the value Short
+/// Rule 5b's `adapter.can_afford_building` reads. If F3 is wired correctly,
+/// the published value drops by ≥ the pending mine's remaining cost.
+#[test]
+fn resource_gate_subtracts_pending_planet_building_from_stockpile() {
+    let mut app = test_app();
+    let (empire, _home) = spawn_empire_with_colony(&mut app);
+    advance_time(&mut app, 1);
+    let (m_before, e_before) = snapshot_current_amounts(&app, empire);
+
+    let colony = find_empire_owned_colony(&mut app, empire);
+    // Mine cost in `create_test_building_registry`: 150 minerals / 50 energy.
+    // Pre-queue with full remaining cost (no investment yet) so the gate
+    // sees the full pending amount.
+    {
+        let mut q = app
+            .world_mut()
+            .get_mut::<BuildingQueue>(colony)
+            .expect("test colony should carry a BuildingQueue");
+        q.queue.push(BuildingOrder {
+            order_id: 99_998,
+            building_id: BuildingId::new("mine"),
+            target_slot: 0,
+            minerals_remaining: Amt::units(150),
+            energy_remaining: Amt::units(50),
+            build_time_remaining: 10,
+        });
+    }
+
+    advance_time(&mut app, 1);
+    let (m_after, e_after) = snapshot_current_amounts(&app, empire);
+
+    let m_subtracted = m_before.sub(m_after);
+    let e_subtracted = e_before.sub(e_after);
+    assert!(
+        m_subtracted >= Amt::units(150),
+        "#532 F3: pending mine's minerals_remaining (150) must lower current_minerals by ≥ 150; \
+         got delta = {:?}, before = {:?}, after = {:?}",
+        m_subtracted,
+        m_before,
+        m_after,
+    );
+    assert!(
+        e_subtracted >= Amt::units(50),
+        "#532 F3: pending mine's energy_remaining (50) must lower current_energy by ≥ 50; \
+         got delta = {:?}, before = {:?}, after = {:?}",
+        e_subtracted,
+        e_before,
+        e_after,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // #532 F2: Rule 8 fortify resource gate (PR #531 finding 2 fold-in)
 // ---------------------------------------------------------------------------

--- a/macrocosmo/tests/ai_resource_gate_hotfix.rs
+++ b/macrocosmo/tests/ai_resource_gate_hotfix.rs
@@ -525,3 +525,170 @@ fn system_building_queue_pending_also_subtracts_from_stockpile() {
         e_subtracted,
     );
 }
+
+// ---------------------------------------------------------------------------
+// #532 F2: Rule 8 fortify resource gate (PR #531 finding 2 fold-in)
+// ---------------------------------------------------------------------------
+
+/// Install a known cheap combat design for Rule 8's adapter pick. The
+/// test design registry seeded by `test_app()` doesn't include a
+/// deterministic cheapest-combat option; we add `patrol_corvette`
+/// (cost 100m / 50e) explicitly so the pick is pinnable.
+fn install_patrol_corvette(app: &mut App) {
+    use macrocosmo::ship_design::{ShipDesignDefinition, ShipDesignRegistry};
+    let mut registry = app.world_mut().resource_mut::<ShipDesignRegistry>();
+    registry.insert(ShipDesignDefinition {
+        id: "patrol_corvette".into(),
+        name: "Patrol Corvette".into(),
+        description: String::new(),
+        hull_id: "corvette".into(),
+        modules: vec![],
+        can_survey: false,
+        can_colonize: false,
+        maintenance: Amt::new(0, 500),
+        build_cost_minerals: Amt::units(100),
+        build_cost_energy: Amt::units(50),
+        build_time: 30,
+        hp: 100.0,
+        sublight_speed: 0.1,
+        ftl_range: 5.0,
+        revision: 0,
+        is_direct_buildable: true,
+    });
+}
+
+/// Attach a shipyard slot modifier to `system` so the empire's
+/// `can_build_ships` metric reaches 1.0 (Rule 8's gate). Mirrors
+/// `build_npc_with_shipyard_colony` in `ai_ship_build_queue.rs` —
+/// pushes onto the existing `SystemModifiers.shipyard_build_parallel_slots`
+/// in place rather than spawning a station ship, so the test stays
+/// minimal. `spawn_test_system` already attaches a default
+/// `SystemModifiers` component.
+fn attach_shipyard_to_system(world: &mut World, system: Entity) {
+    use macrocosmo::amount::SignedAmt;
+    use macrocosmo::galaxy::SystemModifiers;
+    use macrocosmo::modifier::Modifier;
+    let mut sys_mods = world
+        .get_mut::<SystemModifiers>(system)
+        .expect("spawn_test_system attaches SystemModifiers by default");
+    sys_mods
+        .shipyard_build_parallel_slots
+        .push_modifier(Modifier {
+            id: "fixture_shipyard".into(),
+            label: "Fixture Shipyard".into(),
+            base_add: SignedAmt::units(1),
+            multiplier: SignedAmt::ZERO,
+            add: SignedAmt::ZERO,
+            expires_at: None,
+            on_expire_event: None,
+        });
+}
+
+/// Drain the empire's existing stockpile to zero on its home system.
+/// Used to force Rule 8's affordability gate to reject every combat
+/// design. We can't pass `Amt::ZERO` to `spawn_test_colony` because
+/// the helper attaches the stockpile to the *star system* and we
+/// already spawned with `10_000` to keep other tests in this file
+/// happy; this resets the field post-spawn.
+fn drain_stockpile(world: &mut World, system: Entity) {
+    use macrocosmo::colony::ResourceStockpile;
+    if let Some(mut s) = world.get_mut::<ResourceStockpile>(system) {
+        s.minerals = Amt::ZERO;
+        s.energy = Amt::ZERO;
+    }
+}
+
+/// Count ship-kind orders for `empire` across every colony BuildQueue,
+/// optionally filtered by `design_id`. Walks the whole world because
+/// we don't know in advance which colony Rule 8's pipeline picked as
+/// the host.
+fn count_ship_orders_for_empire(app: &mut App, empire: Entity, design_id: Option<&str>) -> usize {
+    let world = app.world_mut();
+    let mut q = world.query::<(&BuildQueue, &FactionOwner)>();
+    q.iter(world)
+        .filter(|(_, owner)| owner.0 == empire)
+        .map(|(queue, _)| {
+            queue
+                .queue
+                .iter()
+                .filter(|o| matches!(o.kind, BuildKind::Ship))
+                .filter(|o| design_id.is_none_or(|id| o.design_id == id))
+                .count()
+        })
+        .sum()
+}
+
+/// #532 F2 (bankrupt case): an empire with a shipyard but zero
+/// stockpile must NOT queue any combat ship via Rule 8. Pre-fix Rule
+/// 8 emitted `fortify_system` (no `design_id`) and the handler's
+/// auto-pick had no affordability check — every Reason tick added an
+/// unaffordable combat order. Post-fix `affordable_fortify_design`
+/// returns `None` for the bankrupt empire and Rule 8 stays silent.
+#[test]
+fn rule_8_fortify_no_build_when_bankrupt_with_shipyard() {
+    let mut app = test_app();
+    install_patrol_corvette(&mut app);
+    let (empire, home) = spawn_empire_with_colony(&mut app);
+
+    // Add a shipyard so `can_build_ships` metric climbs to 1.0 →
+    // Rule 8's first gate passes.
+    attach_shipyard_to_system(app.world_mut(), home);
+    // Bankrupt the stockpile so the F2 affordability gate must
+    // reject every combat design.
+    drain_stockpile(app.world_mut(), home);
+
+    // Run several Reason ticks so the AI pipeline has multiple
+    // chances to emit. If F2 is wired correctly, Rule 8 stays silent
+    // every tick and no `build_ship` order lands.
+    for _ in 0..6 {
+        advance_time(&mut app, 1);
+    }
+
+    let ship_orders = count_ship_orders_for_empire(&mut app, empire, None);
+    assert_eq!(
+        ship_orders, 0,
+        "#532 F2: bankrupt empire with shipyard must NOT queue any ship via Rule 8; \
+         found {} ship order(s) in BuildQueue",
+        ship_orders,
+    );
+}
+
+/// #532 F2 (affordable case): an empire with a shipyard and enough
+/// stockpile to pay for the cheapest combat design must queue exactly
+/// one `build_ship{design_id = "patrol_corvette"}` order via Rule 8's
+/// new build_ship emit path.
+///
+/// Sanity check that the fix doesn't over-correct into "never builds":
+/// the gate refuses bankrupt empires but still permits the build when
+/// resources are present.
+#[test]
+fn rule_8_fortify_queues_build_ship_when_affordable_with_shipyard() {
+    let mut app = test_app();
+    install_patrol_corvette(&mut app);
+    let (empire, home) = spawn_empire_with_colony(&mut app);
+
+    // Shipyard present + stockpile already at 10_000 (set by
+    // `spawn_empire_with_colony`) → both Rule 8 gates pass.
+    attach_shipyard_to_system(app.world_mut(), home);
+
+    // Let the AI pipeline run several ticks. Rule 8 only fires when
+    // `total_ships < colony_count * 2`; the test fixture has 1 Core
+    // ship + 1 colony, so the threshold (= 2) is met for the first
+    // emit and then the handler-side dedup absorbs subsequent ticks.
+    for _ in 0..6 {
+        advance_time(&mut app, 1);
+    }
+
+    // Look specifically for patrol_corvette — the cheapest combat
+    // design we just installed. Rule 8 picks the cheapest affordable
+    // combat design (via `affordable_fortify_design`), so the test
+    // design registry's other combat designs (if any) will lose the
+    // tiebreaker.
+    let corvette_orders = count_ship_orders_for_empire(&mut app, empire, Some("patrol_corvette"));
+    assert!(
+        corvette_orders >= 1,
+        "#532 F2: shipyard + affordable stockpile must queue ≥ 1 patrol_corvette via Rule 8; \
+         got {} corvette order(s)",
+        corvette_orders,
+    );
+}


### PR DESCRIPTION
## Summary

PR #531 code review (`docs/code-review-2026-05-25-ai-resource-gate.md`) surfaced 3 follow-up findings on the AI build / resource gate path. This PR bundles all three as 3 sequential commits (F1 → F2 → F3) on top of `main` @ cd08a7d.

- **F1 (High)** — `handle_build_deliverable` resolved cost / build_time / cargo_size via `ShipDesignRegistry`. Production `infrastructure_core` lives in `DeliverableRegistry`; existing tests masked the bug by injecting a fake `ShipDesignDefinition` with the deliverable id. Rule 3.5 frontier core deployment was silently stalling at the build queue. Now: `DeliverableRegistry` is the source of truth, `BevyMidGameAdapter.can_afford_design` consults both registries, real `cargo_size` (e.g. 5 for infra core) is queued instead of the hardcoded 1.
- **F2 (Medium/High)** — Rule 8 `fortify_system` was the one AI build path PR #531 missed adding an affordability gate to. A bankrupt empire with a shipyard + low ship count could still enqueue one unaffordable combat ship via handler auto-pick. New `MidGameAdapter::affordable_fortify_design()` returns the cheapest direct-buildable combat design that passes the pending-aware gate; Rule 8 emits `build_ship{design_id}` when `Some`, silent when `None`. Mirrors Rules 5a/6's adapter-decides-then-Mid-emits pattern.
- **F3 (Medium)** — Pending-aware gate subtracted from colony `BuildQueue` + system `SystemBuildingQueue` but excluded per-colony `BuildingQueue` (mine/farm/power_plant). Short Rule 5b's `can_afford_building` reads the gate-adjusted stockpile, so cross-id planet buildings could each pass the gate after one consumed most resources (same-tick handler dedup only catches same-id duplicates). Now: Colony query tuple widened to also fetch `&BuildingQueue`, with `minerals_remaining / energy_remaining` subtracted alongside the other queues. Demolition queue intentionally excluded (refund); upgrade queue is AI-unreachable.

Test counts: 3652 (baseline) → **3682 passed, 0 failed, 1 ignored** workspace-wide.

No `SAVE_VERSION` bump — all changes are runtime-only or queued-order field semantics (existing saves continue to decode).

## Test plan

- [x] `cargo test -p macrocosmo --test ai_deliverable_registry_resolution -- --test-threads=1` (F1 regression, 2/2)
- [x] `cargo test -p macrocosmo --test ai_resource_gate_hotfix -- --test-threads=1` (F2+F3 regressions, 9/9)
- [x] `cargo test -p macrocosmo --test ai_region_deadlock_hotfix -- --test-threads=1` (F1 fixture cascade, 4/4)
- [x] `cargo test -p macrocosmo --test ai_decomposition_e2e -- --test-threads=1` (F1 fixture cascade, 1/1)
- [x] `cargo test -p macrocosmo --test ai_ship_build_queue -- --test-threads=1` (F2 sanity, 5/5)
- [x] `cargo test --workspace --tests -- --test-threads=1` (3682/3682)

## Reviewer notes

- **F1 contract change**: `BuildKind::Deliverable.cargo_size` now reflects the deliverable's true value (5 for infra core) instead of the hardcoded `1`. Field type unchanged (`u32`), so `postcard` save format is unaffected — but anything downstream that assumed `cargo_size == 1` for deliverable orders should be re-checked. (`fixtures_smoke.rs` still passes.)
- **F2 telemetry change**: Rule 8 now emits `build_ship` log lines instead of `fortify_system`. Any external grep / dashboard keyed on `"fortify_system"` from Rule 8 telemetry will need an update. `fortify_system` command-kind + handler remain reachable for other paths.
- **F3 query widening**: Same-tuple widening, no new `SystemParam` slot. Top-level `npc_decision_tick` param count remains 16-worst-case (with `cfg(feature = "log")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)