### PR TITLE
fix(visualization): #532 follow-up — route InSystem+InTransit projections through interpolation

### DIFF
--- a/macrocosmo/src/visualization/ships.rs
+++ b/macrocosmo/src/visualization/ships.rs
@@ -457,6 +457,66 @@ pub fn own_ship_marker_screen_pos(
     origin_screen.lerp(dest_screen, frac)
 }
 
+/// #532 follow-up: Routing predicate for the `InSystem | Refitting`
+/// branch of [`draw_ships`].
+///
+/// Background: PR #534 wired the [`projection_screen_pos`] interpolation
+/// into the `InTransitSubLight | InTransitFTL` branch only. But
+/// `compute_ship_projection` in `knowledge::mod` commonly leaves
+/// `projected_state = InSystem` (carried over from the last known
+/// snapshot) while `intended_state = InTransit*`. Those projections
+/// route through `InSystem | Refitting` in `draw_ships` and never reach
+/// the interpolation helper — so the player saw a frozen marker even
+/// after `intended_takes_effect_at`.
+///
+/// This predicate decides whether the `InSystem | Refitting` arm should
+/// detour through [`projection_screen_pos`] (returning `true`) or
+/// continue grouping the ship into the docked-marker layer (returning
+/// `false`). The four conditions below jointly preserve every existing
+/// contract — particularly PR #530's pre-effect no-FTL-leak rule —
+/// while finally letting the post-effect interpolation actually fire.
+///
+/// Returns `true` only when **all** of the following hold:
+/// 1. `intended_state` is `Some` and a transit-style state (FTL /
+///    SubLight). Surveying / Settling intents anchor the ship at the
+///    target system and must not slide the marker between systems.
+/// 2. `intended_system != projected_system`. A reconciled / no-op move
+///    has no divergence to interpolate against; let the default docked
+///    grouping render the ship at its (already correct) system.
+/// 3. `now >= intended_takes_effect_at`. Before the command locally
+///    reaches the ship the marker MUST stay at `projected_system` — this
+///    is PR #530's no-FTL-leak invariant.
+/// 4. `expected_arrival_at` is `Some`. Without an arrival ETA the lerp
+///    endpoint is undefined; fall back to docked rendering rather than
+///    guessing.
+///
+/// The function is `pub` so the routing decision can be unit-tested
+/// directly without spinning up a full Bevy draw frame.
+pub fn should_draw_projected_marker_with_interpolation(
+    projection: &ShipProjection,
+    now: i64,
+) -> bool {
+    let Some(intent) = projection.intended_state.as_ref() else {
+        return false;
+    };
+    if !intent.is_in_transit() {
+        return false;
+    }
+    let Some(dest) = projection.intended_system else {
+        return false;
+    };
+    if Some(dest) == projection.projected_system {
+        return false;
+    }
+    let Some(eff) = projection.intended_takes_effect_at else {
+        return false;
+    };
+    if now < eff {
+        return false;
+    }
+    projection.expected_arrival_at.is_some()
+}
+
 /// #477 / #532: Resolve the on-screen position implied by a
 /// [`ShipProjection`].
 ///
@@ -825,7 +885,40 @@ pub fn draw_ships(
     for item in &render_items {
         match &item.projected_state {
             // Docked-style states render as a circle around the system.
+            //
+            // #532 follow-up: a projection with `projected_state =
+            // InSystem` may still describe a ship that has, from the
+            // dispatcher's POV, already left port — `compute_ship_projection`
+            // keeps the last-known snapshot's state while populating
+            // `intended_state = InTransit*` and the takes-effect / arrival
+            // ETAs. PR #534's interpolation only fired in the transit arm,
+            // so those ships rendered as frozen dots. Detour through
+            // `projection_screen_pos` when the routing predicate confirms
+            // the command has locally reached the ship — otherwise fall
+            // back to the docked grouping (which is the right answer
+            // pre-effect, and remains the right answer when there is no
+            // in-flight transit intent).
             ShipSnapshotState::InSystem | ShipSnapshotState::Refitting => {
+                let projection = viewing_store.get_projection(item.entity);
+                if let Some(projection) = projection {
+                    if should_draw_projected_marker_with_interpolation(projection, clock.elapsed) {
+                        if let Some(marker) =
+                            projection_screen_pos(projection, &stars, view.scale, clock.elapsed)
+                        {
+                            let (r, g, b) = ship_color_rgb(&item.design_id);
+                            // Mirror the InTransit arm's marker shape so
+                            // the ship looks visually identical across
+                            // the dispatch-to-arrival window regardless
+                            // of which projected_state happens to be
+                            // carried in the projection.
+                            gizmos.circle_2d(marker, 3.0, Color::srgba(r, g, b, 0.4));
+                        }
+                        // Skip the docked grouping for this frame — the
+                        // ship is rendered at the interpolated marker
+                        // above.
+                        continue;
+                    }
+                }
                 let Some(system) = item.projected_system else {
                     continue;
                 };

--- a/macrocosmo/tests/ship_projection_interpolation_532.rs
+++ b/macrocosmo/tests/ship_projection_interpolation_532.rs
@@ -23,7 +23,10 @@ use bevy::prelude::*;
 
 use macrocosmo::components::Position;
 use macrocosmo::knowledge::{ShipProjection, ShipSnapshotState};
-use macrocosmo::visualization::ships::{intended_lerp_fraction, own_ship_marker_screen_pos};
+use macrocosmo::visualization::ships::{
+    intended_lerp_fraction, own_ship_marker_screen_pos,
+    should_draw_projected_marker_with_interpolation,
+};
 
 const VIEW_SCALE: f32 = 1.0;
 
@@ -203,5 +206,175 @@ fn steady_state_marker_at_projected() {
         (pos - Vec2::new(0.0, 0.0)).length() < 1e-4,
         "steady-state projection must place marker at projected \
          position; got {pos:?}",
+    );
+}
+
+// ===========================================================================
+// #532 follow-up: routing decision for the `InSystem | Refitting` branch
+// of `draw_ships`.
+//
+// PR #534 wired interpolation into the `InTransit*` arm only. But
+// `compute_ship_projection` keeps `projected_state = InSystem` from the
+// last known snapshot while populating `intended_state = InTransit*` —
+// so the common post-dispatch projection routed through the docked
+// grouping arm and the interpolation never fired.
+//
+// These tests pin the routing predicate that lets `draw_ships` detour
+// `InSystem` projections through `projection_screen_pos` when (and only
+// when) the four jointly-required conditions hold.
+// ===========================================================================
+
+/// Make a projection with `projected_state = InSystem` at `origin` but
+/// `intended_state = InTransit*` heading to `destination`. The
+/// helper-under-test reads only the projection itself, so we use two
+/// distinguishable placeholder entities to model origin != destination.
+fn make_in_system_in_transit_projection(
+    intended_state: ShipSnapshotState,
+    intended_takes_effect_at: Option<i64>,
+    expected_arrival_at: Option<i64>,
+) -> ShipProjection {
+    // Two synthetic entity ids so origin != destination. The routing
+    // helper never derefs these — it only compares them for equality.
+    let origin_sys = Entity::from_bits(1);
+    let destination_sys = Entity::from_bits(2);
+    ShipProjection {
+        entity: Entity::PLACEHOLDER,
+        dispatched_at: 0,
+        expected_arrival_at,
+        expected_return_at: None,
+        // The whole point: projected_state is the docked-style state
+        // (carried over from the last known snapshot) while the
+        // intended layer has already become a transit.
+        projected_state: ShipSnapshotState::InSystem,
+        projected_system: Some(origin_sys),
+        intended_state: Some(intended_state),
+        intended_system: Some(destination_sys),
+        intended_takes_effect_at,
+    }
+}
+
+/// Pre-effect: command has been dispatched but has not yet locally
+/// reached the ship. The marker MUST stay docked at the projected
+/// system — this preserves PR #530's no-FTL-leak contract.
+#[test]
+fn projected_in_system_pre_effect_remains_docked() {
+    let p =
+        make_in_system_in_transit_projection(ShipSnapshotState::InTransitFTL, Some(100), Some(200));
+    // now=50 < takes_effect_at=100 → pre-effect.
+    assert!(
+        !should_draw_projected_marker_with_interpolation(&p, 50),
+        "pre-effect (now < intended_takes_effect_at) must NOT route \
+         through interpolation — that would reintroduce the FTL leak \
+         #530 closed",
+    );
+}
+
+/// Post-effect: command has locally reached the ship, the ship is in
+/// transit, arrival ETA is known. The marker MUST route through
+/// `projection_screen_pos` instead of the docked grouping.
+#[test]
+fn projected_in_system_post_effect_uses_interpolated_marker() {
+    let p =
+        make_in_system_in_transit_projection(ShipSnapshotState::InTransitFTL, Some(100), Some(200));
+    // now=150 ∈ [100, 200] → mid-flight.
+    assert!(
+        should_draw_projected_marker_with_interpolation(&p, 150),
+        "post-effect with transit intent + ETAs MUST route through \
+         interpolation (the whole point of the #532 follow-up)",
+    );
+
+    // Sanity-check the lerp lands strictly between origin and
+    // destination at mid-flight — confirms the helper is wired to the
+    // same lerp the marker draw will use.
+    let frac = intended_lerp_fraction(&p, 150).expect("mid-flight has a lerp fraction");
+    assert!(
+        (frac - 0.5).abs() < 1e-4,
+        "mid-flight lerp fraction must be 0.5; got {frac}",
+    );
+    let pos = own_ship_marker_screen_pos(&p, &origin(), Some(&dest()), VIEW_SCALE, 150);
+    assert!(
+        pos.x > 0.0 && pos.x < 100.0,
+        "mid-flight marker must sit strictly between origin and \
+         destination (not snap to either endpoint); got {pos:?}",
+    );
+}
+
+/// Missing arrival ETA: the lerp endpoint is undefined. The marker
+/// MUST stay docked rather than divide-by-zero or guess. (This mirrors
+/// the steady-state `own_ship_marker_screen_pos` contract at the
+/// routing level.)
+#[test]
+fn projected_in_system_missing_arrival_eta_remains_docked() {
+    let p = make_in_system_in_transit_projection(ShipSnapshotState::InTransitFTL, Some(100), None);
+    // now=150, post-effect but no arrival ETA.
+    assert!(
+        !should_draw_projected_marker_with_interpolation(&p, 150),
+        "missing expected_arrival_at must NOT trigger interpolation \
+         routing — the lerp endpoint would be undefined",
+    );
+}
+
+/// Reconciled state: `projected_system == intended_system`. The
+/// docked grouping at the (already correct) destination is the right
+/// render — interpolating would be a zero-length lerp / no-op.
+#[test]
+fn projected_in_system_reconciled_uses_default() {
+    let same_sys = Entity::from_bits(3);
+    let p = ShipProjection {
+        entity: Entity::PLACEHOLDER,
+        dispatched_at: 0,
+        expected_arrival_at: Some(200),
+        expected_return_at: None,
+        projected_state: ShipSnapshotState::InSystem,
+        projected_system: Some(same_sys),
+        intended_state: Some(ShipSnapshotState::InTransitFTL),
+        intended_system: Some(same_sys),
+        intended_takes_effect_at: Some(100),
+    };
+    // now=250, past arrival. Projected == Intended → reconciled.
+    assert!(
+        !should_draw_projected_marker_with_interpolation(&p, 250),
+        "reconciled projection (projected == intended) must fall back \
+         to the default docked grouping — there is no divergence to \
+         interpolate against",
+    );
+}
+
+/// Non-transit intended state (e.g. Surveying) must NOT route through
+/// interpolation. Surveying anchors the ship at the target system; the
+/// marker should not slide between systems.
+#[test]
+fn projected_in_system_non_transit_intended_does_not_route_through_interpolation() {
+    let p =
+        make_in_system_in_transit_projection(ShipSnapshotState::Surveying, Some(100), Some(200));
+    assert!(
+        !should_draw_projected_marker_with_interpolation(&p, 150),
+        "non-transit intended state must NOT trigger interpolation \
+         routing — Surveying / Settling anchor the ship at the \
+         intended system rather than implying motion between systems",
+    );
+}
+
+/// Steady-state projection (no in-flight command) must NOT route
+/// through interpolation. `intended_state = None` is the default
+/// post-reconcile shape.
+#[test]
+fn projected_in_system_steady_state_does_not_route_through_interpolation() {
+    let p = make_in_system_in_transit_projection(
+        ShipSnapshotState::InTransitFTL, // overwritten below
+        Some(100),
+        Some(200),
+    );
+    let p = ShipProjection {
+        intended_state: None,
+        intended_system: None,
+        intended_takes_effect_at: None,
+        expected_arrival_at: None,
+        ..p
+    };
+    assert!(
+        !should_draw_projected_marker_with_interpolation(&p, 150),
+        "steady-state projection (intended_state = None) must NOT \
+         trigger interpolation routing",
     );
 }


### PR DESCRIPTION
Follow-up to #532 / PR #534. The original PR added the interpolation helpers (`intended_lerp_fraction`, `own_ship_marker_screen_pos`) and wired them into `draw_ships`' `InTransit*` arm only — but `compute_ship_projection` often leaves `projected_state = InSystem` (carried over from the last known snapshot) while `intended_state = InTransit*`. Such projections route through the `InSystem | Refitting` arm which groups the ship into `docked_counts` at `projected_system` and never calls `projection_screen_pos`. So the marker still appeared frozen in the common post-dispatch case despite the helper being correct.

Plan: `docs/plan-532-ship-marker-interpolation-followup.md`.

## Summary

- new pub `should_draw_projected_marker_with_interpolation(projection, now)` encodes four jointly-required routing conditions: intended is in-transit, origin != destination, `now >= intended_takes_effect_at`, `expected_arrival_at` is `Some`
- `draw_ships`' `InSystem | Refitting` arm consults the helper. When `true`, the ship renders at `projection_screen_pos` (mirroring the `InTransit` arm's marker shape) and the `docked_counts` grouping is skipped for that frame. When `false` (including pre-effect), the existing docked grouping is preserved — keeps PR #530's no-FTL-leak contract
- 6 new regression tests cover the routing decision (not just the lerp math):
  - `projected_in_system_pre_effect_remains_docked` — `now < intended_takes_effect_at` returns false
  - `projected_in_system_post_effect_uses_interpolated_marker` — mid-flight returns true + lerp midpoint check
  - `projected_in_system_missing_arrival_eta_remains_docked` — no `expected_arrival_at` falls back
  - `projected_in_system_reconciled_uses_default` — `projected == intended` returns false
  - `projected_in_system_non_transit_intended_does_not_route_through_interpolation` — `Surveying` etc. returns false
  - `projected_in_system_steady_state_does_not_route_through_interpolation` — no `intended_state` returns false
- omniscient path untouched (already uses realtime `ShipState` via `draw_ships_omniscient`)
- transit / loitering / surveying / colonizing branches unchanged

## Test plan

- [x] `cargo test -p macrocosmo --test ship_projection_interpolation_532 -- --test-threads=1` (13/13 — 7 existing + 6 new)
- [x] `cargo test -p macrocosmo --test ship_projection_render -- --test-threads=1` (7/7 — PR #530 FTL-leak regression unchanged)
- [x] `cargo test -p macrocosmo --test ship_projection_intended_render -- --test-threads=1` (11/11)
- [x] `cargo test -p macrocosmo --test ship_projection -- --test-threads=1` (4/4)
- [x] `cargo test --workspace --tests -- --test-threads=1` (exit code 0; tail truncated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)